### PR TITLE
chore: Bump Lean to 4.27.0

### DIFF
--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "leanprover-community",
-   "rev": "9371548b6ac4467fea4dfc675881f6212cc5565d",
+   "rev": "509ad12ac4efd70d96418b481521296f9619bcf0",
    "name": "Qq",
    "manifestFile": "lake-manifest.json",
    "inputRev": "stable",

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.26.0
+leanprover/lean4:v4.27.0


### PR DESCRIPTION
This is a duplicate of #139 but for some reason CI wasn’t triggered there.