### PR TITLE
feat: remove key type K from PartialMap typeclass

### DIFF
--- a/src/Iris/Algebra/BigOp.lean
+++ b/src/Iris/Algebra/BigOp.lean
@@ -11,6 +11,7 @@ public import Iris.Std.List
 public import Iris.Std.PartialMap
 public import Iris.Std.GenSets
 public import Iris.Std.Positives
+import Iris.Std.RocqAlias
 
 namespace Iris.Algebra
 
@@ -28,9 +29,10 @@ open OFE Iris.Std
   | [] => unit
   | x :: xs => op (Φ 0 x) (bigOpL op (fun n => Φ (n + 1)) xs)
 
-@[expose] public def bigOpM {M : Type u} [OFE M] (op : M → M → M) {unit : M} [MonoidOps op unit] {K : Type _}
-    {V : Type _} (Φ : K → V → M) {M' : Type _ → Type _} [LawfulFiniteMap M' K] (m : M' V) : M :=
-  bigOpL op (fun _ kv => Φ kv.1 kv.2) (toList (K := K) m)
+@[expose] public def bigOpM {M : Type u} [OFE M] (op : M → M → M) {unit : M} [MonoidOps op unit]
+    {V : Type _} {M' : Type _ → Type _} [μ : LawfulFiniteMap M']
+    (Φ : μ.K → V → M) (m : M' V) : M :=
+  bigOpL op (fun _ kv => Φ kv.1 kv.2) (toList m)
 
 @[expose] public def bigOpS {M : Type u} [OFE M] (op : M → M → M) {unit : M} [MonoidOps op unit]
     {A : Type _} {S : Type _} [FiniteSet S A] (Φ : A → M) (m : S) : M :=
@@ -260,29 +262,29 @@ open scoped PartialMap
 
 variable {M : Type u} [OFE M] {op : M → M → M} {unit : M} [MonoidOps op unit]
 variable {M' : Type _ → Type _} {K : Type _} {V : Type _}
-variable [LawfulFiniteMap M' K]
+variable [μ : LawfulFiniteMap M']
 
 open BigOpL MonoidOps LawfulPartialMap
 
-theorem bigOpM_equiv_of_perm (Φ : K → V → M) {m₁ m₂ : M' V} (h : m₁ ≡ₘ m₂) :
+theorem bigOpM_equiv_of_perm (Φ : μ.K → V → M) {m₁ m₂ : M' V} (h : m₁ ≡ₘ m₂) :
     ([^ op map] k ↦ x ∈ m₁, Φ k x) ≡ ([^ op map] k ↦ x ∈ m₂, Φ k x) :=
   bigOpL_equiv_of_perm _ (LawfulFiniteMap.toList_perm_of_get?_eq h)
 
-@[simp] theorem bigOpM_empty (Φ : K → V → M) : ([^ op map] k ↦ x ∈ (∅ : M' V), Φ k x) = unit := by
+theorem bigOpM_empty (Φ : μ.K → V → M) : ([^ op map] k ↦ x ∈ (∅ : M' V), Φ k x) = unit := by
   simp [bigOpM, FiniteMap.toList, toList_empty]
 
-theorem bigOpM_insert_equiv (Φ : K → V → M) {m : M' V} {i : K} (x : V) (hi : get? m i = none) :
+theorem bigOpM_insert_equiv (Φ : μ.K → V → M) {m : M' V} {i : μ.K} (x : V) (hi : get? m i = none) :
     ([^ op map] k ↦ v ∈ insert m i x, Φ k v) ≡ op (Φ i x) ([^ op map] k ↦ v ∈ m, Φ k v) :=
   bigOpL_equiv_of_perm _ (LawfulFiniteMap.toList_insert hi)
 
-theorem bigOpM_delete_equiv (Φ : K → V → M) {m : M' V} {i : K} {x : V} (hi : get? m i = some x) :
+theorem bigOpM_delete_equiv (Φ : μ.K → V → M) {m : M' V} {i : μ.K} {x : V} (hi : get? m i = some x) :
     ([^ op map] k ↦ v ∈ m, Φ k v) ≡ op (Φ i x) ([^ op map] k ↦ v ∈ delete m i, Φ k v) :=
   (bigOpM_equiv_of_perm Φ (insert_delete_cancel hi · |>.symm)).trans
     (bigOpM_insert_equiv Φ _ (get?_delete_eq rfl))
 
 open Classical in
 theorem bigOpM_gen_proper_2 {A : Type _} {B : Type _} {R : M → M → Prop}
-    {Φ : K → A → M} {Ψ : K → B → M} {m1 : M' A} {m2 : M' B}
+    {Φ : μ.K → A → M} {Ψ : μ.K → B → M} {m1 : M' A} {m2 : M' B}
     (hR_sub : ∀ {x y}, x ≡ y → R x y) (hR_equiv : Equivalence R)
     (hR_op : ∀ {a a' b b'}, R a a' → R b b' → R (op a b) (op a' b'))
     (hdom : ∀ k, (get? m1 k).isSome = (get? m2 k).isSome)
@@ -294,7 +296,7 @@ theorem bigOpM_gen_proper_2 {A : Type _} {B : Type _} {R : M → M → Prop}
     (∀ {k y1 y2}, get? m1' k = some y1 → get? m2' k = some y2 → R (Φ k y1) (Ψ k y2)) →
     R ([^ op map] k ↦ x ∈ m1', Φ k x) ([^ op map] k ↦ x ∈ m2', Ψ k x)
   suffices h : P m1 from h m2 hdom hf
-  apply LawfulFiniteMap.induction_on (K := K) (P := P)
+  apply LawfulFiniteMap.induction_on (P := P)
   · intro m₁ m₂ heq hP m2' hdom' hf'
     refine hR_equiv.trans (hR_sub (bigOpM_equiv_of_perm Φ heq).symm) ?_
     exact hP m2' (fun k => heq k ▸ hdom' k) (hf' <| (heq _) ▸ ·)
@@ -317,7 +319,7 @@ theorem bigOpM_gen_proper_2 {A : Type _} {B : Type _} {R : M → M → Prop}
         have hkk' : k ≠ k' := fun h => by subst h; rw [hm1'k] at h1'; cases h1'
         exact hf' (by rwa [get?_insert_ne hkk']) (by rwa [get?_delete_ne hkk'] at h2'))
 
-theorem bigOpM_gen_proper {R : M → M → Prop} {Φ Ψ : K → V → M} {m : M' V}
+theorem bigOpM_gen_proper {R : M → M → Prop} {Φ Ψ : μ.K → V → M} {m : M' V}
     (hR_refl : ∀ {x}, R x x) (hR_op : ∀ {a a' b b'}, R a a' → R b b' → R (op a b) (op a' b'))
     (hf : ∀ {k x}, get? m k = some x → R (Φ k x) (Ψ k x)) :
     R ([^ op map] k ↦ x ∈ m, Φ k x) ([^ op map] k ↦ x ∈ m, Ψ k x) := by
@@ -325,56 +327,56 @@ theorem bigOpM_gen_proper {R : M → M → Prop} {Φ Ψ : K → V → M} {m : M'
   obtain ⟨rfl⟩ := hx ▸ hy
   exact hf <| toList_get.mp <| List.mem_iff_getElem?.mpr ⟨_, hx⟩
 
-theorem bigOpM_ext {Φ Ψ : K → V → M} {m : M' V} (hf : ∀ {k x}, get? m k = some x → Φ k x = Ψ k x) :
+theorem bigOpM_ext {Φ Ψ : μ.K → V → M} {m : M' V} (hf : ∀ {k x}, get? m k = some x → Φ k x = Ψ k x) :
     ([^ op map] k ↦ x ∈ m, Φ k x) = ([^ op map] k ↦ x ∈ m, Ψ k x) :=
   bigOpM_gen_proper rfl (· ▸ · ▸ rfl) hf
 
-theorem bigOpM_dist {Φ Ψ : K → V → M} {m : M' V}
+theorem bigOpM_dist {Φ Ψ : μ.K → V → M} {m : M' V}
     (hf : ∀ {k x}, get? m k = some x → Φ k x ≡{n}≡ Ψ k x) :
     ([^ op map] k ↦ x ∈ m, Φ k x) ≡{n}≡ ([^ op map] k ↦ x ∈ m, Ψ k x) :=
   bigOpM_gen_proper .rfl op_dist hf
 
-theorem bigOpM_proper {Φ Ψ : K → V → M} {m : M' V} (hf : ∀ {k x}, get? m k = some x → Φ k x ≡ Ψ k x) :
+theorem bigOpM_proper {Φ Ψ : μ.K → V → M} {m : M' V} (hf : ∀ {k x}, get? m k = some x → Φ k x ≡ Ψ k x) :
     ([^ op map] k ↦ x ∈ m, Φ k x) ≡ ([^ op map] k ↦ x ∈ m, Ψ k x) :=
   bigOpM_gen_proper .rfl op_proper hf
 
-theorem bigOpM_proper_2 [OFE A] {Φ Ψ : K → A → M} {m1 m2 : M' A} (hm : ∀ k, get? m1 k = get? m2 k)
+theorem bigOpM_proper_2 [OFE A] {Φ Ψ : μ.K → A → M} {m1 m2 : M' A} (hm : ∀ k, get? m1 k = get? m2 k)
     (hf : ∀ {k y1 y2}, get? m1 k = some y1 → get? m2 k = some y2 → y1 ≡ y2 → Φ k y1 ≡ Ψ k y2) :
     ([^ op map] k ↦ x ∈ m1, Φ k x) ≡ ([^ op map] k ↦ x ∈ m2, Ψ k x) :=
   bigOpM_gen_proper_2 id equiv_eqv op_proper (fun k => by rw [hm k]) fun h1 h2 =>
     hf h1 h2 (by rw [hm _] at h1; exact (h1.symm.trans h2 |> Option.some.inj) ▸ .rfl)
 
-theorem bigOpM_dist_pointwise {Φ Ψ : K → V → M} {n : Nat} (m : M' V)
+theorem bigOpM_dist_pointwise {Φ Ψ : μ.K → V → M} {n : Nat} (m : M' V)
     (hf : ∀ {k x}, Φ k x ≡{n}≡ Ψ k x) :
     ([^ op map] k ↦ x ∈ m, Φ k x) ≡{n}≡ ([^ op map] k ↦ x ∈ m, Ψ k x) :=
   bigOpM_dist fun _ => hf
 
-theorem bigOpM_proper_pointwise {Φ Ψ : K → V → M} (m : M' V) (hf : ∀ {k x}, Φ k x ≡ Ψ k x) :
+theorem bigOpM_proper_pointwise {Φ Ψ : μ.K → V → M} (m : M' V) (hf : ∀ {k x}, Φ k x ≡ Ψ k x) :
     ([^ op map] k ↦ x ∈ m, Φ k x) ≡ ([^ op map] k ↦ x ∈ m, Ψ k x) :=
   bigOpM_proper (fun _ => hf)
 
-theorem bigOpM_toList_equiv (Φ : K → V → M) (m : M' V) :
-    ([^ op map] k ↦ x ∈ m, Φ k x) ≡ ([^ op list] kx ∈ toList (K := K) m, Φ kx.1 kx.2) :=
+theorem bigOpM_toList_equiv (Φ : μ.K → V → M) (m : M' V) :
+    ([^ op map] k ↦ x ∈ m, Φ k x) ≡ ([^ op list] kx ∈ toList m, Φ kx.1 kx.2) :=
   .rfl
 
-theorem bigOpM_ofList_equiv [DecidableEq K] (Φ : K → V → M) (l : List (K × V)) (hd : NoDupKeys l) :
+theorem bigOpM_ofList_equiv [DecidableEq μ.K] (Φ : μ.K → V → M) (l : List (μ.K × V)) (hd : NoDupKeys l) :
     ([^ op map] k ↦ x ∈ (PartialMap.ofList l : M' V), Φ k x) ≡ ([^ op list] kx ∈ l, Φ kx.1 kx.2) :=
   bigOpL_equiv_of_perm _ (LawfulFiniteMap.toList_ofList hd)
 
-theorem bigOpM_singleton_equiv (Φ : K → V → M) (i : K) (x : V) :
+theorem bigOpM_singleton_equiv (Φ : μ.K → V → M) (i : μ.K) (x : V) :
     ([^ op map] k ↦ v ∈ ({[i := x]} : M' V), Φ k v) ≡ Φ i x := by
   refine bigOpM_insert_equiv _ (m := (∅ : M' V)) _ (get?_empty i) |>.trans ?_
   simpa only [bigOpM_empty] using op_right_id
 
-theorem bigOpM_const_unit_equiv [DecidableEq K] (m : M' V) :
-    bigOpM (K := K) op (fun _ _ => unit) m ≡ unit :=
+theorem bigOpM_const_unit_equiv [DecidableEq μ.K] (m : M' V) :
+    bigOpM op (fun _ _ => unit) m ≡ unit :=
   bigOpL_const_unit_equiv
 
-theorem bigOpM_map_equiv (h : V → B) (Φ : K → B → M) (m : M' V) :
+theorem bigOpM_map_equiv (h : V → B) (Φ : μ.K → B → M) (m : M' V) :
     ([^ op map] k ↦ x ∈ PartialMap.map h m, Φ k x) ≡ ([^ op map] k ↦ v ∈ m, Φ k (h v)) :=
   bigOpL_equiv_of_perm _ LawfulFiniteMap.toList_map |>.trans (bigOpL_map_equiv ..)
 
-theorem bigOpM_filterMap_equiv (Φ : K → V → M) (m : M' V) (hinj : Function.Injective h) :
+theorem bigOpM_filterMap_equiv (Φ : μ.K → V → M) (m : M' V) (hinj : Function.Injective h) :
     ([^ op map] k ↦ x ∈ PartialMap.filterMap h m, Φ k x) ≡
     ([^ op map] k ↦ v ∈ m, (h v).elim unit (Φ k)) := by
   refine (bigOpL_equiv_of_perm _ (LawfulFiniteMap.toList_filterMap hinj)).trans ?_
@@ -382,40 +384,40 @@ theorem bigOpM_filterMap_equiv (Φ : K → V → M) (m : M' V) (hinj : Function.
   refine bigOpL_equiv_of_forall_equiv @fun _ ⟨_, v⟩ => ?_
   cases _ : h v <;> simp_all
 
-theorem bigOpM_insert_delete_equiv (Φ : K → V → M) (m : M' V) (i : K) (x : V) :
+theorem bigOpM_insert_delete_equiv (Φ : μ.K → V → M) (m : M' V) (i : μ.K) (x : V) :
     ([^ op map] k ↦ v ∈ insert m i x, Φ k v) ≡
     op (Φ i x) ([^ op map] k ↦ v ∈ delete m i, Φ k v) :=
   (bigOpM_equiv_of_perm _ (insert_delete · |>.symm)).trans
     (bigOpM_insert_equiv _ _ (get?_delete_eq rfl))
 
-theorem bigOpM_insert_override_equiv {Φ : K → A → M} {m : M' A}
+theorem bigOpM_insert_override_equiv {Φ : μ.K → A → M} {m : M' A}
     (hi : get? m i = some x) (hΦ : Φ i x ≡ Φ i x') :
     ([^ op map] k ↦ v ∈ insert m i x', Φ k v) ≡ ([^ op map] k ↦ v ∈ m, Φ k v) :=
   (bigOpM_insert_delete_equiv Φ m i x').trans
     ((op_proper hΦ.symm .rfl).trans (bigOpM_delete_equiv _ hi).symm)
 
-theorem bigOpM_fn_insert_equiv [DecidableEq K] {B : Type w} (g : K → V → B → M) (f : K → B)
-    {m : M' V} {i : K} (x : V) (b : B) (hi : get? m i = none) :
+theorem bigOpM_fn_insert_equiv [DecidableEq μ.K] {B : Type w} (g : μ.K → V → B → M) (f : μ.K → B)
+    {m : M' V} {i : μ.K} (x : V) (b : B) (hi : get? m i = none) :
     ([^ op map] k ↦ y ∈ insert m i x, g k y (if k = i then b else f k)) ≡
     op (g i x b) ([^ op map] k ↦ y ∈ m, g k y (f k)) :=
   (bigOpM_insert_equiv _ _ hi).trans
     (op_proper (by simp) (bigOpM_proper fun _ => by split <;> simp_all))
 
-theorem bigOpM_fn_insert_equiv' [DecidableEq K] (f : K → M) {m : M' V} {i : K} (x : V) (P : M)
+theorem bigOpM_fn_insert_equiv' [DecidableEq μ.K] (f : μ.K → M) {m : M' V} {i : μ.K} (x : V) (P : M)
     (hi : get? m i = none) :
     ([^ op map] k ↦ _v ∈ insert m i x, if k = i then P else f k) ≡
     op P ([^ op map] k ↦ _v ∈ m, f k) :=
   (bigOpM_insert_equiv _ _ hi).trans
     (op_proper (by simp) (bigOpM_proper fun _ => by split <;> simp_all))
 
-theorem bigOpM_filter_equiv (φ : K → V → Bool) (Φ : K → V → M) (m : M' V) :
+theorem bigOpM_filter_equiv (φ : μ.K → V → Bool) (Φ : μ.K → V → M) (m : M' V) :
     ([^ op map] k ↦ x ∈ PartialMap.filter φ m, Φ k x) ≡
     ([^ op map] k ↦ x ∈ m, if φ k x then Φ k x else unit) :=
   (bigOpL_equiv_of_perm _ LawfulFiniteMap.toList_filter).trans
     (bigOpL_filter_equiv (fun (k, v) => φ k v) (fun (k, v) => Φ k v) _)
 
-theorem toList_union_perm [DecidableEq K] {m1 m2 : M' V} (hdisj : m1 ##ₘ m2) :
-    (toList (K := K) (m1 ∪ m2)).Perm (toList (K := K) m1 ++ toList (K := K) m2) := by
+theorem toList_union_perm [DecidableEq μ.K] {m1 m2 : M' V} (hdisj : m1 ##ₘ m2) :
+    (toList (m1 ∪ m2)).Perm (toList m1 ++ toList m2) := by
   refine (List.perm_ext_iff_of_nodup LawfulFiniteMap.nodup_toList ?_).mpr fun ⟨k, v⟩ => ?_
   · refine List.nodup_append.mpr ⟨LawfulFiniteMap.nodup_toList, LawfulFiniteMap.nodup_toList, ?_⟩
     rintro ⟨k, _⟩ h1 _ h2 rfl
@@ -438,18 +440,18 @@ theorem toList_union_perm [DecidableEq K] {m1 m2 : M' V} (hdisj : m1 ##ₘ m2) :
         · simp [h1, toList_get.mp h, Option.orElse]
         · exact absurd (toList_get.mp h) (by simp [h1])
 
-theorem bigOpM_union_equiv [DecidableEq K] (Φ : K → V → M) (m1 m2 : M' V) (hdisj : m1 ##ₘ m2) :
+theorem bigOpM_union_equiv [DecidableEq μ.K] (Φ : μ.K → V → M) (m1 m2 : M' V) (hdisj : m1 ##ₘ m2) :
     ([^ op map] k ↦ x ∈ m1 ∪ m2, Φ k x) ≡
     op ([^ op map] k ↦ x ∈ m1, Φ k x) ([^ op map] k ↦ x ∈ m2, Φ k x) :=
   (bigOpL_equiv_of_perm _ (toList_union_perm hdisj)).trans
     ((bigOpL_append_equiv ..).trans (op_congr_right (bigOpL_equiv_of_forall_equiv .rfl)))
 
-theorem bigOpM_op_equiv (Φ Ψ : K → V → M) (m : M' V) :
+theorem bigOpM_op_equiv (Φ Ψ : μ.K → V → M) (m : M' V) :
     ([^ op map] k ↦ x ∈ m, op (Φ k x) (Ψ k x)) ≡
     op ([^ op map] k ↦ x ∈ m, Φ k x) ([^ op map] k ↦ x ∈ m, Ψ k x) :=
   bigOpL_op_equiv ..
 
-theorem bigOpM_closed {P : M → Prop} {Φ : K → V → M} {m : M' V}
+theorem bigOpM_closed {P : M → Prop} {Φ : μ.K → V → M} {m : M' V}
     (hunit : P unit) (hop : ∀ {x y}, P x → P y → P (op x y))
     (hf : ∀ {k x}, get? m k = some x → P (Φ k x)) :
     P ([^ op map] k ↦ x ∈ m, Φ k x) :=
@@ -459,7 +461,7 @@ theorem bigOpM_closed {P : M → Prop} {Φ : K → V → M} {m : M' V}
 
 theorem bigOpM_sep_zipWith_equiv {A : Type _} {B : Type _} {C : Type _}
     {f : A → B → C} {g1 : C → A} {g2 : C → B}
-    (h1 : K → A → M) (h2 : K → B → M) {m1 : M' A} {m2 : M' B}
+    (h1 : μ.K → A → M) (h2 : μ.K → B → M) {m1 : M' A} {m2 : M' B}
     (hg1 : ∀ {x y}, g1 (f x y) = x) (hg2 : ∀ {x y}, g2 (f x y) = y)
     (hdom : ∀ k, (get? m1 k).isSome ↔ (get? m2 k).isSome) :
     ([^ op map] k ↦ xy ∈ PartialMap.zipWith f m1 m2, op (h1 k (g1 xy)) (h2 k (g2 xy))) ≡
@@ -474,7 +476,7 @@ theorem bigOpM_sep_zipWith_equiv {A : Type _} {B : Type _} {C : Type _}
       simp_all [Option.bind, Option.map] }
 
 theorem bigOpM_sep_zip_equiv {A : Type _} {B : Type _}
-    (h1 : K → A → M) (h2 : K → B → M) {m1 : M' A} {m2 : M' B}
+    (h1 : μ.K → A → M) (h2 : μ.K → B → M) {m1 : M' A} {m2 : M' B}
     (hdom : ∀ k, (get? m1 k).isSome ↔ (get? m2 k).isSome) :
     ([^ op map] k ↦ xy ∈ PartialMap.zip m1 m2, op (h1 k xy.1) (h2 k xy.2)) ≡
     op ([^ op map] k ↦ x ∈ m1, h1 k x) ([^ op map] k ↦ x ∈ m2, h2 k x) :=
@@ -485,17 +487,17 @@ variable {M₂} [OFE M₂]
 variable {op₁ : M₁ → M₁ → M₁} {op₂ : M₂ → M₂ → M₂} {unit₁ : M₁} {unit₂ : M₂}
 variable [MonoidOps op₁ unit₁] [MonoidOps op₂ unit₂]
 
-theorem bigOpM_hom  [ι : MonoidHomomorphism op₁ op₂ unit₁ unit₂ R h] (f : K → A → M₁) (m : M' A) :
+theorem bigOpM_hom  [ι : MonoidHomomorphism op₁ op₂ unit₁ unit₂ R h] (f : μ.K → A → M₁) (m : M' A) :
     R (h ([^op₁ map] k↦x ∈ m, f k x)) ([^op₂ map] k↦x ∈ m, h (f k x)) := by
   exact bigOpL_hom (H := ι) _ _
 
-theorem bigOpM_weak_hom [DecidableEq K] [ι : WeakMonoidHomomorphism op₁ op₂ unit₁ unit₂ R h]
-    (f : K → A → M₁) (m : M' A) (Hne : ¬ m ≡ₘ ∅) :
+theorem bigOpM_weak_hom [DecidableEq μ.K] [ι : WeakMonoidHomomorphism op₁ op₂ unit₁ unit₂ R h]
+    (f : μ.K → A → M₁) (m : M' A) (Hne : ¬ m ≡ₘ ∅) :
     R (h ([^op₁ map] k↦x ∈ m, f k x)) ([^op₂ map] k↦x ∈ m, h (f k x)) := by
   refine bigOpL_hom_weak (H := ι) _ ?_
   refine fun Hk => Hne ?_
   refine .trans LawfulFiniteMap.ofList_toList.symm ?_
-  rw [show (LawfulFiniteMap.toList (K := K) m) = [] from List.nil_eq.mpr Hk |>.symm]
+  rw [show (LawfulFiniteMap.toList m) = [] from List.nil_eq.mpr Hk |>.symm]
   exact .trans (congrFun rfl) (congrFun rfl )
 
 end BigOpM

--- a/src/Iris/Algebra/Heap.lean
+++ b/src/Iris/Algebra/Heap.lean
@@ -20,48 +20,48 @@ open OFE
 
 namespace PartialMap
 
-instance instOFE [PartialMap M K] [OFE V] : OFE (M V) where
+instance instOFE [μ : PartialMap M] [OFE V] : OFE (M V) where
   Equiv s0 s1  := get? s0 ≡ get? s1
   Dist n s0 s1 := get? s0 ≡{n}≡ get? s1
   dist_eqv     := ⟨fun _ => .of_eq rfl, (·.symm), (·.trans ·)⟩
   equiv_dist   := equiv_dist
   dist_lt      := dist_lt
 
-@[simp] def toMap [PartialMap M K] [OFE V] : (M V) -n> (K → Option V) where
+@[simp] def toMap [μ : PartialMap M] [OFE V] : (M V) -n> (μ.K → Option V) where
   f x := get? x
   ne.1 {_ _ _} H k := H k
 
-@[simp] def ofMap [PartialMap M K] [R : RepFunMap M K] [OFE V] :  (K → Option V) -n> (M V) where
+@[simp] def ofMap [μ : PartialMap M] [R : RepFunMap M] [OFE V] : (μ.K → Option V) -n> (M V) where
   f x := of_fun x
   ne.1 {_ _ _} H k := by simp only [get_of_fun, H k]
 
-instance get?_ne [PartialMap M K] [OFE V] (k : K) : NonExpansive (get? · k : M V → Option V) where
+instance get?_ne [μ : PartialMap M] [OFE V] (k : μ.K) : NonExpansive (get? · k : M V → Option V) where
   ne {_ _ _} Ht := Ht k
 
-instance [LawfulPartialMap M K] [OFE V] (k : K) : NonExpansive₂ (insert · k · : M V → V → M V) where
+instance [μ : LawfulPartialMap M] [OFE V] (k : μ.K) : NonExpansive₂ (insert · k · : M V → V → M V) where
   ne {_ _ _} Hv {_ _} Ht k' := by
     by_cases h : k = k'
     · simp [get?_insert_eq h, Ht]
     · simp [get?_insert_ne h, Hv k']
 
-theorem eqv_of_Equiv [OFE V] [PartialMap M K] {t1 t2 : M V} (H : PartialMap.equiv t1 t2) : t1 ≡ t2 :=
+theorem eqv_of_Equiv [OFE V] [μ : PartialMap M] {t1 t2 : M V} (H : PartialMap.equiv t1 t2) : t1 ≡ t2 :=
   (.of_eq <| H ·)
 
-instance [LawfulPartialMap M K] [OFE V] (op : K → V → V → V) [∀ k, NonExpansive₂ (op k)] :
+instance [μ : LawfulPartialMap M] [OFE V] (op : μ.K → V → V → V) [∀ k, NonExpansive₂ (op k)] :
     NonExpansive₂ (merge (M := M) op) where
   ne _ {_ _} Ht {_ _} Hs k := by simp only [get?_merge]; exact NonExpansive₂.ne (Ht k) (Hs k)
 
 /-- Project a chain of stores through its kth coordinate to a chain of values. -/
-def chain [PartialMap M K] [OFE V] (k : K) (c : Chain (M V)) : Chain (Option V) where
+def chain [μ : PartialMap M] [OFE V] (k : μ.K) (c : Chain (M V)) : Chain (Option V) where
   chain i := get? (c i) k
   cauchy Hni := c.cauchy Hni k
 
-theorem chain_get [PartialMap M K] [OFE V] (k : K) (c : Chain (M V)) :
+theorem chain_get [μ : PartialMap M] [OFE V] (k : μ.K) (c : Chain (M V)) :
     (chain k c) i = get? (c i) k := by simp [chain]
 
 end PartialMap
 
-instance Heap.instCOFE [LawfulPartialMap M K] [COFE V] : COFE (M V) where
+instance Heap.instCOFE [μ : LawfulPartialMap M] [COFE V] : COFE (M V) where
   compl c := bindAlter (fun _ => COFE.compl <| c.map ⟨_, PartialMap.get?_ne ·⟩) (c 0)
   conv_compl {_ c} k := by
     rw [get?_bindAlter]
@@ -80,9 +80,9 @@ namespace Heap
 
 open PartialMap
 
-variable [LawfulPartialMap M K] [CMRA V]
+variable [μ : LawfulPartialMap M] [CMRA V]
 
-@[simp] def op (s1 s2 : M V) : M V := merge (K := K) (fun _ => CMRA.op) s1 s2
+@[simp] def op (s1 s2 : M V) : M V := merge (fun _ => CMRA.op) s1 s2
 @[simp] def unit : M V := empty
 @[simp] def pcore (s : M V) : Option (M V) := some <| bindAlter (fun _ => CMRA.pcore) s
 @[simp] def valid (s : M V) : Prop := ∀ k, ✓ get? s k
@@ -196,7 +196,7 @@ instance instStoreCMRA : CMRA (M V) where
       refine (get?_ne i |>.ne Heq).trans ?_
       simp [CMRA.op, get?_merge, optionOp]
       cases get? y1 i <;> cases get? y2 i <;> simp
-    let extendF (i : K) := CMRA.extend (Hm i) (Hslice i)
+    let extendF (i : μ.K) := CMRA.extend (Hm i) (Hslice i)
     exists bindAlter (fun k (_ : V) => extendF k |>.fst) y1
     exists bindAlter (fun k (_ : V) => extendF k |>.snd.fst) y2
     simp [op]
@@ -236,7 +236,7 @@ namespace Heap
 
 open PartialMap LawfulPartialMap
 
-variable {K V : Type _} [LawfulPartialMap M K] [CMRA V]
+variable {V : Type _} [μ : LawfulPartialMap M] [CMRA V]
 
 open CMRA
 
@@ -289,44 +289,44 @@ theorem insert_equiv_singleton_op_singleton {m : M V} (Hemp : get? m i = none) :
   · rw [← He, Hemp]
   · cases (get? m k) <;> rfl
 
-theorem insert_eq_singleton_op_singleton [IsoFunMap M K] {m : M V} (Hemp : get? m i = none) :
+theorem insert_eq_singleton_op_singleton [IsoFunMap M] {m : M V} (Hemp : get? m i = none) :
     insert m i x = singleton i x • m :=
   IsoFunMap.ext (insert_equiv_singleton_op_singleton Hemp)
 
 open Classical in
-theorem core_singleton_equiv {i : K} {x : V} {cx : V} (Hpcore : CMRA.pcore x = some cx) :
+theorem core_singleton_equiv {i : μ.K} {x : V} {cx : V} (Hpcore : CMRA.pcore x = some cx) :
     equiv (core <| singleton i x : M V) (singleton i cx) := by
   refine fun k => ?_
   simp [← Hpcore, core, CMRA.pcore, get?_singleton, get?_bindAlter]
   split <;> rfl
 
-theorem singleton_core_eq [IsoFunMap M K] {i : K} {x : V} {cx} (Hpcore : CMRA.pcore x = some cx) :
+theorem singleton_core_eq [IsoFunMap M] {i : μ.K} {x : V} {cx} (Hpcore : CMRA.pcore x = some cx) :
     core (singleton i x : M V) = singleton i cx  :=
   IsoFunMap.ext (core_singleton_equiv Hpcore)
 
 open Classical in
-theorem singleton_core_eqv {i : K} {x : V} {cx} (Hpcore : CMRA.pcore x ≡ some cx) :
+theorem singleton_core_eqv {i : μ.K} {x : V} {cx} (Hpcore : CMRA.pcore x ≡ some cx) :
     core (singleton i x : M V) ≡ singleton i cx := by
   intro k
   simp [core, CMRA.pcore, get?_singleton, get?_bindAlter]
   split <;> trivial
 
-theorem singleton_core_total [IsTotal V] {i : K} {x : V} :
+theorem singleton_core_total [IsTotal V] {i : μ.K} {x : V} :
     equiv (core <| singleton i x : M V) ((singleton i (core x))) :=
   core_singleton_equiv (pcore_eq_core x)
 
-theorem singleton_core_total_eq [IsTotal V] [IsoFunMap M K] {i : K} {x : V} :
+theorem singleton_core_total_eq [IsTotal V] [IsoFunMap M] {i : μ.K} {x : V} :
     core (singleton i x : M V) = singleton i (core x) :=
   IsoFunMap.ext singleton_core_total
 
 open Classical in
-theorem singleton_op_singleton {i : K} {x y : V} :
+theorem singleton_op_singleton {i : μ.K} {x y : V} :
     equiv ((singleton i x : M V) • (singleton i y)) (singleton i (x • y)) := by
   refine fun k => ?_
   simp only [CMRA.op, Heap.op, get?_merge, get?_singleton]
   split <;> simp [Option.merge]
 
-theorem singleton_op_singleton_eq [IsoFunMap M K] {i : K} {x y : V} :
+theorem singleton_op_singleton_eq [IsoFunMap M] {i : μ.K} {x y : V} :
     (singleton i x : M V) • (singleton i y) = (singleton i (x • y)) :=
   IsoFunMap.ext singleton_op_singleton
 
@@ -461,7 +461,7 @@ theorem insert_op_equiv {m1 m2 : M V} :
   · simp [CMRA.op, get?_insert_eq He, get?_merge]
   · simp [CMRA.op, get?_insert_ne He, get?_merge]
 
-theorem insert_op_eq [IsoFunMap M K] {m1 m2 : M (Option V)} :
+theorem insert_op_eq [IsoFunMap M] {m1 m2 : M (Option V)} :
     (insert (m1 • m2) i (x • y)) = (insert m1 i x • insert m2 i y) :=
   IsoFunMap.ext insert_op_equiv
 
@@ -473,7 +473,7 @@ theorem disjoint_op_equiv_union {m1 m2 : M V} (Hd : Set.Disjoint (dom m1) (dom m
   refine (Hd j ?_).elim
   simp_all [dom]
 
-theorem disjoint_op_eq_union [IsoFunMap M K] {m1 m2 : M V} (H : Set.Disjoint (dom m1) (dom m2)) :
+theorem disjoint_op_eq_union [IsoFunMap M] {m1 m2 : M V} (H : Set.Disjoint (dom m1) (dom m2)) :
     m1 • m2 = union m1 m2 :=
   IsoFunMap.ext (disjoint_op_equiv_union H)
 
@@ -502,7 +502,7 @@ theorem inc_dom_inc {m1 m2 : M V} (Hinc : m1 ≼ m2) : Set.Included (dom m1) (do
   revert Hz
   cases get? m1 i <;> cases get? m2 i <;> cases z <;> simp [CMRA.op, optionOp]
 
-nonrec instance [HD : CMRA.Discrete V] [PartialMap M K] : Discrete (M V) where
+nonrec instance [HD : CMRA.Discrete V] [μ : PartialMap M] : Discrete (M V) where
   discrete_0 {_ _} H := (OFE.Discrete.discrete_0 <| H ·)
   discrete_valid {_} := (CMRA.Discrete.discrete_valid <| · ·)
 
@@ -510,7 +510,7 @@ end Heap
 
 section HeapFunctor
 
-variable {K} (H : Type _ → Type _) [LawfulPartialMap H K]
+variable (H : Type _ → Type _) [μ : LawfulPartialMap H]
 
 namespace PartialMap
 

--- a/src/Iris/Algebra/Heap.lean
+++ b/src/Iris/Algebra/Heap.lean
@@ -48,7 +48,7 @@ theorem eqv_of_Equiv [OFE V] [μ : PartialMap M] {t1 t2 : M V} (H : PartialMap.e
   (.of_eq <| H ·)
 
 instance [μ : LawfulPartialMap M] [OFE V] (op : μ.K → V → V → V) [∀ k, NonExpansive₂ (op k)] :
-    NonExpansive₂ (merge (M := M) op) where
+    NonExpansive₂ (merge op) where
   ne _ {_ _} Ht {_ _} Hs k := by simp only [get?_merge]; exact NonExpansive₂.ne (Ht k) (Hs k)
 
 /-- Project a chain of stores through its kth coordinate to a chain of values. -/

--- a/src/Iris/Algebra/HeapView.lean
+++ b/src/Iris/Algebra/HeapView.lean
@@ -37,14 +37,14 @@ open Iris
 section heapView
 open Std PartialMap Heap OFE CMRA
 
-variable (F K V : Type _) (H : Type _ → Type _) [UFraction F] [LawfulPartialMap H K] [CMRA V]
+variable (F V : Type _) (H : Type _ → Type _) [UFraction F] [μ : LawfulPartialMap H] [CMRA V]
 
 /-- The view relation for heaps: relates a model heap to a fragment heap at step index `n`. -/
 def HeapR (n : Nat) (m : H V) (f : H (DFrac F × V)) : Prop :=
   ∀ k fv, get? f k = some fv →
     ∃ (v : V) (dq : DFrac F), get? m k = some v ∧ ✓{n} (dq, v) ∧ (some fv ≼{n} some (dq, v))
 
-instance : IsViewRel (HeapR F K V H) where
+instance : IsViewRel (HeapR F V H) where
   mono {n1 m1 f1 n2 m2 f2 Hrel Hm Hf Hn k} vk Hk := by
     obtain Hf' : ∃ z, get? f1 k ≡{n2}≡ some vk • z := by
       have ⟨z, Hz⟩ := lookup_incN (n := n2) (m1 := f2) (m2 := f1) |>.1 Hf k
@@ -74,12 +74,12 @@ instance : IsViewRel (HeapR F K V H) where
 
 namespace HeapR
 
-theorem unit : HeapR F K V H n m UCMRA.unit := by
+theorem unit : HeapR F V H n m UCMRA.unit := by
   simp [HeapR, UCMRA.unit, Heap.unit, get?_empty]
 
-theorem exists_iff_validN {n f} : (∃ m, HeapR F K V H n m f) ↔ ✓{n} f := by
+theorem exists_iff_validN {n f} : (∃ m, HeapR F V H n m f) ↔ ✓{n} f := by
   refine ⟨fun ⟨m, Hrel⟩ => IsViewRel.rel_validN _ _ _ Hrel, fun Hv => ?_⟩
-  let FF : K → (DFrac F × V) → Option V := fun k _ => get? f k |>.bind (·.2)
+  let FF : μ.K → (DFrac F × V) → Option V := fun k _ => get? f k |>.bind (·.2)
   refine ⟨bindAlter FF f, fun k => ?_⟩
   cases h : get? f k
   · simp
@@ -90,7 +90,7 @@ theorem exists_iff_validN {n f} : (∃ m, HeapR F K V H n m f) ↔ ✓{n} f := b
   exact ⟨dq, (h ▸ Hv k : ✓{n} some (dq, v)), incN_refl _⟩
 
 theorem singleton_get_iff n m k dq v :
-    HeapR F K V H n m (PartialMap.singleton k (dq, v)) ↔
+    HeapR F V H n m (PartialMap.singleton k (dq, v)) ↔
       ∃ (v' : V) (dq' : DFrac F),
         get? m k = some v' ∧ ✓{n} (dq', v') ∧ some (dq, v) ≼{n} some (dq', v') := by
   constructor
@@ -104,7 +104,7 @@ theorem singleton_get_iff n m k dq v :
     · rw [PartialMap.singleton, get?_insert_ne h, get?_empty] at Hfv
       cases Hfv
 
-instance [CMRA.Discrete V] : IsViewRelDiscrete (HeapR F K V H) where
+instance [CMRA.Discrete V] : IsViewRelDiscrete (HeapR F V H) where
   discrete n _ _ H k v He := by
     have ⟨v, Hv1, ⟨x, Hx1, Hx2⟩⟩ := H k v He
     refine ⟨v, Hv1, ⟨x, ?_, inc_0_iff_incN n |>.mp Hx2⟩⟩
@@ -113,7 +113,7 @@ instance [CMRA.Discrete V] : IsViewRelDiscrete (HeapR F K V H) where
 end HeapR
 
 /-- A view of a Heap, that gives element-wise ownership. -/
-abbrev HeapView := View F (HeapR F K V H)
+abbrev HeapView := View F (HeapR F V H)
 
 end heapView
 
@@ -121,21 +121,21 @@ namespace HeapView
 
 open Heap OFE View One DFrac CMRA UFraction PartialMap Std LawfulPartialMap
 
-variable {F K V : Type _} {H : Type _ → Type _} [UFraction F] [LawfulPartialMap H K] [CMRA V]
+variable {F V : Type _} {H : Type _ → Type _} [UFraction F] [μ : LawfulPartialMap H] [CMRA V]
 
 /-- Authoritative (fractional) ownership over an entire heap. -/
-def Auth (dq : DFrac F) (m : H V) : HeapView F K V H := ●V{dq} m
+def Auth (dq : DFrac F) (m : H V) : HeapView F V H := ●V{dq} m
 
 /-- Fragmental (fractional) ownership over an allocated element in the heap. -/
-def Frag (k : K) (dq : DFrac F) (v : V) : HeapView F K V H := ◯V (Std.PartialMap.singleton k (dq, v))
+def Frag (k : μ.K) (dq : DFrac F) (v : V) : HeapView F V H := ◯V (Std.PartialMap.singleton k (dq, v))
 
 /-- Fragmental (fractional) ownership over an element in the heap. -/
-def Elem (k : K) (v : DFrac F × V) : HeapView F K V H := ◯V (Std.PartialMap.singleton k v)
+def Elem (k : μ.K) (v : DFrac F × V) : HeapView F V H := ◯V (Std.PartialMap.singleton k v)
 
 -- TODO: Do we need this?
-instance : NonExpansive (Auth dq : _ → HeapView F K V H) := View.auth_ne
+instance : NonExpansive (Auth dq : _ → HeapView F V H) := View.auth_ne
 
-instance : NonExpansive (Frag k dq : _ → HeapView F K V H) where
+instance : NonExpansive (Frag k dq : _ → HeapView F V H) where
   ne _ _ _ Hx := by
     refine frag_ne.ne (fun k' => ?_)
     by_cases h : k = k'
@@ -143,7 +143,7 @@ instance : NonExpansive (Frag k dq : _ → HeapView F K V H) where
       exact dist_prod_ext rfl Hx
     · rw [Std.PartialMap.singleton, get?_insert_ne h, get?_empty, get?_singleton_ne h]
 
-variable {dp dq : DFrac F} {n : Nat} {m1 m2 : H V} {k : K} {v1 v2 : V}
+variable {dp dq : DFrac F} {n : Nat} {m1 m2 : H V} {k : μ.K} {v1 v2 : V}
 
 theorem auth_dfrac_op_equiv : Auth (dp • dq) m1 ≡ Auth dp m1 • Auth dq m1 :=
   View.auth_op_auth_eqv
@@ -155,20 +155,20 @@ theorem equiv_of_valid_auth_op : ✓ Auth dp m1 • Auth dq m2 → m1 ≡ m2 :=
   eqv_of_valid_auth
 
 nonrec theorem auth_validN_iff : ✓{n} Auth dq m1 ↔ ✓ dq :=
-  auth_validN_iff.trans <| and_iff_left_of_imp (fun _ => HeapR.unit _ _ _ _)
+  auth_validN_iff.trans <| and_iff_left_of_imp (fun _ => HeapR.unit _ _ _)
 
 nonrec theorem auth_valid_iff : ✓ Auth dq m1 ↔ ✓ dq :=
-  auth_valid_iff.trans <| and_iff_left_of_imp (fun _ _ => HeapR.unit _ _ _ _)
+  auth_valid_iff.trans <| and_iff_left_of_imp (fun _ _ => HeapR.unit _ _ _)
 
 theorem auth_one_valid : ✓ Auth (.own (F := F) one) m1 := auth_valid_iff.mpr valid_own_one
 
 nonrec theorem auth_op_auth_validN_iff : ✓{n} Auth dp m1 • Auth dq m2 ↔ ✓ dp • dq ∧ m1 ≡{n}≡ m2 :=
   auth_op_auth_validN_iff.trans <|
-  and_congr_right <| fun _ => and_iff_left_of_imp <| fun _ => HeapR.unit _ _ _ _
+  and_congr_right <| fun _ => and_iff_left_of_imp <| fun _ => HeapR.unit _ _ _
 
 nonrec theorem auth_op_auth_valid_iff : ✓ Auth dp m1 • Auth dq m2 ↔ ✓ dp • dq ∧ m1 ≡ m2 :=
   auth_op_auth_valid_iff.trans <|
-  and_congr_right <| fun _ => and_iff_left_of_imp <| fun _ _ => HeapR.unit _ _ _ _
+  and_congr_right <| fun _ => and_iff_left_of_imp <| fun _ _ => HeapR.unit _ _ _
 
 nonrec theorem auth_one_op_auth_one_validN_iff :
     ✓{n} Auth (F := F) (.own one) m1 • Auth (.own one) m2 ↔ False :=
@@ -316,8 +316,8 @@ theorem update_one_delete :
   refine auth_one_op_frag_dealloc <| fun n bf Hrel j => ?_
   match He : Std.PartialMap.get? bf j with
   | none =>
-    intro _ HK
-    simp at HK
+    intro _ Hμ.K
+    simp at Hμ.K
   | some v =>
     by_cases h : k = j
     · specialize Hrel k
@@ -470,7 +470,7 @@ theorem update_frag_discard : Frag (H := H) k dq v1 ~~> Frag k .discard v1 :=
   .lift_updateP (Frag k · v1) _ _ update_of_dfrac_update DFrac.update_discard
 
 theorem update_frag_acquire [IsSplitFraction F] :
-    (Frag k .discard v1 : HeapView F K V H) ~~>: fun a => ∃ q, a = Frag k (.own q) v1 := by
+    (Frag k .discard v1 : HeapView F V H) ~~>: fun a => ∃ q, a = Frag k (.own q) v1 := by
   apply UpdateP.weaken (update_of_dfrac_update _ DFrac.update_acquire)
   rintro y ⟨q, rfl, ⟨q1, rfl⟩⟩
   exists q1
@@ -483,8 +483,8 @@ open Iris.Std PartialMap
 
 theorem heapR_map_eq [OFE A] [OFE B] [OFE A'] [OFE B'] [RFunctor T] (f : A' -n> A) (g : B -n> B')
     (n : Nat) (m : H (T A B)) (mv : H (DFrac F × T A B)) :
-    HeapR F K (T A B) H n m mv →
-    HeapR F K (T A' B') H n
+    HeapR F (T A B) H n m mv →
+    HeapR F (T A' B') H n
       ((mapO H (RFunctor.map f g).toHom).f m)
       ((mapC H (Prod.mapC (CMRA.Hom.id (α := DFrac F))
       (RFunctor.map (F:=T) f g))).f mv) := by
@@ -514,7 +514,7 @@ theorem heapR_map_eq [OFE A] [OFE B] [OFE A'] [OFE B'] [RFunctor T] (f : A' -n> 
       · exact (Hom.monoN _ _ he)
 
 abbrev HeapViewURF T [RFunctor T] : COFE.OFunctorPre :=
-  fun A B _ _ => HeapView F K (T A B) H
+  fun A B _ _ => HeapView F (T A B) H
 
 instance {T} [RFunctor T] : URFunctor (HeapViewURF (F := F) (H := H) T) where
   map {A A'} {B B'} _ _ _ _ f g :=

--- a/src/Iris/BI/BigOp/BigAndMap.lean
+++ b/src/Iris/BI/BigOp/BigAndMap.lean
@@ -19,120 +19,122 @@ open scoped PartialMap
 /-! # Big Conjunction over Maps -/
 
 variable {PROP : Type _} [BI PROP]
-variable {K : Type _} {V : Type _} {M : Type _ → Type _} [LawfulFiniteMap M K]
+variable {V : Type _} {M : Type _ → Type _} [μ : LawfulFiniteMap M]
 
 namespace BigAndM
 
+#check bigAndM
+
 @[simp, rocq_alias big_andM_empty]
-theorem bigAndM_empty {Φ : K → V → PROP} :
+theorem bigAndM_empty {Φ : μ.K → V → PROP} :
     ([∧map] k ↦ x ∈ (∅ : M V), Φ k x) ⊣⊢ True :=
   equiv_iff.mp <| .of_eq <| bigOpM_empty Φ
 
 @[rocq_alias big_andM_empty']
-theorem bigAndM_empty_intro {P : PROP} {Φ : K → V → PROP} :
+theorem bigAndM_empty_intro {P : PROP} {Φ : μ.K → V → PROP} :
     P ⊢ [∧map] k ↦ x ∈ (∅ : M V), Φ k x :=
   true_intro.trans bigAndM_empty.2
 
 @[rocq_alias big_andM_singleton]
-theorem bigAndM_singleton {Φ : K → V → PROP} {i : K} {x : V} :
+theorem bigAndM_singleton {Φ : μ.K → V → PROP} {i : μ.K} {x : V} :
     ([∧map] k ↦ v ∈ (PartialMap.singleton i x : M V), Φ k v) ⊣⊢ Φ i x :=
   equiv_iff.mp <| bigOpM_singleton_equiv Φ i x
 
 @[rocq_alias big_andM_insert]
-theorem bigAndM_insert {Φ : K → V → PROP} {m : M V} {i : K} {x : V}
+theorem bigAndM_insert {Φ : μ.K → V → PROP} {m : M V} {i : μ.K} {x : V}
     (h : get? m i = none) :
     ([∧map] k ↦ v ∈ insert m i x, Φ k v) ⊣⊢ Φ i x ∧ [∧map] k ↦ v ∈ m, Φ k v :=
   equiv_iff.mp <| bigOpM_insert_equiv Φ x h
 
 @[rocq_alias big_andM_insert_delete]
-theorem bigAndM_insert_delete {Φ : K → V → PROP} {m : M V} {i : K} {x : V} :
+theorem bigAndM_insert_delete {Φ : μ.K → V → PROP} {m : M V} {i : μ.K} {x : V} :
     ([∧map] k ↦ v ∈ insert m i x, Φ k v) ⊣⊢
       Φ i x ∧ [∧map] k ↦ v ∈ delete m i, Φ k v :=
   equiv_iff.mp <| bigOpM_insert_delete_equiv Φ m i x
 
 @[rocq_alias big_andM_delete]
-theorem bigAndM_delete {Φ : K → V → PROP} {m : M V} {i : K} {x : V}
+theorem bigAndM_delete {Φ : μ.K → V → PROP} {m : M V} {i : μ.K} {x : V}
     (h : get? m i = some x) :
     ([∧map] k ↦ v ∈ m, Φ k v) ⊣⊢ Φ i x ∧ [∧map] k ↦ v ∈ delete m i, Φ k v :=
   equiv_iff.mp <| bigOpM_delete_equiv Φ h
 
 @[rocq_alias big_andM_mono]
-theorem bigAndM_mono {Φ Ψ : K → V → PROP} {m : M V}
+theorem bigAndM_mono {Φ Ψ : μ.K → V → PROP} {m : M V}
     (h : ∀ {k v}, get? m k = some v → Φ k v ⊢ Ψ k v) :
     ([∧map] k ↦ x ∈ m, Φ k x) ⊢ [∧map] k ↦ x ∈ m, Ψ k x :=
   bigOpM_gen_proper .rfl and_mono (h ·)
 
 @[rocq_alias big_andM_proper]
-theorem bigAndM_equiv {Φ Ψ : K → V → PROP} {m : M V}
+theorem bigAndM_equiv {Φ Ψ : μ.K → V → PROP} {m : M V}
     (h : ∀ {k x}, get? m k = some x → Φ k x ≡ Ψ k x) :
     ([∧map] k ↦ x ∈ m, Φ k x) ≡ [∧map] k ↦ x ∈ m, Ψ k x :=
   bigOpM_proper h
 
-theorem bigAndM_equiv_of_forall_equiv {Φ Ψ : K → V → PROP} {m : M V}
+theorem bigAndM_equiv_of_forall_equiv {Φ Ψ : μ.K → V → PROP} {m : M V}
     (h : ∀ {k x}, Φ k x ≡ Ψ k x) :
     ([∧map] k ↦ x ∈ m, Φ k x) ≡ [∧map] k ↦ x ∈ m, Ψ k x :=
   bigOpM_proper_pointwise m h
 
 @[rocq_alias big_andM_ne]
-theorem bigAndM_dist {Φ Ψ : K → V → PROP} {m : M V} {n : Nat}
+theorem bigAndM_dist {Φ Ψ : μ.K → V → PROP} {m : M V} {n : Nat}
     (h : ∀ {k x}, get? m k = some x → Φ k x ≡{n}≡ Ψ k x) :
     ([∧map] k ↦ x ∈ m, Φ k x) ≡{n}≡ [∧map] k ↦ x ∈ m, Ψ k x :=
   bigOpM_dist h
 
 @[rocq_alias big_andM_mono']
-theorem bigAndM_mono_of_forall {Φ Ψ : K → V → PROP} {m : M V}
+theorem bigAndM_mono_of_forall {Φ Ψ : μ.K → V → PROP} {m : M V}
     (h : ∀ {k x}, Φ k x ⊢ Ψ k x) :
     ([∧map] k ↦ x ∈ m, Φ k x) ⊢ [∧map] k ↦ x ∈ m, Ψ k x :=
   bigAndM_mono fun _ => h
 
-instance bigAndM_affine_inst {Φ : K → V → PROP} {m : M V} [BIAffine PROP] :
+instance bigAndM_affine_inst {Φ : μ.K → V → PROP} {m : M V} [BIAffine PROP] :
     Affine ([∧map] k ↦ x ∈ m, Φ k x) where
   affine := bigOpM_closed (P := fun Q => Q ⊢ emp) true_emp.1
     (fun hx _ => and_elim_l.trans hx) (fun _ => Affine.affine)
 
 @[rocq_alias big_andM_empty_persistent]
-instance bigAndM_nil_persistent_inst {Φ : K → V → PROP} :
+instance bigAndM_nil_persistent_inst {Φ : μ.K → V → PROP} :
     Persistent ([∧map] k ↦ x ∈ (∅ : M V), Φ k x) where
   persistent := bigAndM_empty.1.trans <| Persistent.persistent.trans <|
     persistently_mono bigAndM_empty.2
 
 @[rocq_alias big_andM_persistent]
-theorem bigAndM_persistent {Φ : K → V → PROP} {m : M V}
+theorem bigAndM_persistent {Φ : μ.K → V → PROP} {m : M V}
     (h : ∀ {k x}, get? m k = some x → Persistent (Φ k x)) :
     Persistent ([∧map] k ↦ x ∈ m, Φ k x) where
   persistent := bigOpM_closed (P := fun Q => Q ⊢ <pers> Q) persistently_true.2
     (and_mono · · |>.trans persistently_and.2) (h · |>.persistent)
 
 @[rocq_alias big_andM_persistent']
-instance bigAndM_persistent_inst {Φ : K → V → PROP} {m : M V} [∀ k x, Persistent (Φ k x)] :
+instance bigAndM_persistent_inst {Φ : μ.K → V → PROP} {m : M V} [∀ k x, Persistent (Φ k x)] :
     Persistent ([∧map] k ↦ x ∈ m, Φ k x) :=
   bigAndM_persistent fun _ => inferInstance
 
 @[rocq_alias big_andM_empty_absorbing]
-instance bigAndM_nil_absorbing_inst {Φ : K → V → PROP} :
+instance bigAndM_nil_absorbing_inst {Φ : μ.K → V → PROP} :
     Absorbing ([∧map] k ↦ x ∈ (∅ : M V), Φ k x) where
   absorbing := (absorbingly_mono bigAndM_empty.1).trans <| Absorbing.absorbing.trans bigAndM_empty.2
 
 @[rocq_alias big_andM_absorbing]
-theorem bigAndM_absorbing {Φ : K → V → PROP} {m : M V}
+theorem bigAndM_absorbing {Φ : μ.K → V → PROP} {m : M V}
     (h : ∀ {k x}, get? m k = some x → Absorbing (Φ k x)) :
     Absorbing ([∧map] k ↦ x ∈ m, Φ k x) where
   absorbing := bigOpM_closed (P := fun Q => <absorb> Q ⊢ Q) true_intro
     (absorbingly_and_1.trans <| and_mono · ·) (h · |>.absorbing)
 
 @[rocq_alias big_andM_absorbing']
-instance bigAndM_absorbing_inst {Φ : K → V → PROP} {m : M V} [∀ k x, Absorbing (Φ k x)] :
+instance bigAndM_absorbing_inst {Φ : μ.K → V → PROP} {m : M V} [∀ k x, Absorbing (Φ k x)] :
     Absorbing ([∧map] k ↦ x ∈ m, Φ k x) :=
   bigAndM_absorbing fun _ => inferInstance
 
 @[rocq_alias big_andM_empty_timeless]
-instance bigAndM_nil_timeless_inst {Φ : K → V → PROP} :
+instance bigAndM_nil_timeless_inst {Φ : μ.K → V → PROP} :
     Timeless ([∧map] k ↦ x ∈ (∅ : M V), Φ k x) where
   timeless := (later_congr bigAndM_empty).1.trans <| (later_true.1.trans except0_true.2).trans <|
     except0_mono bigAndM_empty.2
 
 @[rocq_alias big_andM_timeless]
-theorem bigAndM_timeless {Φ : K → V → PROP} {m : M V}
+theorem bigAndM_timeless {Φ : μ.K → V → PROP} {m : M V}
     (h : ∀ {k x}, get? m k = some x → Timeless (Φ k x)) :
     Timeless ([∧map] k ↦ x ∈ m, Φ k x) where
   timeless := bigOpM_closed (P := fun Q => ▷ Q ⊢ ◇ Q)
@@ -141,37 +143,37 @@ theorem bigAndM_timeless {Φ : K → V → PROP} {m : M V}
     (h · |>.timeless)
 
 @[rocq_alias big_andM_timeless']
-instance bigAndM_timeless_inst {Φ : K → V → PROP} {m : M V} [∀ k x, Timeless (Φ k x)] :
+instance bigAndM_timeless_inst {Φ : μ.K → V → PROP} {m : M V} [∀ k x, Timeless (Φ k x)] :
     Timeless ([∧map] k ↦ x ∈ m, Φ k x) :=
   bigAndM_timeless fun _ => inferInstance
 
 @[rocq_alias big_andM_lookup]
-theorem bigAndM_lookup {Φ : K → V → PROP} {m : M V} {i : K} {x : V}
+theorem bigAndM_lookup {Φ : μ.K → V → PROP} {m : M V} {i : μ.K} {x : V}
     (h : get? m i = some x) :
     ([∧map] k ↦ v ∈ m, Φ k v) ⊢ Φ i x :=
   (bigAndM_delete h).1.trans and_elim_l
 
 @[rocq_alias big_andM_lookup_dom]
-theorem bigAndM_lookup_dom {Φ : K → PROP} {m : M V} {i : K} {x : V}
+theorem bigAndM_lookup_dom {Φ : μ.K → PROP} {m : M V} {i : μ.K} {x : V}
     (h : get? m i = some x) :
     ([∧map] k ↦ _v ∈ m, Φ k) ⊢ Φ i :=
   bigAndM_lookup h
 
 @[rocq_alias big_andM_insert_2]
-theorem bigAndM_insert_elim {Φ : K → V → PROP} {m : M V} {i : K} {x : V} :
+theorem bigAndM_insert_elim {Φ : μ.K → V → PROP} {m : M V} {i : μ.K} {x : V} :
     Φ i x ∧ ([∧map] k ↦ v ∈ m, Φ k v) ⊢ [∧map] k ↦ v ∈ insert m i x, Φ k v :=
   match hm : get? m i with
   | none => (bigAndM_insert hm).2
   | some _ => (and_mono_r ((bigAndM_delete hm).1.trans and_elim_r)).trans bigAndM_insert_delete.2
 
 @[rocq_alias big_andM_intro]
-theorem bigAndM_intro {P : PROP} {Φ : K → V → PROP} {m : M V}
+theorem bigAndM_intro {P : PROP} {Φ : μ.K → V → PROP} {m : M V}
     (h : ∀ {k v}, get? m k = some v → P ⊢ Φ k v) :
     P ⊢ [∧map] k ↦ x ∈ m, Φ k x :=
   bigOpM_closed true_intro and_intro (h ·)
 
 @[rocq_alias big_andM_forall]
-theorem bigAndM_forall {Φ : K → V → PROP} {m : M V} :
+theorem bigAndM_forall {Φ : μ.K → V → PROP} {m : M V} :
     ([∧map] k ↦ x ∈ m, Φ k x) ⊣⊢ ∀ k, ∀ v, iprop(⌜get? m k = some v⌝ → Φ k v) := by
   refine ⟨forall_intro fun _ => forall_intro fun _ => ?_, bigAndM_intro fun {k x} hget => ?_⟩
   · exact imp_intro <| and_comm.1.trans <| pure_elim_l (bigAndM_lookup ·)
@@ -179,7 +181,7 @@ theorem bigAndM_forall {Φ : K → V → PROP} {m : M V} :
     (imp_congr_l <| pure_true hget).1.trans true_imp.1
 
 @[rocq_alias big_andM_impl]
-theorem bigAndM_impl {Φ Ψ : K → V → PROP} {m : M V} :
+theorem bigAndM_impl {Φ Ψ : μ.K → V → PROP} {m : M V} :
     ([∧map] k ↦ x ∈ m, Φ k x) ∧ (∀ k v, iprop(⌜get? m k = some v⌝ → Φ k v → Ψ k v)) ⊢
       [∧map] k ↦ x ∈ m, Ψ k x := by
   refine bigAndM_intro fun {k v} hget => (and_mono (bigAndM_lookup hget) <|
@@ -187,80 +189,80 @@ theorem bigAndM_impl {Φ Ψ : K → V → PROP} {m : M V} :
   exact (and_mono .rfl <| (and_intro (pure_intro hget) .rfl).trans imp_elim_r).trans imp_elim_r
 
 @[rocq_alias big_andM_subseteq]
-theorem bigAndM_subseteq {Φ : K → V → PROP} {m₁ m₂ : M V}
+theorem bigAndM_subseteq {Φ : μ.K → V → PROP} {m₁ m₂ : M V}
     (hsub : m₂ ⊆ m₁) :
     ([∧map] k ↦ x ∈ m₁, Φ k x) ⊢ [∧map] k ↦ x ∈ m₂, Φ k x :=
   bigAndM_intro fun hget₂ => bigAndM_lookup <| hsub _ _ hget₂
 
 @[rocq_alias big_andM_and]
-theorem bigAndM_and_equiv {Φ Ψ : K → V → PROP} {m : M V} :
+theorem bigAndM_and_equiv {Φ Ψ : μ.K → V → PROP} {m : M V} :
     ([∧map] k ↦ x ∈ m, iprop(Φ k x ∧ Ψ k x)) ≡
       iprop(([∧map] k ↦ x ∈ m, Φ k x) ∧ [∧map] k ↦ x ∈ m, Ψ k x) :=
   bigOpM_op_equiv Φ Ψ m
 
 @[rocq_alias big_andM_persistently]
-theorem bigAndM_persistently {Φ : K → V → PROP} {m : M V} :
+theorem bigAndM_persistently {Φ : μ.K → V → PROP} {m : M V} :
     (<pers> [∧map] k ↦ x ∈ m, Φ k x) ⊣⊢ [∧map] k ↦ x ∈ m, <pers> Φ k x :=
   letI := MonoidHomomorphism.ofEquiv (PROP := PROP) persistently_ne
        (equiv_iff.mpr persistently_and) (equiv_iff.mpr persistently_true)
   equiv_iff.mp <| bigOpL_hom _ <| toList m
 
 @[rocq_alias big_andM_pure_1]
-theorem bigAndM_pure_intro {φ : K → V → Prop} {m : M V} :
+theorem bigAndM_pure_intro {φ : μ.K → V → Prop} {m : M V} :
     ([∧map] k ↦ x ∈ m, ⌜φ k x⌝ : PROP) ⊢ ⌜PartialMap.all φ m⌝ :=
   bigAndM_forall.1.trans <|
   (forall_mono fun _ => (forall_mono fun _ => pure_imp.1).trans pure_forall.1).trans pure_forall.1
 
 @[rocq_alias big_andM_pure_2]
-theorem bigAndM_pure_elim {φ : K → V → Prop} {m : M V} :
+theorem bigAndM_pure_elim {φ : μ.K → V → Prop} {m : M V} :
     (⌜PartialMap.all φ m⌝ : PROP) ⊢ [∧map] k ↦ x ∈ m, ⌜φ k x⌝ :=
   pure_forall_2.trans <|
   (forall_mono fun _ => pure_forall_2.trans <| forall_mono fun _ => pure_imp_2).trans bigAndM_forall.2
 
 @[rocq_alias big_andM_pure]
-theorem bigAndM_pure {φ : K → V → Prop} {m : M V} :
+theorem bigAndM_pure {φ : μ.K → V → Prop} {m : M V} :
     ([∧map] k ↦ x ∈ m, ⌜φ k x⌝ : PROP) ⊣⊢ ⌜PartialMap.all φ m⌝ :=
   ⟨bigAndM_pure_intro, bigAndM_pure_elim⟩
 
 @[rocq_alias big_andM_later]
-theorem bigAndM_later {Φ : K → V → PROP} {m : M V} :
+theorem bigAndM_later {Φ : μ.K → V → PROP} {m : M V} :
     (▷ [∧map] k ↦ x ∈ m, Φ k x) ⊣⊢ [∧map] k ↦ x ∈ m, (▷ Φ k x) :=
   letI := MonoidHomomorphism.ofEquiv (PROP := PROP) later_ne
     (equiv_iff.mpr later_and) (equiv_iff.mpr later_true)
   equiv_iff.mp <| bigOpL_hom _ <| toList m
 
 @[rocq_alias big_andM_laterN]
-theorem bigAndM_laterN {Φ : K → V → PROP} {m : M V} {n : Nat} :
+theorem bigAndM_laterN {Φ : μ.K → V → PROP} {m : M V} {n : Nat} :
     (▷^[n] [∧map] k ↦ x ∈ m, Φ k x) ⊣⊢ [∧map] k ↦ x ∈ m, ▷^[n] Φ k x :=
   match n with
   | 0 => .rfl
   | _ + 1 => (later_congr bigAndM_laterN).trans bigAndM_later
 
 @[rocq_alias big_andM_map_to_list]
-theorem bigAndM_toList {Φ : K → V → PROP} {m : M V} :
-    ([∧map] k ↦ x ∈ m, Φ k x) ⊣⊢ ([∧list] kv ∈ toList (K := K) m, Φ kv.1 kv.2) :=
+theorem bigAndM_toList {Φ : μ.K → V → PROP} {m : M V} :
+    ([∧map] k ↦ x ∈ m, Φ k x) ⊣⊢ ([∧list] kv ∈ toList m, Φ kv.1 kv.2) :=
   .rfl
 
 @[rocq_alias big_andM_fmap]
-theorem bigAndM_map {Φ : K → V → PROP} {m : M V} {f : V → V} :
+theorem bigAndM_map {Φ : μ.K → V → PROP} {m : M V} {f : V → V} :
     ([∧map] k ↦ y ∈ PartialMap.map f m, Φ k y) ≡ [∧map] k ↦ y ∈ m, Φ k (f y) :=
   bigOpM_map_equiv f Φ m
 
 @[rocq_alias big_andM_omap]
-theorem bigAndM_filterMap {Φ : K → V → PROP} {m : M V} {f : V → Option V}
+theorem bigAndM_filterMap {Φ : μ.K → V → PROP} {m : M V} {f : V → Option V}
     (hinj : Function.Injective f) :
     ([∧map] k ↦ y ∈ PartialMap.filterMap f m, Φ k y) ≡
       [∧map] k ↦ y ∈ m, (f y).elim iprop(True) (Φ k) :=
   bigOpM_filterMap_equiv Φ m hinj
 
 @[rocq_alias big_andM_filter']
-theorem bigAndM_filter_cond {Φ : K → V → PROP} {m : M V} (p : K → V → Bool) :
+theorem bigAndM_filter_cond {Φ : μ.K → V → PROP} {m : M V} (p : μ.K → V → Bool) :
     ([∧map] k ↦ x ∈ PartialMap.filter p m, Φ k x) ≡
       [∧map] k ↦ x ∈ m, if p k x then Φ k x else iprop(True) :=
   bigOpM_filter_equiv p Φ m
 
 @[rocq_alias big_andM_filter]
-theorem bigAndM_filter {Φ : K → V → PROP} {m : M V} (p : K → V → Bool) :
+theorem bigAndM_filter {Φ : μ.K → V → PROP} {m : M V} (p : μ.K → V → Bool) :
     ([∧map] k ↦ x ∈ PartialMap.filter p m, Φ k x) ≡
       [∧map] k ↦ x ∈ m, iprop(⌜p k x = true⌝ → Φ k x) :=
   (bigAndM_filter_cond p).trans <| bigOpM_proper fun {k x} _ => by
@@ -269,32 +271,32 @@ theorem bigAndM_filter {Φ : K → V → PROP} {m : M V} (p : K → V → Bool) 
     | true => simpa using equiv_iff.mpr true_imp.symm
 
 @[rocq_alias big_andM_union]
-theorem bigAndM_union [DecidableEq K] {Φ : K → V → PROP} {m₁ m₂ : M V} (hdisj : m₁ ##ₘ m₂) :
+theorem bigAndM_union [DecidableEq μ.K] {Φ : μ.K → V → PROP} {m₁ m₂ : M V} (hdisj : m₁ ##ₘ m₂) :
     ([∧map] k ↦ y ∈ m₁ ∪ m₂, Φ k y) ⊣⊢
       ([∧map] k ↦ y ∈ m₁, Φ k y) ∧ [∧map] k ↦ y ∈ m₂, Φ k y :=
   equiv_iff.mp <| bigOpM_union_equiv Φ m₁ m₂ hdisj
 
 @[rocq_alias big_andM_insert_override]
-theorem bigAndM_insert_override {Φ : K → V → PROP} {m : M V} {i : K} {x x' : V}
+theorem bigAndM_insert_override {Φ : μ.K → V → PROP} {m : M V} {i : μ.K} {x x' : V}
     (hi : get? m i = some x) (hΦ : Φ i x ≡ Φ i x') :
     ([∧map] k ↦ v ∈ insert m i x', Φ k v) ≡ ([∧map] k ↦ v ∈ m, Φ k v) :=
   bigOpM_insert_override_equiv hi hΦ
 
 @[rocq_alias big_andM_fn_insert]
-theorem bigAndM_fn_insert [DecidableEq K] {B : Type _} {g : K → V → B → PROP} {f : K → B}
-    {m : M V} {i : K} {x : V} {b : B} (hi : get? m i = none) :
+theorem bigAndM_fn_insert [DecidableEq μ.K] {B : Type _} {g : μ.K → V → B → PROP} {f : μ.K → B}
+    {m : M V} {i : μ.K} {x : V} {b : B} (hi : get? m i = none) :
     ([∧map] k ↦ y ∈ insert m i x, g k y (if k = i then b else f k)) ≡
     iprop(g i x b ∧ [∧map] k ↦ y ∈ m, g k y (f k)) :=
   bigOpM_fn_insert_equiv g f x b hi
 
 @[rocq_alias big_andM_fn_insert']
-theorem bigAndM_fn_insert_cond [DecidableEq K] {f : K → PROP} {m : M V} {i : K} {x : V} {P : PROP}
+theorem bigAndM_fn_insert_cond [DecidableEq μ.K] {f : μ.K → PROP} {m : M V} {i : μ.K} {x : V} {P : PROP}
     (hi : get? m i = none) :
     ([∧map] k ↦ _v ∈ insert m i x, if k = i then P else f k) ≡
     iprop(P ∧ [∧map] k ↦ _v ∈ m, f k) :=
   bigOpM_fn_insert_equiv' f x P hi
 
--- TODO: `big_andM_kmap` and `big_andM_map_seq` require `FiniteMapKmapLaws` and
+-- TODO: `big_andM_kmap` and `big_andM_map_seq` require `FiniteMapμ.KmapLaws` and
 -- `FiniteMapSeqLaws` which are not yet available in the current `PartialMap` interface.
 
 end BigAndM

--- a/src/Iris/BI/BigOp/BigOp.lean
+++ b/src/Iris/BI/BigOp/BigOp.lean
@@ -8,6 +8,7 @@ module
 public import Iris.Algebra.Monoid
 public import Iris.Algebra.BigOp
 public import Iris.BI.DerivedLaws
+meta import Iris.Std
 import Lean
 
 namespace Iris.BI
@@ -88,13 +89,13 @@ public section Map
 open Iris.Algebra Iris.Std OFE BIBase
 
 /-- Big separating conjunction over a map with key access. -/
-abbrev bigSepM [BI PROP] {K : Type _} {V : Type _} {M : Type _ → Type _} [LawfulFiniteMap M K]
-    (Φ : K → V → PROP) (m : M V) : PROP :=
+abbrev bigSepM [BI PROP] {K : Type _} {V : Type _} {M : Type _ → Type _} [μ : LawfulFiniteMap M]
+    (Φ : μ.K → V → PROP) (m : M V) : PROP :=
   bigOpM sep Φ m
 
 /-- Big conjunction over a map with key access. -/
-abbrev bigAndM [BI PROP] {K : Type _} {V : Type _} {M : Type _ → Type _} [LawfulFiniteMap M K]
-    (Φ : K → V → PROP) (m : M V) : PROP :=
+abbrev bigAndM [BI PROP] {K : Type _} {V : Type _} {M : Type _ → Type _} [μ : LawfulFiniteMap M]
+    (Φ : μ.K → V → PROP) (m : M V) : PROP :=
   bigOpM and Φ m
 
 end Map
@@ -111,6 +112,61 @@ end Set
 public meta section
 open Lean PrettyPrinter Delaborator SubExpr
 /-! ## Notation -/
+
+class ToList (X : Type _)(A : Type _) where
+  toList : X → List A
+
+instance [μ : Std.LawfulFiniteMap M]: ToList (M A) A where
+  toList m := Std.FiniteMap.toList m |>.map (·.2)
+
+instance [Std.LawfulFiniteSet S A]: ToList S A where
+  toList s := Std.FiniteSet.toList s
+
+instance : ToList (List A) A where
+  toList ls := ls
+
+syntax memBinder := ident " ∈ " term
+syntax memBinders := memBinder ("," ppSpace memBinder)*
+
+declare_syntax_cat iris_bigop
+syntax "✱" : iris_bigop
+syntax "⋁" : iris_bigop
+syntax "⋀" : iris_bigop
+
+syntax (name := iris.bigop) iris_bigop noWs "(" memBinders ")" "," ppSpace term : term
+
+def expandBigOp : TSyntax `iris_bigop → MacroM (TSyntax `ident)
+| `(iris_bigop| ✱ ) =>
+  return Lean.mkIdent ``sep
+| `(iris_bigop| ⋀ ) =>
+  return Lean.mkIdent ``and
+| `(iris_bigop| ⋁ ) =>
+  return Lean.mkIdent ``or
+| _ =>do Lean.Macro.throwUnsupported
+
+def expandMemBindersWith(body : TSyntax `term) : TSyntax ``memBinders → MacroM (TSyntax `term × TSyntax `term)
+| `(memBinders| $x ∈ $ls $[, $xs ∈ $lss]*) => do
+  let vars := (x :: xs.toList)
+  let mut func := body
+  for v in vars.reverse do
+    func := ←`(fun  _ $v => $func)
+  let mut ls := ←`(ToList.toList $ls)
+  for other in lss do
+    ls := ←`(List.zip $ls (ToList.toList $other))
+  return (func, ls)
+| _ => do Lean.Macro.throwUnsupported
+
+macro_rules
+  | `(iris.bigop| $op:iris_bigop( $xs:memBinders ), $body) => do
+    let op ← expandBigOp op
+    let (func, ls) ← expandMemBindersWith body xs
+    `(Algebra.bigOpL $op $func $ls)
+
+variable [BI PROP] (Φ : Nat → PROP)
+#check ⋀(x ∈ [1,2,4]), Φ x
+#check ⋁(x ∈ [1,2,4]), Φ x
+#check ✱(x ∈ [1,2,4]), Φ x
+
 
 -- Notation for bigSepL without index
 syntax "[∗list] " ident " ∈ " term ", " term : term

--- a/src/Iris/BI/BigOp/BigOp.lean
+++ b/src/Iris/BI/BigOp/BigOp.lean
@@ -89,12 +89,12 @@ public section Map
 open Iris.Algebra Iris.Std OFE BIBase
 
 /-- Big separating conjunction over a map with key access. -/
-abbrev bigSepM [BI PROP] {K : Type _} {V : Type _} {M : Type _ → Type _} [μ : LawfulFiniteMap M]
+abbrev bigSepM [BI PROP] {V : Type _} {M : Type _ → Type _} [μ : LawfulFiniteMap M]
     (Φ : μ.K → V → PROP) (m : M V) : PROP :=
   bigOpM sep Φ m
 
 /-- Big conjunction over a map with key access. -/
-abbrev bigAndM [BI PROP] {K : Type _} {V : Type _} {M : Type _ → Type _} [μ : LawfulFiniteMap M]
+abbrev bigAndM [BI PROP] {V : Type _} {M : Type _ → Type _} [μ : LawfulFiniteMap M]
     (Φ : μ.K → V → PROP) (m : M V) : PROP :=
   bigOpM and Φ m
 
@@ -363,8 +363,8 @@ def delabBigSepM : Delab := do
   unless e.isApp do failure
   unless e.getAppFn.isConstOf ``bigSepM do failure
   let args := e.getAppArgs
-  unless args.size == 8 do failure
-  delabBigOpMBody args[6]! 7 6
+  unless args.size == 7 do failure
+  delabBigOpMBody args[5]! 6 5
     (fun k x m P => `([∗map]  $k ↦ $x ∈ $m, $P))
     (fun x m P => `([∗map]  $x ∈ $m, $P))
 
@@ -375,8 +375,8 @@ def delabBigAndM : Delab := do
   unless e.isApp do failure
   unless e.getAppFn.isConstOf ``bigAndM do failure
   let args := e.getAppArgs
-  unless args.size == 8 do failure
-  delabBigOpMBody args[6]! 7 6
+  unless args.size == 7 do failure
+  delabBigOpMBody args[5]! 6 5
     (fun k x m P => `([∧map]  $k ↦ $x ∈ $m, $P))
     (fun x m P => `([∧map]  $x ∈ $m, $P))
 
@@ -388,15 +388,15 @@ def delabBigOpM : Delab := do
   unless e.isApp do failure
   unless e.getAppFn.isConstOf ``Iris.Algebra.bigOpM do failure
   let args := e.getAppArgs
-  unless args.size == 11 do failure
-  let op := args[3]!
+  unless args.size == 10 do failure
+  let op := args[2]!
   let opName := op.getAppFn.constName?
   if opName == some ``BIBase.sep then
-    delabBigOpMBody args[7]! 10 7
+    delabBigOpMBody args[6]! 9 6
       (fun k x m P => `([∗map]  $k ↦ $x ∈ $m, $P))
       (fun x m P => `([∗map]  $x ∈ $m, $P))
   else if opName == some ``BIBase.and then
-    delabBigOpMBody args[7]! 10 7
+    delabBigOpMBody args[6]! 9 6
       (fun k x m P => `([∧map]  $k ↦ $x ∈ $m, $P))
       (fun x m P => `([∧map]  $x ∈ $m, $P))
   else
@@ -513,8 +513,8 @@ end Tests
 
 section MapTests
 open Iris.Std OFE BIBase
-variable [BI PROP] {K : Type _} {M : Type _ → Type _} [LawfulFiniteMap M K]
-  (P : Nat → PROP) (Q : K → Nat → PROP) (m : M Nat)
+variable {PROP} [BI PROP] {M : Type _ → Type _} [μ : LawfulFiniteMap M]
+  (P : Nat → PROP) (Q : μ.K → Nat → PROP) (m : M Nat)
 
 -- bigSepM without key
 /-- info: [∗map] x ∈ m, P x : PROP -/

--- a/src/Iris/BI/BigOp/BigSepMap.lean
+++ b/src/Iris/BI/BigOp/BigSepMap.lean
@@ -23,124 +23,124 @@ open Iris.Algebra BigOpL BigOpM BIBase Iris.Std BigSepL LawfulPartialMap Partial
 /-! # Big Separating Conjunction over Maps -/
 
 variable {PROP : Type _} [BI PROP]
-variable {K : Type _} {V : Type _} {M : Type _ → Type _} [LawfulFiniteMap M K]
+variable {V : Type _} {M : Type _ → Type _} [μ : LawfulFiniteMap M]
 
 namespace BigSepM
 
 @[simp, rocq_alias big_sepM_empty]
-theorem bigSepM_empty {Φ : K → V → PROP} :
+theorem bigSepM_empty {Φ : μ.K → V → PROP} :
     ([∗map] k ↦ x ∈ (∅ : M V), Φ k x) ⊣⊢ emp :=
   equiv_iff.mp <| .of_eq <| bigOpM_empty Φ
 
 @[rocq_alias big_sepM_empty']
-theorem bigSepM_empty_intro {P : PROP} [Affine P] {Φ : K → V → PROP} :
+theorem bigSepM_empty_intro {P : PROP} [Affine P] {Φ : μ.K → V → PROP} :
     P ⊢ [∗map] k ↦ x ∈ (∅ : M V), Φ k x :=
   Affine.affine.trans bigSepM_empty.2
 
 @[rocq_alias big_sepM_singleton]
-theorem bigSepM_singleton {Φ : K → V → PROP} {i : K} {x : V} :
+theorem bigSepM_singleton {Φ : μ.K → V → PROP} {i : μ.K} {x : V} :
     ([∗map] k ↦ v ∈ (singleton i x : M V), Φ k v) ⊣⊢ Φ i x :=
   equiv_iff.mp <| bigOpM_singleton_equiv Φ i x
 
 @[rocq_alias big_sepM_insert]
-theorem bigSepM_insert {Φ : K → V → PROP} {m : M V} {i : K} {x : V}
+theorem bigSepM_insert {Φ : μ.K → V → PROP} {m : M V} {i : μ.K}  {x : V}
     (h : get? m i = none) :
     ([∗map] k ↦ v ∈ insert m i x, Φ k v) ⊣⊢ Φ i x ∗ [∗map] k ↦ v ∈ m, Φ k v :=
   equiv_iff.mp <| bigOpM_insert_equiv Φ x h
 
 @[rocq_alias big_sepM_insert_delete]
-theorem bigSepM_insert_delete {Φ : K → V → PROP} {m : M V} {i : K} {x : V} :
+theorem bigSepM_insert_delete {Φ : μ.K → V → PROP} {m : M V} {i : μ.K} {x : V} :
     ([∗map] k ↦ v ∈ insert m i x, Φ k v) ⊣⊢
       Φ i x ∗ [∗map] k ↦ v ∈ delete m i, Φ k v :=
   equiv_iff.mp <| bigOpM_insert_delete_equiv Φ m i x
 
 @[rocq_alias big_sepM_delete]
-theorem bigSepM_delete {Φ : K → V → PROP} {m : M V} {i : K} {x : V}
+theorem bigSepM_delete {Φ : μ.K → V → PROP} {m : M V} {i : μ.K} {x : V}
     (h : get? m i = some x) :
     ([∗map] k ↦ v ∈ m, Φ k v) ⊣⊢ Φ i x ∗ [∗map] k ↦ v ∈ delete m i, Φ k v :=
   equiv_iff.mp <| bigOpM_delete_equiv Φ h
 
 @[rocq_alias big_sepM_mono]
-theorem bigSepM_mono {Φ Ψ : K → V → PROP} {m : M V}
+theorem bigSepM_mono {Φ Ψ : μ.K → V → PROP} {m : M V}
     (h : ∀ {k v}, get? m k = some v → Φ k v ⊢ Ψ k v) :
     ([∗map] k ↦ x ∈ m, Φ k x) ⊢ [∗map] k ↦ x ∈ m, Ψ k x :=
   bigOpM_gen_proper .rfl sep_mono h
 
 @[rocq_alias big_sepM_proper]
-theorem bigSepM_equiv {Φ Ψ : K → V → PROP} {m : M V}
+theorem bigSepM_equiv {Φ Ψ : μ.K → V → PROP} {m : M V}
     (h : ∀ {k x}, get? m k = some x → Φ k x ≡ Ψ k x) :
     ([∗map] k ↦ x ∈ m, Φ k x) ≡ [∗map] k ↦ x ∈ m, Ψ k x :=
   bigOpM_proper h
 
-theorem bigSepM_equiv_of_forall_equiv {Φ Ψ : K → V → PROP} {m : M V}
+theorem bigSepM_equiv_of_forall_equiv {Φ Ψ : μ.K → V → PROP} {m : M V}
     (h : ∀ {k x}, Φ k x ≡ Ψ k x) :
     ([∗map] k ↦ x ∈ m, Φ k x) ≡ [∗map] k ↦ x ∈ m, Ψ k x :=
   bigOpM_proper_pointwise m h
 
 @[rocq_alias big_sepM_ne]
-theorem bigSepM_dist {Φ Ψ : K → V → PROP} {m : M V} {n : Nat}
+theorem bigSepM_dist {Φ Ψ : μ.K → V → PROP} {m : M V} {n : Nat}
     (h : ∀ {k x}, get? m k = some x → Φ k x ≡{n}≡ Ψ k x) :
     ([∗map] k ↦ x ∈ m, Φ k x) ≡{n}≡ [∗map] k ↦ x ∈ m, Ψ k x :=
   bigOpM_dist h
 
 @[rocq_alias big_sepM_mono']
-theorem bigSepM_mono_of_forall {Φ Ψ : K → V → PROP} {m : M V}
+theorem bigSepM_mono_of_forall {Φ Ψ : μ.K → V → PROP} {m : M V}
     (h : ∀ {k x}, Φ k x ⊢ Ψ k x) :
     ([∗map] k ↦ x ∈ m, Φ k x) ⊢ [∗map] k ↦ x ∈ m, Ψ k x :=
   bigSepM_mono fun _ => h
 
 @[rocq_alias big_sepM_flip_mono]
-theorem bigSepM_flip_mono {Φ Ψ : K → V → PROP} {m : M V}
+theorem bigSepM_flip_mono {Φ Ψ : μ.K → V → PROP} {m : M V}
     (h : ∀ {k x}, Ψ k x ⊢ Φ k x) :
     ([∗map] k ↦ x ∈ m, Ψ k x) ⊢ [∗map] k ↦ x ∈ m, Φ k x :=
   bigSepM_mono fun _ => h
 
 @[rocq_alias big_sepM_empty_persistent]
-instance bigSepM_nil_persistent_inst {Φ : K → V → PROP} :
+instance bigSepM_nil_persistent_inst {Φ : μ.K → V → PROP} :
     Persistent ([∗map] k ↦ x ∈ (∅ : M V), Φ k x) where
   persistent := bigSepM_empty.1.trans (Persistent.persistent.trans (persistently_mono bigSepM_empty.2))
 
 @[rocq_alias big_sepM_persistent]
-theorem bigSepM_persistent {Φ : K → V → PROP} {m : M V}
+theorem bigSepM_persistent {Φ : μ.K → V → PROP} {m : M V}
     (h : ∀ {k x}, get? m k = some x → Persistent (Φ k x)) :
     Persistent ([∗map] k ↦ x ∈ m, Φ k x) where
   persistent := bigOpM_closed (P := fun Q => Q ⊢ <pers> Q) persistently_emp_2
     (fun hx hy => (sep_mono hx hy).trans persistently_sep_2) (h · |>.persistent)
 
 @[rocq_alias big_sepM_persistent']
-instance bigSepM_persistent_inst {Φ : K → V → PROP} {m : M V} [∀ k x, Persistent (Φ k x)] :
+instance bigSepM_persistent_inst {Φ : μ.K → V → PROP} {m : M V} [∀ k x, Persistent (Φ k x)] :
     Persistent ([∗map] k ↦ x ∈ m, Φ k x) :=
   bigSepM_persistent fun _ => inferInstance
 
 @[rocq_alias big_sepM_empty_affine]
-instance bigSepM_nil_affine_inst {Φ : K → V → PROP} :
+instance bigSepM_nil_affine_inst {Φ : μ.K → V → PROP} :
     Affine ([∗map] k ↦ x ∈ (∅ : M V), Φ k x) where
   affine := bigSepM_empty.1.trans Affine.affine
 
 @[rocq_alias big_sepM_affine]
-theorem bigSepM_affine {Φ : K → V → PROP} {m : M V}
+theorem bigSepM_affine {Φ : μ.K → V → PROP} {m : M V}
     (h : ∀ {k x}, get? m k = some x → Affine (Φ k x)) :
     Affine ([∗map] k ↦ x ∈ m, Φ k x) where
   affine := bigOpM_closed (P := fun Q => Q ⊢ emp) .rfl
     (fun hx hy => (sep_mono hx hy).trans sep_emp.1) (h · |>.affine)
 
 @[rocq_alias big_sepM_affine']
-instance bigSepM_affine_inst {Φ : K → V → PROP} {m : M V} [∀ k x, Affine (Φ k x)] :
+instance bigSepM_affine_inst {Φ : μ.K → V → PROP} {m : M V} [∀ k x, Affine (Φ k x)] :
     Affine ([∗map] k ↦ x ∈ m, Φ k x) :=
   bigSepM_affine fun _ => inferInstance
 
-instance bigSepM_affine_biaffine_inst {Φ : K → V → PROP} {m : M V} [BIAffine PROP] :
+instance bigSepM_affine_biaffine_inst {Φ : μ.K → V → PROP} {m : M V} [BIAffine PROP] :
     Affine ([∗map] k ↦ x ∈ m, Φ k x) where
   affine := bigOpM_closed (P := fun Q => Q ⊢ emp) .rfl
     (fun hx hy => (sep_mono hx hy).trans sep_emp.1) (fun _ => Affine.affine)
 
 @[rocq_alias big_sepM_empty_timeless]
-instance bigSepM_nil_timeless_inst [Timeless (emp : PROP)] {Φ : K → V → PROP} :
+instance bigSepM_nil_timeless_inst [Timeless (emp : PROP)] {Φ : μ.K → V → PROP} :
     Timeless ([∗map] k ↦ x ∈ (∅ : M V), Φ k x) where
   timeless := (later_congr bigSepM_empty).1.trans (Timeless.timeless.trans (except0_mono bigSepM_empty.2))
 
 @[rocq_alias big_sepM_timeless]
-theorem bigSepM_timeless [Timeless (emp : PROP)] {Φ : K → V → PROP} {m : M V}
+theorem bigSepM_timeless [Timeless (emp : PROP)] {Φ : μ.K → V → PROP} {m : M V}
     (h : ∀ {k x}, get? m k = some x → Timeless (Φ k x)) :
     Timeless ([∗map] k ↦ x ∈ m, Φ k x) where
   timeless := bigOpM_closed (P := fun Q => ▷ Q ⊢ ◇ Q) Timeless.timeless
@@ -148,18 +148,18 @@ theorem bigSepM_timeless [Timeless (emp : PROP)] {Φ : K → V → PROP} {m : M 
     (h · |>.timeless)
 
 @[rocq_alias big_sepM_timeless']
-instance bigSepM_timeless_inst [Timeless (emp : PROP)] {Φ : K → V → PROP} {m : M V}
+instance bigSepM_timeless_inst [Timeless (emp : PROP)] {Φ : μ.K → V → PROP} {m : M V}
     [∀ k x, Timeless (Φ k x)] :
     Timeless ([∗map] k ↦ x ∈ m, Φ k x) :=
   bigSepM_timeless fun _ => inferInstance
 
 @[rocq_alias big_sepM_empty_absorbing]
-instance bigSepM_nil_absorbing_inst [BIAffine PROP] {Φ : K → V → PROP} :
+instance bigSepM_nil_absorbing_inst [BIAffine PROP] {Φ : μ.K → V → PROP} :
     Absorbing ([∗map] k ↦ x ∈ (∅ : M V), Φ k x) where
   absorbing := (absorbingly_mono bigSepM_empty.1).trans (absorbingly_emp.1.trans (true_emp.1.trans bigSepM_empty.2))
 
 @[rocq_alias big_sepM_absorbing]
-theorem bigSepM_absorbing [BIAffine PROP] {Φ : K → V → PROP} {m : M V}
+theorem bigSepM_absorbing [BIAffine PROP] {Φ : μ.K → V → PROP} {m : M V}
     (h : ∀ {k x}, get? m k = some x → Absorbing (Φ k x)) :
     Absorbing ([∗map] k ↦ x ∈ m, Φ k x) where
   absorbing := bigOpM_closed (P := fun Q => <absorb> Q ⊢ Q)
@@ -167,36 +167,36 @@ theorem bigSepM_absorbing [BIAffine PROP] {Φ : K → V → PROP} {m : M V}
     (fun hx hy => absorbingly_sep.1.trans (sep_mono hx hy)) (h · |>.absorbing)
 
 @[rocq_alias big_sepM_absorbing']
-instance bigSepM_absorbing_inst [BIAffine PROP] {Φ : K → V → PROP} {m : M V}
+instance bigSepM_absorbing_inst [BIAffine PROP] {Φ : μ.K → V → PROP} {m : M V}
     [∀ k x, Absorbing (Φ k x)] :
     Absorbing ([∗map] k ↦ x ∈ m, Φ k x) :=
   bigSepM_absorbing fun _ => inferInstance
 
 @[rocq_alias big_sepM_emp]
-theorem bigSepM_emp [DecidableEq K] {m : M V} :
-    bigSepM (fun (_ : K) (_ : V) => (emp : PROP)) m ⊣⊢ emp :=
+theorem bigSepM_emp [DecidableEq μ.K] {m : M V} :
+    bigSepM (fun (_ : μ.K) (_ : V) => (emp : PROP)) m ⊣⊢ emp :=
   equiv_iff.mp <| bigOpM_const_unit_equiv m
 
 @[rocq_alias big_sepM_sep]
-theorem bigSepM_sep_equiv {Φ Ψ : K → V → PROP} {m : M V} :
+theorem bigSepM_sep_equiv {Φ Ψ : μ.K → V → PROP} {m : M V} :
     ([∗map] k ↦ x ∈ m, iprop(Φ k x ∗ Ψ k x)) ≡
       iprop(([∗map] k ↦ x ∈ m, Φ k x) ∗ [∗map] k ↦ x ∈ m, Ψ k x) :=
   bigOpM_op_equiv Φ Ψ m
 
 @[deprecated "bigSepM_sep_equiv.symm" (since := "26/03/30"), rocq_alias big_sepM_sep_2]
-theorem bigSepM_sep_equiv_symm {Φ Ψ : K → V → PROP} {m : M V} :
+theorem bigSepM_sep_equiv_symm {Φ Ψ : μ.K → V → PROP} {m : M V} :
     iprop(([∗map] k ↦ x ∈ m, Φ k x) ∗ [∗map] k ↦ x ∈ m, Ψ k x) ≡
       [∗map] k ↦ x ∈ m, iprop(Φ k x ∗ Ψ k x) :=
   bigSepM_sep_equiv.symm
 
 @[rocq_alias big_sepM_and]
-theorem bigSepM_and {Φ Ψ : K → V → PROP} {m : M V} :
+theorem bigSepM_and {Φ Ψ : μ.K → V → PROP} {m : M V} :
     ([∗map] k ↦ x ∈ m, Φ k x ∧ Ψ k x) ⊢
       ([∗map] k ↦ x ∈ m, Φ k x) ∧ [∗map] k ↦ x ∈ m, Ψ k x :=
   and_intro (bigSepM_mono fun _ => and_elim_l) (bigSepM_mono fun _ => and_elim_r)
 
 @[rocq_alias big_sepM_wand]
-theorem bigSepM_wand {Φ Ψ : K → V → PROP} {m : M V} :
+theorem bigSepM_wand {Φ Ψ : μ.K → V → PROP} {m : M V} :
     ([∗map] k ↦ x ∈ m, Φ k x) ⊢
       ([∗map] k ↦ x ∈ m, iprop(Φ k x -∗ Ψ k x)) -∗ [∗map] k ↦ x ∈ m, Ψ k x :=
   wand_intro <| (equiv_iff.mp bigSepM_sep_equiv.symm).1.trans <|
@@ -205,7 +205,7 @@ theorem bigSepM_wand {Φ Ψ : K → V → PROP} {m : M V} :
 /-! ## Lookup Lemmas -/
 
 @[rocq_alias big_sepM_lookup_acc]
-theorem bigSepM_lookup_acc {Φ : K → V → PROP} {m : M V} {i : K} {x : V}
+theorem bigSepM_lookup_acc {Φ : μ.K → V → PROP} {m : M V} {i : μ.K} {x : V}
     (h : get? m i = some x) :
     ([∗map] k ↦ v ∈ m, Φ k v) ⊣⊢ Φ i x ∗ (Φ i x -∗ [∗map] k ↦ v ∈ m, Φ k v) := by
   refine ⟨?_, wand_elim_r⟩
@@ -214,21 +214,21 @@ theorem bigSepM_lookup_acc {Φ : K → V → PROP} {m : M V} {i : K} {x : V}
 
 
 @[rocq_alias big_sepM_lookup]
-theorem bigSepM_lookup {Φ : K → V → PROP} {m : M V} {i : K} {x : V}
+theorem bigSepM_lookup {Φ : μ.K → V → PROP} {m : M V} {i : μ.K} {x : V}
     (h : get? m i = some x) :
     [TCOr (∀ k v, Affine (Φ k v)) (Absorbing (Φ i x))] → ([∗map] k ↦ v ∈ m, Φ k v) ⊢ Φ i x
   | TCOr.l => (bigSepM_delete h).1.trans sep_elim_l
   | TCOr.r => (bigSepM_lookup_acc h).1.trans sep_elim_l
 
 @[rocq_alias big_sepM_lookup_dom]
-theorem bigSepM_lookup_dom {Φ : K → PROP} {m : M V} {i : K} {x : V}
+theorem bigSepM_lookup_dom {Φ : μ.K → PROP} {m : M V} {i : μ.K} {x : V}
     (h : get? m i = some x) :
     [TCOr (∀ k, Affine (Φ k)) (Absorbing (Φ i))] → ([∗map] k ↦ _v ∈ m, Φ k) ⊢ Φ i
   | TCOr.l => (bigSepM_delete h).1.trans sep_elim_l
   | TCOr.r => (bigSepM_lookup_acc h).1.trans sep_elim_l
 
 @[rocq_alias big_sepM_insert_acc]
-theorem bigSepM_insert_acc {Φ : K → V → PROP} {m : M V} {i : K} {x : V}
+theorem bigSepM_insert_acc {Φ : μ.K → V → PROP} {m : M V} {i : μ.K} {x : V}
     (h : get? m i = some x) :
     ([∗map] k ↦ v ∈ m, Φ k v) ⊢
       Φ i x ∗ (∀ v', Φ i v' -∗ [∗map] k ↦ v ∈ insert m i v', Φ k v) :=
@@ -236,7 +236,7 @@ theorem bigSepM_insert_acc {Φ : K → V → PROP} {m : M V} {i : K} {x : V}
     wand_intro <| sep_comm.1.trans bigSepM_insert_delete.2
 
 @[rocq_alias big_sepM_insert_2]
-theorem bigSepM_insert_elim {Φ : K → V → PROP} {m : M V} {i : K} {x : V} [∀ k v, Affine (Φ k v)] :
+theorem bigSepM_insert_elim {Φ : μ.K → V → PROP} {m : M V} {i : μ.K} {x : V} [∀ k v, Affine (Φ k v)] :
     ⊢ Φ i x -∗ ([∗map] k ↦ v ∈ m, Φ k v) -∗ [∗map] k ↦ v ∈ insert m i x, Φ k v :=
   entails_wand <| wand_intro <|
   match hm : get? m i with
@@ -244,39 +244,39 @@ theorem bigSepM_insert_elim {Φ : K → V → PROP} {m : M V} {i : K} {x : V} [�
   | some _ => (sep_mono_r ((bigSepM_delete hm).1.trans sep_elim_r)).trans bigSepM_insert_delete.2
 
 @[rocq_alias big_sepM_insert_override]
-theorem bigSepM_insert_exist {Φ : K → V → PROP} {m : M V} {i : K} {x x' : V}
+theorem bigSepM_insert_exist {Φ : μ.K → V → PROP} {m : M V} {i : μ.K} {x x' : V}
     (hi : get? m i = some x) (hΦ : Φ i x ≡ Φ i x') :
     ([∗map] k ↦ v ∈ insert m i x', Φ k v) ≡ [∗map] k ↦ v ∈ m, Φ k v :=
   bigOpM_insert_override_equiv hi hΦ
 
 @[rocq_alias big_sepM_insert_override_1]
-theorem bigSepM_insert_exist_elim {Φ : K → V → PROP} {m : M V} {i : K} {x x' : V}
+theorem bigSepM_insert_exist_elim {Φ : μ.K → V → PROP} {m : M V} {i : μ.K} {x x' : V}
     (hi : get? m i = some x) (hΦ : Φ i x ⊢ Φ i x') :
     ([∗map] k ↦ v ∈ m, Φ k v) ⊢ [∗map] k ↦ v ∈ insert m i x', Φ k v :=
   (bigSepM_delete hi).1.trans <| (sep_mono_l hΦ).trans bigSepM_insert_delete.2
 
 @[rocq_alias big_sepM_insert_override_2]
-theorem bigSepM_insert_exist_intro {Φ : K → V → PROP} {m : M V} {i : K} {x x' : V}
+theorem bigSepM_insert_exist_intro {Φ : μ.K → V → PROP} {m : M V} {i : μ.K} {x x' : V}
     (hi : get? m i = some x) (hΦ : Φ i x' ⊢ Φ i x) :
     ([∗map] k ↦ v ∈ insert m i x', Φ k v) ⊢ [∗map] k ↦ v ∈ m, Φ k v :=
   bigSepM_insert_delete.1.trans <| (sep_mono_l hΦ).trans (bigSepM_delete hi).2
 
 @[rocq_alias big_sepM_fn_insert]
-theorem bigSepM_fn_insert [DecidableEq K] {B : Type _} {g : K → V → B → PROP} {f : K → B}
-    {m : M V} {i : K} {x : V} {b : B} (hi : get? m i = none) :
+theorem bigSepM_fn_insert [DecidableEq μ.K] {B : Type _} {g : μ.K → V → B → PROP} {f : μ.K → B}
+    {m : M V} {i : μ.K} {x : V} {b : B} (hi : get? m i = none) :
     ([∗map] k ↦ y ∈ insert m i x, g k y (if k = i then b else f k)) ≡
     iprop(g i x b ∗ [∗map] k ↦ y ∈ m, g k y (f k)) :=
   bigOpM_fn_insert_equiv g f x b hi
 
 @[rocq_alias big_sepM_fn_insert']
-theorem bigSepM_fn_insert_key [DecidableEq K] {f : K → PROP} {m : M V} {i : K} {x : V} {P : PROP}
+theorem bigSepM_fn_insert_key [DecidableEq μ.K] {f : μ.K → PROP} {m : M V} {i : μ.K} {x : V} {P : PROP}
     (hi : get? m i = none) :
     ([∗map] k ↦ _v ∈ insert m i x, if k = i then P else f k) ≡
     iprop(P ∗ [∗map] k ↦ _v ∈ m, f k) :=
   bigOpM_fn_insert_equiv' f x P hi
 
 @[rocq_alias big_sepM_intro]
-theorem bigSepM_intro {P : PROP} [Intuitionistic P] {Φ : K → V → PROP} {m : M V}
+theorem bigSepM_intro {P : PROP} [Intuitionistic P] {Φ : μ.K → V → PROP} {m : M V}
     (h : ∀ {k v}, get? m k = some v → P ⊢ Φ k v) :
     P ⊢ [∗map] k ↦ x ∈ m, Φ k x := by
   refine bigOpM_closed (P := fun Q => P ⊢ Q)
@@ -284,7 +284,7 @@ theorem bigSepM_intro {P : PROP} [Intuitionistic P] {Φ : K → V → PROP} {m :
   exact Intuitionistic.intuitionistic.trans <| intuitionistically_sep_idem.2.trans <|
     sep_mono (intuitionistically_elim.trans hx) (intuitionistically_elim.trans hy)
 
-theorem bigSepM_forall_intro {Φ : K → V → PROP} {m : M V}
+theorem bigSepM_forall_intro {Φ : μ.K → V → PROP} {m : M V}
     [BIAffine PROP] [∀ k v, Persistent (Φ k v)] :
     ([∗map] k ↦ x ∈ m, Φ k x) ⊢ ∀ k, ∀ v, iprop(⌜get? m k = some v⌝ → Φ k v) :=
   forall_intro fun _ => forall_intro fun _ => imp_intro' <|
@@ -292,7 +292,7 @@ theorem bigSepM_forall_intro {Φ : K → V → PROP} {m : M V}
   (sep_mono_l Persistent.persistent).trans <| sep_comm.1.trans <|
   persistently_absorb_r.trans persistently_elim
 
-theorem bigSepM_forall_elim {Φ : K → V → PROP} {m : M V}
+theorem bigSepM_forall_elim {Φ : μ.K → V → PROP} {m : M V}
     [BIAffine PROP] [inst : ∀ k v, Persistent (Φ k v)] :
     (∀ k v, ⌜get? m k = some v⌝ → Φ k v) ⊢ [∗map] k ↦ x ∈ m, Φ k x :=
   (bigOpM_closed
@@ -305,13 +305,13 @@ theorem bigSepM_forall_elim {Φ : K → V → PROP} {m : M V}
       (imp_congr_l <| pure_true hget).1.trans true_imp.1, inst k x⟩)).1
 
 @[rocq_alias big_sepM_forall]
-theorem bigSepM_forall {Φ : K → V → PROP} {m : M V}
+theorem bigSepM_forall {Φ : μ.K → V → PROP} {m : M V}
     [BIAffine PROP] [∀ k v, Persistent (Φ k v)] :
     ([∗map] k ↦ x ∈ m, Φ k x) ⊣⊢ ∀ k, ∀ v, iprop(⌜get? m k = some v⌝ → Φ k v) :=
   ⟨bigSepM_forall_intro, bigSepM_forall_elim⟩
 
 @[rocq_alias big_sepM_impl]
-theorem bigSepM_impl {Φ Ψ : K → V → PROP} {m : M V} :
+theorem bigSepM_impl {Φ Ψ : μ.K → V → PROP} {m : M V} :
     ([∗map] k ↦ x ∈ m, Φ k x) ⊢
       □ (∀ k v, iprop(⌜get? m k = some v⌝ → Φ k v -∗ Ψ k v)) -∗
       [∗map] k ↦ x ∈ m, Ψ k x := by
@@ -323,18 +323,18 @@ theorem bigSepM_impl {Φ Ψ : K → V → PROP} {m : M V} :
 
 @[rocq_alias big_sepM_dup]
 theorem bigSepM_dup {P : PROP} [Affine P] {m : M V} :
-    □ (P -∗ P ∗ P) ∗ P ⊢ bigSepM (fun (_ : K) (_ : V) => P) m :=
+    □ (P -∗ P ∗ P) ∗ P ⊢ bigSepM (fun (_ : μ.K) (_ : V) => P) m :=
   bigSepL_dup
 
 @[rocq_alias big_sepM_pure_1]
-theorem bigSepM_pure_intro {φ : K → V → Prop} {m : M V} :
+theorem bigSepM_pure_intro {φ : μ.K → V → Prop} {m : M V} :
     ([∗map] k ↦ x ∈ m, (⌜φ k x⌝ : PROP)) ⊢ ⌜all φ m⌝ :=
   bigSepL_pure_intro.trans <| pure_mono fun h k v hget =>
     let ⟨idx, hidx⟩ := List.mem_iff_getElem.mp <| toList_get.mpr hget
     h idx ⟨k, v⟩ <| List.getElem?_eq_some_iff.mpr ⟨hidx.1, hidx.2⟩
 
 @[rocq_alias big_sepM_affinely_pure_2]
-theorem bigSepM_affinely_pure_elim {φ : K → V → Prop} {m : M V} :
+theorem bigSepM_affinely_pure_elim {φ : μ.K → V → Prop} {m : M V} :
     (<affine> ⌜all φ m⌝) ⊢ [∗map] k ↦ x ∈ m, (<affine> ⌜φ k x⌝ : PROP) := by
   refine bigOpM_closed (P := fun Q => (<affine> ⌜all φ m⌝) ⊢ Q)
     affinely_elim_emp (fun hx hy => ?_) (fun hget => affinely_mono <|
@@ -344,18 +344,18 @@ theorem bigSepM_affinely_pure_elim {φ : K → V → Prop} {m : M V} :
     persistent_and_sep_1.trans <| sep_mono hx hy
 
 @[rocq_alias big_sepM_pure]
-theorem bigSepM_pure [BIAffine PROP] {φ : K → V → Prop} {m : M V} :
+theorem bigSepM_pure [BIAffine PROP] {φ : μ.K → V → Prop} {m : M V} :
     ([∗map] k ↦ x ∈ m, ⌜φ k x⌝ : PROP) ⊣⊢ ⌜all φ m⌝ :=
   ⟨bigSepM_pure_intro, (affine_affinely _).2.trans <|
     bigSepM_affinely_pure_elim.trans <| bigSepM_mono fun _ => affinely_elim⟩
 
 @[rocq_alias big_sepM_map_to_list]
-theorem bigSepM_toList {Φ : K → V → PROP} {m : M V} :
-    ([∗map] k ↦ x ∈ m, Φ k x) ⊣⊢ ([∗list] kv ∈ toList (K := K) m, Φ kv.1 kv.2) :=
+theorem bigSepM_toList {Φ : μ.K → V → PROP} {m : M V} :
+    ([∗map] k ↦ x ∈ m, Φ k x) ⊣⊢ ([∗list] kv ∈ toList m, Φ kv.1 kv.2) :=
   .rfl
 
 @[rocq_alias big_sepM_list_to_map]
-theorem bigSepM_ofList [DecidableEq K] {Φ : K → V → PROP} {l : List (K × V)}
+theorem bigSepM_ofList [DecidableEq μ.K] {Φ : μ.K → V → PROP} {l : List (μ.K × V)}
     (hd : NoDupKeys l) :
     ([∗map] k ↦ x ∈ (ofList l : M V), Φ k x) ⊣⊢
       [∗list] kv ∈ l, Φ kv.1 kv.2 :=
@@ -364,59 +364,59 @@ theorem bigSepM_ofList [DecidableEq K] {Φ : K → V → PROP} {l : List (K × V
 /-! ## Persistently and Later -/
 
 @[rocq_alias big_sepM_persistently]
-theorem bigSepM_persistently {Φ : K → V → PROP} {m : M V} [BIAffine PROP] :
+theorem bigSepM_persistently {Φ : μ.K → V → PROP} {m : M V} [BIAffine PROP] :
     (<pers> [∗map] k ↦ x ∈ m, Φ k x) ⊣⊢ [∗map] k ↦ x ∈ m, <pers> Φ k x :=
   letI := MonoidHomomorphism.ofEquiv (PROP := PROP) persistently_ne
     (equiv_iff.mpr persistently_sep) (equiv_iff.mpr persistently_emp')
   equiv_iff.mp <| bigOpL_hom _ (toList m)
 
 @[rocq_alias big_sepM_later]
-theorem bigSepM_later {Φ : K → V → PROP} {m : M V} [BIAffine PROP] :
+theorem bigSepM_later {Φ : μ.K → V → PROP} {m : M V} [BIAffine PROP] :
     (▷ [∗map] k ↦ x ∈ m, Φ k x) ⊣⊢ [∗map] k ↦ x ∈ m, ▷ Φ k x :=
   letI := MonoidHomomorphism.ofEquiv (PROP := PROP) later_ne
     (equiv_iff.mpr later_sep) (equiv_iff.mpr later_emp)
   equiv_iff.mp <| bigOpL_hom _ <| toList m
 
 @[rocq_alias big_sepM_later_2]
-theorem bigSepM_later_2 {Φ : K → V → PROP} {m : M V} :
+theorem bigSepM_later_2 {Φ : μ.K → V → PROP} {m : M V} :
     ([∗map] k ↦ x ∈ m, ▷ Φ k x) ⊢ iprop(▷ [∗map] k ↦ x ∈ m, Φ k x) :=
   bigOpM_gen_proper (R := fun a b => a ⊢ later b)
     later_intro (fun h1 h2 => (sep_mono h1 h2).trans later_sep.2) (fun _ => .rfl)
 
 @[rocq_alias big_sepM_laterN]
-theorem bigSepM_laterN {Φ : K → V → PROP} {m : M V} {n : Nat} [BIAffine PROP] :
+theorem bigSepM_laterN {Φ : μ.K → V → PROP} {m : M V} {n : Nat} [BIAffine PROP] :
     (▷^[n] [∗map] k ↦ x ∈ m, Φ k x) ⊣⊢ [∗map] k ↦ x ∈ m, ▷^[n] Φ k x :=
   match n with
   | 0 => .rfl
   | _ + 1 => (later_congr bigSepM_laterN).trans bigSepM_later
 
 @[rocq_alias big_sepM_laterN_2]
-theorem bigSepM_laterN_2 {Φ : K → V → PROP} {m : M V} {n : Nat} :
+theorem bigSepM_laterN_2 {Φ : μ.K → V → PROP} {m : M V} {n : Nat} :
     ([∗map] k ↦ x ∈ m, ▷^[n] Φ k x) ⊢ ▷^[n] [∗map] k ↦ x ∈ m, Φ k x :=
   match n with
   | 0 => .rfl
   | _ + 1 => bigSepM_later_2.trans <| later_mono bigSepM_laterN_2
 
 @[rocq_alias big_sepM_fmap]
-theorem bigSepM_map {Φ : K → V → PROP} {m : M V} {f : V → V} :
+theorem bigSepM_map {Φ : μ.K → V → PROP} {m : M V} {f : V → V} :
     ([∗map] k ↦ y ∈ map f m, Φ k y) ≡ [∗map] k ↦ y ∈ m, Φ k (f y) :=
   bigOpM_map_equiv f Φ m
 
 @[rocq_alias big_sepM_omap]
-theorem bigSepM_filterMap {Φ : K → V → PROP} {m : M V} {f : V → Option V}
+theorem bigSepM_filterMap {Φ : μ.K → V → PROP} {m : M V} {f : V → Option V}
     (hinj : Function.Injective f) :
     ([∗map] k ↦ y ∈ filterMap f m, Φ k y) ≡
       [∗map] k ↦ y ∈ m, (f y).elim iprop(emp) (Φ k) :=
   bigOpM_filterMap_equiv Φ m hinj
 
 @[rocq_alias big_sepM_filter']
-theorem bigSepM_filter_cond {Φ : K → V → PROP} {m : M V} (p : K → V → Bool) :
+theorem bigSepM_filter_cond {Φ : μ.K → V → PROP} {m : M V} (p : μ.K → V → Bool) :
     ([∗map] k ↦ x ∈ filter p m, Φ k x) ≡
       [∗map] k ↦ x ∈ m, if p k x then Φ k x else emp :=
   bigOpM_filter_equiv p Φ m
 
 @[rocq_alias big_sepM_filter]
-theorem bigSepM_filter [BIAffine PROP] {Φ : K → V → PROP} {m : M V} (p : K → V → Bool) :
+theorem bigSepM_filter [BIAffine PROP] {Φ : μ.K → V → PROP} {m : M V} (p : μ.K → V → Bool) :
     ([∗map] k ↦ x ∈ filter p m, Φ k x) ≡
       [∗map] k ↦ x ∈ m, iprop(⌜p k x = true⌝ → Φ k x) :=
   (bigSepM_filter_cond p).trans <| bigOpM_proper fun {k x} _ => by
@@ -425,12 +425,12 @@ theorem bigSepM_filter [BIAffine PROP] {Φ : K → V → PROP} {m : M V} (p : K 
     | true => simpa using equiv_iff.mpr true_imp.symm
 
 @[rocq_alias big_sepM_union]
-theorem bigSepM_union [DecidableEq K] {Φ : K → V → PROP} {m₁ m₂ : M V} (hdisj : m₁ ##ₘ m₂) :
+theorem bigSepM_union [DecidableEq μ.K] {Φ : μ.K → V → PROP} {m₁ m₂ : M V} (hdisj : m₁ ##ₘ m₂) :
     ([∗map] k ↦ y ∈ m₁ ∪ m₂, Φ k y) ⊣⊢ ([∗map] k ↦ y ∈ m₁, Φ k y) ∗ [∗map] k ↦ y ∈ m₂, Φ k y :=
   equiv_iff.mp <| bigOpM_union_equiv Φ m₁ m₂ hdisj
 
 @[rocq_alias big_sepM_subseteq]
-theorem bigSepM_subseteq [DecidableEq K] {Φ : K → V → PROP} {m₁ m₂ : M V}
+theorem bigSepM_subseteq [DecidableEq μ.K] {Φ : μ.K → V → PROP} {m₁ m₂ : M V}
     [∀ k v, Affine (Φ k v)] (h : m₂ ⊆ m₁) :
     ([∗map] k ↦ x ∈ m₁, Φ k x) ⊢ [∗map] k ↦ x ∈ m₂, Φ k x :=
   (equiv_iff.mp <| bigOpM_equiv_of_perm Φ <| union_difference_cancel h).2.trans <|
@@ -438,16 +438,16 @@ theorem bigSepM_subseteq [DecidableEq K] {Φ : K → V → PROP} {m₁ m₂ : M 
 
 -- FIXME: Refactor for readability
 @[rocq_alias big_sepM_lookup_acc_impl]
-theorem bigSepM_lookup_acc_impl [DecidableEq K] {Φ : K → V → PROP} {m : M V} {i : K} {x : V}
+theorem bigSepM_lookup_acc_impl [DecidableEq μ.K] {Φ : μ.K → V → PROP} {m : M V} {i : μ.K} {x : V}
     (h : get? m i = some x) :
     ([∗map] k ↦ v ∈ m, Φ k v) ⊢
-      Φ i x ∗ ∀ (Ψ : K → V → PROP),
+      Φ i x ∗ ∀ (Ψ : μ.K → V → PROP),
         □ (∀ k v, (⌜get? m k = some v⌝ → ⌜k ≠ i⌝ → Φ k v -∗ Ψ k v)) -∗
         Ψ i x -∗ ([∗map] k ↦ v ∈ m, Ψ k v) := by
   refine (bigSepM_delete h).1.trans <| sep_mono_r <| forall_intro fun Ψ => ?_
   refine wand_intro <| wand_intro <| sep_comm.1.trans <| ?_
   refine .trans ?_ (bigSepM_delete h).2
-  have hki_of {k : K} {v : V} (hget : get? (delete m i) k = some v) : k ≠ i :=
+  have hki_of {k : μ.K} {v : V} (hget : get? (delete m i) k = some v) : k ≠ i :=
     fun heq => absurd hget.symm <| (get?_delete_eq heq.symm) ▸ nofun
   refine (sep_mono_r <| (sep_mono_r <|
     bigSepM_intro (m := delete m i)
@@ -463,7 +463,7 @@ theorem bigSepM_lookup_acc_impl [DecidableEq K] {Φ : K → V → PROP} {m : M V
 
 @[rocq_alias big_sepM_sep_zip_with]
 theorem bigSepM_sep_zipWith {A B C : Type _}
-    {f : A → B → C} {g₁ : C → A} {g₂ : C → B} {Φ₁ : K → A → PROP} {Φ₂ : K → B → PROP}
+    {f : A → B → C} {g₁ : C → A} {g₂ : C → B} {Φ₁ : μ.K → A → PROP} {Φ₂ : μ.K → B → PROP}
     {m₁ : M A} {m₂ : M B} (hg₁ : ∀ {x y}, g₁ (f x y) = x) (hg₂ : ∀ {x y}, g₂ (f x y) = y)
     (hdom : ∀ k, (get? m₁ k).isSome ↔ (get? m₂ k).isSome) :
     ([∗map] k ↦ xy ∈ zipWith f m₁ m₂, Φ₁ k (g₁ xy) ∗ Φ₂ k (g₂ xy)) ⊣⊢
@@ -472,7 +472,7 @@ theorem bigSepM_sep_zipWith {A B C : Type _}
 
 @[rocq_alias big_sepM_sep_zip]
 theorem bigSepM_sep_zip {A B : Type _}
-    {Φ₁ : K → A → PROP} {Φ₂ : K → B → PROP}
+    {Φ₁ : μ.K → A → PROP} {Φ₂ : μ.K → B → PROP}
     {m₁ : M A} {m₂ : M B}
     (hdom : ∀ k, (get? m₁ k).isSome ↔ (get? m₂ k).isSome) :
     ([∗map] k ↦ xy ∈ zip m₁ m₂, Φ₁ k xy.1 ∗ Φ₂ k xy.2) ⊣⊢
@@ -482,21 +482,23 @@ theorem bigSepM_sep_zip {A B : Type _}
 
 -- FIXME: Refactor for readability
 @[rocq_alias big_sepM_impl_strong]
-theorem bigSepM_impl_strong [DecidableEq K] {M₂ : Type _ → Type _} {V₂ : Type _}
-    [LawfulFiniteMap M₂ K] {Φ : K → V → PROP} {Ψ : K → V₂ → PROP} {m₁ : M V} {m₂ : M₂ V₂} :
+theorem bigSepM_impl_strong {M₂ : Type _ → Type _} {V₂ : Type _}
+    [μ₂ : LawfulFiniteMap M₂] [DecidableEq μ.K] {Φ : μ.K → V → PROP} 
+    {Ψ : μ.K → V₂ → PROP} {m₁ : M V} {m₂ : M₂ V₂} (Keq : μ.K = μ₂.K := by rfl) :
     ([∗map] k ↦ x ∈ m₁, Φ k x) ∗
-    □ (∀ k, ∀ y, (get? m₁ k).elim emp (Φ k) -∗ ⌜get? m₂ k = some y⌝ → Ψ k y)
-    ⊢ ([∗map] k ↦ y ∈ m₂, Ψ k y) ∗
-      [∗map] k ↦ x ∈ filter (fun k _ => (get? m₂ k).isNone) m₁, Φ k x := by
-  let P (m₂ : M₂ V₂) : Prop := ∀ m₁ : M V,
-    ([∗map] k ↦ x ∈ m₁, Φ k x) ∗
-    □ (∀ k y, (get? m₁ k).elim emp (Φ k) -∗ ⌜get? m₂ k = some y⌝ → Ψ k y)
-    ⊢ ([∗map] k ↦ y ∈ m₂, Ψ k y) ∗
-      [∗map] k ↦ x ∈ filter (fun k _ => (get? m₂ k).isNone) m₁, Φ k x
-  suffices P m₂ from this m₁
-  refine LawfulFiniteMap.induction_on (K := K) (fun _ _ heq IH m₁ => ?hequiv) ?hemp ?hind m₂
-  case hequiv =>
-    refine (sep_mono_r ?_).trans <| (IH m₁).trans ?_
+    □ (∀ k, ∀ y, (get? m₁ k).elim emp (Φ k) -∗ ⌜get? m₂ (Keq▸k) = some y⌝ → Ψ k y)
+    ⊢ ([∗map] k ↦ y ∈ m₂, Ψ (Keq▸k) y) ∗
+      [∗map] k ↦ x ∈ filter (fun k _ => (get? m₂ (Keq▸k)).isNone) m₁, Φ k x := by
+  /- let P (m₂ : M₂ V₂) : Prop := ∀ m₁ : M V, -/
+  /-   ([∗map] k ↦ x ∈ m₁, Φ k x) ∗ -/
+  /-   □ (∀ k y, (get? m₁ k).elim emp (Φ k) -∗ ⌜get? m₂ (Keq▸k) = some y⌝ → Ψ k y) -/
+  /-   ⊢ ([∗map] k ↦ y ∈ m₂, Ψ (Keq▸k) y) ∗ -/
+  /-     [∗map] k ↦ x ∈ filter (fun k _ => (get? m₂ (Keq▸k)).isNone) m₁, Φ k x -/
+  /- suffices P m₂ from this m₁ -/
+  induction m₂ using LawfulFiniteMap.induction_on generalizing m₁
+  /- refine LawfulFiniteMap.induction_on (fun _ _ heq IH m₁ => ?hequiv) ?hemp ?hind m₂ -/
+  case hequiv _ _ heq IH =>
+    refine (sep_mono_r ?_).trans <| (IH m).trans ?_
     · refine intuitionistically_mono ?_
       refine forall_mono fun k => ?_
       refine forall_mono fun y => ?_
@@ -550,7 +552,7 @@ theorem bigSepM_impl_strong [DecidableEq K] {M₂ : Type _ → Type _} {V₂ : T
       have H : Φ i x ∗ ((get? m₁ i).elim emp (Φ i) -∗ ⌜get? (insert m₂'' i y) i = some y⌝ → Ψ i y) ⊢ Ψ i y := by
         simpa [hm₁i, get?_insert_eq rfl] using (sep_mono_r <| wand_mono_r true_imp.1).trans wand_elim_r
       refine (sep_mono_l <| (sep_mono_r intuitionistically_elim).trans <| (sep_mono_r <| (forall_elim i).trans <| forall_elim y).trans H).trans ?_
-      have hadapt (k : K) (y' : V₂) :
+      have hadapt (k : μ.K) (y' : V₂) :
           ((get? m₁ k).elim emp (Φ k) -∗ ⌜get? (insert m₂'' i y) k = some y'⌝ → Ψ k y') ⊢
           (get? (delete m₁ i) k).elim emp (Φ k) -∗ ⌜get? m₂'' k = some y'⌝ → Ψ k y' :=
         wand_intro <| imp_intro' <| pure_elim_l fun hget => by
@@ -569,18 +571,18 @@ theorem bigSepM_impl_strong [DecidableEq K] {M₂ : Type _ → Type _} {V₂ : T
 /-! ## Map–Set Interaction -/
 
 section MapSet
-variable {S : Type _} [LawfulFiniteSet S K]
+variable {S : Type _} [LawfulFiniteSet S μ.K]
 
 @[rocq_alias big_sepM_dom]
-theorem bigSepM_dom {Φ : K → PROP} {m : M V} :
+theorem bigSepM_dom {Φ : μ.K → PROP} {m : M V} :
     ([∗map] k ↦ _v ∈ m, Φ k) ⊣⊢ ([∗set] k ∈ (FiniteMap.dom_set m : S), Φ k) := by
   exact equiv_iff.mp <|
     ((bigOpL_map_equiv Prod.fst _ _).symm).trans <|
     (bigOpL_equiv_of_perm _ <| LawfulFiniteMap.toList_dom_set_perm m).symm
 
 @[rocq_alias big_sepM_impl_dom_subseteq]
-theorem bigSepM_impl_dom_subseteq [DecidableEq K] {M₂ : Type _ → Type _} {V₂ : Type _}
-    [LawfulFiniteMap M₂ K] {Φ : K → V → PROP} {Ψ : K → V₂ → PROP}
+theorem bigSepM_impl_dom_subseteq [DecidableEq μ.K] {M₂ : Type _ → Type _} {V₂ : Type _}
+    [LawfulFiniteMap M₂ μ.K] {Φ : μ.K → V → PROP} {Ψ : μ.K → V₂ → PROP}
     {m₁ : M V} {m₂ : M₂ V₂} (hdom : FiniteMap.dom_set (S := S) m₂ ⊆ FiniteMap.dom_set m₁) :
     ([∗map] k ↦ x ∈ m₁, Φ k x) ⊢
     □ (∀ k, ∀ x, ∀ y, ⌜get? m₁ k = some x⌝ → ⌜get? m₂ k = some y⌝ → Φ k x -∗ Ψ k y) -∗

--- a/src/Iris/BI/BigOp/BigSepMap.lean
+++ b/src/Iris/BI/BigOp/BigSepMap.lean
@@ -330,7 +330,7 @@ theorem bigSepM_dup {P : PROP} [Affine P] {m : M V} :
 theorem bigSepM_pure_intro {φ : K → V → Prop} {m : M V} :
     ([∗map] k ↦ x ∈ m, (⌜φ k x⌝ : PROP)) ⊢ ⌜all φ m⌝ :=
   bigSepL_pure_intro.trans <| pure_mono fun h k v hget =>
-    let ⟨idx, hidx⟩ := List.mem_iff_getElem.mp <| toList_get (M := M).mpr hget
+    let ⟨idx, hidx⟩ := List.mem_iff_getElem.mp <| toList_get.mpr hget
     h idx ⟨k, v⟩ <| List.getElem?_eq_some_iff.mpr ⟨hidx.1, hidx.2⟩
 
 @[rocq_alias big_sepM_affinely_pure_2]
@@ -448,7 +448,7 @@ theorem bigSepM_lookup_acc_impl [DecidableEq K] {Φ : K → V → PROP} {m : M V
   refine wand_intro <| wand_intro <| sep_comm.1.trans <| ?_
   refine .trans ?_ (bigSepM_delete h).2
   have hki_of {k : K} {v : V} (hget : get? (delete m i) k = some v) : k ≠ i :=
-    fun heq => absurd hget.symm <| (get?_delete_eq (M := M) heq.symm) ▸ nofun
+    fun heq => absurd hget.symm <| (get?_delete_eq heq.symm) ▸ nofun
   refine (sep_mono_r <| (sep_mono_r <|
     bigSepM_intro (m := delete m i)
       (Φ := fun k v => if k = i then emp else iprop(Φ k v -∗ Ψ k v))

--- a/src/Iris/BI/BigOp/BigSepSet.lean
+++ b/src/Iris/BI/BigOp/BigSepSet.lean
@@ -305,9 +305,9 @@ theorem bigSepS_comm_set {B : Type _} {T : Type _} [LawfulFiniteSet T B]
     bigSepS_elements.symm
 
 @[rocq_alias big_sepS_sepM]
-theorem bigSepS_comm_map {B : Type _} {M : Type _ → Type _} {K : Type _}
-    [LawfulFiniteMap M K]
-    (Φ : A → K → B → PROP) (X : S) (m : M B) :
+theorem bigSepS_comm_map {B : Type _} {M : Type _ → Type _}
+    [μ : LawfulFiniteMap M]
+    (Φ : A → μ.K → B → PROP) (X : S) (m : M B) :
     ([∗set] x ∈ X, [∗map] k↦y ∈ m, Φ x k y) ⊣⊢
       ([∗map] k↦y ∈ m, [∗set] x ∈ X, Φ x k y) := by
   refine bigSepS_elements.trans ?_

--- a/src/Iris/BI/Plainly.lean
+++ b/src/Iris/BI/Plainly.lean
@@ -649,11 +649,11 @@ instance  bigSepS_plain {S} [Pos.Countable S] {A} [LawfulFiniteSet S A] (Φ : A 
     case hemp => simp only [BigOpS.bigOpS_empty, plain]
     case hadd x s x_s IH =>
       calc iprop([^ sep set] x ∈ insert x s, Φ x)
-        _ ⊣⊢ Φ x ∗ [^ sep set] x ∈  s, Φ x := BI.equiv_iff.1 (BigOpS.bigOpS_insert x_s)
+        _ ⊣⊢ Φ x ∗ [^ sep set] x ∈  s, Φ x := BI.equiv_iff.1 (BigOpS.insert x_s)
         _  ⊢ ■ Φ x ∗ ■ [^ sep set] x ∈ s, Φ x := sep_mono (h x |>.plain) IH
         _  ⊢ ■ (Φ x ∗ [^ sep set] x ∈ s, Φ x) := plainly_sep_2
         _ ⊣⊢ ■ [^ sep set] y ∈ insert x s, Φ y :=
-          .ofMono plainly_mono <| BI.equiv_iff.1 (BigOpS.bigOpS_insert x_s).symm
+          .ofMono plainly_mono <| BI.equiv_iff.1 (BigOpS.insert x_s).symm
 
 instance plainly_timeless (P : PROP) [Timeless P] : Timeless iprop(■ P) :=
   inferInstanceAs (Timeless iprop(<si_pure> <si_emp_valid> P))

--- a/src/Iris/Std/HeapInstances.lean
+++ b/src/Iris/Std/HeapInstances.lean
@@ -36,7 +36,8 @@ section FunPartialMap
 variable {K V : Type _} [DecidableEq K]
 
 /-- Functions form a partial map. -/
-instance instPartialMapFun : PartialMap (K → Option ·) K where
+instance instPartialMapFun : PartialMap (K → Option ·) where
+  K := K
   get? t k := t k
   insert t k v := fun k' => if k = k' then some v else t k'
   delete t k := fun k' => if k = k' then none else t k'
@@ -49,7 +50,7 @@ instance instPartialMapFun : PartialMap (K → Option ·) K where
     | none, some y => some y
     | some x, some y => some <| f k x y
 
-instance : LawfulPartialMap (K → Option ·) K where
+instance : LawfulPartialMap (K → Option ·) where
   get?_empty := by simp [get?, empty]
   get?_insert_eq := by simp [get?, insert]; grind
   get?_insert_ne := by simp [get?, insert]; grind
@@ -193,7 +194,8 @@ abbrev op_lift (op : V → V → V) (v1 v2 : Option V) : Option V :=
   | none, none => none
 
 /-- PartialMap instance for AssocList. -/
-instance AssocList.instPartialMapAssocList : Iris.Std.PartialMap AssocList Nat where
+instance AssocList.instPartialMapAssocList : Iris.Std.PartialMap AssocList where
+  K := Nat
   get? f k := f.lookup k
   insert f k v := f.update k (some v)
   delete f k := f.update k none
@@ -202,7 +204,7 @@ instance AssocList.instPartialMapAssocList : Iris.Std.PartialMap AssocList Nat w
   merge op t1 t2 :=
     construct (fun n => op_lift (op n) (t1.lookup n) (t2.lookup n)) (max t1.fresh t2.fresh)
 
-instance AssocList.instLawfulPartialMapAssocList : Iris.Std.LawfulPartialMap AssocList Nat where
+instance AssocList.instLawfulPartialMapAssocList : Iris.Std.LawfulPartialMap AssocList where
   get?_empty := by simp [get?]
   get?_insert_eq := by simp [get?, insert]; grind
   get?_insert_ne := by simp [get?, insert]; grind
@@ -278,7 +280,8 @@ open Iris.Std
 variable {K V : Type _} [Ord K] [TransOrd K] [LawfulEqOrd K]
 
 /-- TreeMap forms a Store with Option values. -/
-instance instStoreTreeMap : PartialMap (TreeMap K · compare) K where
+instance instStoreTreeMap : PartialMap (TreeMap K · compare) where
+  K := K
   get? t k := t[k]?
   insert t k v := t.alter k (fun _ => some v)
   delete t k := t.alter k (fun _ => none)
@@ -386,7 +389,7 @@ theorem getElem?_mergeWith' {t₁ t₂ : TreeMap K V compare} {f : K → V → V
     simp [← hval, hfind]
     simp [eq_of_compare hkv_cmp]
 
-instance : LawfulPartialMap (TreeMap K · compare) K where
+instance : LawfulPartialMap (TreeMap K · compare) where
   get?_empty := by simp [Iris.Std.get?, Iris.Std.empty]
   get?_insert_eq := by simp [Iris.Std.get?, Iris.Std.insert]; grind
   get?_insert_ne := by simp [Iris.Std.get?, Iris.Std.insert]; grind
@@ -395,10 +398,10 @@ instance : LawfulPartialMap (TreeMap K · compare) K where
   get?_bindAlter := by simp [Iris.Std.get?, Iris.Std.bindAlter]
   get?_merge := getElem?_mergeWith'
 
-instance : FiniteMap (TreeMap K · compare) K where
+instance : FiniteMap (TreeMap K · compare) where
   toList t := t.toList
 
-instance : LawfulFiniteMap (TreeMap K · compare) K where
+instance : LawfulFiniteMap (TreeMap K · compare) where
   toList_empty := rfl
   toList_noDupKeys := by
     intro V m
@@ -440,7 +443,8 @@ variable {K V : Type _} [Ord K] [TransOrd K] [LawfulEqOrd K]
 Note: This requires that `cmp k k' = .eq` implies `k = k'` (i.e., `LawfulEqCmp`).
 -/
 
-instance : PartialMap (ExtTreeMap K · compare) K where
+instance : PartialMap (ExtTreeMap K · compare) where
+  K := K
   get? t k := t[k]?
   insert t k v := t.alter k (fun _ => some v)
   delete t k := t.alter k (fun _ => none)
@@ -460,7 +464,7 @@ theorem getElem?_mergeWith' {t₁ t₂ : ExtTreeMap K V compare} :
   | _ m₁ => induction q₂ using Quotient.ind with
     | _ m₂ => exact Std.TreeMap.getElem?_mergeWith'
 
-instance : LawfulPartialMap (ExtTreeMap K · compare) K where
+instance : LawfulPartialMap (ExtTreeMap K · compare) where
   get?_empty := by simp [Iris.Std.get?, Iris.Std.empty]
   get?_insert_eq := by simp [Iris.Std.get?, Iris.Std.insert]; grind
   get?_insert_ne := by simp [Iris.Std.get?, Iris.Std.insert]; grind
@@ -469,10 +473,10 @@ instance : LawfulPartialMap (ExtTreeMap K · compare) K where
   get?_bindAlter := by simp [Iris.Std.get?, Iris.Std.bindAlter]
   get?_merge := getElem?_mergeWith'
 
-instance : FiniteMap (ExtTreeMap K · compare) K where
+instance : FiniteMap (ExtTreeMap K · compare) where
   toList t := t.toList
 
-instance : LawfulFiniteMap (ExtTreeMap K · compare) K where
+instance : LawfulFiniteMap (ExtTreeMap K · compare) where
   toList_empty := rfl
   toList_noDupKeys {V m} := by
     suffices h : List.Pairwise (fun a b => ¬compare a b = eq) (m.toList.map (·.1)) by

--- a/src/Iris/Std/PartialMap.lean
+++ b/src/Iris/Std/PartialMap.lean
@@ -310,7 +310,7 @@ theorem get?_insert_rev {m : M V} {i : μ.K} {x y : V} :
 
 theorem empty_subset (m : M V) : (∅ : M V) ⊆ m := by
   intro k v h
-  simp [show get? (∅ : M V) k = none from get?_empty (M := M) k] at h
+  simp [show get? (∅ : M V) k = none from get?_empty k] at h
 
 theorem disjoint_empty_left (m : M V) : (∅ : M V) ##ₘ m := by
   intro k ⟨h₁, _⟩
@@ -748,7 +748,7 @@ theorem isSome_zip {m₁ : M V} {m₂ : M V'} {k : μ.K} :
   rw [get?_zip]
   cases h1 : get? m₁ k <;> cases h2 : get? m₂ k <;> simp
 
-theorem ofList_cons {L : List (μ.K × V)} : ofList (M := M) ((k, v) :: L) = insert (ofList L) k v :=
+theorem ofList_cons {L : List (μ.K × V)} : ofList ((k, v) :: L) = insert (ofList L) k v :=
   rfl
 
 theorem noDupKeys_cons {L : List (μ.K × V)} : NoDupKeys (h :: L) → NoDupKeys L := by
@@ -775,7 +775,7 @@ theorem noDupKeys_inj {L : List (μ.K × V)} (Hdup : NoDupKeys L) (Hin : (k, v) 
       | inr hmem' => exact IH ht hmem hmem'
 
 theorem get?_ofList_some [DecidableEq μ.K] {L : List (μ.K × V)}
-    (Hin : (k, v) ∈ L) (Hdup : NoDupKeys L) : get? (ofList (M := M) L) k = some v := by
+    (Hin : (k, v) ∈ L) (Hdup : NoDupKeys L) : get? (ofList L) k = some v := by
   induction L
   · simp at Hin
   rename_i h t IH
@@ -790,7 +790,7 @@ theorem get?_ofList_some [DecidableEq μ.K] {L : List (μ.K × V)}
 
 theorem get?_ofList_none {L : List (μ.K × V)}
     (Hin : ¬ ∃ v, (k, v) ∈ L) (Hdup : NoDupKeys L) :
-    get? (ofList (M := M) L) k = none  := by
+    get? (ofList L) k = none  := by
   induction L
   · simp [ofList, get?_empty]
   rename_i h t IH
@@ -859,7 +859,7 @@ theorem induction_on [DecidableEq μ.K] {P : M V → Prop}
   | cons kv rest ih =>
     rw [ofList_cons]
     apply hins kv.1 kv.2
-    · refine get?_ofList_none (M := M) ?_ (noDupKeys_cons hnd)
+    · refine get?_ofList_none ?_ (noDupKeys_cons hnd)
       intro ⟨v, hv⟩
       exact (List.nodup_cons.mp hnd).1 (List.mem_map_of_mem (f := Prod.fst) (a := (kv.1, v)) hv)
     · exact ih (noDupKeys_cons hnd)
@@ -880,14 +880,14 @@ theorem mem_of_mem_ofList [DecidableEq μ.K] {l : List (μ.K × V)} {i : μ.K} {
       exact List.mem_cons_of_mem (k, v) (IH H)
 
 theorem toList_ofList [DecidableEq μ.K] {l : List (μ.K × V)} (Hdup : NoDupKeys l) :
-    (toList (M := M) (ofList l : M V)).Perm l := by
+    (toList (ofList l : M V)).Perm l := by
   refine (List.perm_ext_iff_of_nodup nodup_toList ?_).mpr fun ⟨k, v⟩ => ⟨?_, ?_⟩
   · exact NoDupKeys_noDup Hdup
   · exact (mem_of_mem_ofList <| toList_get.mp ·)
   · exact (toList_get.mpr <| get?_ofList_some · Hdup)
 
 theorem toList_perm_of_get?_eq {m₁ m₂ : M V} (h : ∀ k, get? m₁ k = get? m₂ k) :
-    (toList (M := M) m₁).Perm (toList (M := M) m₂) := by
+    (toList m₁).Perm (toList m₂) := by
   refine (List.perm_ext_iff_of_nodup nodup_toList nodup_toList).mpr fun ⟨k, v⟩ => ⟨?_, ?_⟩
   · intro H
     refine toList_get.mpr ?_
@@ -899,7 +899,7 @@ theorem toList_perm_of_get?_eq {m₁ m₂ : M V} (h : ∀ k, get? m₁ k = get? 
     exact toList_get.mp H
 
 theorem toList_insert {m : M V} {k : μ.K} {v : V} (h : get? m k = none) :
-    (toList (M := M) (insert m k v)).Perm ((k, v) :: toList (M := M) m) := by
+    (toList (insert m k v)).Perm ((k, v) :: toList m) := by
   refine (List.perm_ext_iff_of_nodup nodup_toList ?_).mpr fun ⟨k', v'⟩ => ⟨?_, ?_⟩
   · refine  List.nodup_cons.mpr ⟨?_, nodup_toList⟩
     exact fun H => Option.some_ne_none _ (h ▸ toList_get.mp H).symm
@@ -927,7 +927,7 @@ theorem toList_insert {m : M V} {k : μ.K} {v : V} (h : get? m k = none) :
         refine toList_get.mp H
 
 theorem toList_delete {m : M V} {k : μ.K} {v : V} (h : get? m k = some v) :
-    (toList (M := M) m).Perm ((k, v) :: toList (M := M) (delete m k)) := by
+    (toList m).Perm ((k, v) :: toList (delete m k)) := by
   refine (List.perm_ext_iff_of_nodup nodup_toList ?_).mpr fun ⟨k', v'⟩ => ⟨?_, ?_⟩
   · refine List.nodup_cons.mpr ⟨?_, nodup_toList⟩
     intro H
@@ -971,16 +971,16 @@ theorem ofList_injective [DecidableEq μ.K] {l₁ l₂ : List (μ.K × V)}
   intro He
   refine (List.perm_ext_iff_of_nodup (NoDupKeys_noDup hnodup1) (NoDupKeys_noDup hnodup2)).mpr ?_
   refine fun ⟨k, v⟩ => ⟨fun H => ?_, fun H => ?_⟩
-  · apply mem_of_mem_ofList (M := M)
+  · apply mem_of_mem_ofList
     rw [← He k]
     exact get?_ofList_some H (List.nodup_iff_pairwise_ne.mpr hnodup1)
-  · apply mem_of_mem_ofList (M := M)
+  · apply mem_of_mem_ofList
     rw [He k]
     exact get?_ofList_some H (List.nodup_iff_pairwise_ne.mpr hnodup2)
 
 theorem toList_insert_delete {m : M V} {k : μ.K} {v : V} :
-    (toList (M := M) (insert m k v)).Perm
-      (toList (M := M) (insert (delete m k) k v)) := by
+    (toList (insert m k v)).Perm
+      (toList (insert (delete m k) k v)) := by
   apply toList_perm_of_get?_eq
   intro k'
   by_cases h : k = k'
@@ -988,7 +988,7 @@ theorem toList_insert_delete {m : M V} {k : μ.K} {v : V} :
   · simp [LawfulPartialMap.get?_insert_ne h, LawfulPartialMap.get?_delete_ne h]
 
 theorem toList_map {f : V → V'} {m : M V}  :
-    (toList (M := M) (PartialMap.map f m)).Perm
+    (toList (PartialMap.map f m)).Perm
       ((toList m).map (fun kv => (kv.1, f kv.2))) := by
   refine (List.perm_ext_iff_of_nodup nodup_toList ?_).mpr fun ⟨k, v⟩ => ⟨?_, ?_⟩
   · refine FromMathlib.Nodup.map_on ?_ nodup_toList
@@ -1010,7 +1010,7 @@ theorem toList_map {f : V → V'} {m : M V}  :
     rfl
 
 theorem toList_filterMap {f : V → Option V} {m : M V} (HI : Function.Injective f) :
-    (toList (M := M) (PartialMap.filterMap f m)).Perm
+    (toList (PartialMap.filterMap f m)).Perm
       ((toList m).filterMap (fun kv => (f kv.2).map (kv.1, ·))) := by
   refine (List.perm_ext_iff_of_nodup nodup_toList ?_).mpr fun ⟨k, v⟩ => ⟨?_, ?_⟩
   · refine FromMathlib.Nodup.filterMap ?_ nodup_toList
@@ -1035,10 +1035,10 @@ theorem toList_filterMap {f : V → Option V} {m : M V} (HI : Function.Injective
     refine ⟨a.snd, toList_get.mp Ha₁, H'⟩
 
 theorem toList_filter {φ : μ.K → V → Bool} {m : M V} :
-    (toList (M := M) (PartialMap.filter φ m)).Perm
+    (toList (PartialMap.filter φ m)).Perm
       ((toList m).filter (fun kv => φ kv.1 kv.2)) := by
   refine (List.perm_ext_iff_of_nodup nodup_toList ?_).mpr fun ⟨k, v⟩ => ⟨?_, ?_⟩
-  · exact FromMathlib.Nodup.filter ?_ (nodup_toList (M := M))
+  · exact FromMathlib.Nodup.filter _ nodup_toList
   · intro H
     refine List.mem_filter.mpr ?_
     have H' := toList_get.mp H
@@ -1055,7 +1055,7 @@ theorem toList_filter {φ : μ.K → V → Bool} {m : M V} :
     simp [get?_filter, toList_get.mp H.1, H.2]
 
 theorem toList_zip {m₁ : M V} {m₂ : M V'} :
-    (toList (M := M) (PartialMap.zip m₁ m₂)).Perm
+    (toList (PartialMap.zip m₁ m₂)).Perm
       ((toList m₁).filterMap fun kv₁ =>
         (get? m₂ kv₁.1).map fun v₂ => (kv₁.1, (kv₁.2, v₂))) := by
   refine (List.perm_ext_iff_of_nodup nodup_toList ?_).mpr fun ⟨k, v⟩ => ⟨?_, ?_⟩

--- a/src/Iris/Std/PartialMap.lean
+++ b/src/Iris/Std/PartialMap.lean
@@ -36,7 +36,8 @@ represented.
 namespace Iris.Std
 
 /-- Base typeclass for partial maps: maps from keys `K` to optional values `V`. -/
-class PartialMap (M : Type _ → Type _) (K : outParam (Type _)) where
+class PartialMap (M : Type u → Type v) where
+  K : Type u
   get? : M V → K → Option V
   insert : M V → K → V → M V
   delete : M V → K → M V
@@ -45,29 +46,31 @@ class PartialMap (M : Type _ → Type _) (K : outParam (Type _)) where
   merge (op : K → V → V → V) : M V → M V → M V
 export PartialMap (get? insert delete empty bindAlter merge)
 
+attribute [reducible] PartialMap.K
+
 /-- A FiniteMap is a PartialMap with a toList operation. Like in Stdpp, the order in
 which the elements are passed into the list is unspecified. -/
-class FiniteMap M K extends PartialMap M K where
+class FiniteMap M extends PartialMap M where
   toList : M V → List (K × V)
 export FiniteMap (toList)
 
 /-- RepFunMap: The map T is capable of representing all partial functions out of
 K. -/
-class RepFunMap (T : Type _ → Type _) (K : outParam (Type _)) [PartialMap T K] where
-  of_fun : (K → Option V) → T V
-  get_of_fun (f : K → Option V) (k : K) : get? (of_fun f) k = f k
+class RepFunMap (T : Type _ → Type _) [μ : PartialMap T] where
+  of_fun : (μ.K → Option V) → T V
+  get_of_fun (f : μ.K → Option V) (k : μ.K) : get? (of_fun f) k = f k
 export RepFunMap (of_fun get_of_fun)
 
 /-- IsoFunStore: The map T is isomorphic to the type of functions out of `K`. In
 other words, equality of T is the same as equality of functions, so the CMRA on
 these partial functions is leibniz. -/
-class IsoFunMap (T : Type _ → Type _) (K : outParam (Type _)) [PartialMap T K]
-  extends RepFunMap T K where
+class IsoFunMap (T : Type _ → Type _) [μ : PartialMap T]
+  extends RepFunMap T where
   of_fun_get {t : T V} : of_fun (get? t) = t
 export IsoFunMap (of_fun_get)
 
 @[ext]
-theorem IsoFunMap.ext [PartialMap T K] [IsoFunMap T K] {t1 t2 : T V}
+theorem IsoFunMap.ext [PartialMap T] [IsoFunMap T] {t1 t2 : T V}
     (h : ∀ k, get? t1 k = get? t2 k) : t1 = t2 := by
   rw [← of_fun_get (t := t1), ← of_fun_get (t := t2)]
   congr 1
@@ -75,7 +78,7 @@ theorem IsoFunMap.ext [PartialMap T K] [IsoFunMap T K] {t1 t2 : T V}
   exact h k
 
 /-- An AllocHeap is a heap which can allocate elements under some condition. -/
-class Heap (M : Type _ → Type _) (K : outParam (Type _)) extends PartialMap M K where
+class Heap (M : Type _ → Type _) (K : outParam (Type _)) extends PartialMap M where
   notFull : M V → Prop
   fresh {m : M V} : notFull m → K
   get?_fresh {m : M V} {H : notFull m} : get? m (fresh H) = none
@@ -89,13 +92,13 @@ export UnboundedHeap (notFull_empty notFull_insert_fresh)
 
 namespace PartialMap
 
-variable {K V M} [PartialMap M K]
+variable {V M} [μ : PartialMap M]
 
 /-- The empty partial map can be written as `∅`. -/
 instance : EmptyCollection (M V) := ⟨PartialMap.empty⟩
 
 /-- Singleton map containing exactly one key-value pair. -/
-def singleton (k : K) (v : V) : M V := insert empty k v
+def singleton (k : μ.K) (v : V) : M V := insert empty k v
 
 /-- Two maps have disjoint domains. -/
 def disjoint (m₁ m₂ : M V) : Prop := ∀ k, ¬((get? m₁ k).isSome ∧ (get? m₂ k).isSome)
@@ -104,24 +107,24 @@ def disjoint (m₁ m₂ : M V) : Prop := ∀ k, ¬((get? m₁ k).isSome ∧ (get
 def submap (m₁ m₂ : M V) : Prop := ∀ k v, get? m₁ k = some v → get? m₂ k = some v
 
 /-- Construct a map from a list of key-value pairs. Later entries override earlier ones. -/
-def ofList (l : List (K × V)) : M V :=
+def ofList (l : List (μ.K × V)) : M V :=
   l.foldr (fun (k, v) acc => insert acc k v) empty
 
 /-- Partial maps support the subset relation `⊆` via the submap relation. -/
 instance : HasSubset (M V) := ⟨submap⟩
 
 /-- Membership: a key is in the map if it has a value. -/
-def mem (m : M V) (k : K) : Prop := (get? m k).isSome
+def mem (m : M V) (k : μ.K) : Prop := (get? m k).isSome
 
 /-- Keys can be tested for membership in partial maps using `∈`. -/
-instance : Membership K (M V) := ⟨fun m k => (get? m k).isSome⟩
+instance : Membership μ.K (M V) := ⟨fun m k => (get? m k).isSome⟩
 
 /-- Universal quantification over map entries. -/
-def all (P : K → V → Prop) (m : M V) : Prop :=
+def all (P : μ.K → V → Prop) (m : M V) : Prop :=
   ∀ k v, get? m k = some v → P k v
 
 /-- The domain of a heap is the set of keys that map to .some values. -/
-def dom (m : M V) : K → Prop := fun k => (get? m k).isSome
+def dom (m : M V) : μ.K → Prop := fun k => (get? m k).isSome
 
 -- Should this be part of the typeclass, or should we use this derived one?
 @[simp] def union : M V → M V → M V := merge (fun _ v _ => v)
@@ -138,7 +141,7 @@ def filterMap (f : V → Option V) : M V → M V :=
   bindAlter (fun _ v => f v)
 
 /-- Filter entries by a predicate on key-value pairs. -/
-def filter (φ : K → V → Bool) : M V → M V :=
+def filter (φ : μ.K → V → Bool) : M V → M V :=
   bindAlter (fun k v => if φ k v then some v else none)
 
 /-- Difference: remove all keys in `m₂` from `m₁`. -/
@@ -159,17 +162,17 @@ instance : SDiff (M V) := ⟨difference⟩
 
 theorem equiv.refl : ∀ {a : M V}, equiv a a := by simp only [equiv, implies_true]
 
-instance instEquivRefl : Reflexive (@equiv K V M _) := ⟨equiv.refl⟩
+instance instEquivRefl : Reflexive (@equiv V M _) := ⟨equiv.refl⟩
 
 theorem equiv.trans : ∀ {a b c : M V}, equiv a b → equiv b c → equiv a c := by simp_all
 
 /-- Pointwise equivalence is transitive. -/
-instance instEquivTrans : Trans equiv (@equiv K V M _) equiv := ⟨equiv.trans⟩
+instance instEquivTrans : Trans equiv (@equiv V M _) equiv := ⟨equiv.trans⟩
 
 @[simp] def equiv.symm :  ∀  (a b : M V), equiv a b → equiv b a :=
   fun _ _ h k => (h k).symm
 
-instance instEquivSymm : Std.Symm (@equiv K V M _) := ⟨equiv.symm⟩
+instance instEquivSymm : Std.Symm (@equiv V M _) := ⟨equiv.symm⟩
 
 scoped syntax term:65 " ≡ₘ " term:66 : term
 scoped macro_rules
@@ -194,7 +197,7 @@ theorem subset_trans {m₁ m₂ m₃ : M V} (h₁ : m₁ ⊆ m₂) (h₂ : m₂ 
 theorem disjoint_comm {m₁ m₂ : M V} (h : disjoint m₁ m₂) : disjoint m₂ m₁ :=
   fun k ⟨h₂, h₁⟩ => h k ⟨h₁, h₂⟩
 
-theorem all_mono (P Q : K → V → Prop) {m : M V}
+theorem all_mono (P Q : μ.K → V → Prop) {m : M V}
     (hp : PartialMap.all P m) (himpl : ∀ k v, P k v → Q k v) :
     PartialMap.all Q m :=
   fun k v hget => himpl k v (hp k v hget)
@@ -218,13 +221,14 @@ end PartialMap
 /-- An association list has no duplicate keys -/
 def NoDupKeys (L : List (K × A)) : Prop := L.map (·.1) |>.Nodup
 
+
 class ExtensionalPartialMap (M : Type _ → Type _) (K : outParam (Type _))
-    extends PartialMap M K where
+    extends PartialMap M where
   equiv_iff_eq {m₁ m₂ : M V} : PartialMap.equiv m₁ m₂ ↔ m₁ = m₂
 
 /-- Laws that a partial map implementation must satisfy. -/
-class LawfulPartialMap (M : Type _ → Type _) (K : outParam (Type _))
-    extends PartialMap M K where
+class LawfulPartialMap (M : Type _ → Type _)
+    extends PartialMap M where
   get?_empty k : get? (empty : M V) k = none
   get?_insert_eq {m : M V} {k k' v} : k = k' → get? (insert m k v) k' = some v
   get?_insert_ne {m : M V} {k k' v} : k ≠ k' → get? (insert m k v) k' = get? m k'
@@ -237,7 +241,7 @@ class LawfulPartialMap (M : Type _ → Type _) (K : outParam (Type _))
 export LawfulPartialMap (get?_empty get?_insert_eq get?_insert_ne get?_delete_eq
   get?_delete_ne get?_bindAlter get?_merge)
 
-class LawfulFiniteMap M K extends LawfulPartialMap M K, FiniteMap M K where
+class LawfulFiniteMap M extends LawfulPartialMap M, FiniteMap M where
   toList_empty : toList (∅ : M V) = []
   toList_noDupKeys : NoDupKeys (toList (m : M V))
   toList_get : (k, v) ∈ toList m ↔ get? m k = some v
@@ -245,20 +249,20 @@ export LawfulFiniteMap (toList_empty toList_noDupKeys toList_get)
 
 namespace FiniteMap
 
-variable {K V : Type _} {M : Type _ → Type _} [FiniteMap M K]
+variable {K V : Type _} {M : Type _ → Type _} [μ : FiniteMap M]
 
 -- /-- Convert the map to a list of key-value pairs. The order is unspecified. -/
 -- def toList (m : M V) : List (K × V) :=
 --   mapFold (fun k v acc => (k, v) :: acc) [] m
 
-def mapFold {A : Type _} (f : K → V → A → A) (a : A) (m : M V) : A :=
-  List.foldl (fun a' ⟨k, v⟩ => f k v a') a (toList (K := K) m)
+def mapFold {A : Type _} (f : μ.K → V → A → A) (a : A) (m : M V) : A :=
+  List.foldl (fun a' ⟨k, v⟩ => f k v a') a (toList m)
 
 /-- Convert a list to a map with sequential natural number keys starting from `start`. -/
-def map_seq [FiniteMap M Nat] (start : Nat) (l : List V) : M V :=
-  PartialMap.ofList (l.mapIdx (fun i v => (start + i, v)))
+def map_seq [FiniteMap M] (start : Nat) (l : List V) (h : μ.K = Nat := by rfl) : M V :=
+    μ.ofList (l.mapIdx (fun i v => (cast h.symm <| start + i, v)))
 
-def dom_set [LawfulSet S K] (m : M V) : S :=
+def dom_set [LawfulSet S μ.K] (m : M V) : S :=
   LawfulSet.ofList (mapFold (fun k _ acc => k :: acc) [] m)
 
 end FiniteMap
@@ -267,40 +271,40 @@ namespace LawfulPartialMap
 
 open PartialMap
 
-variable {K V : Type _} {M : Type _ → Type _} [LawfulPartialMap M K]
+variable {K V : Type _} {M : Type _ → Type _} [μ : LawfulPartialMap M]
 
-theorem get?_insert [DecidableEq K] {m : M V} {k k' : K} {v : V} :
+theorem get?_insert [DecidableEq μ.K] {m : M V} {k k' : μ.K} {v : V} :
     get? (insert m k v) k' = if k = k' then some v else get? m k' := by
   split <;> rename_i h
   · exact get?_insert_eq h
   · exact get?_insert_ne h
 
-theorem get?_delete [DecidableEq K] {m : M V} {k k' : K} :
+theorem get?_delete [DecidableEq μ.K] {m : M V} {k k' : μ.K} :
     get? (delete m k) k' = if k = k' then none else get? m k' := by
   split <;> rename_i h
   · exact get?_delete_eq h
   · exact get?_delete_ne h
 
-theorem get?_insert_delete_same {m : M V} {k k' : K} {v : V} :
+theorem get?_insert_delete_same {m : M V} {k k' : μ.K} {v : V} :
     get? (insert (delete m k) k v) k' = get? (insert m k v) k' := by
   by_cases h : k = k'
   · simp [h, get?_insert_eq]
   · simp [get?_insert_ne h, get?_delete_ne h]
 
-theorem get?_singleton_eq {k k' : K} {v : V} (h : k = k') : get? ({[k := v]} : M V) k' = some v := by
+theorem get?_singleton_eq {k k' : μ.K} {v : V} (h : k = k') : get? ({[k := v]} : M V) k' = some v := by
   simp [PartialMap.singleton, get?_insert_eq h]
 
-theorem get?_singleton_ne {k k' : K} {v : V} (h : k ≠ k') : get? ({[k := v]} : M V) k' = none := by
+theorem get?_singleton_ne {k k' : μ.K} {v : V} (h : k ≠ k') : get? ({[k := v]} : M V) k' = none := by
   simp [PartialMap.singleton, get?_insert_ne h, get?_empty]
 
-theorem get?_singleton [DecidableEq K] {k k' : K} {v : V} :
+theorem get?_singleton [DecidableEq μ.K] {k k' : μ.K} {v : V} :
     get? ({[k := v]} : M V) k' = if k = k' then some v else none := by
   split <;> rename_i h
   · exact get?_singleton_eq h
   · exact get?_singleton_ne h
 
 /-- Value at a key after insert must equal the inserted value. -/
-theorem get?_insert_rev {m : M V} {i : K} {x y : V} :
+theorem get?_insert_rev {m : M V} {i : μ.K} {x y : V} :
     get? (insert m i x) i = some y → x = y := by
   simp [get?_insert_eq rfl]
 
@@ -316,30 +320,30 @@ theorem disjoint_empty_right (m : M V) : m ##ₘ (∅ : M V) := by
   intro k ⟨_, h₂⟩
   simp [show get? (∅ : M V) k = none from get?_empty k] at h₂
 
-theorem get?_insert_some_iff [DecidableEq K] {m : M V} {i j : K} {x y : V} :
+theorem get?_insert_some_iff [DecidableEq μ.K] {m : M V} {i j : μ.K} {x y : V} :
     get? (insert m i x) j = some y ↔ (i = j ∧ x = y) ∨ (i ≠ j ∧ get? m j = some y) := by
   rw [get?_insert]; split <;> simp_all
 
-theorem get?_insert_none_iff [DecidableEq K] {m : M V} {i j : K} {x : V} :
+theorem get?_insert_none_iff [DecidableEq μ.K] {m : M V} {i j : μ.K} {x : V} :
     get? (insert m i x) j = none ↔ get? m j = none ∧ i ≠ j := by
   rw [get?_insert]; split <;> simp_all
 
-theorem get?_delete_some_iff [DecidableEq K] {m : M V} {i j : K} {y : V} :
+theorem get?_delete_some_iff [DecidableEq μ.K] {m : M V} {i j : μ.K} {y : V} :
     get? (delete m i) j = some y ↔ i ≠ j ∧ get? m j = some y := by
   rw [get?_delete]; split <;> simp_all
 
-theorem get?_delete_none_iff [DecidableEq K] {m : M V} {i j : K} :
+theorem get?_delete_none_iff [DecidableEq μ.K] {m : M V} {i j : μ.K} :
     get? (delete m i) j = none ↔ i = j ∨ get? m j = none := by
   rw [get?_delete]; split <;> simp_all
 
-theorem insert_delete_cancel {m : M V} {i : K} {v : V} (h : get? m i = some v) :
+theorem insert_delete_cancel {m : M V} {i : μ.K} {v : V} (h : get? m i = some v) :
     insert (delete m i) i v ≡ₘ m := by
   intros j
   by_cases hij : i = j
   · rw [get?_insert_eq hij, ← h, hij]
   · rw [get?_insert_ne hij, get?_delete_ne hij]
 
-theorem delete_insert_cancel {m : M V} {i : K} {x : V} (h : get? m i = none) :
+theorem delete_insert_cancel {m : M V} {i : μ.K} {x : V} (h : get? m i = none) :
     delete (insert m i x) i ≡ₘ m := by
   intro j
   by_cases hij : i = j
@@ -349,14 +353,14 @@ theorem delete_insert_cancel {m : M V} {i : K} {x : V} (h : get? m i = none) :
 theorem eq_empty_iff {m : M V} : (m ≡ₘ ∅) ↔ ∀ k, get? m k = none :=
   ⟨fun h k => (h k) ▸ get?_empty k, fun h k => (h k) ▸ (get?_empty k).symm⟩
 
-theorem delete_delete {m : M V} {i : K} :
+theorem delete_delete {m : M V} {i : μ.K} :
     delete (delete m i) i ≡ₘ delete m i := by
   intro j
   by_cases h : i = j
   · rw [get?_delete_eq h, get?_delete_eq h]
   · rw [get?_delete_ne h]
 
-theorem delete_delete_comm {m : M V} {i j : K} :
+theorem delete_delete_comm {m : M V} {i j : μ.K} :
     delete (delete m i) j ≡ₘ delete (delete m j) i := by
   intro k
   by_cases hik : i = k <;> by_cases hjk : j = k
@@ -365,21 +369,21 @@ theorem delete_delete_comm {m : M V} {i j : K} :
   · rw [get?_delete_ne hik, get?_delete_eq hjk, get?_delete_eq hjk]
   · rw [get?_delete_ne hik, get?_delete_ne hjk, get?_delete_ne hik, get?_delete_ne hjk]
 
-theorem insert_insert_same {m : M V} {i : K} {x y : V} :
+theorem insert_insert_same {m : M V} {i : μ.K} {x y : V} :
     insert (insert m i x) i y ≡ₘ insert m i y := by
   intro j
   by_cases h : i = j
   · rw [get?_insert_eq h, get?_insert_eq h]
   · rw [get?_insert_ne h, get?_insert_ne h, get?_insert_ne h]
 
-theorem insert_delete {m : M V} {i : K} {x : V} :
+theorem insert_delete {m : M V} {i : μ.K} {x : V} :
     insert (delete m i) i x ≡ₘ insert m i x := by
   intro j
   by_cases h : i = j
   · rw [get?_insert_eq h, get?_insert_eq h]
   · rw [get?_insert_ne h, get?_delete_ne h, get?_insert_ne h]
 
-theorem insert_insert_comm {m : M V} {i j : K} {x y : V} (h : i ≠ j) :
+theorem insert_insert_comm {m : M V} {i j : μ.K} {x y : V} (h : i ≠ j) :
     insert (insert m i x) j y ≡ₘ insert (insert m j y) i x := by
   intro k
   by_cases hik : i = k <;> by_cases hjk : j = k
@@ -388,7 +392,7 @@ theorem insert_insert_comm {m : M V} {i j : K} {x y : V} (h : i ≠ j) :
   · rw [get?_insert_eq hjk, get?_insert_ne hik, get?_insert_eq hjk]
   · rw [get?_insert_ne hjk, get?_insert_ne hik, get?_insert_ne hik, get?_insert_ne hjk]
 
-theorem delete_insert_of_ne {m : M V} {i j : K} {x : V} (h : i ≠ j) :
+theorem delete_insert_of_ne {m : M V} {i j : μ.K} {x : V} (h : i ≠ j) :
     delete (insert m i x) j ≡ₘ insert (delete m j) i x := by
   intro k
   by_cases hik : i = k <;> by_cases hjk : j = k
@@ -397,32 +401,32 @@ theorem delete_insert_of_ne {m : M V} {i j : K} {x : V} (h : i ≠ j) :
   · rw [get?_insert_ne hik, get?_delete_eq hjk, get?_delete_eq hjk]
   · rw [get?_delete_ne hjk, get?_insert_ne hik, get?_insert_ne hik, get?_delete_ne hjk]
 
-theorem delete_empty {i : K} : delete (empty : M V) i ≡ₘ empty := by
+theorem delete_empty {i : μ.K} : delete (empty : M V) i ≡ₘ empty := by
   intro j
   by_cases h : i = j
   · rw [get?_delete_eq h, get?_empty]
   · rw [get?_delete_ne h, get?_empty]
 
-theorem delete_of_get? {m : M V} {i : K} (h : get? m i = none) : delete m i ≡ₘ m := by
+theorem delete_of_get? {m : M V} {i : μ.K} (h : get? m i = none) : delete m i ≡ₘ m := by
   intro j
   by_cases hij : i = j
   · rw [get?_delete_eq hij, ← h, hij]
   · rw [get?_delete_ne hij]
 
-theorem insert_get? {m : M V} {i : K} {x : V} (h : get? m i = some x) :
+theorem insert_get? {m : M V} {i : μ.K} {x : V} (h : get? m i = some x) :
     insert m i x ≡ₘ m := by
   intro j
   by_cases hij : i = j
   · rw [get?_insert_eq hij, ← h, hij]
   · rw [get?_insert_ne hij]
 
-theorem insert_ne_empty {m : M V} {i : K} {x : V} : ¬(insert m i x ≡ₘ empty) := by
+theorem insert_ne_empty {m : M V} {i : μ.K} {x : V} : ¬(insert m i x ≡ₘ empty) := by
   intro h
   have : get? (insert m i x) i = none := (h i) ▸ get?_empty i
   rw [get?_insert_eq rfl] at this
   cases this
 
-theorem delete_subset_self {m : M V} {i : K} : delete m i ⊆ m := by
+theorem delete_subset_self {m : M V} {i : μ.K} : delete m i ⊆ m := by
   intro k v h
   by_cases hik : i = k
   · rw [get?_delete_eq hik] at h
@@ -430,7 +434,7 @@ theorem delete_subset_self {m : M V} {i : K} : delete m i ⊆ m := by
   · rw [get?_delete_ne hik] at h
     exact h
 
-theorem subset_insert {m : M V} {i : K} {x : V} (h : get? m i = none) :
+theorem subset_insert {m : M V} {i : μ.K} {x : V} (h : get? m i = none) :
     m ⊆ insert m i x := by
   intro k v hk
   by_cases hik : i = k
@@ -440,7 +444,7 @@ theorem subset_insert {m : M V} {i : K} {x : V} (h : get? m i = none) :
   · rw [get?_insert_ne hik]
     exact hk
 
-theorem delete_subset_delete {m₁ m₂ : M V} {i : K} (h : m₁ ⊆ m₂) : delete m₁ i ⊆ delete m₂ i := by
+theorem delete_subset_delete {m₁ m₂ : M V} {i : μ.K} (h : m₁ ⊆ m₂) : delete m₁ i ⊆ delete m₂ i := by
   intro k v hk
   by_cases hik : i = k
   · rw [get?_delete_eq hik] at hk
@@ -448,7 +452,7 @@ theorem delete_subset_delete {m₁ m₂ : M V} {i : K} (h : m₁ ⊆ m₂) : del
   · rw [get?_delete_ne hik] at hk ⊢
     exact h k v hk
 
-theorem insert_subset_insert {m₁ m₂ : M V} {i : K} {x : V} (h : m₁ ⊆ m₂) :
+theorem insert_subset_insert {m₁ m₂ : M V} {i : μ.K} {x : V} (h : m₁ ⊆ m₂) :
     insert m₁ i x ⊆ insert m₂ i x := by
   intro k v hk
   by_cases hik : i = k
@@ -457,31 +461,31 @@ theorem insert_subset_insert {m₁ m₂ : M V} {i : K} {x : V} (h : m₁ ⊆ m�
   · rw [get?_insert_ne hik] at hk ⊢
     exact h k v hk
 
-theorem singleton_ne_empty {i : K} {x : V} : ¬({[i := x]} ≡ₘ (∅ : M V)) := insert_ne_empty
+theorem singleton_ne_empty {i : μ.K} {x : V} : ¬({[i := x]} ≡ₘ (∅ : M V)) := insert_ne_empty
 
-theorem delete_singleton_eq {i : K} {x : V} : delete ({[i := x]} : M V) i ≡ₘ empty := by
+theorem delete_singleton_eq {i : μ.K} {x : V} : delete ({[i := x]} : M V) i ≡ₘ empty := by
   intro j
   by_cases h : i = j
   · rw [get?_delete_eq h, get?_empty]
   · rw [get?_delete_ne h, get?_singleton_ne h, get?_empty]
 
-theorem delete_singleton_ne {i j : K} {x : V} (h : i ≠ j) :
+theorem delete_singleton_ne {i j : μ.K} {x : V} (h : i ≠ j) :
     delete ({[j := x]} : M V) i ≡ₘ {[j := x]} := by
   intro k
   by_cases hik : i = k
   · rw [get?_delete_eq hik, get?_singleton_ne (hik ▸ h.symm)]
   · rw [get?_delete_ne hik]
 
-theorem all_empty (P : K → V → Prop) : PartialMap.all P (empty : M V) := by
+theorem all_empty (P : μ.K → V → Prop) : PartialMap.all P (empty : M V) := by
   intro k v h
   rw [get?_empty k] at h
   cases h
 
-theorem all_insert_of_all (P : K → V → Prop) {m : M V} {i : K} {x : V}
+theorem all_insert_of_all (P : μ.K → V → Prop) {m : M V} {i : μ.K} {x : V}
     (h : PartialMap.all P (insert m i x)) : P i x :=
   h _ _ (get?_insert_eq rfl)
 
-theorem all_of_all_insert (P : K → V → Prop) {m : M V} {i : K} {x : V}
+theorem all_of_all_insert (P : μ.K → V → Prop) {m : M V} {i : μ.K} {x : V}
     (hi : get? m i = none) (h : PartialMap.all P (insert m i x)) :
     PartialMap.all P m := by
   intro k v hget
@@ -491,7 +495,7 @@ theorem all_of_all_insert (P : K → V → Prop) {m : M V} {i : K} {x : V}
   · apply h k v
     simp [get?_insert_ne hik, hget]
 
-theorem all_insert (P : K → V → Prop) {m : M V} {i : K} {x : V}
+theorem all_insert (P : μ.K → V → Prop) {m : M V} {i : μ.K} {x : V}
     (hpix : P i x) (h : PartialMap.all P m) : PartialMap.all P (insert m i x) := by
   intro k v hget
   by_cases hik : i = k
@@ -503,12 +507,12 @@ theorem all_insert (P : K → V → Prop) {m : M V} {i : K} {x : V}
     simp [get?_insert_ne hik] at hget
     assumption
 
-theorem all_insert_iff (P : K → V → Prop) {m : M V} {i : K} {x : V} (hi : get? m i = none) :
+theorem all_insert_iff (P : μ.K → V → Prop) {m : M V} {i : μ.K} {x : V} (hi : get? m i = none) :
     (PartialMap.all P (insert m i x) ↔ P i x ∧ PartialMap.all P m) :=
   ⟨fun h => ⟨all_insert_of_all P h, all_of_all_insert P hi h⟩,
    fun ⟨hpix, h⟩ => all_insert P hpix h⟩
 
-theorem all_singleton (P : K → V → Prop) {i : K} {x : V} :
+theorem all_singleton (P : μ.K → V → Prop) {i : μ.K} {x : V} :
     PartialMap.all P ({[i := x]} : M V) ↔ P i x := by
   constructor
   · exact fun h => h i x (get?_singleton_eq rfl)
@@ -518,7 +522,7 @@ theorem all_singleton (P : K → V → Prop) {i : K} {x : V} :
       exact hget ▸ h ▸ hpix
     · simp [get?_singleton_ne h] at hget
 
-theorem all_delete (P : K → V → Prop) {m : M V} {i : K}
+theorem all_delete (P : μ.K → V → Prop) {m : M V} {i : μ.K}
     (h : PartialMap.all P m) : PartialMap.all P (delete m i) := by
   intro k v hget
   by_cases hik : i = k
@@ -526,7 +530,7 @@ theorem all_delete (P : K → V → Prop) {m : M V} {i : K}
   · rw [get?_delete_ne hik] at hget
     exact h k v hget
 
-theorem disjoint_insert_left {m₁ m₂ : M V} {i : K} {x : V}
+theorem disjoint_insert_left {m₁ m₂ : M V} {i : μ.K} {x : V}
     (hi : get? m₂ i = none) (hdisj : m₁ ##ₘ m₂) : insert m₁ i x ##ₘ m₂ := by
   intro k ⟨hs1, hs2⟩
   by_cases hik : i = k
@@ -535,7 +539,7 @@ theorem disjoint_insert_left {m₁ m₂ : M V} {i : K} {x : V}
   · simp [get?_insert_ne hik] at hs1
     exact hdisj k ⟨hs1, hs2⟩
 
-theorem disjoint_insert_right {m₁ m₂ : M V} {i : K} {x : V}
+theorem disjoint_insert_right {m₁ m₂ : M V} {i : μ.K} {x : V}
     (hi : get? m₁ i = none) (hdisj : m₁ ##ₘ m₂) : m₁ ##ₘ insert m₂ i x := by
   intro k ⟨hs1, hs2⟩
   by_cases hik : i = k
@@ -544,7 +548,7 @@ theorem disjoint_insert_right {m₁ m₂ : M V} {i : K} {x : V}
   · simp [get?_insert_ne hik] at hs2
     exact hdisj k ⟨hs1, hs2⟩
 
-theorem disjoint_delete_left {m₁ m₂ : M V} {i : K}
+theorem disjoint_delete_left {m₁ m₂ : M V} {i : μ.K}
     (hdisj : m₁ ##ₘ m₂) : delete m₁ i ##ₘ m₂ := by
   intro k ⟨hs1, hs2⟩
   by_cases hik : i = k
@@ -553,7 +557,7 @@ theorem disjoint_delete_left {m₁ m₂ : M V} {i : K}
   · simp [get?_delete_ne hik] at hs1
     exact hdisj k ⟨hs1, hs2⟩
 
-theorem disjoint_delete_right {m₁ m₂ : M V} {i : K}
+theorem disjoint_delete_right {m₁ m₂ : M V} {i : μ.K}
     (hdisj : m₁ ##ₘ m₂) : m₁ ##ₘ delete m₂ i := by
   intro k ⟨hs1, hs2⟩
   by_cases hik : i = k
@@ -562,7 +566,7 @@ theorem disjoint_delete_right {m₁ m₂ : M V} {i : K}
   · simp [get?_delete_ne hik] at hs2
     exact hdisj k ⟨hs1, hs2⟩
 
-theorem disjoint_singleton_left {m : M V} {i : K} {x : V}
+theorem disjoint_singleton_left {m : M V} {i : μ.K} {x : V}
     (hi : get? m i = none) : {[i := x]} ##ₘ m := by
   intro k ⟨hs1, hs2⟩
   by_cases hik : i = k
@@ -570,7 +574,7 @@ theorem disjoint_singleton_left {m : M V} {i : K} {x : V}
     simp [hi] at hs2
   · simp [PartialMap.singleton, get?_insert_ne hik, get?_empty] at hs1
 
-theorem disjoint_singleton_right {m : M V} {i : K} {x : V}
+theorem disjoint_singleton_right {m : M V} {i : μ.K} {x : V}
     (hi : get? m i = none) : m ##ₘ {[i := x]} := by
   intro k ⟨hs1, hs2⟩
   by_cases hik : i = k
@@ -578,17 +582,17 @@ theorem disjoint_singleton_right {m : M V} {i : K} {x : V}
     simp [hi] at hs1
   · simp [PartialMap.singleton, get?_insert_ne hik, get?_empty] at hs2
 
-theorem get?_insert_isSome [DecidableEq K] {m : M V} {i j : K} {x : V} :
+theorem get?_insert_isSome [DecidableEq μ.K] {m : M V} {i j : μ.K} {x : V} :
     (get? (insert m i x) j).isSome ↔ i = j ∨ (i ≠ j ∧ (get? m j).isSome) := by
   rw [get?_insert]
   split <;> simp_all
 
-theorem get?_delete_isSome [DecidableEq K] {m : M V} {i j : K} :
+theorem get?_delete_isSome [DecidableEq μ.K] {m : M V} {i j : μ.K} :
     (get? (delete m i) j).isSome ↔ i ≠ j ∧ (get? m j).isSome := by
   rw [get?_delete]
   split <;> simp_all
 
-theorem get?_difference {m₁ m₂ : M V} {k : K} :
+theorem get?_difference {m₁ m₂ : M V} {k : μ.K} :
     get? (m₁ \ m₂) k = if (get? m₂ k).isSome then none else get? m₁ k := by
   simp only [SDiff.sdiff, PartialMap.difference, get?_bindAlter]
   cases hm2 : get? m₂ k <;> cases hm1 : get? m₁ k <;> simp
@@ -611,17 +615,17 @@ theorem union_difference_cancel {m₁ m₂ : M V} (h : m₂ ⊆ m₁) :
     simp [Option.merge]
     exact (h k v hm2).symm
 
-theorem get?_union {m₁ m₂ : M V} {k : K} :
+theorem get?_union {m₁ m₂ : M V} {k : μ.K} :
     get? (union m₁ m₂) k = (get? m₁ k).orElse (fun _ => get? m₂ k) := by
   simp only [PartialMap.union, get?_merge]
   cases get? m₁ k <;> cases get? m₂ k <;> simp [Option.merge, Option.orElse]
 
-theorem get?_union_none {m₁ m₂ : M V} {i : K} :
+theorem get?_union_none {m₁ m₂ : M V} {i : μ.K} :
     get? (union m₁ m₂) i = none ↔ get? m₁ i = none ∧ get? m₂ i = none := by
   rw [get?_union]
   cases h1 : get? m₁ i <;> cases h2 : get? m₂ i <;> simp [Option.orElse]
 
-theorem union_insert_left {m₁ m₂ : M V} {i : K} {x : V} :
+theorem union_insert_left {m₁ m₂ : M V} {i : μ.K} {x : V} :
     insert (union m₁ m₂) i x ≡ₘ union (insert m₁ i x) m₂ := by
   intro k
   by_cases hik : i = k
@@ -629,7 +633,7 @@ theorem union_insert_left {m₁ m₂ : M V} {i : K} {x : V} :
     cases h : get? m₂ i <;> simp [get?_insert_eq rfl, PartialMap.union, get?_merge, Option.merge, h]
   · simp [get?_insert_ne hik, PartialMap.union, get?_merge]
 
-theorem get?_map {f : V → V'} {m : M V} {k : K} :
+theorem get?_map {f : V → V'} {m : M V} {k : μ.K} :
     get? (PartialMap.map f m) k = (get? m k).map f := by
   simp only [PartialMap.map, get?_bindAlter]
   cases get? m k <;> simp
@@ -640,20 +644,20 @@ theorem map_id {m : M V} :
   rw [get?_map]
   cases get? m k <;> simp
 
-theorem get?_filterMap {f : V → Option V} {m : M V} {k : K} :
+theorem get?_filterMap {f : V → Option V} {m : M V} {k : μ.K} :
     get? (filterMap f m) k = (get? m k).bind f := by
   simp [filterMap, get?_bindAlter]
 
-theorem get?_filter {φ : K → V → Bool} {m : M V} {k : K} :
+theorem get?_filter {φ : μ.K → V → Bool} {m : M V} {k : μ.K} :
     get? (filter φ m) k = (get? m k).bind (fun v => if φ k v then some v else none) := by
   simp [Option.bind, filter, get?_bindAlter]
 
-theorem get?_zipWith {f : V → V' → V''} {m₁ : M V} {m₂ : M V'} {k : K} :
+theorem get?_zipWith {f : V → V' → V''} {m₁ : M V} {m₂ : M V'} {k : μ.K} :
     get? (zipWith f m₁ m₂) k = (get? m₁ k).bind fun v₁ => (get? m₂ k).map fun v₂ => f v₁ v₂ := by
   simp [zipWith, get?_bindAlter]
   cases h1 : get? m₁ k <;> cases h2 : get? m₂ k <;> simp [Option.bind]
 
-theorem get?_zip {m₁ : M V} {m₂ : M V'} {k : K} :
+theorem get?_zip {m₁ : M V} {m₂ : M V'} {k : μ.K} :
     get? (zip m₁ m₂) k = (get? m₁ k).bind fun v₁ => (get? m₂ k).map fun v₂ => (v₁, v₂) := by
   simp [zip, zipWith, get?_bindAlter]
   cases h1 : get? m₁ k <;> cases h2 : get? m₂ k <;> simp [Option.bind]
@@ -672,7 +676,7 @@ theorem map_zipWith_left {f : V → V' → V''} {g : V''' → V} {m₁ : M V'''}
   simp [get?_map, get?_zip, get?_zipWith]
   cases get? m₁ k <;> cases get? m₂ k <;> simp [Option.bind, Option.map]
 
-theorem zipWith_insert {f : V → V' → V''} {m₁ : M V} {m₂ : M V'} {k : K} {v : V} {v' : V'} :
+theorem zipWith_insert {f : V → V' → V''} {m₁ : M V} {m₂ : M V'} {k : μ.K} {v : V} {v' : V'} :
     zipWith f (insert m₁ k v) (insert m₂ k v') ≡ₘ
       insert (zipWith f m₁ m₂) k (f v v') := by
   intro k'
@@ -681,7 +685,7 @@ theorem zipWith_insert {f : V → V' → V''} {m₁ : M V} {m₂ : M V'} {k : K}
     simp [get?_zipWith, get?_insert_eq rfl]
   · simp [get?_zipWith, get?_insert_ne h]
 
-theorem zipWith_delete {f : V → V' → V''} {m₁ : M V} {m₂ : M V'} {k : K} :
+theorem zipWith_delete {f : V → V' → V''} {m₁ : M V} {m₂ : M V'} {k : μ.K} :
     zipWith f (delete m₁ k) (delete m₂ k) ≡ₘ delete (zipWith f m₁ m₂) k := by
   intro k'
   by_cases h : k = k'
@@ -712,7 +716,7 @@ theorem zip_fst_snd {m : M (V × V')} :
   simp [zip, zipWith, get?_map, get?_bindAlter]
   cases h : get? m k <;> simp [Option.bind, Option.map]
 
-theorem isSome_zipWith {f : V → V' → V''} {m₁ : M V} {m₂ : M V'} {k : K} :
+theorem isSome_zipWith {f : V → V' → V''} {m₁ : M V} {m₂ : M V'} {k : μ.K} :
     (get? (zipWith f m₁ m₂) k).isSome ↔
       (get? m₁ k).isSome ∧ (get? m₂ k).isSome := by
   rw [get?_zipWith]
@@ -730,28 +734,28 @@ theorem zip_empty_right {m : M V} :
   cases h : get? m k <;> simp
 
 -- -- FIXME: universe issue
--- theorem zip_insert {m₁ : M V} {m₂ : M V'} {k : K} {v : V} {v' : V'} :
+-- theorem zip_insert {m₁ : M V} {m₂ : M V'} {k : μ.K} {v : V} {v' : V'} :
 --     zip (insert m₁ k v) (insert m₂ k v') ≡ₘ insert (zip m₁ m₂) k (v, v') := by
 --   sorry
 
 -- FIXME: universe issue
--- theorem zip_delete {m₁ : M V} {m₂ : M V'} {k : K} :
+-- theorem zip_delete {m₁ : M V} {m₂ : M V'} {k : μ.K} :
 --     zip (delete m₁ k) (delete m₂ k) ≡ₘ delete (zip m₁ m₂) k := by
 --   sorry
 
-theorem isSome_zip {m₁ : M V} {m₂ : M V'} {k : K} :
+theorem isSome_zip {m₁ : M V} {m₂ : M V'} {k : μ.K} :
     (get? (zip m₁ m₂) k).isSome ↔ (get? m₁ k).isSome ∧ (get? m₂ k).isSome := by
   rw [get?_zip]
   cases h1 : get? m₁ k <;> cases h2 : get? m₂ k <;> simp
 
-theorem ofList_cons {L : List (K × V)} : ofList (M := M) ((k, v) :: L) = insert (ofList L) k v :=
+theorem ofList_cons {L : List (μ.K × V)} : ofList (M := M) ((k, v) :: L) = insert (ofList L) k v :=
   rfl
 
-theorem noDupKeys_cons {L : List (K × V)} : NoDupKeys (h :: L) → NoDupKeys L := by
+theorem noDupKeys_cons {L : List (μ.K × V)} : NoDupKeys (h :: L) → NoDupKeys L := by
   unfold NoDupKeys
   grind
 
-theorem noDupKeys_inj {L : List (K × V)} (Hdup : NoDupKeys L) (Hin : (k, v) ∈ L)
+theorem noDupKeys_inj {L : List (μ.K × V)} (Hdup : NoDupKeys L) (Hin : (k, v) ∈ L)
     (Hin' : (k, v') ∈ L) : v = v' := by
   induction L with
   | nil => cases Hin
@@ -770,7 +774,7 @@ theorem noDupKeys_inj {L : List (K × V)} (Hdup : NoDupKeys L) (Hin : (k, v) ∈
       | inl heq' => grind
       | inr hmem' => exact IH ht hmem hmem'
 
-theorem get?_ofList_some [DecidableEq K] {L : List (K × V)}
+theorem get?_ofList_some [DecidableEq μ.K] {L : List (μ.K × V)}
     (Hin : (k, v) ∈ L) (Hdup : NoDupKeys L) : get? (ofList (M := M) L) k = some v := by
   induction L
   · simp at Hin
@@ -784,7 +788,7 @@ theorem get?_ofList_some [DecidableEq K] {L : List (K × V)}
     · exact .inl ⟨Hk, (noDupKeys_inj Hdup Hin (Hk ▸ List.mem_cons_self)).symm⟩
     · exact .inr ⟨Ne.intro Hk, IH Hin' (noDupKeys_cons Hdup)⟩
 
-theorem get?_ofList_none {L : List (K × V)}
+theorem get?_ofList_none {L : List (μ.K × V)}
     (Hin : ¬ ∃ v, (k, v) ∈ L) (Hdup : NoDupKeys L) :
     get? (ofList (M := M) L) k = none  := by
   induction L
@@ -801,7 +805,7 @@ end LawfulPartialMap
 
 namespace LawfulFiniteMap
 
-variable {K V : Type _} {M : Type _ → Type _} [LawfulFiniteMap M K]
+variable {K V : Type _} {M : Type _ → Type _} [μ : LawfulFiniteMap M]
 
 open FiniteMap LawfulFiniteMap PartialMap LawfulPartialMap
 
@@ -818,7 +822,7 @@ open FiniteMap LawfulFiniteMap PartialMap LawfulPartialMap
 --     P (insert m i x)) →
 --   ∀ m, P m
 
-theorem toList_get?_none {m : M V} : (∀ v, (k, v) ∉ toList (K := K) m) ↔ get? m k = none := by
+theorem toList_get?_none {m : M V} : (∀ v, (k, v) ∉ toList m) ↔ get? m k = none := by
   constructor
   · intro Hn
     refine Option.eq_none_iff_forall_ne_some.mpr ?_
@@ -830,11 +834,11 @@ theorem NoDupKeys_noDup {L : List (K × V)} : NoDupKeys L → L.Nodup := by
   refine fun H => FromMathlib.List.Nodup.of_map (fun x => x.fst) ?_
   exact H
 
-theorem nodup_toList {m : M V} : (toList (K := K) m).Nodup :=
+theorem nodup_toList {m : M V} : (toList m).Nodup :=
   NoDupKeys_noDup toList_noDupKeys
 
-theorem ofList_toList [DecidableEq K] {m : M V} :
-    PartialMap.equiv (ofList (toList (K := K) m)) m := by
+theorem ofList_toList [DecidableEq μ.K] {m : M V} :
+    PartialMap.equiv (ofList (toList m)) m := by
   intro k
   rcases h : get? m k with _|v
   · refine get?_ofList_none ?_ toList_noDupKeys
@@ -842,7 +846,7 @@ theorem ofList_toList [DecidableEq K] {m : M V} :
     cases h ▸ toList_get.mp Hk
   · exact get?_ofList_some (toList_get.mpr h) toList_noDupKeys
 
-theorem induction_on [DecidableEq K] {P : M V → Prop}
+theorem induction_on [DecidableEq μ.K] {P : M V → Prop}
     (hequiv : ∀ m₁ m₂, PartialMap.equiv m₁ m₂ → P m₁ → P m₂)
     (hemp : P PartialMap.empty)
     (hins : ∀ i x m, get? m i = none → P m → P (PartialMap.insert m i x))
@@ -860,7 +864,7 @@ theorem induction_on [DecidableEq K] {P : M V → Prop}
       exact (List.nodup_cons.mp hnd).1 (List.mem_map_of_mem (f := Prod.fst) (a := (kv.1, v)) hv)
     · exact ih (noDupKeys_cons hnd)
 
-theorem mem_of_mem_ofList [DecidableEq K] {l : List (K × V)} {i : K} {x : V}
+theorem mem_of_mem_ofList [DecidableEq μ.K] {l : List (μ.K × V)} {i : μ.K} {x : V}
     (H : get? (ofList l : M V) i = some x) : (i, x) ∈ l := by
   induction l
   · simp [ofList, get?_empty] at H
@@ -875,15 +879,15 @@ theorem mem_of_mem_ofList [DecidableEq K] {l : List (K × V)} {i : K} {x : V}
     · rw [get?_insert_ne He] at H
       exact List.mem_cons_of_mem (k, v) (IH H)
 
-theorem toList_ofList [DecidableEq K] {l : List (K × V)} (Hdup : NoDupKeys l) :
-    (toList (M := M) (K := K) (ofList l : M V)).Perm l := by
+theorem toList_ofList [DecidableEq μ.K] {l : List (μ.K × V)} (Hdup : NoDupKeys l) :
+    (toList (M := M) (ofList l : M V)).Perm l := by
   refine (List.perm_ext_iff_of_nodup nodup_toList ?_).mpr fun ⟨k, v⟩ => ⟨?_, ?_⟩
   · exact NoDupKeys_noDup Hdup
   · exact (mem_of_mem_ofList <| toList_get.mp ·)
   · exact (toList_get.mpr <| get?_ofList_some · Hdup)
 
 theorem toList_perm_of_get?_eq {m₁ m₂ : M V} (h : ∀ k, get? m₁ k = get? m₂ k) :
-    (toList (M := M) (K := K) m₁).Perm (toList (M := M) (K := K) m₂) := by
+    (toList (M := M) m₁).Perm (toList (M := M) m₂) := by
   refine (List.perm_ext_iff_of_nodup nodup_toList nodup_toList).mpr fun ⟨k, v⟩ => ⟨?_, ?_⟩
   · intro H
     refine toList_get.mpr ?_
@@ -894,8 +898,8 @@ theorem toList_perm_of_get?_eq {m₁ m₂ : M V} (h : ∀ k, get? m₁ k = get? 
     rw [h k]
     exact toList_get.mp H
 
-theorem toList_insert {m : M V} {k : K} {v : V} (h : get? m k = none) :
-    (toList (M := M) (K := K) (insert m k v)).Perm ((k, v) :: toList (M := M) (K := K) m) := by
+theorem toList_insert {m : M V} {k : μ.K} {v : V} (h : get? m k = none) :
+    (toList (M := M) (insert m k v)).Perm ((k, v) :: toList (M := M) m) := by
   refine (List.perm_ext_iff_of_nodup nodup_toList ?_).mpr fun ⟨k', v'⟩ => ⟨?_, ?_⟩
   · refine  List.nodup_cons.mpr ⟨?_, nodup_toList⟩
     exact fun H => Option.some_ne_none _ (h ▸ toList_get.mp H).symm
@@ -922,8 +926,8 @@ theorem toList_insert {m : M V} {k : K} {v : V} (h : get? m k = none) :
         rw [get?_insert_ne He]
         refine toList_get.mp H
 
-theorem toList_delete {m : M V} {k : K} {v : V} (h : get? m k = some v) :
-    (toList (M := M) (K := K) m).Perm ((k, v) :: toList (M := M) (K := K) (delete m k)) := by
+theorem toList_delete {m : M V} {k : μ.K} {v : V} (h : get? m k = some v) :
+    (toList (M := M) m).Perm ((k, v) :: toList (M := M) (delete m k)) := by
   refine (List.perm_ext_iff_of_nodup nodup_toList ?_).mpr fun ⟨k', v'⟩ => ⟨?_, ?_⟩
   · refine List.nodup_cons.mpr ⟨?_, nodup_toList⟩
     intro H
@@ -951,17 +955,17 @@ theorem toList_delete {m : M V} {k : K} {v : V} (h : get? m k = some v) :
       · rw [get?_delete_ne He] at H''
         exact H''
 
-theorem all_iff_toList {P : K → V → Prop} {m : M V} :
+theorem all_iff_toList {P : μ.K → V → Prop} {m : M V} :
     PartialMap.all P m ↔ ∀ kv ∈ toList m, P kv.1 kv.2 :=
   ⟨fun H ⟨k, v⟩ Hm => H k v (toList_get.mp Hm),
    fun H k v hg => H (k, v) (toList_get.mpr hg)⟩
 
-theorem mem_ofList [DecidableEq K] {l : List (K × V)} {i : K} {x : V}
+theorem mem_ofList [DecidableEq μ.K] {l : List (μ.K × V)} {i : μ.K} {x : V}
     (hnodup : (l.map Prod.fst).Nodup) :
     (i, x) ∈ l ↔ get? (ofList l : M V) i = some x :=
   ⟨(get?_ofList_some · hnodup), mem_of_mem_ofList⟩
 
-theorem ofList_injective [DecidableEq K] {l₁ l₂ : List (K × V)}
+theorem ofList_injective [DecidableEq μ.K] {l₁ l₂ : List (μ.K × V)}
     (hnodup1 : (l₁.map Prod.fst).Nodup) (hnodup2 : (l₂.map Prod.fst).Nodup) :
     PartialMap.equiv (ofList l₁ : M V) (ofList l₂) → l₁.Perm l₂ := by
   intro He
@@ -974,9 +978,9 @@ theorem ofList_injective [DecidableEq K] {l₁ l₂ : List (K × V)}
     rw [He k]
     exact get?_ofList_some H (List.nodup_iff_pairwise_ne.mpr hnodup2)
 
-theorem toList_insert_delete {m : M V} {k : K} {v : V} :
-    (toList (M := M) (K := K) (insert m k v)).Perm
-      (toList (M := M) (K := K) (insert (delete m k) k v)) := by
+theorem toList_insert_delete {m : M V} {k : μ.K} {v : V} :
+    (toList (M := M) (insert m k v)).Perm
+      (toList (M := M) (insert (delete m k) k v)) := by
   apply toList_perm_of_get?_eq
   intro k'
   by_cases h : k = k'
@@ -984,7 +988,7 @@ theorem toList_insert_delete {m : M V} {k : K} {v : V} :
   · simp [LawfulPartialMap.get?_insert_ne h, LawfulPartialMap.get?_delete_ne h]
 
 theorem toList_map {f : V → V'} {m : M V}  :
-    (toList (M := M) (K := K) (PartialMap.map f m)).Perm
+    (toList (M := M) (PartialMap.map f m)).Perm
       ((toList m).map (fun kv => (kv.1, f kv.2))) := by
   refine (List.perm_ext_iff_of_nodup nodup_toList ?_).mpr fun ⟨k, v⟩ => ⟨?_, ?_⟩
   · refine FromMathlib.Nodup.map_on ?_ nodup_toList
@@ -1006,7 +1010,7 @@ theorem toList_map {f : V → V'} {m : M V}  :
     rfl
 
 theorem toList_filterMap {f : V → Option V} {m : M V} (HI : Function.Injective f) :
-    (toList (M := M) (K := K) (PartialMap.filterMap f m)).Perm
+    (toList (M := M) (PartialMap.filterMap f m)).Perm
       ((toList m).filterMap (fun kv => (f kv.2).map (kv.1, ·))) := by
   refine (List.perm_ext_iff_of_nodup nodup_toList ?_).mpr fun ⟨k, v⟩ => ⟨?_, ?_⟩
   · refine FromMathlib.Nodup.filterMap ?_ nodup_toList
@@ -1030,11 +1034,11 @@ theorem toList_filterMap {f : V → Option V} {m : M V} (HI : Function.Injective
     obtain ⟨H', rfl⟩ := Ha₂
     refine ⟨a.snd, toList_get.mp Ha₁, H'⟩
 
-theorem toList_filter {φ : K → V → Bool} {m : M V} :
-    (toList (M := M) (K := K) (PartialMap.filter φ m)).Perm
+theorem toList_filter {φ : μ.K → V → Bool} {m : M V} :
+    (toList (M := M) (PartialMap.filter φ m)).Perm
       ((toList m).filter (fun kv => φ kv.1 kv.2)) := by
   refine (List.perm_ext_iff_of_nodup nodup_toList ?_).mpr fun ⟨k, v⟩ => ⟨?_, ?_⟩
-  · exact FromMathlib.Nodup.filter ?_ (nodup_toList (M := M) (K := K))
+  · exact FromMathlib.Nodup.filter ?_ (nodup_toList (M := M))
   · intro H
     refine List.mem_filter.mpr ?_
     have H' := toList_get.mp H
@@ -1051,7 +1055,7 @@ theorem toList_filter {φ : K → V → Bool} {m : M V} :
     simp [get?_filter, toList_get.mp H.1, H.2]
 
 theorem toList_zip {m₁ : M V} {m₂ : M V'} :
-    (toList (M := M) (K := K) (PartialMap.zip m₁ m₂)).Perm
+    (toList (M := M) (PartialMap.zip m₁ m₂)).Perm
       ((toList m₁).filterMap fun kv₁ =>
         (get? m₂ kv₁.1).map fun v₂ => (kv₁.1, (kv₁.2, v₂))) := by
   refine (List.perm_ext_iff_of_nodup nodup_toList ?_).mpr fun ⟨k, v⟩ => ⟨?_, ?_⟩
@@ -1078,12 +1082,12 @@ theorem toList_zip {m₁ : M V} {m₂ : M V'} :
     refine ⟨a.2, toList_get.mp Ha₁, ?_⟩
     simp [Hb₁]
 
-theorem mem_dom_set [LawfulSet S K] {m : M V} : k ∈ (dom_set m : S) ↔ (get? m k).isSome := by
+theorem mem_dom_set [LawfulSet S μ.K] {m : M V} : k ∈ (dom_set m : S) ↔ (get? m k).isSome := by
   simpa [dom_set, ←LawfulSet.mem_ofList, FiniteMap.mapFold, Option.isSome_iff_exists,
     ←LawfulFiniteMap.toList_get] using .rfl
 
-theorem toList_dom_set_perm [LawfulFiniteSet S K] (m : M V) :
-    (FiniteSet.toList (dom_set m : S)).Perm ((toList (K := K) m).map Prod.fst) := by
+theorem toList_dom_set_perm [LawfulFiniteSet S μ.K] (m : M V) :
+    (FiniteSet.toList (dom_set m : S)).Perm ((toList m).map Prod.fst) := by
   refine (List.perm_ext_iff_of_nodup FiniteSet.toList_nodup toList_noDupKeys).mpr fun x => ?_
   simp only [FiniteSet.mem_toList, mem_dom_set, List.mem_map]
   constructor


### PR DESCRIPTION
## Description
Proposed change to make the `PartialMap` interface more usable, by fixing a lot of issues with the `K` type not being inferred correctly in different function applications. [Link to Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/Adding.20missing.20definitions.20to.20.60Plainly.2Elean.60/near/585523260) in which this PR is mentioned.

This PR addresses this issue by embedding the type `K` inside of the typeclass' definition, as a new field. The issue with this approach is that one can no longer make reference to maps which share the same keys easily in theorems. One theorem which suffers one such problem is `bigSepM_impl_strong`.

## Checklist
* [ ] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [ ] I have updated `PORTING.md` as appropriate
* [ ] I have added my name to the `authors` section of any appropriate files
