### PR TITLE
feat: add Löb induction example

### DIFF
--- a/src/Iris/Examples/IProp.lean
+++ b/src/Iris/Examples/IProp.lean
@@ -172,7 +172,7 @@ example (e e' : Expr) Φ (Hstep : ∀ {s : State}, @step _ _ Value _ (e, s) = (e
    Then, it suffies to have access to P, and show that access to P' is enough to verify e'. -/
 example (e e' : Expr) (P P' : IProp GF) Φ
       (Hstep : ∀ s, iprop(P ∗ @state_interp State GF _ s ⊢ ∃ s',
-          ⌜@step _ _ Value _ (e, s) = (e', s')⌝ ∗ |==> (P' ∗ @state_interp State GF _ s'))) :
+          ⌜ step Value (e, s) = (e', s')⌝ ∗ |==> (P' ∗ @state_interp State GF _ s'))) :
     P ∗ (P' -∗ wp e' Φ) ⊢ wp e Φ := by
   iintro ⟨HP, Hspec⟩
   iapply wp_unfold
@@ -189,6 +189,23 @@ example (e e' : Expr) (P P' : IProp GF) Φ
   isplitl [Hs]
   · iexact Hs
   · iapply Hspec $$ HP'
+
+/- Looping programs, by Löb induction -/
+example (e : Expr) Φ (Hloop : ∀ σ : State, step Value (e, σ) = (e, σ)) :
+    ⊢ wp e Φ := by
+  iapply BILoeb.loeb_weak
+  iintro HLöb
+  iapply wp_unfold
+  iright
+  iintro %s Hs
+  iexists e, s
+  isplitr
+  · ipure_intro; exact Hloop s
+  iintro !> !>
+  isplitl [Hs]
+  · iassumption
+  · iassumption
+  · exact true_intro
 
 end Example3
 


### PR DESCRIPTION
## Description
Example of a looping program, proven using Löb induction

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have updated `PORTING.md` as appropriate
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
