### PR TITLE
fix: allow postponing meta variables in ihave

### DIFF
--- a/src/Iris/ProofMode/Classes.lean
+++ b/src/Iris/ProofMode/Classes.lean
@@ -32,7 +32,7 @@ inductive AsEmpValid.Direction where
   | from
 
 @[ipm_class]
-class AsEmpValid (d : AsEmpValid.Direction) (φ : Prop) {PROP : outParam (Type _)} (P : outParam PROP) [BI PROP] where
+class AsEmpValid (d : AsEmpValid.Direction) (φ : Prop) {PROP : semiOutParam (Type _)} (P : outParam PROP) [semiOutParam (BI PROP)] where
   as_emp_valid : (d = .into → φ → ⊢ P) ∧ (d = .from → (⊢ P) → φ)
 
 theorem asEmpValid_1 [BI PROP] (P : PROP) [AsEmpValid .into φ P] : φ → ⊢ P :=

--- a/src/Iris/ProofMode/SynthInstance.lean
+++ b/src/Iris/ProofMode/SynthInstance.lean
@@ -79,7 +79,10 @@ partial def synthInstanceMainCore (mvar : Expr) : MetaM (Option Unit) := do
     let backtrackSet := ipmBacktrackExt.getState (← getEnv)
     let mvarType  ← inferType mvar
     let mvarType  ← instantiateMVars mvarType
-    if !(ipmClassesExt.getState (← getEnv)).contains mvarType.getAppFn.constName then
+    let bodyConstName ← forallTelescopeReducing mvarType fun _ typeBody => do
+      let typeBody ← whnf typeBody
+      return typeBody.getAppFn.constName
+    if !(ipmClassesExt.getState (← getEnv)).contains bodyConstName then
       return ← withTraceNode `Meta.synthInstance (λ _ => return m!"switch to normal synthInstance") do
         let some e ← synthInstance? mvarType | return none
         mvar.mvarId!.assign e

--- a/src/Iris/ProofMode/Tactics/Apply.lean
+++ b/src/Iris/ProofMode/Tactics/Apply.lean
@@ -51,7 +51,7 @@ elab "iapply" colGt pmt:pmTerm : tactic => do
   let pmt ← liftMacroM <| PMTerm.parse pmt
   ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
   -- elaborate the proof mode term `pmt` to the hypothesis `out`
-  let ⟨e, hyps', p, out, pf⟩ ← iHave hyps pmt true (mayPostpone := true)
+  let ⟨e, hyps', p, out, pf⟩ ← iHave hyps pmt true
   -- if `□?p out` directly matches goal, behave like `iexact`
   if let some _ ← ProofModeM.trySynthInstanceQ q(FromAssumption $p .in $out $goal) then
     -- ensure the context can be discarded

--- a/src/Iris/ProofMode/Tactics/HaveCore.lean
+++ b/src/Iris/ProofMode/Tactics/HaveCore.lean
@@ -37,7 +37,6 @@ Assert a hypothesis from either a hypothesis name or a Lean proof term `tm`.
 - `hyps`: Current proof mode hypothesis context
 - `keep`: If `true` and `tm` is a persistent Iris hypothesis, keep it in the context;
   if `false`, remove it
-- `mayPostpone`: If `true`, allow postponing elaboration of metavariables in `tm`
 
 ## Returns
 A tuple containing:
@@ -48,7 +47,7 @@ A tuple containing:
 - `pf`: Proof of `hyps ⊢ hyps' ∗ □?p out`
 -/
 private def iHaveCore {e} (hyps : @Hyps u prop bi e)
-  (tm : Term) (keep : Bool) (mayPostpone : Bool) :
+  (tm : Term) (keep : Bool) :
   ProofModeM ((e' : _) × Hyps bi e' × (p : Q(Bool)) × (out : Q($prop)) × Q($e ⊢ $e' ∗ □?$p $out)) := do
   if let some uniq ← try? <| hyps.findWithInfo ⟨tm⟩ then
     -- assertion from the Iris context
@@ -56,7 +55,7 @@ private def iHaveCore {e} (hyps : @Hyps u prop bi e)
     return ⟨_, hyps, p, out', q($pf.1)⟩
   else
     -- lean hypothesis
-    let val ← instantiateMVars <| ← elabTerm tm none mayPostpone
+    let val ← instantiateMVars <| ← elabTerm tm none (mayPostpone := true)
     let ty ← instantiateMVars <| ← inferType val
 
     let ⟨newMVars, _, _⟩ ← forallMetaTelescope ty
@@ -85,10 +84,10 @@ private def iHaveCore {e} (hyps : @Hyps u prop bi e)
     return ⟨_, hyps, q(true), hyp, q(have_asEmpValid $val)⟩
 
 def iHave {e} (hyps : @Hyps u prop bi e)
-  (pmt : PMTerm) (keep : Bool) (try_dup_context : Bool := false) (mayPostpone := false) :
+  (pmt : PMTerm) (keep : Bool) (try_dup_context : Bool := false) :
   ProofModeM ((e' : _) × Hyps bi e' × (p : Q(Bool)) × (out : Q($prop)) × Q($e ⊢ $e' ∗ □?$p $out)) := do
   -- assert `term` as hypothesis `A`
-  let ⟨_, hyps', p, A, pf⟩ ← iHaveCore hyps pmt.term keep mayPostpone
+  let ⟨_, hyps', p, A, pf⟩ ← iHaveCore hyps pmt.term keep
   -- specialize `A` with `spats`
   let ⟨_, hyps'', pb, B, pf'⟩ ← iSpecializeCore hyps' p A pmt.spats (try_dup_context := try_dup_context)
   return ⟨_, hyps'', pb, B, q($(pf).trans $pf')⟩


### PR DESCRIPTION
## Description
This allows one to avoid specifying the type of the goal manually in some cases. Such problems were found by https://github.com/leanprover-community/iris-lean/pull/314