### PR TITLE
feat: add language interface

### DIFF
--- a/src/Iris/ProgramLogic/Language.lean
+++ b/src/Iris/ProgramLogic/Language.lean
@@ -7,8 +7,6 @@ public import Iris.Std.Relation
 public meta import Lean.PrettyPrinter.Delaborator
 public import Batteries.Data.List.Basic
 
--- TODO: Not convinced if `of_val` should be `ToVal.coe` using `Coe`
---       directly, or if some other typeclass should be preferred.
 -- TODO: Term levels for the different notations were chosen arbitrarily.
 --       Make sure they are adequate.
 -- TODO: Rename all `Context.fill` lemmas to something more consistent.
@@ -46,11 +44,11 @@ variable {Expr : Type e}{Val : Type v}{State : Type σ}{Obs : Type o}
 
 class ToVal (Expr : Type e) (Val : outParam <| Type v ) where
   toVal : Expr → Option Val
-  [coe : Coe Val Expr]
+  ofVal : Val → Expr
   /-- If `toVal` is defined for an expression, `coe` is its inverse -/
-  coe_of_toVal_eq (e : Expr)(v : Val) : toVal e = some v → (v : Expr) = e
+  coe_of_toVal_eq (e : Expr)(v : Val) : toVal e = some v → ofVal v = e
   /-- `toVal` is defined `coe`, and works as its inverse -/
-  toVal_coe (v : Val) : toVal (v : Expr) = some v
+  toVal_coe (v : Val) : toVal (ofVal v) = some v
 export ToVal (toVal)
 
 attribute [rocq_alias language.to_val] ToVal.toVal
@@ -63,7 +61,8 @@ namespace ToVal
 
 variable [ToVal Expr Val]
 
-instance : Coe Val Expr := ToVal.coe
+attribute [coe] ToVal.ofVal
+instance : Coe Val Expr where coe := ToVal.ofVal
 
 @[grind! .]
 theorem toVal_eq_iff_coe (e : Expr)(v : Val): (v : Expr) = e ↔ toVal e = some v :=
@@ -265,7 +264,7 @@ theorem val_irreducible :
   grind only [irreducible, val_stuck, = Option.isSome_none]
 
 @[rocq_alias of_val_inj]
-instance [ι : ToVal Expr Val]: Function.Injective (ι.coe.coe) := by
+instance [ι : ToVal Expr Val]: Function.Injective (ι.ofVal) := by
   intro x y h
   simpa [ToVal.toVal_coe] using congrArg (toVal) h
 

--- a/src/Iris/ProgramLogic/Language.lean
+++ b/src/Iris/ProgramLogic/Language.lean
@@ -1,7 +1,7 @@
 module
 
-public import Iris.Std.RocqAlias
-public import Iris.Std.RocqIgnore
+meta import Iris.Std.RocqAlias
+meta import Iris.Std.RocqIgnore
 public import Iris.Std.FromMathlib
 public import Iris.Std.Relation
 public import Iris.Std.List

--- a/src/Iris/ProgramLogic/Language.lean
+++ b/src/Iris/ProgramLogic/Language.lean
@@ -22,13 +22,6 @@ open FromMathlib
 
 variable {Expr : Type e}{Val : Type v}{State : Type σ}{Obs : Type o}
 
--- DECISION: We assume that one Expr type maps to one Val type
--- If this where to not be true, once could reuse the same API by simply
--- adding some construction `WithVal Val Expr` which associates `Val` to
--- `Expr`. Alternatively, one could make this dependency more explicit
--- by having `Expr` depend on `Val`, but we don't make this choice here
--- since it'd be cumbersome to write.
-
 class ToVal (Expr : Type e) (Val : outParam <| Type v ) where
   toVal : Expr → Option Val
   ofVal : Val → Expr
@@ -61,9 +54,6 @@ instance [ι : ToVal Expr Val]: Function.Injective (ι.ofVal) := by
   simpa [ToVal.toVal_coe] using congrArg (toVal) h
 
 end ToVal
-
--- DECISION: Same decision as for `Val` ended up being made for
--- `Obs` and `State`
 
 class PrimStep
     (Expr : Type e)
@@ -103,9 +93,6 @@ def notStuck [ToVal Expr Val]: Expr × State → Prop
 | (e, σ) => (toVal e).isSome ∨ reducible (e, σ)
 
 end PureConfigurationTypes
-
--- DECISION: We assume that one `Expr` pair refers to exactly one
--- type of observations `Obs` and states `State`.
 
 class Language
     (Expr  : Type e)

--- a/src/Iris/ProgramLogic/Language.lean
+++ b/src/Iris/ProgramLogic/Language.lean
@@ -1,7 +1,5 @@
 module
 
--- TODO: Change propositions to start with an upper case letter.
-
 public import Iris.Std.RocqAlias
 public import Iris.Std.RocqIgnore
 public import Iris.Std.FromMathlib
@@ -152,12 +150,12 @@ instance : Context (Λ := Λ) (id (α := Expr)) where
 
 /-- A single atomic step in a threaded context -/
 @[grind]
-inductive step : List Expr × State → List Obs → List Expr × State → Prop
+inductive Step : List Expr × State → List Obs → List Expr × State → Prop
   where
   | atomic : ∀ e σ  obs e' σ' eₜ,
     (e, σ) -<obs>->ₜ (e', σ', eₜ) →
     ∀ (t₁ t₂: List Expr),
-    step (t₁ ++ e :: t₂, σ) obs (t₁ ++ e' :: t₂ ++ eₜ, σ')
+    Step (t₁ ++ e :: t₂, σ) obs (t₁ ++ e' :: t₂ ++ eₜ, σ')
     -- NOTE: Using `t₁ ++ e :: t₂` instead of `t₁ ++ [e] ++ t₂` because in
     -- Lean `[x] ++ xs` is not definitionallly equal to `x :: xs`. This is
     -- because `++` does not correspond to a function on lists, but a
@@ -168,44 +166,44 @@ inductive step : List Expr × State → List Obs → List Expr × State → Prop
 def step.of_primStep : ∀ {e σ}{obs : List Obs}{e'} {σ' : State} {eₜ},
     (e, σ) -<obs>->ₜ (e', σ', eₜ) →
     ∀ {t₁ t₂: List Expr},
-    step (t₁ ++ e :: t₂, σ) obs (t₁ ++ e' :: t₂ ++ eₜ, σ') :=
-  (Language.step.atomic _ _ _ _ _ _ · _ _)
+    Step (t₁ ++ e :: t₂, σ) obs (t₁ ++ e' :: t₂ ++ eₜ, σ') :=
+  (Language.Step.atomic _ _ _ _ _ _ · _ _)
 
-@[inherit_doc step]
+@[inherit_doc Step]
 scoped macro conf:term:40 " -<" noWs obs:term:max noWs ">->ₜₚ " conf':term:41 : term =>
