### PR TITLE
fix: change Qq revision to an existing one

### DIFF
--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -15,7 +15,7 @@
    "type": "git",
    "subDir": null,
    "scope": "leanprover-community",
-   "rev": "bf4cd323a0d088f361a94fcadb8db5cf1e9f3768",
+   "rev": "b8f98e9087e02c8553945a2c5abf07cec8e798c3",
    "name": "Qq",
    "manifestFile": "lake-manifest.json",
    "inputRev": "stable",


### PR DESCRIPTION
## Description

The previous Qq revision is no longer present, and the version obtained from `lake update` has been bumped to a different `lean-toolchain` (v4.29.0). This PR changes the `lake-manifest.json` directly, to have `iris-lean` build in `master` for Lean 4.28.

 -   Prior: https://github.com/leanprover-community/quote4/commit/bf4cd323a0d088f361a94fcadb8db5cf1e9f3768

 -    Proposed: https://github.com/leanprover-community/quote4/commit/b8f98e9087e02c8553945a2c5abf07cec8e798c3

## Checklist
* [X] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [X] I have updated `PORTING.md` as appropriate
* [X] I have added my name to the `authors` section of any appropriate files