### PR TITLE
fix: remove duplicate CMRA.Discrete instances for DFrac

### DIFF
--- a/src/Iris/Algebra/DFrac.lean
+++ b/src/Iris/Algebra/DFrac.lean
@@ -161,12 +161,6 @@ instance : CMRA.Discrete (DFrac F) where
 
 theorem is_discrete {q : DFrac F} : OFE.DiscreteE q := ⟨congrArg id⟩
 
-instance : CMRA.Discrete (DFrac F) where
-  discrete_valid {x} := by simp [CMRA.Valid, CMRA.ValidN]
-
-instance : CMRA.Discrete (DFrac F) where
-  discrete_valid {x} := by simp [CMRA.Valid, CMRA.ValidN]
-
 theorem DFrac.update_discard {dq : DFrac F} : dq ~~> .discard := by
   intros n q H
   apply (CMRA.valid_iff_validN' n).mp


### PR DESCRIPTION
## Summary

- Removes two duplicate `CMRA.Discrete (DFrac F)` instances in `src/Iris/Algebra/DFrac.lean`
- The instance was declared three times with identical implementations; this keeps only the first one

Redundant global typeclass candidates can degrade or destabilize instance search.

## Test plan
- [x] `lake build Iris.Algebra.DFrac` passes


Made with [Cursor](https://cursor.com)