### PR TITLE
fix: make FiniteMap K param an outParam

### DIFF
--- a/src/Iris/Algebra/BigOp.lean
+++ b/src/Iris/Algebra/BigOp.lean
@@ -30,7 +30,7 @@ open OFE Iris.Std
 
 @[expose] public def bigOpM {M : Type u} [OFE M] (op : M → M → M) {unit : M} [MonoidOps op unit] {K : Type _}
     {V : Type _} (Φ : K → V → M) {M' : Type _ → Type _} [LawfulFiniteMap M' K] (m : M' V) : M :=
-  bigOpL op (fun _ kv => Φ kv.1 kv.2) (toList (K := K) m)
+  bigOpL op (fun _ kv => Φ kv.1 kv.2) (toList m)
 
 @[expose] public def bigOpS {M : Type u} [OFE M] (op : M → M → M) {unit : M} [MonoidOps op unit]
     {A : Type _} {S : Type _} [FiniteSet S A] (Φ : A → M) (m : S) : M :=
@@ -294,7 +294,7 @@ theorem bigOpM_gen_proper_2 {A : Type _} {B : Type _} {R : M → M → Prop}
     (∀ {k y1 y2}, get? m1' k = some y1 → get? m2' k = some y2 → R (Φ k y1) (Ψ k y2)) →
     R ([^ op map] k ↦ x ∈ m1', Φ k x) ([^ op map] k ↦ x ∈ m2', Ψ k x)
   suffices h : P m1 from h m2 hdom hf
-  apply LawfulFiniteMap.induction_on (K := K) (P := P)
+  apply LawfulFiniteMap.induction_on (P := P)
   · intro m₁ m₂ heq hP m2' hdom' hf'
     refine hR_equiv.trans (hR_sub (bigOpM_equiv_of_perm Φ heq).symm) ?_
     exact hP m2' (fun k => heq k ▸ hdom' k) (hf' <| (heq _) ▸ ·)
@@ -354,7 +354,7 @@ theorem bigOpM_proper_pointwise {Φ Ψ : K → V → M} (m : M' V) (hf : ∀ {k 
   bigOpM_proper (fun _ => hf)
 
 theorem bigOpM_toList_equiv (Φ : K → V → M) (m : M' V) :
-    ([^ op map] k ↦ x ∈ m, Φ k x) ≡ ([^ op list] kx ∈ toList (K := K) m, Φ kx.1 kx.2) :=
+    ([^ op map] k ↦ x ∈ m, Φ k x) ≡ ([^ op list] kx ∈ toList m, Φ kx.1 kx.2) :=
   .rfl
 
 theorem bigOpM_ofList_equiv [DecidableEq K] (Φ : K → V → M) (l : List (K × V)) (hd : NoDupKeys l) :
@@ -367,7 +367,7 @@ theorem bigOpM_singleton_equiv (Φ : K → V → M) (i : K) (x : V) :
   simpa only [bigOpM_empty] using op_right_id
 
 theorem bigOpM_const_unit_equiv [DecidableEq K] (m : M' V) :
-    bigOpM (K := K) op (fun _ _ => unit) m ≡ unit :=
+    bigOpM op (fun _ _ => unit) m ≡ unit :=
   bigOpL_const_unit_equiv
 
 theorem bigOpM_map_equiv (h : V → B) (Φ : K → B → M) (m : M' V) :
@@ -415,7 +415,7 @@ theorem bigOpM_filter_equiv (φ : K → V → Bool) (Φ : K → V → M) (m : M'
     (bigOpL_filter_equiv (fun (k, v) => φ k v) (fun (k, v) => Φ k v) _)
 
 theorem toList_union_perm [DecidableEq K] {m1 m2 : M' V} (hdisj : m1 ##ₘ m2) :
-    (toList (K := K) (m1 ∪ m2)).Perm (toList (K := K) m1 ++ toList (K := K) m2) := by
+    (toList (m1 ∪ m2)).Perm (toList m1 ++ toList m2) := by
   refine (List.perm_ext_iff_of_nodup LawfulFiniteMap.nodup_toList ?_).mpr fun ⟨k, v⟩ => ?_
   · refine List.nodup_append.mpr ⟨LawfulFiniteMap.nodup_toList, LawfulFiniteMap.nodup_toList, ?_⟩
     rintro ⟨k, _⟩ h1 _ h2 rfl
@@ -495,7 +495,7 @@ theorem bigOpM_weak_hom [DecidableEq K] [ι : WeakMonoidHomomorphism op₁ op₂
   refine bigOpL_hom_weak (H := ι) _ ?_
   refine fun Hk => Hne ?_
   refine .trans LawfulFiniteMap.ofList_toList.symm ?_
-  rw [show (LawfulFiniteMap.toList (K := K) m) = [] from List.nil_eq.mpr Hk |>.symm]
+  rw [show (LawfulFiniteMap.toList m) = [] from List.nil_eq.mpr Hk |>.symm]
   exact .trans (congrFun rfl) (congrFun rfl )
 
 end BigOpM

--- a/src/Iris/Algebra/Heap.lean
+++ b/src/Iris/Algebra/Heap.lean
@@ -82,7 +82,7 @@ open PartialMap
 
 variable [LawfulPartialMap M K] [CMRA V]
 
-@[simp] def op (s1 s2 : M V) : M V := merge (K := K) (fun _ => CMRA.op) s1 s2
+@[simp] def op (s1 s2 : M V) : M V := merge (fun _ => CMRA.op) s1 s2
 @[simp] def unit : M V := empty
 @[simp] def pcore (s : M V) : Option (M V) := some <| bindAlter (fun _ => CMRA.pcore) s
 @[simp] def valid (s : M V) : Prop := ∀ k, ✓ get? s k

--- a/src/Iris/BI/BigOp/BigAndMap.lean
+++ b/src/Iris/BI/BigOp/BigAndMap.lean
@@ -238,7 +238,7 @@ theorem bigAndM_laterN {Φ : K → V → PROP} {m : M V} {n : Nat} :
 
 @[rocq_alias big_andM_map_to_list]
 theorem bigAndM_toList {Φ : K → V → PROP} {m : M V} :
-    ([∧map] k ↦ x ∈ m, Φ k x) ⊣⊢ ([∧list] kv ∈ toList (K := K) m, Φ kv.1 kv.2) :=
+    ([∧map] k ↦ x ∈ m, Φ k x) ⊣⊢ ([∧list] kv ∈ toList m, Φ kv.1 kv.2) :=
   .rfl
 
 @[rocq_alias big_andM_fmap]

--- a/src/Iris/BI/BigOp/BigSepMap.lean
+++ b/src/Iris/BI/BigOp/BigSepMap.lean
@@ -351,7 +351,7 @@ theorem bigSepM_pure [BIAffine PROP] {φ : K → V → Prop} {m : M V} :
 
 @[rocq_alias big_sepM_map_to_list]
 theorem bigSepM_toList {Φ : K → V → PROP} {m : M V} :
-    ([∗map] k ↦ x ∈ m, Φ k x) ⊣⊢ ([∗list] kv ∈ toList (K := K) m, Φ kv.1 kv.2) :=
+    ([∗map] k ↦ x ∈ m, Φ k x) ⊣⊢ ([∗list] kv ∈ toList m, Φ kv.1 kv.2) :=
   .rfl
 
 @[rocq_alias big_sepM_list_to_map]
@@ -494,7 +494,7 @@ theorem bigSepM_impl_strong [DecidableEq K] {M₂ : Type _ → Type _} {V₂ : T
     ⊢ ([∗map] k ↦ y ∈ m₂, Ψ k y) ∗
       [∗map] k ↦ x ∈ filter (fun k _ => (get? m₂ k).isNone) m₁, Φ k x
   suffices P m₂ from this m₁
-  refine LawfulFiniteMap.induction_on (K := K) (fun _ _ heq IH m₁ => ?hequiv) ?hemp ?hind m₂
+  refine LawfulFiniteMap.induction_on (fun _ _ heq IH m₁ => ?hequiv) ?hemp ?hind m₂
   case hequiv =>
     refine (sep_mono_r ?_).trans <| (IH m₁).trans ?_
     · refine intuitionistically_mono ?_

--- a/src/Iris/BI/Plainly.lean
+++ b/src/Iris/BI/Plainly.lean
@@ -611,7 +611,7 @@ instance  bigSepM__plain {K} [DecidableEq K] {M A} [ι : LawfulFiniteMap M K] (�
   (m : M A) [h : ∀ k x, Plain (Φ k x)] :
     Plain ([∗map] k↦x ∈ m, Φ k x) where
   plain := by
-    induction m using Iris.Std.LawfulFiniteMap.induction_on (K := K) (M := M)
+    induction m using Iris.Std.LawfulFiniteMap.induction_on
     case hequiv m₁ m₂ m₁m₂ H =>
       have h : iprop([∗map] k ↦ x ∈ m₁, Φ k x) ≡ [∗map] k ↦ x ∈ m₂, Φ k x :=
           Algebra.BigOpM.bigOpM_equiv_of_perm (M' := M) _ m₁m₂
@@ -620,7 +620,7 @@ instance  bigSepM__plain {K} [DecidableEq K] {M A} [ι : LawfulFiniteMap M K] (�
         _  ⊢ ■ [∗map] k ↦ x ∈ m₁, Φ k x := H
         _ ⊣⊢ ■ [∗map] k ↦ x ∈ m₂, Φ k x := .ofMono plainly_mono <| BI.equiv_iff.1 h
     case hemp =>
-      rw [show empty (M := M) (K := K) = ∅ from rfl]
+      rw [show empty = ∅ from rfl]
       simp only [Algebra.BigOpM.bigOpM_empty, plain]
     case hins k v m get?_m_k IH=>
       calc iprop([∗map] k ↦ x ∈ Std.insert m k v, Φ k x)

--- a/src/Iris/Std/PartialMap.lean
+++ b/src/Iris/Std/PartialMap.lean
@@ -47,7 +47,7 @@ export PartialMap (get? insert delete empty bindAlter merge)
 
 /-- A FiniteMap is a PartialMap with a toList operation. Like in Stdpp, the order in
 which the elements are passed into the list is unspecified. -/
-class FiniteMap M K extends PartialMap M K where
+class FiniteMap (M : Type _ → Type _) (K : outParam (Type _)) extends PartialMap M K where
   toList : M V → List (K × V)
 export FiniteMap (toList)
 
@@ -237,7 +237,8 @@ class LawfulPartialMap (M : Type _ → Type _) (K : outParam (Type _))
 export LawfulPartialMap (get?_empty get?_insert_eq get?_insert_ne get?_delete_eq
   get?_delete_ne get?_bindAlter get?_merge)
 
-class LawfulFiniteMap M K extends LawfulPartialMap M K, FiniteMap M K where
+class LawfulFiniteMap (M : Type _ → Type _) (K : outParam (Type _)) 
+    extends LawfulPartialMap M K, FiniteMap M K where
   toList_empty : toList (∅ : M V) = []
   toList_noDupKeys : NoDupKeys (toList (m : M V))
   toList_get : (k, v) ∈ toList m ↔ get? m k = some v
@@ -252,7 +253,7 @@ variable {K V : Type _} {M : Type _ → Type _} [FiniteMap M K]
 --   mapFold (fun k v acc => (k, v) :: acc) [] m
 
 def mapFold {A : Type _} (f : K → V → A → A) (a : A) (m : M V) : A :=
-  List.foldl (fun a' ⟨k, v⟩ => f k v a') a (toList (K := K) m)
+  List.foldl (fun a' ⟨k, v⟩ => f k v a') a (toList m)
 
 /-- Convert a list to a map with sequential natural number keys starting from `start`. -/
 def map_seq [FiniteMap M Nat] (start : Nat) (l : List V) : M V :=
@@ -306,7 +307,7 @@ theorem get?_insert_rev {m : M V} {i : K} {x y : V} :
 
 theorem empty_subset (m : M V) : (∅ : M V) ⊆ m := by
   intro k v h
-  simp [show get? (∅ : M V) k = none from get?_empty (M := M) k] at h
+  simp [show get? (∅ : M V) k = none from get?_empty k] at h
 
 theorem disjoint_empty_left (m : M V) : (∅ : M V) ##ₘ m := by
   intro k ⟨h₁, _⟩
@@ -818,7 +819,7 @@ open FiniteMap LawfulFiniteMap PartialMap LawfulPartialMap
 --     P (insert m i x)) →
 --   ∀ m, P m
 
-theorem toList_get?_none {m : M V} : (∀ v, (k, v) ∉ toList (K := K) m) ↔ get? m k = none := by
+theorem toList_get?_none {m : M V} : (∀ v, (k, v) ∉ toList m) ↔ get? m k = none := by
   constructor
   · intro Hn
     refine Option.eq_none_iff_forall_ne_some.mpr ?_
@@ -830,11 +831,11 @@ theorem NoDupKeys_noDup {L : List (K × V)} : NoDupKeys L → L.Nodup := by
   refine fun H => FromMathlib.List.Nodup.of_map (fun x => x.fst) ?_
   exact H
 
-theorem nodup_toList {m : M V} : (toList (K := K) m).Nodup :=
+theorem nodup_toList {m : M V} : (toList m).Nodup :=
   NoDupKeys_noDup toList_noDupKeys
 
 theorem ofList_toList [DecidableEq K] {m : M V} :
-    PartialMap.equiv (ofList (toList (K := K) m)) m := by
+    PartialMap.equiv (ofList (toList m)) m := by
   intro k
   rcases h : get? m k with _|v
   · refine get?_ofList_none ?_ toList_noDupKeys
@@ -855,7 +856,7 @@ theorem induction_on [DecidableEq K] {P : M V → Prop}
   | cons kv rest ih =>
     rw [ofList_cons]
     apply hins kv.1 kv.2
-    · refine get?_ofList_none (M := M) ?_ (noDupKeys_cons hnd)
+    · refine get?_ofList_none ?_ (noDupKeys_cons hnd)
       intro ⟨v, hv⟩
       exact (List.nodup_cons.mp hnd).1 (List.mem_map_of_mem (f := Prod.fst) (a := (kv.1, v)) hv)
     · exact ih (noDupKeys_cons hnd)
@@ -876,14 +877,14 @@ theorem mem_of_mem_ofList [DecidableEq K] {l : List (K × V)} {i : K} {x : V}
       exact List.mem_cons_of_mem (k, v) (IH H)
 
 theorem toList_ofList [DecidableEq K] {l : List (K × V)} (Hdup : NoDupKeys l) :
-    (toList (M := M) (K := K) (ofList l : M V)).Perm l := by
+    (toList (ofList l : M V)).Perm l := by
   refine (List.perm_ext_iff_of_nodup nodup_toList ?_).mpr fun ⟨k, v⟩ => ⟨?_, ?_⟩
   · exact NoDupKeys_noDup Hdup
   · exact (mem_of_mem_ofList <| toList_get.mp ·)
   · exact (toList_get.mpr <| get?_ofList_some · Hdup)
 
 theorem toList_perm_of_get?_eq {m₁ m₂ : M V} (h : ∀ k, get? m₁ k = get? m₂ k) :
-    (toList (M := M) (K := K) m₁).Perm (toList (M := M) (K := K) m₂) := by
+    (toList m₁).Perm (toList m₂) := by
   refine (List.perm_ext_iff_of_nodup nodup_toList nodup_toList).mpr fun ⟨k, v⟩ => ⟨?_, ?_⟩
   · intro H
     refine toList_get.mpr ?_
@@ -895,7 +896,7 @@ theorem toList_perm_of_get?_eq {m₁ m₂ : M V} (h : ∀ k, get? m₁ k = get? 
     exact toList_get.mp H
 
 theorem toList_insert {m : M V} {k : K} {v : V} (h : get? m k = none) :
-    (toList (M := M) (K := K) (insert m k v)).Perm ((k, v) :: toList (M := M) (K := K) m) := by
+    (toList (insert m k v)).Perm ((k, v) :: toList m) := by
   refine (List.perm_ext_iff_of_nodup nodup_toList ?_).mpr fun ⟨k', v'⟩ => ⟨?_, ?_⟩
   · refine  List.nodup_cons.mpr ⟨?_, nodup_toList⟩
     exact fun H => Option.some_ne_none _ (h ▸ toList_get.mp H).symm
@@ -923,7 +924,7 @@ theorem toList_insert {m : M V} {k : K} {v : V} (h : get? m k = none) :
         refine toList_get.mp H
 
 theorem toList_delete {m : M V} {k : K} {v : V} (h : get? m k = some v) :
-    (toList (M := M) (K := K) m).Perm ((k, v) :: toList (M := M) (K := K) (delete m k)) := by
+    (toList m).Perm ((k, v) :: toList (delete m k)) := by
   refine (List.perm_ext_iff_of_nodup nodup_toList ?_).mpr fun ⟨k', v'⟩ => ⟨?_, ?_⟩
   · refine List.nodup_cons.mpr ⟨?_, nodup_toList⟩
     intro H
@@ -975,8 +976,8 @@ theorem ofList_injective [DecidableEq K] {l₁ l₂ : List (K × V)}
     exact get?_ofList_some H (List.nodup_iff_pairwise_ne.mpr hnodup2)
 
 theorem toList_insert_delete {m : M V} {k : K} {v : V} :
-    (toList (M := M) (K := K) (insert m k v)).Perm
-      (toList (M := M) (K := K) (insert (delete m k) k v)) := by
+    (toList (insert m k v)).Perm
+      (toList (insert (delete m k) k v)) := by
   apply toList_perm_of_get?_eq
   intro k'
   by_cases h : k = k'
@@ -984,7 +985,7 @@ theorem toList_insert_delete {m : M V} {k : K} {v : V} :
   · simp [LawfulPartialMap.get?_insert_ne h, LawfulPartialMap.get?_delete_ne h]
 
 theorem toList_map {f : V → V'} {m : M V}  :
-    (toList (M := M) (K := K) (PartialMap.map f m)).Perm
+    (toList (PartialMap.map f m)).Perm
       ((toList m).map (fun kv => (kv.1, f kv.2))) := by
   refine (List.perm_ext_iff_of_nodup nodup_toList ?_).mpr fun ⟨k, v⟩ => ⟨?_, ?_⟩
   · refine FromMathlib.Nodup.map_on ?_ nodup_toList
@@ -1006,7 +1007,7 @@ theorem toList_map {f : V → V'} {m : M V}  :
     rfl
 
 theorem toList_filterMap {f : V → Option V} {m : M V} (HI : Function.Injective f) :
-    (toList (M := M) (K := K) (PartialMap.filterMap f m)).Perm
+    (toList (PartialMap.filterMap f m)).Perm
       ((toList m).filterMap (fun kv => (f kv.2).map (kv.1, ·))) := by
   refine (List.perm_ext_iff_of_nodup nodup_toList ?_).mpr fun ⟨k, v⟩ => ⟨?_, ?_⟩
   · refine FromMathlib.Nodup.filterMap ?_ nodup_toList
@@ -1031,10 +1032,10 @@ theorem toList_filterMap {f : V → Option V} {m : M V} (HI : Function.Injective
     refine ⟨a.snd, toList_get.mp Ha₁, H'⟩
 
 theorem toList_filter {φ : K → V → Bool} {m : M V} :
-    (toList (M := M) (K := K) (PartialMap.filter φ m)).Perm
+    (toList (PartialMap.filter φ m)).Perm
       ((toList m).filter (fun kv => φ kv.1 kv.2)) := by
   refine (List.perm_ext_iff_of_nodup nodup_toList ?_).mpr fun ⟨k, v⟩ => ⟨?_, ?_⟩
-  · exact FromMathlib.Nodup.filter ?_ (nodup_toList (M := M) (K := K))
+  · exact FromMathlib.Nodup.filter ?_ (nodup_toList (M := M))
   · intro H
     refine List.mem_filter.mpr ?_
     have H' := toList_get.mp H
@@ -1051,7 +1052,7 @@ theorem toList_filter {φ : K → V → Bool} {m : M V} :
     simp [get?_filter, toList_get.mp H.1, H.2]
 
 theorem toList_zip {m₁ : M V} {m₂ : M V'} :
-    (toList (M := M) (K := K) (PartialMap.zip m₁ m₂)).Perm
+    (toList (M := M) (PartialMap.zip m₁ m₂)).Perm
       ((toList m₁).filterMap fun kv₁ =>
         (get? m₂ kv₁.1).map fun v₂ => (kv₁.1, (kv₁.2, v₂))) := by
   refine (List.perm_ext_iff_of_nodup nodup_toList ?_).mpr fun ⟨k, v⟩ => ⟨?_, ?_⟩
@@ -1083,7 +1084,7 @@ theorem mem_dom_set [LawfulSet S K] {m : M V} : k ∈ (dom_set m : S) ↔ (get? 
     ←LawfulFiniteMap.toList_get] using .rfl
 
 theorem toList_dom_set_perm [LawfulFiniteSet S K] (m : M V) :
-    (FiniteSet.toList (dom_set m : S)).Perm ((toList (K := K) m).map Prod.fst) := by
+    (FiniteSet.toList (dom_set m : S)).Perm ((toList m).map Prod.fst) := by
   refine (List.perm_ext_iff_of_nodup FiniteSet.toList_nodup toList_noDupKeys).mpr fun x => ?_
   simp only [FiniteSet.mem_toList, mem_dom_set, List.mem_map]
   constructor


### PR DESCRIPTION
## Description
Make `FiniteMap` and `LawfulFiniteMap`'s `K` argument type an `outParam`.

## Checklist
* [X] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [X] I have updated `PORTING.md` as appropriate
* [x] I have added my name to the `authors` section of any appropriate files