### PR TITLE
fix: make rocq_ignore attribute a Lean module

### DIFF
--- a/src/Iris/Std/RocqIgnore.lean
+++ b/src/Iris/Std/RocqIgnore.lean
@@ -4,7 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu
 -/
 
-import Lean
+module
+
+public meta import Lean
 import Iris.Std.RocqAlias
 
 /-!
@@ -22,12 +24,13 @@ A command for marking Rocq definitions as intentionally not ported.
 open Lean Elab Command
 
 /-- Environment extension tracking all `#rocq_ignore` entries as `(rocqName, reason)` pairs. -/
-initialize rocqIgnoreExt : SimplePersistentEnvExtension (Name × String) (Array (Name × String)) ←
+meta initialize rocqIgnoreExt : SimplePersistentEnvExtension (Name × String) (Array (Name × String)) ←
   registerSimplePersistentEnvExtension {
     addEntryFn := Array.push
     addImportedFn := fun es => es.foldl (fun acc a => a.foldl Array.push acc) #[]
   }
 
 /-- Mark a Rocq definition as intentionally not ported. -/
+@[expose]
 elab "#rocq_ignore" id:ident reason:str : command => do
   modifyEnv (rocqIgnoreExt.addEntry · (id.getId, reason.getString))


### PR DESCRIPTION
## Description
Rocq ignore not being defined in a module prevents it from being used in modules.

## Checklist
* [X] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [X] I have updated `PORTING.md` as appropriate
* [X] I have added my name to the `authors` section of any appropriate files
