### PR TITLE
feat: Add FiniteMap interface

### DIFF
--- a/src/Iris/Std/FiniteMapInstances.lean
+++ b/src/Iris/Std/FiniteMapInstances.lean
@@ -1,0 +1,165 @@
+/-
+Copyright (c) 2025 Zongyuan Liu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zongyuan Liu
+-/
+import Iris.Std.FiniteMap
+import Iris.Std.List
+import Std
+
+/-! ## FiniteMap Instance for Std.ExtTreeMap
+
+This file instantiates the abstract finite map interface `Iris.Std.FiniteMap` with Lean's `Std.ExtTreeMap`.
+-/
+namespace Iris.Std
+
+/-- Instance of FiniteMap for Std.ExtTreeMap. -/
+instance {K : Type u} [Ord K] [Std.TransCmp (α := K) compare] [Std.LawfulEqCmp (α := K) compare] [DecidableEq K]:
+    FiniteMap K (Std.ExtTreeMap K) where
+  get? m k := m.get? k
+  insert m k v := m.insert k v
+  delete m k := m.erase k
+  toList m := m.toList
+  ofList l := Std.ExtTreeMap.ofList l.reverse
+  fold := fun f init m => m.foldr f init
+
+namespace FiniteMapInst
+
+variable {K : Type _} [Ord K] [Std.TransCmp (α := K) compare] [Std.LawfulEqCmp (α := K) compare] [DecidableEq K]
+
+/-- The FiniteMapLaws instance for ExtTreeMap. -/
+instance : FiniteMapLaws K (Std.ExtTreeMap K) where
+  ext := by
+    intro m₁ m₂ h
+    apply Std.ExtTreeMap.ext_getElem?
+
+  get?_empty := by
+    intro k
+    simp [FiniteMap.get?]
+
+  get?_insert_same := by
+    intro m k v
+    simp [FiniteMap.get?, FiniteMap.insert]
+
+  get?_insert_ne := by
+    intro m _ k k' h
+    simp [FiniteMap.get?, FiniteMap.insert, Std.ExtTreeMap.getElem?_insert]
+    intro h h'
+    trivial
+
+  get?_delete_same := by
+    intro m k
+    simp [FiniteMap.get?, FiniteMap.delete]
+
+  get?_delete_ne := by
+    intro m k k' h h'
+    simp [FiniteMap.get?, FiniteMap.delete, Std.ExtTreeMap.getElem?_erase]
+    intro h h'
+    trivial
+
+  ofList_nil := by
+    simp [FiniteMap.ofList]
+
+  ofList_cons := by
+    intro k v l l_1
+    simp only [FiniteMap.ofList, FiniteMap.insert]
+    rw [List.reverse_cons, Std.ExtTreeMap.ofList_eq_insertMany_empty, Std.ExtTreeMap.ofList_eq_insertMany_empty, Std.ExtTreeMap.insertMany_append, Std.ExtTreeMap.insertMany_list_singleton]
+
+  toList_spec := by
+    intro V m
+    constructor
+    · simp only [FiniteMap.toList]
+      have hdistinct : m.toList.Pairwise (fun a b => ¬compare a.1 b.1 = .eq) :=
+        Std.ExtTreeMap.distinct_keys_toList
+      apply hdistinct.imp
+      intro a b hne heq
+      subst heq
+      have : compare a.1 a.1 = .eq := Std.LawfulEqCmp.compare_eq_iff_eq.mpr rfl
+      exact hne this
+    · intro i x
+      simp only [FiniteMap.toList, FiniteMap.get?]
+      exact Std.ExtTreeMap.mem_toList_iff_getElem?_eq_some
+
+
+/-- The FiniteMapLawsSelf instance for ExtTreeMap. -/
+instance : FiniteMapLawsSelf K (Std.ExtTreeMap K) where
+  toList_filterMap := by
+    intro V m f
+    haveI : DecidableEq V := Classical.typeDecidableEq V
+    simp only [FiniteMap.toList, FiniteMap.filterMap, FiniteMap.ofList]
+
+    obtain H := FiniteMapLaws.toList_ofList (M := (Std.ExtTreeMap K)) (K := K) (V := V) (l := (List.filterMap (fun kv => Option.map (fun x => (kv.fst, x)) (f kv.snd)) m.toList))
+
+    simp only [FiniteMap.toList, FiniteMap.ofList] at H
+    apply H
+    rw [List.map_filterMap]
+    have eq_goal : (List.filterMap (fun x => Option.map Prod.fst (Option.map (fun x_1 => (x.fst, x_1)) (f x.snd))) m.toList) =
+                   (List.filterMap (fun x => Option.map (fun _ => x.fst) (f x.snd)) m.toList) := by
+      congr 1
+      ext x
+      rw [Option.map_map]
+      rfl
+    rw [eq_goal]
+    have nodup_keys : (m.toList.map Prod.fst).Nodup := by
+      rw [Std.ExtTreeMap.map_fst_toList_eq_keys]
+      exact Std.ExtTreeMap.nodup_keys
+    exact List.nodup_filterMap_of_nodup_keys m.toList f nodup_keys
+
+  toList_filter := by
+    intro V m φ
+    simp [FiniteMap.toList, FiniteMap.filter, FiniteMap.ofList]
+    haveI : DecidableEq V := Classical.typeDecidableEq V
+    obtain H := FiniteMapLaws.toList_ofList (M := (Std.ExtTreeMap K)) (K := K) (V := V) (l := (List.filter (fun x => φ x.fst x.snd) m.toList))
+
+    simp only [FiniteMap.toList, FiniteMap.ofList] at H
+    apply H
+
+    have nodup_keys : (m.toList.map Prod.fst).Nodup := by
+      rw [Std.ExtTreeMap.map_fst_toList_eq_keys]
+      exact Std.ExtTreeMap.nodup_keys
+
+    exact List.nodup_map_fst_filter m.toList (fun x => φ x.fst x.snd) nodup_keys
+
+/-- The FiniteMapKmapLaws instance for ExtTreeMap with key type transformation. -/
+instance {K' : Type _} [Ord K'] [Std.TransCmp (α := K') compare] [Std.LawfulEqCmp (α := K') compare] [DecidableEq K'] :
+    FiniteMapKmapLaws K K' (Std.ExtTreeMap K) (Std.ExtTreeMap K') where
+  toList_kmap := by
+    intro V f m hinj
+    simp [FiniteMap.toList, FiniteMap.kmap, FiniteMap.ofList]
+    haveI : DecidableEq V := Classical.typeDecidableEq V
+    obtain H := FiniteMapLaws.toList_ofList (M := (Std.ExtTreeMap K')) (K := K') (V := V) (l := (List.map (fun x => (f x.fst, x.snd)) m.toList))
+
+    simp only [FiniteMap.toList, FiniteMap.ofList] at H
+    apply H
+
+    have nodup_keys : (m.toList.map Prod.fst).Nodup := by
+      rw [Std.ExtTreeMap.map_fst_toList_eq_keys]
+      exact Std.ExtTreeMap.nodup_keys
+
+    exact List.nodup_map_fst_map_injective m.toList f hinj nodup_keys
+
+/-- The FiniteMapSeqLaws instance for ExtTreeMap with Nat keys. -/
+instance [Std.TransCmp (α := Nat) compare] [Std.LawfulEqCmp (α := Nat) compare] :
+    FiniteMapSeqLaws (Std.ExtTreeMap Nat) where
+  toList_map_seq := by
+    intro V start l
+    simp [FiniteMap.toList, FiniteMap.map_seq, FiniteMap.ofList]
+    haveI : DecidableEq V := Classical.typeDecidableEq V
+
+    have heq : List.mapIdx (fun i v => (start + i, v)) l = (List.range' start l.length).zip l :=
+      List.mapIdx_add_eq_zip_range' start l
+
+    rw [heq]
+
+    obtain H := FiniteMapLaws.toList_ofList (M := (Std.ExtTreeMap Nat)) (K := Nat) (V := V) (l := ((List.range' start l.length).zip l))
+
+    simp only [FiniteMap.toList, FiniteMap.ofList] at H
+    apply H
+
+    -- The keys from range' are all distinct
+    rw [← heq]
+    exact List.nodup_map_fst_mapIdx_add start l
+
+end FiniteMapInst
+
+end Iris.Std

--- a/src/Iris/Std/List.lean
+++ b/src/Iris/Std/List.lean
@@ -13,27 +13,64 @@ not available in Lean core.
 
 namespace Iris.Std.List
 
+/-- Bidirectional relationship between lookup and membership for lists with no duplicate keys.
+    For a list with no duplicate keys, `List.lookup k l = some v` if and only if `(k, v) ∈ l`. -/
+theorem list_lookup_some_iff_mem {A B : Type _} [DecidableEq A]
+    (k : A) (v : B) (l : List (A × B))
+    (hnodup : (l.map Prod.fst).Nodup) :
+    List.lookup k l = some v ↔ (k, v) ∈ l := by
+  induction l with
+  | nil => simp [List.lookup]
+  | cons hd tl ih =>
+    simp only [List.lookup, List.mem_cons]
+    rw [List.map_cons, List.nodup_cons] at hnodup
+    split
+    · next heq =>
+      constructor
+      · intro h; left; cases Option.some.inj h; ext
+        · apply eq_of_beq heq
+        · rfl
+      · intro h; cases h with
+        | inl h => cases h; rfl
+        | inr h => have : k ∈ tl.map Prod.fst := by simp; exact ⟨v, h⟩
+                   exact absurd (by rw [← eq_of_beq heq]; exact this) hnodup.1
+    · next hneq =>
+      rw [ih hnodup.2]; constructor
+      · intro h; exact Or.inr h
+      · intro h; cases h with
+        | inl h => cases h; simp at hneq
+        | inr h => exact h
+
+/-- If lookup returns some value, the key-value pair is in the list. -/
+theorem list_lookup_some_mem {A B : Type _} [DecidableEq A]
+    (k : A) (v : B) (l : List (A × B)) :
+    List.lookup k l = some v → (k, v) ∈ l := by
+  intro h
+  induction l with
+  | nil => contradiction
+  | cons hd tl ih =>
+    simp only [List.lookup, List.mem_cons] at h ⊢
+    split at h
+    · next heq => left; cases Option.some.inj h; ext; apply eq_of_beq heq; rfl
+    · exact Or.inr (ih h)
+
+/-- If a key-value pair is in the list with no duplicate keys, lookup returns that value. -/
+theorem list_mem_lookup_some {A B : Type _} [DecidableEq A]
+    (k : A) (v : B) (l : List (A × B))
+    (hnodup : (l.map Prod.fst).Nodup) :
+    (k, v) ∈ l → List.lookup k l = some v := by
+  exact (list_lookup_some_iff_mem k v l hnodup).mpr
+
 /-- For a Nodup list, erasing an element removes it completely. -/
 theorem not_mem_erase_self_of_nodup {α : Type _} [DecidableEq α] (x : α) (l : List α)
     (hnd : l.Nodup) : x ∉ l.erase x := by
   induction l with
   | nil => exact List.not_mem_nil
   | cons y ys ih =>
-    simp only [List.erase_cons]
-    rw [List.nodup_cons] at hnd
+    simp only [List.erase_cons]; rw [List.nodup_cons] at hnd
     split
-    · next h =>
-      have heq : y = x := eq_of_beq h
-      rw [← heq]
-      exact hnd.1
-    · next h =>
-      simp only [List.mem_cons]
-      intro hor
-      cases hor with
-      | inl heq =>
-        have : (y == x) = true := beq_iff_eq.mpr heq.symm
-        exact absurd this h
-      | inr hmem => exact ih hnd.2 hmem
+    · next h => rw [← eq_of_beq h]; exact hnd.1
+    · next h => simp; exact ⟨fun heq => absurd (beq_iff_eq.mpr heq.symm) h, ih hnd.2⟩
 
 /-- Two Nodup lists with the same membership are permutations of each other.
     Corresponds to Rocq's `NoDup_Permutation`. -/
@@ -44,35 +81,18 @@ theorem perm_of_nodup_of_mem_iff {α : Type _} [DecidableEq α]
   | nil =>
     cases l₂ with
     | nil => exact List.Perm.refl []
-    | cons y ys =>
-      have : y ∈ ([] : List α) := (hmem y).mpr List.mem_cons_self
-      exact absurd this List.not_mem_nil
+    | cons y ys => exact absurd ((hmem y).mpr List.mem_cons_self) List.not_mem_nil
   | cons x xs ih =>
-    have hx_in_l₂ : x ∈ l₂ := (hmem x).mp List.mem_cons_self
-    have hperm₂ : l₂.Perm (x :: l₂.erase x) := List.perm_cons_erase hx_in_l₂
     rw [List.nodup_cons] at hnd₁
-    have hx_notin_xs : x ∉ xs := hnd₁.1
-    have hnd_xs : xs.Nodup := hnd₁.2
-    have hnd_erase : (l₂.erase x).Nodup := hnd₂.erase x
-    have hmem_erase : ∀ y, y ∈ xs ↔ y ∈ l₂.erase x := by
-      intro y
-      constructor
-      · intro hy
-        have hne : y ≠ x := fun heq => hx_notin_xs (heq ▸ hy)
-        have hy_l₂ : y ∈ l₂ := (hmem y).mp (List.mem_cons_of_mem x hy)
-        exact (List.mem_erase_of_ne hne).mpr hy_l₂
-      · intro hy
-        have hne : y ≠ x := by
-          intro heq
-          rw [heq] at hy
-          exact not_mem_erase_self_of_nodup x l₂ hnd₂ hy
-        have hy_l₂ : y ∈ l₂ := List.mem_of_mem_erase hy
-        have hy_l₁ : y ∈ x :: xs := (hmem y).mpr hy_l₂
+    have hmem_erase : ∀ y, y ∈ xs ↔ y ∈ l₂.erase x := fun y => ⟨
+      fun hy => (List.mem_erase_of_ne (fun (heq : y = x) => hnd₁.1 (heq ▸ hy))).mpr ((hmem y).mp (List.mem_cons_of_mem x hy)),
+      fun hy => by
+        have hy_l₁ : y ∈ x :: xs := (hmem y).mpr (List.mem_of_mem_erase hy)
         cases List.mem_cons.mp hy_l₁ with
-        | inl heq => exact absurd heq hne
-        | inr h => exact h
-    have hperm_xs : xs.Perm (l₂.erase x) := ih hnd_xs hnd_erase hmem_erase
-    exact (List.Perm.cons x hperm_xs).trans hperm₂.symm
+        | inl heq => exact absurd (heq ▸ hy) (not_mem_erase_self_of_nodup x l₂ hnd₂)
+        | inr h => exact h⟩
+    exact (List.Perm.cons x (ih hnd₁.2 (hnd₂.erase x) hmem_erase)).trans
+          (List.perm_cons_erase ((hmem x).mp List.mem_cons_self)).symm
 
 
 theorem nodup_of_nodup_map_fst {α β : Type _} (l : List (α × β))
@@ -88,5 +108,105 @@ theorem nodup_of_nodup_map_fst {α β : Type _} (l : List (α × β))
       exact h.1 this
     · rw [List.map_cons, List.nodup_cons] at h
       exact ih h.2
+
+/-- If a list has no duplicate keys (Nodup on first components),
+    then filtering preserves this property on the first components. -/
+theorem nodup_map_fst_filter {α β : Type _}
+    (l : List (α × β)) (p : α × β → Bool)
+    (h : (l.map Prod.fst).Nodup) :
+    ((List.filter p l).map Prod.fst).Nodup := by
+  induction l with
+  | nil => simp
+  | cons kv tail ih =>
+    rw [List.map_cons, List.nodup_cons] at h
+    simp only [List.filter]; split
+    · rw [List.map_cons, List.nodup_cons]
+      refine ⟨fun hmem => h.1 ?_, ih h.2⟩
+      clear h ih; induction tail with
+      | nil => simp at hmem
+      | cons kv' tail' ih_tail =>
+        simp only [List.filter] at hmem
+        split at hmem
+        · rw [List.map_cons, List.mem_cons] at hmem
+          rcases hmem with heq | hmem'
+          · rw [List.map_cons, List.mem_cons]; exact Or.inl heq
+          · rw [List.map_cons, List.mem_cons]; exact Or.inr (ih_tail hmem')
+        · rw [List.map_cons, List.mem_cons]; exact Or.inr (ih_tail hmem)
+    · exact ih h.2
+
+/-- If a list has no duplicate keys (Nodup on first components) and we map keys
+    with an injective function, the result also has no duplicate keys. -/
+theorem nodup_map_fst_map_injective {α β γ : Type _}
+    (l : List (α × β)) (f : α → γ)
+    (hinj : ∀ {x y : α}, f x = f y → x = y)
+    (h : (l.map Prod.fst).Nodup) :
+    ((List.map (fun x => (f x.fst, x.snd)) l).map Prod.fst).Nodup := by
+  rw [List.map_map]
+  induction l with
+  | nil => constructor
+  | cons kv tail ih =>
+    rw [List.map_cons, List.nodup_cons] at h ⊢
+    refine ⟨fun hmem => h.1 ?_, ih h.2⟩
+    clear h ih; induction tail with
+    | nil => simp at hmem
+    | cons kv' tail' ih_tail =>
+      rw [List.map_cons, List.mem_cons] at hmem
+      rcases hmem with heq | hmem'
+      · simp [hinj heq]
+      · simp [ih_tail hmem']
+
+/-- mapIdx with addition creates the same result as zipping with range'. -/
+theorem mapIdx_add_eq_zip_range' {α : Type _} (start : Nat) (l : List α) :
+    List.mapIdx (fun i v => (start + i, v)) l = (List.range' start l.length).zip l := by
+  induction l generalizing start with
+  | nil =>
+    rw [List.mapIdx_nil, List.length_nil, List.range'_zero, List.zip_nil_left]
+  | cons hd tl ih =>
+    rw [List.mapIdx_cons, List.length_cons, List.range'_succ, List.zip_cons_cons]
+    congr 1
+    have heq : (fun (i : Nat) (v : α) => (start + (i + 1), v)) = (fun (i : Nat) (v : α) => (start + 1 + i, v)) := by
+      funext i v
+      simp only [Nat.add_assoc, Nat.add_comm 1]
+    rw [heq]
+    exact ih (start + 1)
+
+/-- The keys from mapIdx with addition are all distinct. -/
+theorem nodup_map_fst_mapIdx_add {α : Type _} (start : Nat) (l : List α) :
+    (List.mapIdx (fun i v => (start + i, v)) l).map Prod.fst |>.Nodup := by
+  rw [mapIdx_add_eq_zip_range', List.map_fst_zip]
+  · exact List.nodup_range' (step := 1)
+  · rw [List.length_range']
+    omega
+
+/-- If a list has no duplicate keys (Nodup on first components),
+    then filtering by mapping the second components preserves this property. -/
+theorem nodup_filterMap_of_nodup_keys {α β : Type _}
+    (l : List (α × β)) (f : β → Option β)
+    (h : (l.map Prod.fst).Nodup) :
+    (List.filterMap (fun x => Option.map (fun _ => x.fst) (f x.snd)) l).Nodup := by
+  induction l with
+  | nil => simp
+  | cons kv tail ih =>
+    rw [List.map_cons, List.nodup_cons] at h
+    simp only [List.filterMap]; split
+    · exact ih h.2
+    · next b heq =>
+      have hb : b = kv.fst := by
+        obtain ⟨_, _, hf⟩ := Option.map_eq_some_iff.1 heq; exact hf.symm
+      subst hb; constructor
+      · intro a' hmem heq; subst heq; apply h.1; clear h ih heq
+        induction tail with
+        | nil => simp at hmem
+        | cons kv' tail' ih_tail =>
+          simp only [List.filterMap] at hmem; split at hmem
+          · simp [ih_tail hmem]
+          · next b' heq' =>
+            have hb' : b' = kv'.fst := by
+              obtain ⟨_, _, hf⟩ := Option.map_eq_some_iff.1 heq'; exact hf.symm
+            subst hb'; simp only [List.mem_cons] at hmem
+            rcases hmem with heq | hmem'
+            · simp [heq]
+            · simp [ih_tail hmem']
+      · exact ih h.2
 
 end Iris.Std.List


### PR DESCRIPTION
## Description
This PR introduces a finite map interface inspired by `stdpp`’s `fin_map`.  It also includes various ported stdpp lemmas used in #113.


## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [ ] I have updated `PORTING.md` as appropriate
* [x] I have added my name to the `authors` section of any appropriate files
