### PR TITLE
fix: remove duplicate printing of trace result

### DIFF
--- a/src/Iris/ProofMode/SynthInstance.lean
+++ b/src/Iris/ProofMode/SynthInstance.lean
@@ -80,20 +80,20 @@ partial def synthInstanceMainCore (mvar : Expr) : MetaM (Option Unit) := do
     let mvarType  ← inferType mvar
     let mvarType  ← instantiateMVars mvarType
     if !(ipmClassesExt.getState (← getEnv)).contains mvarType.getAppFn.constName then
-      return ← withTraceNode `Meta.synthInstance (return m!"{·.toTraceResult.toEmoji} switch to normal synthInstance") do
+      return ← withTraceNode `Meta.synthInstance (λ _ => return m!"switch to normal synthInstance") do
         let some e ← synthInstance? mvarType | return none
         mvar.mvarId!.assign e
         return some ()
 
     let mctx0 ← getMCtx
-    withTraceNode `Meta.synthInstance (return m!"{·.toTraceResult.toEmoji} new goal {MessageData.withMCtx mctx0 m!"{mvarType}"} => {mvarType}") do
+    withTraceNode `Meta.synthInstance (λ _ => return m!"new goal {MessageData.withMCtx mctx0 m!"{mvarType}"} => {mvarType}") do
     let instances ← SynthInstance.getInstances mvarType
     let mctx      ← getMCtx
     if instances.isEmpty then
       return none
     for inst in instances.reverse do
       let (res, match?) ← withTraceNode `Meta.synthInstance
-        (λ r => withMCtx mctx do return MessageData.withMCtx mctx m!"{(r.map (·.1)).toTraceResult.toEmoji} apply {inst.val} to {← instantiateMVars (← inferType mvar)}") do
+        (λ _ => withMCtx mctx do return MessageData.withMCtx mctx m!"apply {inst.val} to {← instantiateMVars (← inferType mvar)}") do
         setMCtx mctx
         let some (mctx', subgoals) ← withAssignableSyntheticOpaque (SynthInstance.tryResolve mvar inst) | return (none, false)
         setMCtx mctx'
@@ -123,7 +123,7 @@ def synthInstanceCore? (type : Expr) (maxResultSize? : Option Nat := none) : Met
   let opts ← getOptions
   let maxResultSize := maxResultSize?.getD (synthInstance.maxSize.get opts)
   withTraceNode `Meta.synthInstance
-    (return m!"IPM: {·.toTraceResult.toEmoji} {← instantiateMVars type}") do
+    (λ _ => return m!"IPM: {← instantiateMVars type}") do
   withConfig (fun config => { config with isDefEqStuckEx := true, transparency := TransparencyMode.instances,
                                           foApprox := true, ctxApprox := true, constApprox := false, univApprox := false }) do
   withInTypeClassResolution do

--- a/src/Iris/Tests/Instances.lean
+++ b/src/Iris/Tests/Instances.lean
@@ -53,3 +53,40 @@ variable [BI PROP] (P1 P2 : Nat → PROP)
 #guard_msgs in #ipm_synth (IntoWand false false iprop(P1 _ -∗ P2 1) .in (P1 1) .out _)
 
 end mvars
+
+section trace
+
+variable [BI PROP] (P1 : PROP)
+
+/--
+info: solution: FromAssumption false InOut.out P1 P1, new goals: []
+---
+trace: [Meta.synthInstance] ✅️ IPM: FromAssumption false InOut.out P1 P1
+  [Meta.synthInstance] ✅️ new goal FromAssumption false InOut.out ?_ P1 => FromAssumption false InOut.out P1 P1
+    [Meta.synthInstance.instances] #[@fromAssumption_exact]
+    [Meta.synthInstance] ✅️ apply @fromAssumption_exact to FromAssumption false InOut.out ?_ P1
+      [Meta.synthInstance.tryResolve] ✅️ FromAssumption false InOut.out P1 P1 ≟ FromAssumption false InOut.out P1 P1
+      [Meta.synthInstance] ✅️ switch to normal synthInstance
+        [Meta.synthInstance] ✅️ BI PROP
+          [Meta.synthInstance] ✅️ new goal BI PROP
+            [Meta.synthInstance.instances] #[@Sbi.toBI, inst✝]
+          [Meta.synthInstance.apply] ✅️ apply inst✝ to BI PROP
+            [Meta.synthInstance.tryResolve] ✅️ BI PROP ≟ BI PROP
+            [Meta.synthInstance.answer] ✅️ BI PROP
+          [Meta.synthInstance] result inst✝
+  [Meta.synthInstance] result fromAssumption_exact false InOut.out P1
+---
+trace: [Meta.synthInstance] ✅️ BI PROP
+  [Meta.synthInstance] ✅️ new goal BI PROP
+    [Meta.synthInstance.instances] #[@Sbi.toBI, inst✝]
+  [Meta.synthInstance.apply] ✅️ apply inst✝ to BI PROP
+    [Meta.synthInstance.tryResolve] ✅️ BI PROP ≟ BI PROP
+    [Meta.synthInstance.answer] ✅️ BI PROP
+  [Meta.synthInstance] result inst✝
+-/
+#guard_msgs in
+set_option trace.Meta.synthInstance true in
+set_option pp.mvars false in
+#ipm_synth (FromAssumption false .out _ P1)
+
+end trace


### PR DESCRIPTION
## Description
This PR fixes the duplicate printing of the trace result introduced by the update to Lean 4.29.0.