- `(Language.step $conf $obs $conf')
+ `(Language.Step $conf $obs $conf')
 
 -- FIXME: Not displaying properly (?)
 open Lean PrettyPrinter Delaborator SubExpr in
-@[app_unexpander Language.step]
+@[app_unexpander Step]
 meta def unexpandLanguageStep : Unexpander
-| `(Language.step $conf $obs $conf') =>
+| `(Language.Step $conf $obs $conf') =>
   `($conf -<$obs>->ₜₚ $conf')
 | _ => throw ()
 
 /-- The (possibly zero) sequence of `Language.step`s -/
 @[grind]
-inductive nsteps : Nat → List Expr × State → List Obs → List Expr × State → Prop
+inductive NSteps : Nat → List Expr × State → List Obs → List Expr × State → Prop
   where
-  | refl (ρ : List Expr × State): nsteps 0 ρ [] ρ
+  | refl (ρ : List Expr × State): NSteps 0 ρ [] ρ
   | cons n (ρ₁ ρ₂ ρ₃ : List Expr × State) (obs obs' : List Obs) :
       ρ₁ -<obs>->ₜₚ ρ₂ →
-      nsteps n ρ₂ obs' ρ₃ →
-      nsteps (n+1) ρ₁ (obs ++ obs') ρ₃
+      NSteps n ρ₂ obs' ρ₃ →
+      NSteps (n+1) ρ₁ (obs ++ obs') ρ₃
 
-@[inherit_doc nsteps]
+@[inherit_doc NSteps]
 scoped macro conf:term:40 " -<" noWs obs:term:max noWs ">->ₜₚ* " conf':term:41 : term =>
- `(Language.nsteps $conf ($obs) $conf')
+ `(Language.NSteps $conf ($obs) $conf')
 
 open Lean PrettyPrinter Delaborator SubExpr in
-@[app_unexpander Language.nsteps]
+@[app_unexpander NSteps]
 meta def unexpandLanguageNsteps : Unexpander
-| `(Language.nsteps $conf $obs $conf') =>
+| `(Language.NSteps $conf $obs $conf') =>
   `($conf -<$obs>->ₜₚ* $conf')
 | _ => throw ()
 
 /-- A sequence of `Language.step`s with no observation information -/
-def erasedStep (ρ  ρ₂: List Expr × State) := ∃ obs, step ρ obs ρ₂
+def erasedStep (ρ  ρ₂: List Expr × State) := ∃ obs, Step ρ obs ρ₂
 
 @[inherit_doc erasedStep]
 scoped macro conf:term:40 " -·->ₜₚ " conf':term:41 : term =>
@@ -394,7 +392,7 @@ theorem step_update_of_getElem? {i obs efs} {t : List Expr} (σ₁ σ₂ : State
     (t, σ₁) -<obs>->ₜₚ (t.set i e' ++ efs, σ₂) := by
   grind only [= getElem?_neg, = getElem?_pos, = List.getElem?_some_iff_append,
     = List.getElem?_append, = List.getElem?_cons, = List.set_append, = List.set_cons_zero,
-    step.atomic]
+    Step.atomic]
 
 open List in
 @[rocq_alias erased_step_Permutation]

--- a/src/Iris/ProgramLogic/Language.lean
+++ b/src/Iris/ProgramLogic/Language.lean
@@ -8,7 +8,9 @@ public import Iris.Std.List
 public meta import Lean.PrettyPrinter.Delaborator
 public import Batteries.Data.List.Basic
 
--- TODO: Ensure all the relevant `rocq_alias` are added
+#rocq_ignore LanguageMixin "This feature was implemented differently using typeclasses"
+#rocq_ignore language      "This feature was implemented differently using typeclasses"
+
 -- TODO: Ask «Why chose List here? It seems any monoid would do.» for the
 --       observations being a `List Obs`.
 -- TODO: Consider renaming `ToVal` typeclass to something better, since
@@ -51,7 +53,7 @@ variable [ToVal Expr Val]
 attribute [coe] ToVal.ofVal
 instance : Coe Val Expr where coe := ToVal.ofVal
 
-@[grind! .]
+@[grind! ., rocq_alias of_to_val_flip]
 theorem toVal_eq_iff_coe (e : Expr)(v : Val): (v : Expr) = e ↔ toVal e = some v :=
   ⟨(· ▸ ToVal.toVal_coe v), coe_of_toVal_eq_some e v⟩
 
@@ -125,21 +127,10 @@ namespace Language
 
 variable [Λ : Language Expr State Obs Val]
 
-inductive Atomicity where
-| WeaklyAtomic
-| StronglyAtomic
-
-class Atomic (a : Atomicity) (e : Expr) : Prop where
-  atomic : ∀ (σ : State) obs e' σ' eₜ,
-    (e, σ) -<obs>-> (e', σ', eₜ) →
-    match a with
-    | .WeaklyAtomic => ¬ reducible (e', σ')
-    | .StronglyAtomic => (toVal e').isSome
-
 variable {e e': Expr}{σ σ': State}{v v' : Val}
 
 /-- A single atomic step in a threaded context -/
-@[grind]
+@[grind, rocq_alias step]
 inductive Step : List Expr × State → List Obs → List Expr × State → Prop
   where
   | atomic : ∀ e σ  obs e' σ' eₜ,
@@ -163,7 +154,7 @@ def Step.of_primStep : ∀ {e σ}{obs : List Obs}{e'} {σ' : State} {eₜ},
 scoped notation conf:40 " -<" obs:max ">->ₜₚ " conf':41 => Language.Step conf obs conf'
 
 /-- The (possibly zero) sequence of `Language.step`s -/
-@[grind]
+@[grind, rocq_alias nsteps]
 inductive NSteps : Nat → List Expr × State → List Obs → List Expr × State → Prop
   where
   | refl (ρ : List Expr × State): NSteps 0 ρ [] ρ
@@ -245,6 +236,28 @@ theorem not_not_suck {e : Expr} {σ : State} :
     simp only [Option.isSome_none, Bool.false_eq_true, false_or, not_reducible_iff_irreducible,
       true_and]
 
+@[rocq_alias prim_step_not_stuck]
+theorem primStep_notStuck {e : Expr} {σ obs e' σ' eₜ} :
+    (e, σ) -<obs>-> (e', σ', eₜ) →
+    notStuck (e, σ) :=
+  fun h => .inr ⟨_, _, _, _, h⟩
+end ReducibilityLemmas
+
+@[rocq_alias atomicity]
+inductive Atomicity where
+| WeaklyAtomic
+| StronglyAtomic
+
+#rocq_ignore stuckness_to_atomicity "There is no `Stuckness` implementation yet."
+
+@[rocq_alias Atomic]
+class Atomic (a : Atomicity) (e : Expr) : Prop where
+  atomic : ∀ (σ : State) obs e' σ' eₜ,
+    (e, σ) -<obs>-> (e', σ', eₜ) →
+    match a with
+    | .WeaklyAtomic => ¬ reducible (e', σ')
+    | .StronglyAtomic => (toVal e').isSome
+
 @[rocq_alias strongly_atomic_atomic]
 theorem stronglyAtomic_atomic a :
     Atomic (State := State) .StronglyAtomic e →
@@ -256,14 +269,9 @@ theorem stronglyAtomic_atomic a :
     constructor
     grind only [not_reducible_iff_irreducible, val_irreducible]
 
-@[rocq_alias prim_step_not_stuck]
-theorem primStep_notStuck {e : Expr} {σ obs e' σ' eₜ} :
-    (e, σ) -<obs>-> (e', σ', eₜ) →
-    notStuck (e, σ) :=
-  fun h => .inr ⟨_, _, _, _, h⟩
-end ReducibilityLemmas
 
 /-- `Context K` says `K` models an evaluation context for the language -/
+@[rocq_alias LanguageCtx]
 class Context(K: Expr → Expr) where
   toVal_eq_none_fill : ∀ {e : Expr},
     toVal e = none → toVal (K e) = none
@@ -436,7 +444,7 @@ scoped notation conf:40 " -ᵖ-> " conf':41 => purePrimStep conf conf'
 /-- `e₁ -ᵖ->^[n] e₂` represents a sequence of `n` pure steps taken
     from `e₁` up to `e₂`.
 -/
-scoped notation conf:40 " -ᵖ->^[" n "] " conf':41 => Relation.iterate purePrimStep n conf conf'
+scoped notation conf:40 " -ᵖ->^[" n "] " conf':41 => Relation.Iterate purePrimStep n conf conf'
 
 /-- `e₁ -ᵖ->* e₂` represents a sequence of some number of pure steps
     taken from `e₁` up to `e₂`.
@@ -444,7 +452,7 @@ scoped notation conf:40 " -ᵖ->^[" n "] " conf':41 => Relation.iterate purePrim
 scoped notation conf:40 " -ᵖ->* " conf':41 => Relation.ReflTransGen purePrimStep conf conf'
 
 @[rocq_alias pure_steps_tp]
-def pureSteps (t₁ t₂ : List Expr) := List.Forall₂ (· -ᵖ->* ·) t₁ t₂
+abbrev pureSteps (t₁ t₂ : List Expr) := List.Forall₂ (· -ᵖ->* ·) t₁ t₂
 
 /-- `e₁ -ᵖ->ₜₚ* e₂` represents a sequence of some number of pure steps
     taken from `e₁` up to `e₂`.
@@ -458,6 +466,7 @@ meta def unexpandLanguagePureSteps : Unexpander
   `($conf -ᵖ->ₜₚ* $conf')
 | _ => throw ()
 
+@[rocq_alias PureExec]
 class PureExec (φ : Prop) (n : Nat) (e₁ e₂ : Expr) : Prop where
   pureExec : φ → e₁ -ᵖ->^[n] e₂
 
@@ -485,7 +494,7 @@ theorem iterate_purePrimStep_fill (K : Expr → Expr) [Context K] {e₁ e₂} :
   induction h with
   | rfl => constructor
   | tail y first last IH =>
-    apply Relation.iterate.tail (K y) IH (purePrimStep_fill K last)
+    apply Relation.Iterate.tail (K y) IH (purePrimStep_fill K last)
 
 @[rocq_alias rtc_pure_step_ctx]
 theorem ReflTransGen_pureStep_fill (K : Expr → Expr) [Context K] {e₁ e₂} :
@@ -533,13 +542,13 @@ theorem as_val_isSome e :
   grind only [!ToVal.toVal_eq_iff_coe, = Option.isSome_some]
 
 /--
-  Let thread pools `t₁` and `t₃` be such that each thread
-  in `t₁` makes (zero or more) pure steps to the
-  corresponding thread in `t₃`.
-
   Let `t₂` be a thread pool such that `t₁` under state
   `σ₁` makes a (single) step to threadpool `t₂` and
   state `σ₂`.
+
+  Let thread pools `t₁` and `t₃` be such that each thread
+  in `t₁` makes (zero or more) pure steps to the
+  corresponding thread in `t₃`.
 
   In this situation, either the step from `t₁` to `t₂`
   corresponds to one of the pure steps between `t₁` and
@@ -552,7 +561,7 @@ theorem erasedStep_pureSteps (t₁ t₂ t₃ : List Expr) (σ₁ σ₂ : State) 
     (t₁, σ₁)  -·->ₜₚ  (t₂, σ₂) →
        t₁     -ᵖ->ₜₚ*    t₃ →
     (σ₁ = σ₂ ∧ t₂ -ᵖ->ₜₚ* t₃) ∨ -- t₂ was actually obtained form a pure reduction
-    (∃ i e eₜ e' obs,
+    (∃ i e eₜ e' obs,           -- t₃ didn't touch the expression e which changed in t₂
       t₁[i]? = some e ∧
       t₃[i]? = some e ∧
       t₂ = t₁.set i e' ++ eₜ ∧
@@ -564,7 +573,7 @@ theorem erasedStep_pureSteps (t₁ t₂ t₃ : List Expr) (σ₁ σ₂ : State) 
          ∧ ss -ᵖ->ₜₚ* ss₃
          ∧ ps -ᵖ->ₜₚ* ps₃ ∧ ps.length = ps₃.length
          ∧ e -ᵖ->* e₃ from by
-      grind [pureSteps]
+      grind
   rcases Relation.ReflTransGen.cases_head e_e₃ with (rfl | ⟨e', firstPureStep, lastSteps⟩)
   · right
     exists (ps₃.length), e, eₜ, e₂, obs
@@ -627,7 +636,7 @@ info: e -ᵖ->^[0] e : Prop
 -/
 #guard_msgs in
 variable (e : Expr) [Language Expr State Obs Val] in
-#check (Relation.iterate Language.purePrimStep 0 e e)
+#check (Relation.Iterate Language.purePrimStep 0 e e)
 
 /--
 info: e -ᵖ->* e : Prop

--- a/src/Iris/ProgramLogic/Language.lean
+++ b/src/Iris/ProgramLogic/Language.lean
@@ -1,7 +1,6 @@
 module
 
-meta import Iris.Std.RocqAlias
-meta import Iris.Std.RocqIgnore
+meta import Iris.Std.RocqPorting
 public import Iris.Std.FromMathlib
 public import Iris.Std.Relation
 public import Iris.Std.List

--- a/src/Iris/ProgramLogic/Language.lean
+++ b/src/Iris/ProgramLogic/Language.lean
@@ -7,11 +7,35 @@ public import Iris.Std.Relation
 public meta import Lean.PrettyPrinter.Delaborator
 public import Batteries.Data.List.Basic
 
+-- TODO: Not convinced if `of_val` should be `ToVal.coe` using `Coe`
+--       directly, or if some other typeclass should be preferred.
+-- TODO: Term levels for the different notations were chosen arbitrarily.
+--       Make sure they are adequate.
+-- TODO: Rename all `Context.fill` lemmas to something more consistent.
+--       In particular, for some other constructions they are referred to
+--       to as `_ctx`.
+-- TODO: Rethink steping notations (probabl drop `ₜ` for `primStep`)
+--       (e,σ)    -<obs>->ₜ        (e',σ',eₜ)  (primStep)
+--       (t,σ)    -<obs>->ₜₚ       (t',σ')     (Step)
+--       (t,σ)    -<obs>->ₜₚ^[n]   (t',σ')     (NSteps)
+--       (t,σ)    -·->ₜₚ           (t',σ')     (erasedStep)
+--         e      -ᵖ->               e'        (pureStep)
+--         e      -ᵖ->^[n]           e'        (iterate pureStep)
+--         e      -ᵖ->*              e'        (ReflTransGen pureStep)
+--         t      -ᵖ->ₜₚ*            t'        (Forall₂ (· -ᵖ->* ·))
+-- TODO: Add macro tests / consider making them all use `notation` over
+--       `macro`
+-- TODO: Ensure all the relevant `rocq_alias` are added
+-- TODO: Ask «Why chose List here? It seems any monoid would do.» for the
+--       observations being a `List Obs`.
+-- TODO: Consider renaming `ToVal` typeclass to something better, since
+--       it's not just the `toVal` operation it carries.
+
 @[expose] public section
 
-variable {Expr : Type e}{Val : Type v}{State : Type σ}{Obs : Type o}
-
 open FromMathlib
+
+variable {Expr : Type e}{Val : Type v}{State : Type σ}{Obs : Type o}
 
 -- DECISION: We assume that one Expr type maps to one Val type
 -- If this where to not be true, once could reuse the same API by simply
@@ -22,20 +46,24 @@ open FromMathlib
 
 class ToVal (Expr : Type e) (Val : outParam <| Type v ) where
   toVal : Expr → Option Val
-  [coe : Coe Val Expr] -- TODO: Not convinced if this should be `coe` directly
+  [coe : Coe Val Expr]
   /-- If `toVal` is defined for an expression, `coe` is its inverse -/
   coe_of_toVal_eq (e : Expr)(v : Val) : toVal e = some v → (v : Expr) = e
   /-- `toVal` is defined `coe`, and works as its inverse -/
   toVal_coe (v : Val) : toVal (v : Expr) = some v
 export ToVal (toVal)
 
+attribute [rocq_alias language.to_val] ToVal.toVal
 attribute [rocq_alias mixin_of_to_val] ToVal.coe_of_toVal_eq
 attribute [rocq_alias mixin_to_of_val, simp, grind =] ToVal.toVal_coe
 
+#rocq_ignore language.of_val "This function was implemented as a coercion from Expr to Val, so there is no need for an explicit `of_val` function."
+
 namespace ToVal
-instance [ToVal Expr Val] : Coe Val Expr := ToVal.coe
 
 variable [ToVal Expr Val]
+
+instance : Coe Val Expr := ToVal.coe
 
 @[grind! .]
 theorem toVal_eq_iff_coe (e : Expr)(v : Val): (v : Expr) = e ↔ toVal e = some v :=
@@ -44,14 +72,16 @@ theorem toVal_eq_iff_coe (e : Expr)(v : Val): (v : Expr) = e ↔ toVal e = some 
 end ToVal
 
 -- DECISION: Same decision as for `Val` ended up being made for
--- `Obs`, and probably `State` should follow next
+-- `Obs` and `State`
 
-class PrimStep(Expr : Type e)(State : outParam <| Type σ)(Obs : outParam <| Type o) where
+class PrimStep
+    (Expr : Type e)
+    (State : outParam (Type σ))
+    (Obs : outParam (Type o)) where
   /-- The primitive reduction relation of the language -/
   primStep   : Expr × State → Obs → Expr × State × List Expr → Prop
 
 namespace PrimStep
--- TODO: Term numbers chosen arbitrarily. Make sure they are adequate.
 @[inherit_doc PrimStep.primStep]
 scoped macro conf:term:40 " -<" noWs obs:term:max noWs ">->ₜ " conf':term:41 : term =>
  `(PrimStep.primStep $conf $obs $conf')
@@ -72,7 +102,7 @@ variable [PrimStep Expr State Obs]
 @[rocq_alias reducible]
 def reducible : Expr × State → Prop
 | (e, σ) => ∃ obs e' σ' eₜ,
-   (e, σ) -<obs>->ₜ (e', σ', eₜ)
+    (e, σ) -<obs>->ₜ (e', σ', eₜ)
 
 @[rocq_alias reducible_no_obs]
 def pureReducible [PrimStep Expr State (List Obs)] : Expr × State → Prop
@@ -90,17 +120,16 @@ def notStuck [ToVal Expr Val]: Expr × State → Prop
 
 end PureConfigurationTypes
 
--- DECISION: We assume that one (Expr, State) pair refers to exactly one
--- type of observations.
+-- DECISION: We assume that one `Expr` pair refers to exactly one
+-- type of observations `Obs` and states `State`.
 
 class Language
     (Expr  : Type e)
-    (State : outParam <| Type σ)
+    (State : outParam (Type σ))
     (Obs   : outParam (Type o))
     (Val   : outParam (Type v))
   extends
     PrimStep Expr State (List Obs),
-     -- ↑ Why chose List here? It seems any monoid would do.
     ToVal Expr Val where
   /-- Values in a language should not reduce -/
   val_stuck : ∀ {e} {σ : State} {obs e' σ' eₜ},
@@ -108,26 +137,24 @@ class Language
 
 attribute [rocq_alias mixin_val_stuck] Language.val_stuck
 
+namespace Language
+
+variable [Λ : Language Expr State Obs Val]
+
 inductive Atomicity where
 | WeaklyAtomic
 | StronglyAtomic
 
-class Atomic (a : Atomicity) (e : Expr)
-  [Language Expr State Obs Val] :
-    Prop where
+class Atomic (a : Atomicity) (e : Expr) : Prop where
   atomic : ∀ (σ : State) obs e' σ' eₜ,
     (e, σ) -<obs>->ₜ (e', σ', eₜ) →
     match a with
     | .WeaklyAtomic => ¬ reducible (e', σ')
     | .StronglyAtomic => (toVal e').isSome
 
-
-namespace Language
-variable [Λ : Language Expr State Obs Val]
 variable {e e': Expr}{σ σ': State}{v v' : Val}
 
--- TODO: Rename all `fill` lemmas to something more consistent
-/-- `K` models an evaluation context for the language -/
+/-- `Context K` says `K` models an evaluation context for the language -/
 class Context(K: Expr → Expr) where
   fill_toVal_eq_none : ∀ {e : Expr},
     toVal e = none → toVal (K e) = none
@@ -163,7 +190,7 @@ inductive Step : List Expr × State → List Obs → List Expr × State → Prop
     -- Since most lemmas about an element appearing in the middle of a list
     -- are in the shape `t₁ ++ e :: t₂`, this form is preferred.
 
-def step.of_primStep : ∀ {e σ}{obs : List Obs}{e'} {σ' : State} {eₜ},
+def Step.of_primStep : ∀ {e σ}{obs : List Obs}{e'} {σ' : State} {eₜ},
     (e, σ) -<obs>->ₜ (e', σ', eₜ) →
     ∀ {t₁ t₂: List Expr},
     Step (t₁ ++ e :: t₂, σ) obs (t₁ ++ e' :: t₂ ++ eₜ, σ') :=
@@ -192,14 +219,14 @@ inductive NSteps : Nat → List Expr × State → List Obs → List Expr × Stat
       NSteps (n+1) ρ₁ (obs ++ obs') ρ₃
 
 @[inherit_doc NSteps]
-scoped macro conf:term:40 " -<" noWs obs:term:max noWs ">->ₜₚ* " conf':term:41 : term =>
- `(Language.NSteps $conf ($obs) $conf')
+scoped macro conf:term:40 " -<" noWs obs:term:max noWs ">->ₜₚ^[" noWs n:term:max noWs "] " conf':term:41 : term =>
+ `(Language.NSteps $n $conf ($obs) $conf')
 
 open Lean PrettyPrinter Delaborator SubExpr in
 @[app_unexpander NSteps]
 meta def unexpandLanguageNsteps : Unexpander
-| `(Language.NSteps $conf $obs $conf') =>
-  `($conf -<$obs>->ₜₚ* $conf')
+| `(Language.NSteps $n $conf $obs $conf') =>
+  `($conf -<$obs>->ₜₚ^[$n] $conf')
 | _ => throw ()
 
 /-- A sequence of `Language.step`s with no observation information -/
@@ -212,8 +239,8 @@ scoped macro conf:term:40 " -·->ₜₚ " conf':term:41 : term =>
 open Lean PrettyPrinter Delaborator SubExpr in
 @[app_unexpander Language.erasedStep]
 meta def unexpandLanguageErasedStep : Unexpander
-| `(Language.erasedStep $conf $conf2) =>
-  `($conf -·->ₜₚ $conf2)
+| `(Language.erasedStep $conf $conf') =>
+  `($conf -·->ₜₚ $conf')
 | _ => throw ()
 
 @[rocq_alias not_reducible, grind =]
@@ -365,7 +392,7 @@ theorem perm_of_step (t₁ t₁' t₂ : List Expr) :
         apply (List.perm_cons e).mp
         exact (perm_middle.symm.trans t1perm).trans perm_middle
       _ ~ ps' ++ e' :: ss' := perm_middle.symm
-  · apply Language.step.of_primStep red
+  · apply Language.Step.of_primStep red
 
 @[grind =]
 private theorem _root_.List.getElem?_some_iff_append
@@ -429,8 +456,8 @@ scoped macro conf:term:40 " -ᵖ-> " conf':term:41 : term =>
 open Lean PrettyPrinter Delaborator SubExpr in
 @[app_unexpander Language.purePrimStep]
 meta def unexpandLanguagePurePrimStep : Unexpander
-| `(purePrimStep $conf $conf2) =>
-  `($conf -ᵖ-> $conf2)
+| `(purePrimStep $conf $conf') =>
+  `($conf -ᵖ-> $conf')
 | _ => throw ()
 
 /-- `e₁ -ᵖ->^[n] e₂` represents a sequence of `n` pure steps taken
@@ -611,9 +638,9 @@ theorem erasedStep_pureSteps (t₁ t₂ t₃ : List Expr) (σ₁ σ₂ : State) 
       getElem?_pos, Std.le_refl, List.getElem_append_right, Nat.sub_self, List.getElem_cons_zero,
       List.append_assoc, List.cons_append, List.set_append_right, List.set_cons_zero, and_self,
       length_ps, pstep]
-  · obtain ⟨pRed, uniqStep⟩ := firstPureStep
+  · left
+    obtain ⟨pRed, uniqStep⟩ := firstPureStep
     obtain ⟨rlf, rfl, rfl, rfl⟩ := uniqStep pstep
-    left
     have : e -ᵖ-> e' := by grind only [purePrimStep]
     simp only [pureSteps, List.append_nil, true_and]
     apply List.Forall₂.append ps_ps₃

--- a/src/Iris/ProgramLogic/Language.lean
+++ b/src/Iris/ProgramLogic/Language.lean
@@ -8,15 +8,6 @@ public import Iris.Std.List
 public meta import Lean.PrettyPrinter.Delaborator
 public import Batteries.Data.List.Basic
 
--- TODO: Rethink steping notations (probabl drop `ₜ` for `primStep`)
---       (e,σ)    -<obs>->ₜ        (e',σ',eₜ)  (primStep)
---       (t,σ)    -<obs>->ₜₚ       (t',σ')     (Step)
---       (t,σ)    -<obs>->ₜₚ^[n]   (t',σ')     (NSteps)
---       (t,σ)    -·->ₜₚ           (t',σ')     (erasedStep)
---         e      -ᵖ->               e'        (pureStep)
---         e      -ᵖ->^[n]           e'        (iterate pureStep)
---         e      -ᵖ->*              e'        (ReflTransGen pureStep)
---         t      -ᵖ->ₜₚ*            t'        (Forall₂ (· -ᵖ->* ·))
 -- TODO: Ensure all the relevant `rocq_alias` are added
 -- TODO: Ask «Why chose List here? It seems any monoid would do.» for the
 --       observations being a `List Obs`.
@@ -84,7 +75,7 @@ class PrimStep
 namespace PrimStep
 
 @[inherit_doc PrimStep.primStep]
-scoped notation conf:40 " -<" obs:max ">->ₜ " conf':41  => PrimStep.primStep conf obs conf'
+scoped notation conf:40 " -<" obs:max ">-> " conf':41  => PrimStep.primStep conf obs conf'
 
 end PrimStep
 open PrimStep
@@ -95,15 +86,15 @@ variable [PrimStep Expr State Obs]
 @[rocq_alias reducible]
 def reducible : Expr × State → Prop
 | (e, σ) => ∃ obs e' σ' eₜ,
-    (e, σ) -<obs>->ₜ (e', σ', eₜ)
+    (e, σ) -<obs>-> (e', σ', eₜ)
 
 @[rocq_alias reducible_no_obs]
 def pureReducible [PrimStep Expr State (List Obs)] : Expr × State → Prop
 | (e, σ) => ∃ e' σ' eₜ,
-    (e, σ) -<[]>->ₜ (e', σ', eₜ)
+    (e, σ) -<[]>-> (e', σ', eₜ)
 
 def irreducible : Expr × State → Prop
-| (e, σ) => ∀ obs e' σ' eₜ, ¬ (e, σ) -<obs>->ₜ (e', σ', eₜ)
+| (e, σ) => ∀ obs e' σ' eₜ, ¬ (e, σ) -<obs>-> (e', σ', eₜ)
 
 def stuck [ToVal Expr Val]: Expr × State → Prop
 | (e, σ) => toVal e = none ∧ irreducible (e, σ)
@@ -126,7 +117,7 @@ class Language
     ToVal Expr Val where
   /-- Values in a language should not reduce -/
   val_stuck : ∀ {e} {σ : State} {obs e' σ' eₜ},
-    (e, σ) -<obs>->ₜ (e', σ', eₜ) → toVal e = none
+    (e, σ) -<obs>-> (e', σ', eₜ) → toVal e = none
 
 attribute [rocq_alias mixin_val_stuck] Language.val_stuck
 
@@ -140,7 +131,7 @@ inductive Atomicity where
 
 class Atomic (a : Atomicity) (e : Expr) : Prop where
   atomic : ∀ (σ : State) obs e' σ' eₜ,
-    (e, σ) -<obs>->ₜ (e', σ', eₜ) →
+    (e, σ) -<obs>-> (e', σ', eₜ) →
     match a with
     | .WeaklyAtomic => ¬ reducible (e', σ')
     | .StronglyAtomic => (toVal e').isSome
@@ -152,7 +143,7 @@ variable {e e': Expr}{σ σ': State}{v v' : Val}
 inductive Step : List Expr × State → List Obs → List Expr × State → Prop
   where
   | atomic : ∀ e σ  obs e' σ' eₜ,
-    (e, σ) -<obs>->ₜ (e', σ', eₜ) →
+    (e, σ) -<obs>-> (e', σ', eₜ) →
     ∀ (t₁ t₂: List Expr),
     Step (t₁ ++ e :: t₂, σ) obs (t₁ ++ e' :: t₂ ++ eₜ, σ')
     -- NOTE: Using `t₁ ++ e :: t₂` instead of `t₁ ++ [e] ++ t₂` because in
@@ -163,7 +154,7 @@ inductive Step : List Expr × State → List Obs → List Expr × State → Prop
     -- are in the shape `t₁ ++ e :: t₂`, this form is preferred.
 
 def Step.of_primStep : ∀ {e σ}{obs : List Obs}{e'} {σ' : State} {eₜ},
-    (e, σ) -<obs>->ₜ (e', σ', eₜ) →
+    (e, σ) -<obs>-> (e', σ', eₜ) →
     ∀ {t₁ t₂: List Expr},
     Step (t₁ ++ e :: t₂, σ) obs (t₁ ++ e' :: t₂ ++ eₜ, σ') :=
   (Language.Step.atomic _ _ _ _ _ _ · _ _)
@@ -238,7 +229,7 @@ theorem stronglyAtomic_atomic a :
 
 @[rocq_alias prim_step_not_stuck]
 theorem primStep_notStuck {e : Expr} {σ obs e' σ' eₜ} :
-    (e, σ) -<obs>->ₜ (e', σ', eₜ) →
+    (e, σ) -<obs>-> (e', σ', eₜ) →
     notStuck (e, σ) :=
   fun h => .inr ⟨_, _, _, _, h⟩
 end ReducibilityLemmas
@@ -248,12 +239,12 @@ class Context(K: Expr → Expr) where
   toVal_eq_none_fill : ∀ {e : Expr},
     toVal e = none → toVal (K e) = none
   primStep_fill : ∀ {e} {σ : State} {obs e' σ' eₜ},
-    (e, σ) -<obs>->ₜ (e', σ', eₜ) →
-    (K e, σ)-<obs>->ₜ(K e', σ', eₜ)
+    (e, σ) -<obs>-> (e', σ', eₜ) →
+    (K e, σ) -<obs>-> (K e', σ', eₜ)
   primStep_fill_inv : ∀ {e} {σ : State} {obs K_e' σ' eₜ},
     toVal e = .none →
-    (K e, σ) -<obs>->ₜ (K_e', σ', eₜ) →
-    ∃ e', K_e' = K e' ∧ (e, σ) -<obs>->ₜ (e', σ', eₜ)
+    (K e, σ) -<obs>-> (K_e', σ', eₜ) →
+    ∃ e', K_e' = K e' ∧ (e, σ) -<obs>-> (e', σ', eₜ)
 
 attribute [rocq_alias fill_not_val] Context.toVal_eq_none_fill
 attribute [rocq_alias fill_step] Context.primStep_fill
@@ -374,7 +365,7 @@ theorem perm_of_step (t₁ t₁' t₂ : List Expr) :
 @[rocq_alias step_insert]
 theorem step_update_of_getElem? {i obs efs} {t : List Expr} (σ₁ σ₂ : State):
     t[i]? = some e →
-    (e, σ₁) -<obs>->ₜ (e', σ₂, efs) →
+    (e, σ₁) -<obs>-> (e', σ₂, efs) →
     (t, σ₁) -<obs>->ₜₚ (t.set i e' ++ efs, σ₂) := by
   grind only [= getElem?_neg, = getElem?_pos, = Iris.Std.List.getElem?_some_iff_append,
     = List.getElem?_append, = List.getElem?_cons, = List.set_append, = List.set_cons_zero,
@@ -396,7 +387,7 @@ theorem perm_of_erasedStep (t₁ t₁' t₂ : List Expr) :
 section PureSteps
 
 /-- There is a pure step between `e₁` and `e₂` iff there is
-    a reduction step `(e₁, σ) -<[]>->ₜ (e₂, σ, [])` for some
+    a reduction step `(e₁, σ) -<[]>-> (e₂, σ, [])` for some
     σ and it is unique.
 
     Intuitively, the reduction is deterministic and does not
@@ -406,7 +397,7 @@ section PureSteps
 def purePrimStep (e₁ e₂ : Expr) :=
   (∀ σ : State, pureReducible (e₁, σ)) ∧
   (∀ {σ₁ σ₂ : State} {obs e₂' eₜ},
-    (e₁, σ₁) -<obs>->ₜ (e₂', σ₂, eₜ) →
+    (e₁, σ₁) -<obs>-> (e₂', σ₂, eₜ) →
     obs = [] ∧ σ₁ = σ₂ ∧ e₂ = e₂' ∧ eₜ = []
   )
 
@@ -536,7 +527,7 @@ theorem erasedStep_pureSteps (t₁ t₂ t₃ : List Expr) (σ₁ σ₂ : State) 
       t₁[i]? = some e ∧
       t₃[i]? = some e ∧
       t₂ = t₁.set i e' ++ eₜ ∧
-      (e, σ₁) -<obs>->ₜ (e', σ₂, eₜ)
+      (e, σ₁) -<obs>-> (e', σ₂, eₜ)
     ) := by
   rintro ⟨obs, ⟨e, σ₁, obs, e₂, σ₂, eₜ, pstep, ps, ss⟩⟩ Hps
   obtain ⟨ps₃, e₃, ss₃, rfl, ss_ss₃, ps_ps₃, length_ps, e_e₃⟩ :=
@@ -568,7 +559,7 @@ open Language
 section notations
 
 /--
-info: (e, σ) -<obs>->ₜ (e, σ, []) : Prop
+info: (e, σ) -<obs>-> (e, σ, []) : Prop
 -/
 #guard_msgs in
 variable (e : Expr) (σ : State) (obs : Obs) [PrimStep Expr State Obs] in

--- a/src/Iris/ProgramLogic/Language.lean
+++ b/src/Iris/ProgramLogic/Language.lean
@@ -15,8 +15,6 @@ public import Batteries.Data.List.Basic
 --       observations being a `List Obs`.
 -- TODO: Consider renaming `ToVal` typeclass to something better, since
 --       it's not just the `toVal` operation it carries.
--- TODO: Consider changing `Language.NSteps` to use `Relation.iterate`
---       instead of mirroring its structure
 
 @[expose] public section
 

--- a/src/Iris/ProgramLogic/Language.lean
+++ b/src/Iris/ProgramLogic/Language.lean
@@ -1,0 +1,624 @@
+module
+
+-- TODO: Change propositions to start with an upper case letter.
+
+public import Iris.Std.RocqAlias
+public import Iris.Std.RocqIgnore
+public import Iris.Std.FromMathlib
+public import Iris.Std.Relation
+public meta import Lean.PrettyPrinter.Delaborator
+public import Batteries.Data.List.Basic
+
+@[expose] public section
+
+variable {Expr : Type e}{Val : Type v}{State : Type σ}{Obs : Type o}
+
+open FromMathlib
+
+-- DECISION: We assume that one Expr type maps to one Val type
+-- If this where to not be true, once could reuse the same API by simply
+-- adding some construction `WithVal Val Expr` which associates `Val` to
+-- `Expr`. Alternatively, one could make this dependency more explicit
+-- by having `Expr` depend on `Val`, but we don't make this choice here
+-- since it'd be cumbersome to write.
+
+class ToVal (Expr : Type e) (Val : outParam <| Type v ) where
+  toVal : Expr → Option Val
+  [coe : Coe Val Expr] -- TODO: Not convinced if this should be `coe` directly
+  /-- If `toVal` is defined for an expression, `coe` is its inverse -/
+  coe_of_toVal_eq (e : Expr)(v : Val) : toVal e = some v → (v : Expr) = e
+  /-- `toVal` is defined `coe`, and works as its inverse -/
+  toVal_coe (v : Val) : toVal (v : Expr) = some v
+export ToVal (toVal)
+
+attribute [rocq_alias mixin_of_to_val] ToVal.coe_of_toVal_eq
+attribute [rocq_alias mixin_to_of_val, simp, grind =] ToVal.toVal_coe
+
+namespace ToVal
+instance [ToVal Expr Val] : Coe Val Expr := ToVal.coe
+
+variable [ToVal Expr Val]
+
+@[grind! .]
+theorem toVal_eq_iff_coe (e : Expr)(v : Val): (v : Expr) = e ↔ toVal e = some v :=
+  ⟨(· ▸ ToVal.toVal_coe v), ToVal.coe_of_toVal_eq e v⟩
+
+end ToVal
+
+-- DECISION: Same decision as for `Val` ended up being made for
+-- `Obs`, and probably `State` should follow next
+
+class PrimStep(Expr : Type e)(State : outParam <| Type σ)(Obs : outParam <| Type o) where
+  /-- The primitive reduction relation of the language -/
+  primStep   : Expr × State → Obs → Expr × State × List Expr → Prop
+
+namespace PrimStep
+-- TODO: Term numbers chosen arbitrarily. Make sure they are adequate.
+@[inherit_doc PrimStep.primStep]
+scoped macro conf:term:40 " -<" noWs obs:term:max noWs ">->ₜ " conf':term:41 : term =>
+ `(PrimStep.primStep $conf $obs $conf')
+
+open Lean PrettyPrinter Delaborator SubExpr in
+@[app_unexpander PrimStep.primStep]
+meta def unexpandPrimStep : Unexpander
+| `(primStep $conf $obs $conf') =>
+  `($conf -<$obs>->ₜ $conf')
+| _ => throw ()
+
+end PrimStep
+open PrimStep
+
+section PureConfigurationTypes
+variable [PrimStep Expr State Obs]
+
+@[rocq_alias reducible]
+def reducible : Expr × State → Prop
+| (e, σ) => ∃ obs e' σ' eₜ,
+   (e, σ) -<obs>->ₜ (e', σ', eₜ)
+
+@[rocq_alias reducible_no_obs]
+def pureReducible [PrimStep Expr State (List Obs)] : Expr × State → Prop
+| (e, σ) => ∃ e' σ' eₜ,
+    (e, σ) -<[]>->ₜ (e', σ', eₜ)
+
+def irreducible : Expr × State → Prop
+| (e, σ) => ∀ obs e' σ' eₜ, ¬ (e, σ) -<obs>->ₜ (e', σ', eₜ)
+
+def stuck [ToVal Expr Val]: Expr × State → Prop
+| (e, σ) => toVal e = none ∧ irreducible (e, σ)
+
+def notStuck [ToVal Expr Val]: Expr × State → Prop
+| (e, σ) => (toVal e).isSome ∨ reducible (e, σ)
+
+end PureConfigurationTypes
+
+-- DECISION: We assume that one (Expr, State) pair refers to exactly one
+-- type of observations.
+
+class Language
+    (Expr  : Type e)
+    (State : outParam <| Type σ)
+    (Obs   : outParam (Type o))
+    (Val   : outParam (Type v))
+  extends
+    PrimStep Expr State (List Obs),
+     -- ↑ Why chose List here? It seems any monoid would do.
+    ToVal Expr Val where
+  /-- Values in a language should not reduce -/
+  val_stuck : ∀ {e} {σ : State} {obs e' σ' eₜ},
+    (e, σ) -<obs>->ₜ (e', σ', eₜ) → toVal e = none
+
+attribute [rocq_alias mixin_val_stuck] Language.val_stuck
+
+inductive Atomicity where
+| WeaklyAtomic
+| StronglyAtomic
+
+class Atomic (a : Atomicity) (e : Expr)
+  [Language Expr State Obs Val] :
+    Prop where
+  atomic : ∀ (σ : State) obs e' σ' eₜ,
+    (e, σ) -<obs>->ₜ (e', σ', eₜ) →
+    match a with
+    | .WeaklyAtomic => ¬ reducible (e', σ')
+    | .StronglyAtomic => (toVal e').isSome
+
+
+namespace Language
+variable [Λ : Language Expr State Obs Val]
+variable {e e': Expr}{σ σ': State}{v v' : Val}
+
+-- TODO: Rename all `fill` lemmas to something more consistent
+/-- `K` models an evaluation context for the language -/
+class Context(K: Expr → Expr) where
+  fill_toVal_eq_none : ∀ {e : Expr},
+    toVal e = none → toVal (K e) = none
+  fill_primStep : ∀ {e} {σ : State} {obs e' σ' eₜ},
+    (e, σ) -<obs>->ₜ (e', σ', eₜ) →
+    (K e, σ)-<obs>->ₜ(K e', σ', eₜ)
+  fill_primStep_inv : ∀ {e} {σ : State} {obs K_e' σ' eₜ},
+    toVal e = .none →
+    (K e, σ) -<obs>->ₜ (K_e', σ', eₜ) →
+    ∃ e', K_e' = K e' ∧ (e, σ) -<obs>->ₜ (e', σ', eₜ)
+
+attribute [rocq_alias fill_not_val] Context.fill_toVal_eq_none
+attribute [rocq_alias fill_step] Context.fill_primStep
+attribute [rocq_alias fill_step_inv] Context.fill_primStep_inv
+
+instance : Context (Λ := Λ) (id (α := Expr)) where
+  fill_toVal_eq_none e := by grind only [id]
+  fill_primStep      := by grind only [id]
+  fill_primStep_inv  := by grind only [id]
+
+/-- A single atomic step in a threaded context -/
+@[grind]
+inductive step : List Expr × State → List Obs → List Expr × State → Prop
+  where
+  | atomic : ∀ e σ  obs e' σ' eₜ,
+    (e, σ) -<obs>->ₜ (e', σ', eₜ) →
+    ∀ (t₁ t₂: List Expr),
+    step (t₁ ++ e :: t₂, σ) obs (t₁ ++ e' :: t₂ ++ eₜ, σ')
+    -- NOTE: Using `t₁ ++ e :: t₂` instead of `t₁ ++ [e] ++ t₂` because in
+    -- Lean `[x] ++ xs` is not definitionallly equal to `x :: xs`. This is
+    -- because `++` does not correspond to a function on lists, but a
+    -- typeclass `Append.append` of which `List` has an instance.
+    -- Since most lemmas about an element appearing in the middle of a list
+    -- are in the shape `t₁ ++ e :: t₂`, this form is preferred.
+
+def step.of_primStep : ∀ {e σ}{obs : List Obs}{e'} {σ' : State} {eₜ},
+    (e, σ) -<obs>->ₜ (e', σ', eₜ) →
+    ∀ {t₁ t₂: List Expr},
+    step (t₁ ++ e :: t₂, σ) obs (t₁ ++ e' :: t₂ ++ eₜ, σ') :=
+  (Language.step.atomic _ _ _ _ _ _ · _ _)
+
+@[inherit_doc step]
+scoped macro conf:term:40 " -<" noWs obs:term:max noWs ">->ₜₚ " conf':term:41 : term =>
+ `(Language.step $conf $obs $conf')
+
+-- FIXME: Not displaying properly (?)
+open Lean PrettyPrinter Delaborator SubExpr in
+@[app_unexpander Language.step]
+meta def unexpandLanguageStep : Unexpander
+| `(Language.step $conf $obs $conf') =>
+  `($conf -<$obs>->ₜₚ $conf')
+| _ => throw ()
+
+/-- The (possibly zero) sequence of `Language.step`s -/
+@[grind]
+inductive nsteps : Nat → List Expr × State → List Obs → List Expr × State → Prop
+  where
+  | refl (ρ : List Expr × State): nsteps 0 ρ [] ρ
+  | cons n (ρ₁ ρ₂ ρ₃ : List Expr × State) (obs obs' : List Obs) :
+      ρ₁ -<obs>->ₜₚ ρ₂ →
+      nsteps n ρ₂ obs' ρ₃ →
+      nsteps (n+1) ρ₁ (obs ++ obs') ρ₃
+
+@[inherit_doc nsteps]
+scoped macro conf:term:40 " -<" noWs obs:term:max noWs ">->ₜₚ* " conf':term:41 : term =>
+ `(Language.nsteps $conf ($obs) $conf')
+
+open Lean PrettyPrinter Delaborator SubExpr in
+@[app_unexpander Language.nsteps]
+meta def unexpandLanguageNsteps : Unexpander
+| `(Language.nsteps $conf $obs $conf') =>
+  `($conf -<$obs>->ₜₚ* $conf')
+| _ => throw ()
+
+/-- A sequence of `Language.step`s with no observation information -/
+def erasedStep (ρ  ρ₂: List Expr × State) := ∃ obs, step ρ obs ρ₂
+
+@[inherit_doc erasedStep]
+scoped macro conf:term:40 " -·->ₜₚ " conf':term:41 : term =>
+ `(Language.erasedStep $conf $conf')
+
+open Lean PrettyPrinter Delaborator SubExpr in
+@[app_unexpander Language.erasedStep]
+meta def unexpandLanguageErasedStep : Unexpander
+| `(Language.erasedStep $conf $conf2) =>
+  `($conf -·->ₜₚ $conf2)
+| _ => throw ()
+
+@[rocq_alias not_reducible, grind =]
+theorem not_reducible_iff_irreducible {e : Expr} {σ : State} :
+    (¬ reducible (e, σ)) ↔ irreducible (e, σ) := by
+  grind only [reducible, irreducible]
+
+@[rocq_alias reducible_not_val, grind .]
+theorem toVal_none_of_reducible :
+    reducible (e, σ) → toVal e = none := by
+  grind only [reducible, val_stuck]
+
+@[rocq_alias reducible_no_obs_reducible, grind .]
+theorem reducible_of_pureReducible :
+    pureReducible (e, σ) → reducible (e, σ) := by
+  grind only [pureReducible, reducible]
+
+@[rocq_alias val_irreducible]
+theorem val_irreducible :
+    (toVal e).isSome →
+    irreducible (e, σ) := by
+  grind only [irreducible, val_stuck, = Option.isSome_none]
+
+@[rocq_alias of_val_inj]
+instance [ι : ToVal Expr Val]: Function.Injective (ι.coe.coe) := by
+  intro x y h
+  simpa [ToVal.toVal_coe] using congrArg (toVal) h
+
+@[rocq_alias not_not_stuck, grind =]
+theorem not_not_suck {e : Expr} {σ : State} :
+    (¬ notStuck (e, σ)) ↔ stuck (e, σ) := by
+  dsimp [stuck, notStuck]
+  match h : (toVal e) with
+  | some v =>
+    simp only [Option.isSome_some, true_or, not_true_eq_false, reduceCtorEq, false_and]
+  | none =>
+    simp only [Option.isSome_none, Bool.false_eq_true, false_or, not_reducible_iff_irreducible,
+      true_and]
+
+@[rocq_alias strongly_atomic_atomic]
+theorem stronglyAtomic_atomic a :
+    Atomic (State := State) .StronglyAtomic e →
+    Atomic (State := State) a e := by
+  match a with
+  | .StronglyAtomic => intros; assumption
+  | .WeaklyAtomic =>
+    rintro ⟨h⟩
+    constructor
+    grind only [not_reducible_iff_irreducible, val_irreducible]
+
+@[rocq_alias reducible_fill]
+theorem reducible_fill (K : Expr → Expr) [Λ.Context K] ⦃e : Expr⦄ ⦃σ : State⦄ :
+    reducible (e,σ) → reducible ((K e), σ) :=
+  fun ⟨obs, e', σ', eₜ, h⟩ =>
+    ⟨obs, K e', σ', eₜ, Context.fill_primStep h⟩
+
+@[rocq_alias reducible_fill_inv]
+theorem reducible_fill_inv (K : Expr → Expr) [Λ.Context K] ⦃e : Expr⦄ ⦃σ : State⦄ :
+    toVal e = none → reducible (K e, σ) → reducible (e,σ) :=
+  fun toVal_none ⟨obs, _, σ', eₜ, K_red⟩ =>
+    have ⟨e₂, _, red⟩ := Context.fill_primStep_inv toVal_none K_red
+    ⟨obs, e₂, σ', eₜ, red⟩
+
+@[rocq_alias reducible_no_obs_fill]
+theorem pureReducible_fill (K : Expr → Expr) [Λ.Context K] ⦃e : Expr⦄ ⦃σ : State⦄ :
+    pureReducible (e, σ) →
+    pureReducible (K e, σ) :=
+  fun ⟨e', σ', eₜ, h⟩ =>
+    ⟨K e', σ', eₜ, Context.fill_primStep h⟩
+
+@[rocq_alias reducible_no_obs_fill_inv]
+theorem pureReducible_fill_inv (K : Expr → Expr) [Λ.Context K] ⦃e : Expr⦄ ⦃σ : State⦄ :
+    toVal e = none → pureReducible (K e, σ) → pureReducible (e,σ) :=
+  fun toVal_none ⟨_, σ', eₜ, K_red⟩ =>
+    have ⟨e₂, _, red⟩ := Context.fill_primStep_inv toVal_none K_red
+    ⟨e₂, σ', eₜ, red⟩
+
+@[rocq_alias irrreducible_fill]
+theorem irreducible_fill (K : Expr → Expr) [Λ.Context K] ⦃e : Expr⦄ ⦃σ : State⦄ :
+    toVal e = none →
+    irreducible (e, σ) →
+    irreducible (K e, σ) :=
+  fun toVal_none irred =>
+    not_reducible_iff_irreducible.1 <|
+    fun red =>
+    not_reducible_iff_irreducible.2 irred <|
+    reducible_fill_inv K toVal_none red
+
+@[rocq_alias irreducible_fill_inv]
+theorem irreducible_fill_inv {K : Expr → Expr} [Λ.Context K] ⦃e : Expr⦄ ⦃σ : State⦄ :
+    irreducible (K e, σ) →
+    irreducible (e,σ) :=
+  fun irred =>
+    not_reducible_iff_irreducible.1 <|
+    fun red =>
+    not_reducible_iff_irreducible.2 irred <|
+    reducible_fill K red
+
+@[rocq_alias not_stuck_fill_inv]
+theorem notStuck_fill_inv (K : Expr → Expr) [Λ.Context K] :
+    notStuck (K e, σ) → notStuck (e, σ)  := by
+  intros hyp
+  dsimp only [notStuck]
+  match hyp with
+  | .inl hyp =>
+    simp [Option.isSome_iff_exists] at hyp ⊢
+    match h : toVal e with
+    | none =>
+      left
+      have := Context.fill_toVal_eq_none (K := K) h
+      grind only
+    | some v => grind only
+  | .inr hyp =>
+    match h₂ : toVal e with
+    | none =>
+      right
+      apply reducible_fill_inv K h₂ hyp
+    | some v =>
+      left
+      simp only [Option.isSome]
+
+@[rocq_alias stuck_fill]
+theorem stuck_fill (K : Expr → Expr) [Λ.Context K] :
+    stuck (e, σ) → stuck (K e, σ)  :=
+  fun ⟨toVal_e, irred⟩ =>
+    ⟨ Context.fill_toVal_eq_none toVal_e
+    , irreducible_fill K toVal_e irred⟩
+
+open List in
+@[rocq_alias step_Permutation]
+theorem perm_of_step (t₁ t₁' t₂ : List Expr) :
+    ∀ ⦃obs : List Obs⦄⦃σ₁ σ₂ : State⦄,
+    t₁ ~ t₁' →
+    (t₁, σ₁) -<obs>->ₜₚ (t₂, σ₂) →
+    ∃ t₂', t₂ ~ t₂'
+         ∧ (t₁', σ₁) -<obs>->ₜₚ (t₂', σ₂)
+     := by
+  rintro obs σ₁ σ₂ t1perm
+    ⟨e, σ₁, obs, e', σ₂, eₜ, red, ps, ss⟩
+  obtain ⟨ps', ss', rfl⟩ := t₁'.mem_iff_append.1 (show e ∈ t₁' from by
+    grind only [usr append_assoc, usr Perm.mem_iff, = cons_append, = mem_append, = mem_cons])
+  exists ps' ++ e' :: ss' ++ eₜ
+  constructor
+  · apply List.Perm.append_right
+    calc ps ++ e' :: ss
+      _ ~ e' :: (ps ++ ss) := perm_middle
+      _ ~ e' :: (ps' ++ ss') := by
+        apply (List.perm_cons e').mpr
+        apply (List.perm_cons e).mp
+        exact (perm_middle.symm.trans t1perm).trans perm_middle
+      _ ~ ps' ++ e' :: ss' := perm_middle.symm
+  · apply Language.step.of_primStep red
+
+@[grind =]
+private theorem _root_.List.getElem?_some_iff_append
+{a : α} {i : Nat} {l : List α} : l[i]? = some a ↔ ∃ s t : List α, l = s ++ a :: t ∧ s.length = i := by
+  constructor
+  · intros h
+    induction i generalizing l with
+    | zero =>
+      rcases l with _ | ⟨hd, tl⟩
+      · simp at h
+      · simpa using h
+    | succ i IH =>
+      rcases l with _ | ⟨hd, tl⟩
+      · simp at h
+      simp at h
+      grind only [=_ List.cons_append, = List.length_cons]
+  · rintro ⟨ps, ss, rfl, h2⟩
+    grind only [= List.getElem?_append, = List.getElem?_cons]
+
+@[rocq_alias step_insert]
+theorem step_update_of_getElem? {i obs efs} {t : List Expr} (σ₁ σ₂ : State):
+    t[i]? = some e →
+    (e, σ₁) -<obs>->ₜ (e', σ₂, efs) →
+    (t, σ₁) -<obs>->ₜₚ (t.set i e' ++ efs, σ₂) := by
+  grind only [= getElem?_neg, = getElem?_pos, = List.getElem?_some_iff_append,
+    = List.getElem?_append, = List.getElem?_cons, = List.set_append, = List.set_cons_zero,
+    step.atomic]
+
+open List in
+@[rocq_alias erased_step_Permutation]
+theorem perm_of_erasedStep (t₁ t₁' t₂ : List Expr) :
+    ∀ ⦃σ₁ σ₂ : State⦄,
+    t₁ ~ t₁' →
+    (t₁, σ₁) -·->ₜₚ (t₂, σ₂) →
+    ∃ t₂', t₂ ~ t₂'
+         ∧ (t₁', σ₁) -·->ₜₚ (t₂', σ₂)
+     :=
+  fun _ _ t1perm ⟨obs, red⟩ =>
+  have ⟨t₂', t2perm, red'⟩ := perm_of_step _ _ _ t1perm red
+  ⟨t₂', t2perm, obs, red'⟩
+
+/-- There is a pure step between `e₁` and `e₂` iff there is
+    a reduction step `(e₁, σ) -<[]>->ₜ (e₂, σ, [])` for some
+    σ and it is unique.
+
+    Intuitively, the reduction is deterministic and does not
+    depend on the environment.
+-/
+@[rocq_alias pure_step]
+def purePrimStep (e₁ e₂ : Expr) :=
+  (∀ σ : State, pureReducible (e₁, σ)) ∧
+  (∀ {σ₁ σ₂ : State} {obs e₂' eₜ},
+    (e₁, σ₁) -<obs>->ₜ (e₂', σ₂, eₜ) →
+    obs = [] ∧ σ₁ = σ₂ ∧ e₂ = e₂' ∧ eₜ = []
+  )
+
+@[inherit_doc purePrimStep]
+scoped macro conf:term:40 " -ᵖ-> " conf':term:41 : term =>
+  `(purePrimStep $conf $conf')
+
+open Lean PrettyPrinter Delaborator SubExpr in
+@[app_unexpander Language.purePrimStep]
+meta def unexpandLanguagePurePrimStep : Unexpander
+| `(purePrimStep $conf $conf2) =>
+  `($conf -ᵖ-> $conf2)
+| _ => throw ()
+
+/-- `e₁ -ᵖ->^[n] e₂` represents a sequence of `n` pure steps taken
+    from `e₁` up to `e₂`.
+-/
+scoped macro conf:term:40 " -ᵖ->^[" noWs n:term noWs "] " conf':term:41 : term =>
+  `(Relation.iterate purePrimStep $n $conf $conf')
+
+open Lean PrettyPrinter Delaborator SubExpr in
+@[app_unexpander Relation.iterate]
+meta def unexpandIterateLanguagePurePrimStep : Unexpander
+| `(Relation.iterate purePrimStep $n  $conf $conf') =>
+  `($conf -ᵖ->^[$n] $conf')
+| _ => throw ()
+
+private theorem _root_.ReflTrans_iff_exists_iterate {α : Type _} {R : α → α → Prop} :
+    ∀ {x y},
+    Relation.ReflTransGen R x y ↔ ∃ n, Relation.iterate R n x y := by
+  intros x y
+  constructor
+  · intros rtcR
+    induction rtcR with
+    | refl =>
+      exists 0; constructor
+    | tail rtcMid Rlast IH =>
+      obtain ⟨n, h⟩ := IH
+      exists (n+1)
+      apply Relation.iterate.tail _ h Rlast
+  · rintro ⟨n, itR⟩
+    induction itR with
+    | rfl => constructor
+    | tail z itMid Rlast IH =>
+      apply Relation.ReflTransGen.tail IH Rlast
+
+/-- `e₁ -ᵖ->* e₂` represents a sequence of some number of pure steps
+    taken from `e₁` up to `e₂`.
+-/
+scoped macro conf:term:40 " -ᵖ->* " conf':term:41 : term =>
+  `(Relation.ReflTransGen purePrimStep $conf $conf')
+
+open Lean PrettyPrinter Delaborator SubExpr in
+@[app_unexpander Relation.ReflTransGen]
+meta def unexpandReflTransGenLanguagePurePrimStep : Unexpander
+| `(Relation.ReflTransGen purePrimStep $conf $conf') =>
+  `($conf -ᵖ->* $conf')
+| _ => throw ()
+
+@[rocq_alias pure_steps_tp]
+def pureSteps (t₁ t₂ : List Expr) := List.Forall₂ (· -ᵖ->* ·) t₁ t₂
+
+/-- `e₁ -ᵖ->ₜₚ* e₂` represents a sequence of some number of pure steps
+    taken from `e₁` up to `e₂`.
+-/
+scoped macro conf:term:40 " -ᵖ->ₜₚ* " conf':term:41 : term =>
+  `(Language.pureSteps $conf $conf')
+
+open Lean PrettyPrinter Delaborator SubExpr in
+@[app_unexpander Language.pureSteps]
+meta def unexpandLanguagePureSteps : Unexpander
+| `(pureSteps $conf $conf') =>
+  `($conf -ᵖ->ₜₚ* $conf')
+| _ => throw ()
+
+class PureExec (φ : Prop) (n : Nat) (e₁ e₂ : Expr) : Prop where
+  pureExec : φ → e₁ -ᵖ->^[n] e₂
+
+@[rocq_alias pure_step_ctx]
+theorem purePrimStep_fill (K : Expr → Expr) [Context K] {e₁ e₂ : Expr} :
+    e₁ -ᵖ-> e₂ →
+    K e₁ -ᵖ-> K e₂ := by
+  rintro ⟨pRed,Hstep⟩
+  constructor
+  · exact (pureReducible_fill K <| pRed ·)
+  · intros σ₁ σ₂ obs K_e₂' eₜ primStep
+    have : toVal e₁ = none := by
+      apply toVal_none_of_reducible (σ := σ₁)
+      -- Any state works
+      apply reducible_of_pureReducible
+      apply pRed
+    obtain ⟨e₂', rfl, primStep⟩ := Context.fill_primStep_inv this primStep
+    grind only
+
+@[rocq_alias pure_step_nsteps_ctx]
+theorem iterate_purePrimStep_fill (K : Expr → Expr) [Context K] {e₁ e₂} :
+    e₁ -ᵖ->^[n] e₂ →
+    K e₁ -ᵖ->^[n] K e₂ := by
+  intro h
+  induction h with
+  | rfl => constructor
+  | tail y first last IH =>
+    apply Relation.iterate.tail (K y) IH (purePrimStep_fill K last)
+
+@[rocq_alias rtc_pure_step_ctx]
+theorem ReflTransGen_pureStep_fill (K : Expr → Expr) [Context K] {e₁ e₂} :
+    e₁ -ᵖ->* e₂ →
+    K e₁ -ᵖ->* K e₂ := by
+  intros h
+  replace ⟨n, h⟩:= ReflTrans_iff_exists_iterate.1 h
+  exact ReflTrans_iff_exists_iterate.2 ⟨n, iterate_purePrimStep_fill K h⟩
+
+@[rocq_alias pure_exec_ctx]
+theorem pureExec_fill (K : Expr → Expr) [Context K] {φ n e₁ e₂} :
+    PureExec φ n e₁ e₂ →
+    PureExec φ n (K e₁) (K e₂) := by
+  rintro ⟨h⟩
+  constructor
+  intros hφ
+  exact iterate_purePrimStep_fill K (h hφ)
+
+class IntoVal (e : Expr)(v : Val) where
+  into_val : (v : Expr) = e
+
+class AsVal (e : Expr) where
+  as_val : ∃ v, (v : Expr) = e
+
+#rocq_ignore as_vals_of_val "We have not yet implemented TCForall."
+
+@[rocq_alias as_val_is_Some]
+theorem as_val_isSome e :
+    (∃ v : Val, (v : Expr) = e) → (toVal e).isSome := by
+  grind only [!ToVal.toVal_eq_iff_coe, = Option.isSome_some]
+
+@[rocq_alias prim_step_not_stuck]
+theorem primStep_notStuck {e : Expr} {σ obs e' σ' eₜ} :
+    (e, σ) -<obs>->ₜ (e', σ', eₜ) →
+    notStuck (e, σ) :=
+  fun h => .inr ⟨_, _, _, _, h⟩
+
+@[rocq_alias rtc_pure_step_val]
+theorem ReflTransGen_purePrimStep_val [Inhabited State] {v : Val} {e : Expr} :
+    (v: Expr) -ᵖ->* e →
+    toVal e = some v := by
+  intros h
+  induction h with
+  | refl => exact (ToVal.toVal_coe _)
+  | tail H1 H2 IH =>
+    obtain ⟨red, stepUniq⟩ := H2
+    have ⟨e', σ', eₜ, step⟩ := red default
+    grind only [Language.val_stuck]
+
+/--
+  Let thread pools `t₁` and `t₃` be such that each thread
+  in `t₁` makes (zero or more) pure steps to the
+  corresponding thread in `t₃`.
+
+  Let `t₂` be a thread pool such that `t₁` under state
+  `σ₁` makes a (single) step to threadpool `t₂` and
+  state `σ₂`.
+
+  In this situation, either the step from `t₁` to `t₂`
+  corresponds to one of the pure steps between `t₁` and
+  `t₃` or, there is an `i` such that the `i`-th thread
+  does not participate in the pure steps between `t₁`
+  and `t₃` and `t₂` corresponds t taking a step in the
+  `i`-th thread starting from `t₁`.
+-/
+theorem erasedStep_pureSteps (t₁ t₂ t₃ : List Expr) (σ₁ σ₂ : State) :
+    (t₁, σ₁)  -·->ₜₚ  (t₂, σ₂) →
+       t₁     -ᵖ->ₜₚ*    t₃ →
+    (σ₁ = σ₂ ∧ t₂ -ᵖ->ₜₚ* t₃) ∨ -- t₂ was actually obtained form a pure reduction
+    (∃ i e eₜ e' obs,
+      t₁[i]? = some e ∧
+      t₃[i]? = some e ∧
+      t₂ = t₁.set i e' ++ eₜ ∧
+      (e, σ₁) -<obs>->ₜ (e', σ₂, eₜ)
+    ) := by
+  rintro ⟨obs, ⟨e, σ₁, obs, e₂, σ₂, eₜ, pstep, ps, ss⟩⟩ Hps
+  obtain ⟨ps₃, e₃, ss₃, rfl, ss_ss₃, ps_ps₃, length_ps, e_e₃⟩ :=
+    show ∃ ps₃ e₃ ss₃, t₃ = ps₃ ++ e₃ :: ss₃
+         ∧ ss -ᵖ->ₜₚ* ss₃
+         ∧ ps -ᵖ->ₜₚ* ps₃ ∧ ps.length = ps₃.length
+         ∧ e -ᵖ->* e₃ from by
+      grind [pureSteps]
+  rcases Relation.ReflTransGen.cases_head e_e₃ with (rfl | ⟨e', firstPureStep, lastSteps⟩)
+  · right
+    exists (ps₃.length), e, eₜ, e₂, obs
+    simp only [List.length_append, List.length_cons, Nat.lt_add_right_iff_pos, Nat.zero_lt_succ,
+      getElem?_pos, Std.le_refl, List.getElem_append_right, Nat.sub_self, List.getElem_cons_zero,
+      List.append_assoc, List.cons_append, List.set_append_right, List.set_cons_zero, and_self,
+      length_ps, pstep]
+  · obtain ⟨pRed, uniqStep⟩ := firstPureStep
+    obtain ⟨rlf, rfl, rfl, rfl⟩ := uniqStep pstep
+    left
+    have : e -ᵖ-> e' := by grind only [purePrimStep]
+    simp only [pureSteps, List.append_nil, true_and]
+    apply List.Forall₂.append ps_ps₃
+    apply List.Forall₂.cons lastSteps ss_ss₃
+
+end Language

--- a/src/Iris/ProgramLogic/Language.lean
+++ b/src/Iris/ProgramLogic/Language.lean
@@ -8,9 +8,6 @@ public import Iris.Std.List
 public meta import Lean.PrettyPrinter.Delaborator
 public import Batteries.Data.List.Basic
 
--- TODO: Rename all `Context.fill` lemmas to something more consistent.
---       In particular, for some other constructions they are referred to
---       to as `_ctx`.
 -- TODO: Rethink steping notations (probabl drop `ₜ` for `primStep`)
 --       (e,σ)    -<obs>->ₜ        (e',σ',eₜ)  (primStep)
 --       (t,σ)    -<obs>->ₜₚ       (t',σ')     (Step)
@@ -150,27 +147,6 @@ class Atomic (a : Atomicity) (e : Expr) : Prop where
 
 variable {e e': Expr}{σ σ': State}{v v' : Val}
 
-/-- `Context K` says `K` models an evaluation context for the language -/
-class Context(K: Expr → Expr) where
-  fill_toVal_eq_none : ∀ {e : Expr},
-    toVal e = none → toVal (K e) = none
-  fill_primStep : ∀ {e} {σ : State} {obs e' σ' eₜ},
-    (e, σ) -<obs>->ₜ (e', σ', eₜ) →
-    (K e, σ)-<obs>->ₜ(K e', σ', eₜ)
-  fill_primStep_inv : ∀ {e} {σ : State} {obs K_e' σ' eₜ},
-    toVal e = .none →
-    (K e, σ) -<obs>->ₜ (K_e', σ', eₜ) →
-    ∃ e', K_e' = K e' ∧ (e, σ) -<obs>->ₜ (e', σ', eₜ)
-
-attribute [rocq_alias fill_not_val] Context.fill_toVal_eq_none
-attribute [rocq_alias fill_step] Context.fill_primStep
-attribute [rocq_alias fill_step_inv] Context.fill_primStep_inv
-
-instance : Context (Λ := Λ) (id (α := Expr)) where
-  fill_toVal_eq_none e := by grind only [id]
-  fill_primStep      := by grind only [id]
-  fill_primStep_inv  := by grind only [id]
-
 /-- A single atomic step in a threaded context -/
 @[grind]
 inductive Step : List Expr × State → List Obs → List Expr × State → Prop
@@ -267,19 +243,40 @@ theorem primStep_notStuck {e : Expr} {σ obs e' σ' eₜ} :
   fun h => .inr ⟨_, _, _, _, h⟩
 end ReducibilityLemmas
 
-section ContextLemmas
+/-- `Context K` says `K` models an evaluation context for the language -/
+class Context(K: Expr → Expr) where
+  toVal_eq_none_fill : ∀ {e : Expr},
+    toVal e = none → toVal (K e) = none
+  primStep_fill : ∀ {e} {σ : State} {obs e' σ' eₜ},
+    (e, σ) -<obs>->ₜ (e', σ', eₜ) →
+    (K e, σ)-<obs>->ₜ(K e', σ', eₜ)
+  primStep_fill_inv : ∀ {e} {σ : State} {obs K_e' σ' eₜ},
+    toVal e = .none →
+    (K e, σ) -<obs>->ₜ (K_e', σ', eₜ) →
+    ∃ e', K_e' = K e' ∧ (e, σ) -<obs>->ₜ (e', σ', eₜ)
+
+attribute [rocq_alias fill_not_val] Context.toVal_eq_none_fill
+attribute [rocq_alias fill_step] Context.primStep_fill
+attribute [rocq_alias fill_step_inv] Context.primStep_fill_inv
+
+namespace Context
+
+instance : Context (Λ := Λ) (id (α := Expr)) where
+  toVal_eq_none_fill e := by grind only [id]
+  primStep_fill      := by grind only [id]
+  primStep_fill_inv  := by grind only [id]
 
 @[rocq_alias reducible_fill]
 theorem reducible_fill (K : Expr → Expr) [Λ.Context K] ⦃e : Expr⦄ ⦃σ : State⦄ :
     reducible (e,σ) → reducible ((K e), σ) :=
   fun ⟨obs, e', σ', eₜ, h⟩ =>
-    ⟨obs, K e', σ', eₜ, Context.fill_primStep h⟩
+    ⟨obs, K e', σ', eₜ, primStep_fill h⟩
 
 @[rocq_alias reducible_fill_inv]
 theorem reducible_fill_inv (K : Expr → Expr) [Λ.Context K] ⦃e : Expr⦄ ⦃σ : State⦄ :
     toVal e = none → reducible (K e, σ) → reducible (e,σ) :=
   fun toVal_none ⟨obs, _, σ', eₜ, K_red⟩ =>
-    have ⟨e₂, _, red⟩ := Context.fill_primStep_inv toVal_none K_red
+    have ⟨e₂, _, red⟩ := primStep_fill_inv toVal_none K_red
     ⟨obs, e₂, σ', eₜ, red⟩
 
 @[rocq_alias reducible_no_obs_fill]
@@ -287,13 +284,13 @@ theorem pureReducible_fill (K : Expr → Expr) [Λ.Context K] ⦃e : Expr⦄ ⦃
     pureReducible (e, σ) →
     pureReducible (K e, σ) :=
   fun ⟨e', σ', eₜ, h⟩ =>
-    ⟨K e', σ', eₜ, Context.fill_primStep h⟩
+    ⟨K e', σ', eₜ, primStep_fill h⟩
 
 @[rocq_alias reducible_no_obs_fill_inv]
 theorem pureReducible_fill_inv (K : Expr → Expr) [Λ.Context K] ⦃e : Expr⦄ ⦃σ : State⦄ :
     toVal e = none → pureReducible (K e, σ) → pureReducible (e,σ) :=
   fun toVal_none ⟨_, σ', eₜ, K_red⟩ =>
-    have ⟨e₂, _, red⟩ := Context.fill_primStep_inv toVal_none K_red
+    have ⟨e₂, _, red⟩ := primStep_fill_inv toVal_none K_red
     ⟨e₂, σ', eₜ, red⟩
 
 @[rocq_alias irrreducible_fill]
@@ -328,7 +325,7 @@ theorem notStuck_fill_inv (K : Expr → Expr) [Λ.Context K] :
     match h : toVal e with
     | none =>
       left
-      have := Context.fill_toVal_eq_none (K := K) h
+      have := toVal_eq_none_fill (K := K) h
       grind only
     | some v => grind only
   | .inr hyp =>
@@ -344,10 +341,10 @@ theorem notStuck_fill_inv (K : Expr → Expr) [Λ.Context K] :
 theorem stuck_fill (K : Expr → Expr) [Λ.Context K] :
     stuck (e, σ) → stuck (K e, σ)  :=
   fun ⟨toVal_e, irred⟩ =>
-    ⟨ Context.fill_toVal_eq_none toVal_e
+    ⟨ toVal_eq_none_fill toVal_e
     , irreducible_fill K toVal_e irred⟩
 
-end ContextLemmas
+end Context
 
 open List in
 @[rocq_alias step_Permutation]
@@ -450,14 +447,14 @@ theorem purePrimStep_fill (K : Expr → Expr) [Context K] {e₁ e₂ : Expr} :
     K e₁ -ᵖ-> K e₂ := by
   rintro ⟨pRed,Hstep⟩
   constructor
-  · exact (pureReducible_fill K <| pRed ·)
+  · exact (Context.pureReducible_fill K <| pRed ·)
   · intros σ₁ σ₂ obs K_e₂' eₜ primStep
     have : toVal e₁ = none := by
       apply toVal_none_of_reducible (σ := σ₁)
       -- Any state works
       apply reducible_of_pureReducible
       apply pRed
-    obtain ⟨e₂', rfl, primStep⟩ := Context.fill_primStep_inv this primStep
+    obtain ⟨e₂', rfl, primStep⟩ := Context.primStep_fill_inv this primStep
     grind only
 
 @[rocq_alias pure_step_nsteps_ctx]

--- a/src/Iris/ProgramLogic/Language.lean
+++ b/src/Iris/ProgramLogic/Language.lean
@@ -4,6 +4,7 @@ public import Iris.Std.RocqAlias
 public import Iris.Std.RocqIgnore
 public import Iris.Std.FromMathlib
 public import Iris.Std.Relation
+public import Iris.Std.List
 public meta import Lean.PrettyPrinter.Delaborator
 public import Batteries.Data.List.Basic
 
@@ -44,16 +45,16 @@ class ToVal (Expr : Type e) (Val : outParam <| Type v ) where
   toVal : Expr → Option Val
   ofVal : Val → Expr
   /-- If `toVal` is defined for an expression, `coe` is its inverse -/
-  coe_of_toVal_eq (e : Expr)(v : Val) : toVal e = some v → ofVal v = e
+  coe_of_toVal_eq_some (e : Expr)(v : Val) : toVal e = some v → ofVal v = e
   /-- `toVal` is defined `coe`, and works as its inverse -/
   toVal_coe (v : Val) : toVal (ofVal v) = some v
-export ToVal (toVal coe_of_toVal_eq toVal_coe)
+export ToVal (toVal coe_of_toVal_eq_some toVal_coe)
 
 attribute [rocq_alias language.to_val] ToVal.toVal
-attribute [rocq_alias mixin_of_to_val] ToVal.coe_of_toVal_eq
-attribute [rocq_alias mixin_to_of_val, simp, grind =] ToVal.toVal_coe
-
-#rocq_ignore language.of_val "This function was implemented as a coercion from Expr to Val, so there is no need for an explicit `of_val` function."
+attribute [rocq_alias language.of_val] ToVal.ofVal
+attribute [rocq_alias mixin_of_to_val] coe_of_toVal_eq_some
+attribute [rocq_alias mixin_to_of_val] ToVal.toVal_coe
+attribute [simp, grind =] ToVal.toVal_coe
 
 namespace ToVal
 
@@ -64,7 +65,12 @@ instance : Coe Val Expr where coe := ToVal.ofVal
 
 @[grind! .]
 theorem toVal_eq_iff_coe (e : Expr)(v : Val): (v : Expr) = e ↔ toVal e = some v :=
-  ⟨(· ▸ ToVal.toVal_coe v), ToVal.coe_of_toVal_eq e v⟩
+  ⟨(· ▸ ToVal.toVal_coe v), coe_of_toVal_eq_some e v⟩
+
+@[rocq_alias of_val_inj]
+instance [ι : ToVal Expr Val]: Function.Injective (ι.ofVal) := by
+  intro x y h
+  simpa [ToVal.toVal_coe] using congrArg (toVal) h
 
 end ToVal
 
@@ -209,6 +215,8 @@ def erasedStep (ρ  ρ₂: List Expr × State) := ∃ obs, Step ρ obs ρ₂
 @[inherit_doc erasedStep]
 scoped notation conf:40 " -·->ₜₚ " conf':41 => Language.erasedStep conf conf'
 
+section ReducibilityLemmas
+
 @[rocq_alias not_reducible, grind =]
 theorem not_reducible_iff_irreducible {e : Expr} {σ : State} :
     (¬ reducible (e, σ)) ↔ irreducible (e, σ) := by
@@ -229,11 +237,6 @@ theorem val_irreducible :
     (toVal e).isSome →
     irreducible (e, σ) := by
   grind only [irreducible, val_stuck, = Option.isSome_none]
-
-@[rocq_alias of_val_inj]
-instance [ι : ToVal Expr Val]: Function.Injective (ι.ofVal) := by
-  intro x y h
-  simpa [ToVal.toVal_coe] using congrArg (toVal) h
 
 @[rocq_alias not_not_stuck, grind =]
 theorem not_not_suck {e : Expr} {σ : State} :
@@ -256,6 +259,15 @@ theorem stronglyAtomic_atomic a :
     rintro ⟨h⟩
     constructor
     grind only [not_reducible_iff_irreducible, val_irreducible]
+
+@[rocq_alias prim_step_not_stuck]
+theorem primStep_notStuck {e : Expr} {σ obs e' σ' eₜ} :
+    (e, σ) -<obs>->ₜ (e', σ', eₜ) →
+    notStuck (e, σ) :=
+  fun h => .inr ⟨_, _, _, _, h⟩
+end ReducibilityLemmas
+
+section ContextLemmas
 
 @[rocq_alias reducible_fill]
 theorem reducible_fill (K : Expr → Expr) [Λ.Context K] ⦃e : Expr⦄ ⦃σ : State⦄ :
@@ -335,6 +347,8 @@ theorem stuck_fill (K : Expr → Expr) [Λ.Context K] :
     ⟨ Context.fill_toVal_eq_none toVal_e
     , irreducible_fill K toVal_e irred⟩
 
+end ContextLemmas
+
 open List in
 @[rocq_alias step_Permutation]
 theorem perm_of_step (t₁ t₁' t₂ : List Expr) :
@@ -360,30 +374,12 @@ theorem perm_of_step (t₁ t₁' t₂ : List Expr) :
       _ ~ ps' ++ e' :: ss' := perm_middle.symm
   · apply Language.Step.of_primStep red
 
-@[grind =]
-private theorem _root_.List.getElem?_some_iff_append
-{a : α} {i : Nat} {l : List α} : l[i]? = some a ↔ ∃ s t : List α, l = s ++ a :: t ∧ s.length = i := by
-  constructor
-  · intros h
-    induction i generalizing l with
-    | zero =>
-      rcases l with _ | ⟨hd, tl⟩
-      · simp at h
-      · simpa using h
-    | succ i IH =>
-      rcases l with _ | ⟨hd, tl⟩
-      · simp at h
-      simp at h
-      grind only [=_ List.cons_append, = List.length_cons]
-  · rintro ⟨ps, ss, rfl, h2⟩
-    grind only [= List.getElem?_append, = List.getElem?_cons]
-
 @[rocq_alias step_insert]
 theorem step_update_of_getElem? {i obs efs} {t : List Expr} (σ₁ σ₂ : State):
     t[i]? = some e →
     (e, σ₁) -<obs>->ₜ (e', σ₂, efs) →
     (t, σ₁) -<obs>->ₜₚ (t.set i e' ++ efs, σ₂) := by
-  grind only [= getElem?_neg, = getElem?_pos, = List.getElem?_some_iff_append,
+  grind only [= getElem?_neg, = getElem?_pos, = Iris.Std.List.getElem?_some_iff_append,
     = List.getElem?_append, = List.getElem?_cons, = List.set_append, = List.set_cons_zero,
     Step.atomic]
 
@@ -399,6 +395,8 @@ theorem perm_of_erasedStep (t₁ t₁' t₂ : List Expr) :
   fun _ _ t1perm ⟨obs, red⟩ =>
   have ⟨t₂', t2perm, red'⟩ := perm_of_step _ _ _ t1perm red
   ⟨t₂', t2perm, obs, red'⟩
+
+section PureSteps
 
 /-- There is a pure step between `e₁` and `e₂` iff there is
     a reduction step `(e₁, σ) -<[]>->ₜ (e₂, σ, [])` for some
@@ -422,25 +420,6 @@ scoped notation conf:40 " -ᵖ-> " conf':41 => purePrimStep conf conf'
     from `e₁` up to `e₂`.
 -/
 scoped notation conf:40 " -ᵖ->^[" n "] " conf':41 => Relation.iterate purePrimStep n conf conf'
-
-private theorem _root_.ReflTrans_iff_exists_iterate {α : Type _} {R : α → α → Prop} :
-    ∀ {x y},
-    Relation.ReflTransGen R x y ↔ ∃ n, Relation.iterate R n x y := by
-  intros x y
-  constructor
-  · intros rtcR
-    induction rtcR with
-    | refl =>
-      exists 0; constructor
-    | tail rtcMid Rlast IH =>
-      obtain ⟨n, h⟩ := IH
-      exists (n+1)
-      apply Relation.iterate.tail _ h Rlast
-  · rintro ⟨n, itR⟩
-    induction itR with
-    | rfl => constructor
-    | tail z itMid Rlast IH =>
-      apply Relation.ReflTransGen.tail IH Rlast
 
 /-- `e₁ -ᵖ->* e₂` represents a sequence of some number of pure steps
     taken from `e₁` up to `e₂`.
@@ -496,8 +475,8 @@ theorem ReflTransGen_pureStep_fill (K : Expr → Expr) [Context K] {e₁ e₂} :
     e₁ -ᵖ->* e₂ →
     K e₁ -ᵖ->* K e₂ := by
   intros h
-  replace ⟨n, h⟩:= ReflTrans_iff_exists_iterate.1 h
-  exact ReflTrans_iff_exists_iterate.2 ⟨n, iterate_purePrimStep_fill K h⟩
+  replace ⟨n, h⟩:= Relation.ReflTrans_iff_exists_iterate.1 h
+  exact Relation.ReflTrans_iff_exists_iterate.2 ⟨n, iterate_purePrimStep_fill K h⟩
 
 @[rocq_alias pure_exec_ctx]
 theorem pureExec_fill (K : Expr → Expr) [Context K] {φ n e₁ e₂} :
@@ -507,6 +486,21 @@ theorem pureExec_fill (K : Expr → Expr) [Context K] {φ n e₁ e₂} :
   constructor
   intros hφ
   exact iterate_purePrimStep_fill K (h hφ)
+
+
+@[rocq_alias rtc_pure_step_val]
+theorem ReflTransGen_purePrimStep_val [Inhabited State] {v : Val} {e : Expr} :
+    (v: Expr) -ᵖ->* e →
+    toVal e = some v := by
+  intros h
+  induction h with
+  | refl => exact (ToVal.toVal_coe _)
+  | tail H1 H2 IH =>
+    obtain ⟨red, stepUniq⟩ := H2
+    have ⟨e', σ', eₜ, step⟩ := red default
+    grind only [Language.val_stuck]
+
+end PureSteps
 
 class IntoVal (e : Expr)(v : Val) where
   into_val : (v : Expr) = e
@@ -520,24 +514,6 @@ class AsVal (e : Expr) where
 theorem as_val_isSome e :
     (∃ v : Val, (v : Expr) = e) → (toVal e).isSome := by
   grind only [!ToVal.toVal_eq_iff_coe, = Option.isSome_some]
-
-@[rocq_alias prim_step_not_stuck]
-theorem primStep_notStuck {e : Expr} {σ obs e' σ' eₜ} :
-    (e, σ) -<obs>->ₜ (e', σ', eₜ) →
-    notStuck (e, σ) :=
-  fun h => .inr ⟨_, _, _, _, h⟩
-
-@[rocq_alias rtc_pure_step_val]
-theorem ReflTransGen_purePrimStep_val [Inhabited State] {v : Val} {e : Expr} :
-    (v: Expr) -ᵖ->* e →
-    toVal e = some v := by
-  intros h
-  induction h with
-  | refl => exact (ToVal.toVal_coe _)
-  | tail H1 H2 IH =>
-    obtain ⟨red, stepUniq⟩ := H2
-    have ⟨e', σ', eₜ, step⟩ := red default
-    grind only [Language.val_stuck]
 
 /--
   Let thread pools `t₁` and `t₃` be such that each thread
@@ -584,7 +560,7 @@ theorem erasedStep_pureSteps (t₁ t₂ t₃ : List Expr) (σ₁ σ₂ : State) 
     obtain ⟨rlf, rfl, rfl, rfl⟩ := uniqStep pstep
     have : e -ᵖ-> e' := by grind only [purePrimStep]
     simp only [pureSteps, List.append_nil, true_and]
-    apply List.Forall₂.append ps_ps₃
+    apply Iris.Std.List.Forall₂.append ps_ps₃
     apply List.Forall₂.cons lastSteps ss_ss₃
 
 end Language

--- a/src/Iris/ProgramLogic/Language.lean
+++ b/src/Iris/ProgramLogic/Language.lean
@@ -7,8 +7,6 @@ public import Iris.Std.Relation
 public meta import Lean.PrettyPrinter.Delaborator
 public import Batteries.Data.List.Basic
 
--- TODO: Term levels for the different notations were chosen arbitrarily.
---       Make sure they are adequate.
 -- TODO: Rename all `Context.fill` lemmas to something more consistent.
 --       In particular, for some other constructions they are referred to
 --       to as `_ctx`.

--- a/src/Iris/ProgramLogic/Language.lean
+++ b/src/Iris/ProgramLogic/Language.lean
@@ -11,8 +11,6 @@ public import Batteries.Data.List.Basic
 #rocq_ignore LanguageMixin "This feature was implemented differently using typeclasses"
 #rocq_ignore language      "This feature was implemented differently using typeclasses"
 
--- TODO: Ask «Why chose List here? It seems any monoid would do.» for the
---       observations being a `List Obs`.
 -- TODO: Consider renaming `ToVal` typeclass to something better, since
 --       it's not just the `toVal` operation it carries.
 

--- a/src/Iris/ProgramLogic/Language.lean
+++ b/src/Iris/ProgramLogic/Language.lean
@@ -21,13 +21,15 @@ public import Batteries.Data.List.Basic
 --         e      -ᵖ->^[n]           e'        (iterate pureStep)
 --         e      -ᵖ->*              e'        (ReflTransGen pureStep)
 --         t      -ᵖ->ₜₚ*            t'        (Forall₂ (· -ᵖ->* ·))
--- TODO: Add macro tests / consider making them all use `notation` over
---       `macro`
 -- TODO: Ensure all the relevant `rocq_alias` are added
 -- TODO: Ask «Why chose List here? It seems any monoid would do.» for the
 --       observations being a `List Obs`.
 -- TODO: Consider renaming `ToVal` typeclass to something better, since
 --       it's not just the `toVal` operation it carries.
+-- TODO: Move out of `FromMathlib` those definitions which don't actually
+--       come from Mathlib!
+-- TODO: Consider changing `Language.NSteps` to use `Relation.iterate`
+--       instead of mirroring its structure
 
 @[expose] public section
 
@@ -49,7 +51,7 @@ class ToVal (Expr : Type e) (Val : outParam <| Type v ) where
   coe_of_toVal_eq (e : Expr)(v : Val) : toVal e = some v → ofVal v = e
   /-- `toVal` is defined `coe`, and works as its inverse -/
   toVal_coe (v : Val) : toVal (ofVal v) = some v
-export ToVal (toVal)
+export ToVal (toVal coe_of_toVal_eq toVal_coe)
 
 attribute [rocq_alias language.to_val] ToVal.toVal
 attribute [rocq_alias mixin_of_to_val] ToVal.coe_of_toVal_eq
@@ -81,16 +83,9 @@ class PrimStep
   primStep   : Expr × State → Obs → Expr × State × List Expr → Prop
 
 namespace PrimStep
-@[inherit_doc PrimStep.primStep]
-scoped macro conf:term:40 " -<" noWs obs:term:max noWs ">->ₜ " conf':term:41 : term =>
- `(PrimStep.primStep $conf $obs $conf')
 
-open Lean PrettyPrinter Delaborator SubExpr in
-@[app_unexpander PrimStep.primStep]
-meta def unexpandPrimStep : Unexpander
-| `(primStep $conf $obs $conf') =>
-  `($conf -<$obs>->ₜ $conf')
-| _ => throw ()
+@[inherit_doc PrimStep.primStep]
+scoped notation conf:40 " -<" obs:max ">->ₜ " conf':41  => PrimStep.primStep conf obs conf'
 
 end PrimStep
 open PrimStep
@@ -196,16 +191,7 @@ def Step.of_primStep : ∀ {e σ}{obs : List Obs}{e'} {σ' : State} {eₜ},
   (Language.Step.atomic _ _ _ _ _ _ · _ _)
 
 @[inherit_doc Step]
-scoped macro conf:term:40 " -<" noWs obs:term:max noWs ">->ₜₚ " conf':term:41 : term =>
- `(Language.Step $conf $obs $conf')
-
--- FIXME: Not displaying properly (?)
-open Lean PrettyPrinter Delaborator SubExpr in
-@[app_unexpander Step]
-meta def unexpandLanguageStep : Unexpander
-| `(Language.Step $conf $obs $conf') =>
-  `($conf -<$obs>->ₜₚ $conf')
-| _ => throw ()
+scoped notation conf:40 " -<" obs:max ">->ₜₚ " conf':41 => Language.Step conf obs conf'
 
 /-- The (possibly zero) sequence of `Language.step`s -/
 @[grind]
@@ -218,29 +204,14 @@ inductive NSteps : Nat → List Expr × State → List Obs → List Expr × Stat
       NSteps (n+1) ρ₁ (obs ++ obs') ρ₃
 
 @[inherit_doc NSteps]
-scoped macro conf:term:40 " -<" noWs obs:term:max noWs ">->ₜₚ^[" noWs n:term:max noWs "] " conf':term:41 : term =>
- `(Language.NSteps $n $conf ($obs) $conf')
-
-open Lean PrettyPrinter Delaborator SubExpr in
-@[app_unexpander NSteps]
-meta def unexpandLanguageNsteps : Unexpander
-| `(Language.NSteps $n $conf $obs $conf') =>
-  `($conf -<$obs>->ₜₚ^[$n] $conf')
-| _ => throw ()
+scoped notation conf:40 " -<" obs:max ">->ₜₚ^[" n:max "] " conf':41 =>
+ Language.NSteps n conf obs conf'
 
 /-- A sequence of `Language.step`s with no observation information -/
 def erasedStep (ρ  ρ₂: List Expr × State) := ∃ obs, Step ρ obs ρ₂
 
 @[inherit_doc erasedStep]
-scoped macro conf:term:40 " -·->ₜₚ " conf':term:41 : term =>
- `(Language.erasedStep $conf $conf')
-
-open Lean PrettyPrinter Delaborator SubExpr in
-@[app_unexpander Language.erasedStep]
-meta def unexpandLanguageErasedStep : Unexpander
-| `(Language.erasedStep $conf $conf') =>
-  `($conf -·->ₜₚ $conf')
-| _ => throw ()
+scoped notation conf:40 " -·->ₜₚ " conf':41 => Language.erasedStep conf conf'
 
 @[rocq_alias not_reducible, grind =]
 theorem not_reducible_iff_irreducible {e : Expr} {σ : State} :
@@ -449,28 +420,12 @@ def purePrimStep (e₁ e₂ : Expr) :=
   )
 
 @[inherit_doc purePrimStep]
-scoped macro conf:term:40 " -ᵖ-> " conf':term:41 : term =>
-  `(purePrimStep $conf $conf')
-
-open Lean PrettyPrinter Delaborator SubExpr in
-@[app_unexpander Language.purePrimStep]
-meta def unexpandLanguagePurePrimStep : Unexpander
-| `(purePrimStep $conf $conf') =>
-  `($conf -ᵖ-> $conf')
-| _ => throw ()
+scoped notation conf:40 " -ᵖ-> " conf':41 => purePrimStep conf conf'
 
 /-- `e₁ -ᵖ->^[n] e₂` represents a sequence of `n` pure steps taken
     from `e₁` up to `e₂`.
 -/
-scoped macro conf:term:40 " -ᵖ->^[" noWs n:term noWs "] " conf':term:41 : term =>
-  `(Relation.iterate purePrimStep $n $conf $conf')
-
-open Lean PrettyPrinter Delaborator SubExpr in
-@[app_unexpander Relation.iterate]
-meta def unexpandIterateLanguagePurePrimStep : Unexpander
-| `(Relation.iterate purePrimStep $n  $conf $conf') =>
-  `($conf -ᵖ->^[$n] $conf')
-| _ => throw ()
+scoped notation conf:40 " -ᵖ->^[" n "] " conf':41 => Relation.iterate purePrimStep n conf conf'
 
 private theorem _root_.ReflTrans_iff_exists_iterate {α : Type _} {R : α → α → Prop} :
     ∀ {x y},
@@ -494,15 +449,7 @@ private theorem _root_.ReflTrans_iff_exists_iterate {α : Type _} {R : α → α
 /-- `e₁ -ᵖ->* e₂` represents a sequence of some number of pure steps
     taken from `e₁` up to `e₂`.
 -/
-scoped macro conf:term:40 " -ᵖ->* " conf':term:41 : term =>
-  `(Relation.ReflTransGen purePrimStep $conf $conf')
-
-open Lean PrettyPrinter Delaborator SubExpr in
-@[app_unexpander Relation.ReflTransGen]
-meta def unexpandReflTransGenLanguagePurePrimStep : Unexpander
-| `(Relation.ReflTransGen purePrimStep $conf $conf') =>
-  `($conf -ᵖ->* $conf')
-| _ => throw ()
+scoped notation conf:40 " -ᵖ->* " conf':41 => Relation.ReflTransGen purePrimStep conf conf'
 
 @[rocq_alias pure_steps_tp]
 def pureSteps (t₁ t₂ : List Expr) := List.Forall₂ (· -ᵖ->* ·) t₁ t₂
@@ -510,8 +457,7 @@ def pureSteps (t₁ t₂ : List Expr) := List.Forall₂ (· -ᵖ->* ·) t₁ t�
 /-- `e₁ -ᵖ->ₜₚ* e₂` represents a sequence of some number of pure steps
     taken from `e₁` up to `e₂`.
 -/
-scoped macro conf:term:40 " -ᵖ->ₜₚ* " conf':term:41 : term =>
-  `(Language.pureSteps $conf $conf')
+scoped notation conf:40 " -ᵖ->ₜₚ* " conf':41 => Language.pureSteps conf conf'
 
 open Lean PrettyPrinter Delaborator SubExpr in
 @[app_unexpander Language.pureSteps]
@@ -646,3 +592,75 @@ theorem erasedStep_pureSteps (t₁ t₂ t₃ : List Expr) (σ₁ σ₂ : State) 
     apply List.Forall₂.cons lastSteps ss_ss₃
 
 end Language
+
+section test
+open Language
+
+section notations
+
+/--
+info: (e, σ) -<obs>->ₜ (e, σ, []) : Prop
+-/
+#guard_msgs in
+variable (e : Expr) (σ : State) (obs : Obs) [PrimStep Expr State Obs] in
+#check (PrimStep.primStep (e, σ) obs (e,σ,[]))
+
+/--
+info: (t, σ) -<obs>->ₜₚ (t, σ) : Prop
+-/
+#guard_msgs in
+variable (t : List Expr) (σ : State) (obs : List Obs) [Language Expr State Obs Val] in
+#check (Language.Step (t, σ) obs (t,σ))
+
+/--
+info: (t, σ) -<obs>->ₜₚ^[0] (t, σ) : Prop
+-/
+#guard_msgs in
+variable (t : List Expr) (σ : State) (obs : List Obs) [Language Expr State Obs Val] in
+#check (Language.NSteps 0 (t, σ) obs (t,σ))
+
+/--
+info: (t, σ) -·->ₜₚ (t, σ) : Prop
+-/
+#guard_msgs in
+variable (t : List Expr) (σ : State) [Language Expr State Obs Val] in
+#check (Language.erasedStep (t, σ) (t,σ))
+
+/--
+info: e -ᵖ-> e : Prop
+-/
+#guard_msgs in
+variable (e : Expr) [Language Expr State Obs Val] in
+#check (Language.purePrimStep e e)
+
+/--
+info: e -ᵖ->^[0] e : Prop
+-/
+#guard_msgs in
+variable (e : Expr) [Language Expr State Obs Val] in
+#check (Relation.iterate Language.purePrimStep 0 e e)
+
+/--
+info: e -ᵖ->* e : Prop
+-/
+#guard_msgs in
+variable (e : Expr) [Language Expr State Obs Val] in
+#check (Relation.ReflTransGen Language.purePrimStep e e)
+
+/--
+info: e -ᵖ->* e : Prop
+-/
+#guard_msgs in
+variable (e : Expr) [Language Expr State Obs Val] in
+#check (Relation.ReflTransGen Language.purePrimStep e e)
+
+/--
+info: t -ᵖ->ₜₚ* t : Prop
+-/
+#guard_msgs in
+variable (t : List Expr) [Language Expr State Obs Val] in
+#check (Language.pureSteps t t)
+
+end notations
+
+end test

--- a/src/Iris/ProgramLogic/Language.lean
+++ b/src/Iris/ProgramLogic/Language.lean
@@ -13,6 +13,8 @@ public import Batteries.Data.List.Basic
 -- TODO: Consider renaming `ToVal` typeclass to something better, since
 --       it's not just the `toVal` operation it carries.
 
+namespace Iris.ProgramLogic
+
 @[expose] public section
 
 open FromMathlib

--- a/src/Iris/ProgramLogic/Language.lean
+++ b/src/Iris/ProgramLogic/Language.lean
@@ -122,11 +122,8 @@ inductive Step : List Expr × State → List Obs → List Expr × State → Prop
     (e, σ) -<obs>-> (e', σ', eₜ) →
     ∀ (t₁ t₂: List Expr),
     Step (t₁ ++ e :: t₂, σ) obs (t₁ ++ e' :: t₂ ++ eₜ, σ')
-    -- NOTE: Using `t₁ ++ e :: t₂` instead of `t₁ ++ [e] ++ t₂` because in
-    -- Lean `[x] ++ xs` is not definitionallly equal to `x :: xs`. This is
-    -- because `++` does not correspond to a function on lists, but a
-    -- typeclass `Append.append` of which `List` has an instance.
-    -- Since most lemmas about an element appearing in the middle of a list
+    -- NOTE: Using `t₁ ++ e :: t₂` instead of `t₁ ++ [e] ++ t₂` because
+    -- most lemmas about an element appearing in the middle of a list
     -- are in the shape `t₁ ++ e :: t₂`, this form is preferred.
 
 def Step.of_primStep : ∀ {e σ}{obs : List Obs}{e'} {σ' : State} {eₜ},

--- a/src/Iris/ProgramLogic/Language.lean
+++ b/src/Iris/ProgramLogic/Language.lean
@@ -26,8 +26,6 @@ public import Batteries.Data.List.Basic
 --       observations being a `List Obs`.
 -- TODO: Consider renaming `ToVal` typeclass to something better, since
 --       it's not just the `toVal` operation it carries.
--- TODO: Move out of `FromMathlib` those definitions which don't actually
---       come from Mathlib!
 -- TODO: Consider changing `Language.NSteps` to use `Relation.iterate`
 --       instead of mirroring its structure
 

--- a/src/Iris/ProgramLogic/Language.lean
+++ b/src/Iris/ProgramLogic/Language.lean
@@ -176,11 +176,40 @@ inductive NSteps : Nat → List Expr × State → List Obs → List Expr × Stat
 scoped notation conf:40 " -<" obs:max ">->ₜₚ^[" n:max "] " conf':41 =>
  Language.NSteps n conf obs conf'
 
-/-- A sequence of `Language.step`s with no observation information -/
+/-- A `Language.step`s with no observation information -/
+@[rocq_alias erased_step]
 def erasedStep (ρ  ρ₂: List Expr × State) := ∃ obs, Step ρ obs ρ₂
 
 @[inherit_doc erasedStep]
 scoped notation conf:40 " -·->ₜₚ " conf':41 => Language.erasedStep conf conf'
+
+/-- A sequence of `Language.erasedStep`s -/
+scoped notation conf:40 " -·->ₜₚ* " conf':41 =>
+  Relation.ReflTransGen erasedStep conf conf'
+
+open Relation in
+@[rocq_alias erased_step_nsteps]
+theorem erasedStep_NSteps (ρ₁ ρ₂ : List Expr × State) :
+    ρ₁ -·->ₜₚ* ρ₂ ↔ ∃ n obs, ρ₁ -<obs>->ₜₚ^[n] ρ₂ := by
+  constructor <;> intros hyp
+  · replace ⟨n, hyp⟩ := ReflTrans_iff_exists_iterate.1 hyp
+    exists n
+    induction hyp using Relation.Iterate.head_induction_on with
+    | rfl => exists []; constructor
+    | head ρ' firstStep lastSteps IH =>
+      replace ⟨obs, firstStep⟩ := firstStep
+      replace ⟨obs', IH⟩ := IH
+      exists (obs ++ obs')
+      constructor <;> assumption
+  · replace ⟨n, obs, hyp⟩ := hyp
+    apply ReflTrans_iff_exists_iterate.2
+    exists n
+    induction hyp with
+    | refl => constructor
+    | cons n ρ₁ ρ₂ ρ₃ obs obs' =>
+      apply Iterate.head
+      · exists obs
+      · assumption
 
 section ReducibilityLemmas
 

--- a/src/Iris/Std/FromMathlib.lean
+++ b/src/Iris/Std/FromMathlib.lean
@@ -4,9 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-@[expose] public section
+public import Batteries.Data.List.Basic
 
-module
 
 @[expose] public section
 
@@ -56,5 +55,73 @@ theorem Nodup.map_on {f : α → β} (H : ∀ x ∈ l, ∀ y ∈ l, f x = f y �
 /-- NB. Copied from Mathlib -/
 theorem Nodup.filter (p : α → Bool) {l} : List.Nodup l → List.Nodup (List.filter p l) := by
   simpa using List.Pairwise.filter p
+
+inductive Relation.ReflTransGen (r : α → α → Prop) (a : α) : α → Prop
+  | refl : ReflTransGen r a a
+  | tail {b c : α} : ReflTransGen r a b → r b c → ReflTransGen r a c
+
+namespace Relation.ReflTransGen
+
+theorem head (hab : r a b) (hbc : ReflTransGen r b c) : ReflTransGen r a c := by
+  induction hbc with
+  | refl => exact refl.tail hab
+  | tail _ hcd hac => exact hac.tail hcd
+
+@[elab_as_elim]
+theorem head_induction_on {motive : ∀ a : α, ReflTransGen r a b → Prop} {a : α}
+    (h : ReflTransGen r a b) (refl : motive b refl)
+    (head : ∀ {a c} (h' : r a c) (h : ReflTransGen r c b), motive c h → motive a (h.head h')) :
+    motive a h := by
+  induction h with
+  | refl => exact refl
+  | @tail b c _ hbc ih =>
+  apply ih
+  · exact head hbc _ refl
+  · exact fun h1 h2 ↦ head h1 (h2.tail hbc)
+
+theorem cases_head (h : ReflTransGen r a b) : a = b ∨ ∃ c, r a c ∧ ReflTransGen r c b := by
+  induction h using ReflTransGen.head_induction_on <;> grind
+
+end Relation.ReflTransGen
+
+@[grind .]
+theorem List.forall₂_zip : ∀ {l₁ l₂}, List.Forall₂ R l₁ l₂ → ∀ {a b}, (a, b) ∈ l₁.zip l₂ → R a b
+  | _, _, List.Forall₂.cons h₁ h₂, x, y, hx => by
+    rw [List.zip, List.zipWith, List.mem_cons] at hx
+    match hx with
+    | Or.inl rfl => exact h₁
+    | Or.inr h₃ => exact forall₂_zip h₂ h₃
+
+@[match_pattern]
+def List.Forall₂.append : ∀ {l₁ l₁' l₂ l₂'}, List.Forall₂ R l₁ l₂ → List.Forall₂ R l₁' l₂' → List.Forall₂ R (l₁ ++ l₁') (l₂ ++ l₂')
+  | _, _, _, _, .nil, h => h
+  | _, _, _, _, .cons step rest, h => .cons step (append rest h)
+
+@[grind →]
+theorem List.exists_of_forall₂_cons : ∀ {l₁ l₂}{x},
+    List.Forall₂ R (x :: l₁) l₂ → ∃ y l₂', l₂ = y :: l₂' ∧ R x y ∧ List.Forall₂ R l₁ l₂' := by
+  intro l₁ l₂ x h
+  cases h with
+  | cons y l₂' => grind only
+
+@[grind →]
+theorem List.exists_of_forall₂_append : ∀ {l₁ l₁' l},
+    List.Forall₂ R (l₁ ++ l₁') l → ∃ l₂ l₂', l = l₂ ++ l₂' ∧ List.Forall₂ R l₁ l₂ ∧ List.Forall₂ R l₁' l₂' ∧ l₁.length = l₂.length := by
+  intro l₁ l₁' l h
+  induction l₁ generalizing l with
+  | nil =>
+    exists [], l
+    simpa using h
+  | cons x l₁ IH =>
+    grind only [= List.cons_append, → exists_of_forall₂_cons,
+      =_ List.cons_append, = List.length_cons, List.Forall₂.cons]
+    -- obtain ⟨y, l, rfl, x_y, h⟩ := List.exists_of_forall₂_cons h
+    -- obtain ⟨l₂, l₂', h, Rleft, Rright, hlen⟩ := IH h
+    -- exists (y :: l₂), l₂'
+    -- refine ⟨h ▸ rfl, List.Forall₂.cons x_y Rleft, Rright, ?_⟩
+    -- simp only [List.length_cons, hlen]
+
+
+
 
 end FromMathlib

--- a/src/Iris/Std/FromMathlib.lean
+++ b/src/Iris/Std/FromMathlib.lean
@@ -92,36 +92,4 @@ theorem List.forall₂_zip : ∀ {l₁ l₂}, List.Forall₂ R l₁ l₂ → ∀
     | Or.inl rfl => exact h₁
     | Or.inr h₃ => exact forall₂_zip h₂ h₃
 
-@[match_pattern]
-def List.Forall₂.append : ∀ {l₁ l₁' l₂ l₂'}, List.Forall₂ R l₁ l₂ → List.Forall₂ R l₁' l₂' → List.Forall₂ R (l₁ ++ l₁') (l₂ ++ l₂')
-  | _, _, _, _, .nil, h => h
-  | _, _, _, _, .cons step rest, h => .cons step (append rest h)
-
-@[grind →]
-theorem List.exists_of_forall₂_cons : ∀ {l₁ l₂}{x},
-    List.Forall₂ R (x :: l₁) l₂ → ∃ y l₂', l₂ = y :: l₂' ∧ R x y ∧ List.Forall₂ R l₁ l₂' := by
-  intro l₁ l₂ x h
-  cases h with
-  | cons y l₂' => grind only
-
-@[grind →]
-theorem List.exists_of_forall₂_append : ∀ {l₁ l₁' l},
-    List.Forall₂ R (l₁ ++ l₁') l → ∃ l₂ l₂', l = l₂ ++ l₂' ∧ List.Forall₂ R l₁ l₂ ∧ List.Forall₂ R l₁' l₂' ∧ l₁.length = l₂.length := by
-  intro l₁ l₁' l h
-  induction l₁ generalizing l with
-  | nil =>
-    exists [], l
-    simpa using h
-  | cons x l₁ IH =>
-    grind only [= List.cons_append, → exists_of_forall₂_cons,
-      =_ List.cons_append, = List.length_cons, List.Forall₂.cons]
-    -- obtain ⟨y, l, rfl, x_y, h⟩ := List.exists_of_forall₂_cons h
-    -- obtain ⟨l₂, l₂', h, Rleft, Rright, hlen⟩ := IH h
-    -- exists (y :: l₂), l₂'
-    -- refine ⟨h ▸ rfl, List.Forall₂.cons x_y Rleft, Rright, ?_⟩
-    -- simp only [List.length_cons, hlen]
-
-
-
-
 end FromMathlib

--- a/src/Iris/Std/List.lean
+++ b/src/Iris/Std/List.lean
@@ -5,6 +5,9 @@ Authors: Zongyuan Liu
 -/
 module
 
+public import Iris.Std.FromMathlib
+public import Batteries.Data.List.Basic
+
 /-!
 # List Lemmas
 
@@ -23,5 +26,34 @@ inductive Equiv {α : Type _} (R : α → α → Prop) : List α → List α →
 
 @[expose] def zipIdxInt {α : Type _} (l : List α) (n : Int) : List (α × Int) :=
   l.mapIdx (fun i v => (v, (i : Int) + n))
+
+@[expose, match_pattern]
+def List.Forall₂.append : ∀ {l₁ l₁' l₂ l₂'}, List.Forall₂ R l₁ l₂ → List.Forall₂ R l₁' l₂' → List.Forall₂ R (l₁ ++ l₁') (l₂ ++ l₂')
+  | _, _, _, _, .nil, h => h
+  | _, _, _, _, .cons step rest, h => .cons step (append rest h)
+
+@[grind →]
+theorem List.exists_of_forall₂_cons : ∀ {l₁ l₂}{x},
+    List.Forall₂ R (x :: l₁) l₂ → ∃ y l₂', l₂ = y :: l₂' ∧ R x y ∧ List.Forall₂ R l₁ l₂' := by
+  intro l₁ l₂ x h
+  cases h with
+  | cons y l₂' => grind only
+
+@[grind →]
+theorem List.exists_of_forall₂_append : ∀ {l₁ l₁' l},
+    List.Forall₂ R (l₁ ++ l₁') l → ∃ l₂ l₂', l = l₂ ++ l₂' ∧ List.Forall₂ R l₁ l₂ ∧ List.Forall₂ R l₁' l₂' ∧ l₁.length = l₂.length := by
+  intro l₁ l₁' l h
+  induction l₁ generalizing l with
+  | nil =>
+    exists [], l
+    simpa using h
+  | cons x l₁ IH =>
+    grind only [= List.cons_append, → exists_of_forall₂_cons,
+      =_ List.cons_append, = List.length_cons, List.Forall₂.cons]
+    -- obtain ⟨y, l, rfl, x_y, h⟩ := List.exists_of_forall₂_cons h
+    -- obtain ⟨l₂, l₂', h, Rleft, Rright, hlen⟩ := IH h
+    -- exists (y :: l₂), l₂'
+    -- refine ⟨h ▸ rfl, List.Forall₂.cons x_y Rleft, Rright, ?_⟩
+    -- simp only [List.length_cons, hlen]
 
 end Iris.Std.List

--- a/src/Iris/Std/List.lean
+++ b/src/Iris/Std/List.lean
@@ -28,19 +28,19 @@ inductive Equiv {α : Type _} (R : α → α → Prop) : List α → List α →
   l.mapIdx (fun i v => (v, (i : Int) + n))
 
 @[expose, match_pattern]
-def List.Forall₂.append : ∀ {l₁ l₁' l₂ l₂'}, List.Forall₂ R l₁ l₂ → List.Forall₂ R l₁' l₂' → List.Forall₂ R (l₁ ++ l₁') (l₂ ++ l₂')
+def Forall₂.append : ∀ {l₁ l₁' l₂ l₂'}, List.Forall₂ R l₁ l₂ → List.Forall₂ R l₁' l₂' → List.Forall₂ R (l₁ ++ l₁') (l₂ ++ l₂')
   | _, _, _, _, .nil, h => h
   | _, _, _, _, .cons step rest, h => .cons step (append rest h)
 
 @[grind →]
-theorem List.exists_of_forall₂_cons : ∀ {l₁ l₂}{x},
+theorem exists_of_forall₂_cons : ∀ {l₁ l₂}{x},
     List.Forall₂ R (x :: l₁) l₂ → ∃ y l₂', l₂ = y :: l₂' ∧ R x y ∧ List.Forall₂ R l₁ l₂' := by
   intro l₁ l₂ x h
   cases h with
   | cons y l₂' => grind only
 
 @[grind →]
-theorem List.exists_of_forall₂_append : ∀ {l₁ l₁' l},
+theorem exists_of_forall₂_append : ∀ {l₁ l₁' l},
     List.Forall₂ R (l₁ ++ l₁') l → ∃ l₂ l₂', l = l₂ ++ l₂' ∧ List.Forall₂ R l₁ l₂ ∧ List.Forall₂ R l₁' l₂' ∧ l₁.length = l₂.length := by
   intro l₁ l₁' l h
   induction l₁ generalizing l with
@@ -55,5 +55,23 @@ theorem List.exists_of_forall₂_append : ∀ {l₁ l₁' l},
     -- exists (y :: l₂), l₂'
     -- refine ⟨h ▸ rfl, List.Forall₂.cons x_y Rleft, Rright, ?_⟩
     -- simp only [List.length_cons, hlen]
+
+@[grind =]
+theorem getElem?_some_iff_append
+{a : α} {i : Nat} {l : List α} : l[i]? = some a ↔ ∃ s t : List α, l = s ++ a :: t ∧ s.length = i := by
+  constructor
+  · intros h
+    induction i generalizing l with
+    | zero =>
+      rcases l with _ | ⟨hd, tl⟩
+      · simp at h
+      · simpa using h
+    | succ i IH =>
+      rcases l with _ | ⟨hd, tl⟩
+      · simp at h
+      simp at h
+      grind only [=_ List.cons_append, = List.length_cons]
+  · rintro ⟨ps, ss, rfl, h2⟩
+    grind only [= List.getElem?_append, = List.getElem?_cons]
 
 end Iris.Std.List

--- a/src/Iris/Std/Relation.lean
+++ b/src/Iris/Std/Relation.lean
@@ -1,6 +1,10 @@
 module
 
-@[expose] public section
+public import Iris.Std.FromMathlib
+
+open FromMathlib
+
+public section
 
 namespace Relation
 
@@ -10,3 +14,22 @@ inductive iterate {α : Type _} (R : α → α → Prop) : Nat → α → α →
 | tail (y: α) {n : Nat}{x z : α} : iterate R n x y → R y z → iterate R (n+1) x z
 
 attribute [simp] iterate.rfl iterate.tail
+
+theorem ReflTrans_iff_exists_iterate {α : Type _} {R : α → α → Prop} :
+    ∀ {x y},
+    Relation.ReflTransGen R x y ↔ ∃ n, Relation.iterate R n x y := by
+  intros x y
+  constructor
+  · intros rtcR
+    induction rtcR with
+    | refl =>
+      exists 0; constructor
+    | tail rtcMid Rlast IH =>
+      obtain ⟨n, h⟩ := IH
+      exists (n+1)
+      apply Relation.iterate.tail _ h Rlast
+  · rintro ⟨n, itR⟩
+    induction itR with
+    | rfl => constructor
+    | tail z itMid Rlast IH =>
+      apply Relation.ReflTransGen.tail IH Rlast

--- a/src/Iris/Std/Relation.lean
+++ b/src/Iris/Std/Relation.lean
@@ -9,15 +9,15 @@ public section
 namespace Relation
 
 /-- Composes a relation `n` times -/
-inductive iterate {α : Type _} (R : α → α → Prop) : Nat → α → α → Prop where
-| rfl (x : α): iterate R 0 x x
-| tail (y: α) {n : Nat}{x z : α} : iterate R n x y → R y z → iterate R (n+1) x z
+inductive Iterate {α : Type _} (R : α → α → Prop) : Nat → α → α → Prop where
+| rfl (x : α): Iterate R 0 x x
+| tail (y: α) {n : Nat}{x z : α} : Iterate R n x y → R y z → Iterate R (n+1) x z
 
-attribute [simp] iterate.rfl iterate.tail
+attribute [simp] Iterate.rfl Iterate.tail
 
 theorem ReflTrans_iff_exists_iterate {α : Type _} {R : α → α → Prop} :
     ∀ {x y},
-    Relation.ReflTransGen R x y ↔ ∃ n, Relation.iterate R n x y := by
+    Relation.ReflTransGen R x y ↔ ∃ n, Iterate R n x y := by
   intros x y
   constructor
   · intros rtcR
@@ -27,9 +27,28 @@ theorem ReflTrans_iff_exists_iterate {α : Type _} {R : α → α → Prop} :
     | tail rtcMid Rlast IH =>
       obtain ⟨n, h⟩ := IH
       exists (n+1)
-      apply Relation.iterate.tail _ h Rlast
+      apply Relation.Iterate.tail _ h Rlast
   · rintro ⟨n, itR⟩
     induction itR with
     | rfl => constructor
     | tail z itMid Rlast IH =>
       apply Relation.ReflTransGen.tail IH Rlast
+
+theorem Iterate.head (hab : r a b) (hbc : Iterate r n b c) : Iterate r (n+1) a c :=
+  match hbc with
+  | .rfl x => .tail a (.rfl a) hab
+  | .tail y hcd hac =>
+    .tail y (head hab hcd) hac
+
+theorem Iterate.head_induction_on {b : α}
+  {motive : ∀ (n : Nat) (a : α), Iterate r n a b → Prop}
+  (rfl : motive _ _ (.rfl b))
+  (head : ∀ {n a } c (h' : r a c) (h : Iterate r n c b), motive _ _ h → motive _ _ (h.head h'))
+  {n : Nat} {a : α} (h : Iterate r n a b) :
+    motive _ _ h := by
+  induction h with
+  | rfl => exact rfl
+  | tail y hxy hyz ih =>
+    apply ih
+    · exact head _ hyz _ rfl
+    · exact fun _ h1 h2 ↦ head _ h1 (h2.tail _ hyz)

--- a/src/Iris/Std/Relation.lean
+++ b/src/Iris/Std/Relation.lean
@@ -1,0 +1,12 @@
+module
+
+@[expose] public section
+
+namespace Relation
+
+/-- Composes a relation `n` times -/
+inductive iterate {α : Type _} (R : α → α → Prop) : Nat → α → α → Prop where
+| rfl (x : α): iterate R 0 x x
+| tail (y: α) {n : Nat}{x z : α} : iterate R n x y → R y z → iterate R (n+1) x z
+
+attribute [simp] iterate.rfl iterate.tail


### PR DESCRIPTION
## Description
Port the file `program_logic/language.v`. I needed to make multiple changes to the file while porting, since the Rocq definition was using canonical structures, which is something that doesn't exist in Lean. This interface instead relies on various typeclasses, and assumptions about them (for instance, one `Expr` may only have one `Val`, `State` and `Obs` types associated, since they are marked as `outParam`s).

Main differences:
 - Identifiers were changed to follow Mathlib's naming guidelines.
 - The `language` structure is now a `Language` typeclass, which embeds separate `ToVal` and `PrimStep` typeclasses.
 - Added a coercion for `ofVal`, with most relevant theorems defined in terms of it (SUBJECT TO CHANGE).
 - Added notations for the different kinds of steps.
 - The `primStep` notation now makes use of a product `Expr x State` instead of taking them as separate parameters.

Some other changes needed to implement this file
 - Added `Relation.ReflTransGen` from Mathlib.
 - Added a new `Relation.Iterate` construction.
 - Added some lemmas about `Forall₂`.

## Checklist
* [X] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [ ] I have updated `PORTING.md` as appropriate
* [ ] I have added my name to the `authors` section of any appropriate files