### PR TITLE
feat: Allow tactics in IPM synthesis

### DIFF
--- a/Iris/Iris/ProofMode/SynthInstance.lean
+++ b/Iris/Iris/ProofMode/SynthInstance.lean
@@ -7,6 +7,7 @@ module
 
 public import Qq
 public import Iris.BI
+public import Iris.ProofMode.SynthInstanceAttr
 
 public meta section
 
@@ -39,41 +40,6 @@ open Lean Elab Tactic Meta Qq BI Std
 def MessageData.withMCtx (mctx : MetavarContext) (d : MessageData) : MessageData :=
   .lazy λ ctx => return MessageData.withContext {env := ctx.env, mctx := mctx, lctx := ctx.lctx, opts := ctx.opts} d
 
-initialize ipmClassesExt :
-    SimpleScopedEnvExtension Name (Std.HashSet Name)  ←
-  registerSimpleScopedEnvExtension {
-    addEntry := fun s n => s.insert n
-    initial := ∅
-  }
-
-syntax (name := ipm_class) "ipm_class" : attr
-
-/-- This attribute should be used for classes that use the special IPM synthInstance below. -/
-initialize registerBuiltinAttribute {
-  name := `ipm_class
-  descr := "proof mode class"
-  add := fun decl _stx _kind =>
-    ipmClassesExt.add decl
-}
-
-initialize ipmBacktrackExt :
-    SimpleScopedEnvExtension Name (Std.HashSet Name)  ←
-  registerSimpleScopedEnvExtension {
-    addEntry := fun s n => s.insert n
-    initial := ∅
-  }
-
-syntax (name := ipm_backtrack) "ipm_backtrack" : attr
-
-/-- This attribute marks instances on which the proof mode synthesis should backtrack. -/
-initialize registerBuiltinAttribute {
-  name := `ipm_backtrack
-  descr := "Enable backtracking for this instance"
-  add := fun decl _stx _kind =>
-    ipmBacktrackExt.add decl
-}
-
-
 partial def synthInstanceMainCore (mvar : Expr) : MetaM (Option Unit) := do
   withIncRecDepth do
     let backtrackSet := ipmBacktrackExt.getState (← getEnv)
@@ -90,10 +56,42 @@ partial def synthInstanceMainCore (mvar : Expr) : MetaM (Option Unit) := do
 
     let mctx0 ← getMCtx
     withTraceNode `Meta.synthInstance (λ _ => return m!"new goal {MessageData.withMCtx mctx0 m!"{mvarType}"} => {mvarType}") do
+
+    -- first tactics and then instances. We cannot interleave them
+    -- since we don't know the priorities of the instances.
+    let tactics ← forallTelescopeReducing mvarType fun _ type => do
+      (synthTacticExt.getState (← getEnv)).getUnify type
+    let tactics := tactics.insertionSort fun e₁ e₂ => e₁.prio < e₂.prio
+    trace[Meta.synthInstance.tactics] m!"{tactics}"
+
+    let mctx ← getMCtx
+    for tac in tactics.reverse do
+      let res ← withTraceNode `Meta.synthInstance
+        (λ _ => withMCtx mctx do return MessageData.withMCtx mctx m!"apply tactic {tac.name} to {← instantiateMVars (← inferType mvar)}") do
+        setMCtx mctx
+        forallTelescopeReducing mvarType fun xs mvarTypeBody => do
+          let res ← tac.tac.run mvarTypeBody
+          match res with
+          | .success instVal =>
+            trace[Meta.synthInstance] m!"{tac.name} success: {instVal}"
+            let mut instType ← inferType instVal
+            let .true ← isDefEq mvarTypeBody instType | throwError "{tac.name} produced an ill-typed term: {instVal}"
+            let instVal ← mkLambdaFVars xs instVal (etaReduce := true)
+            let .true ← isDefEq mvar instVal | throwError "{tac.name} produced an ill-typed term: {instVal}"
+            return .success default
+          | _ => return res
+      match res with
+      | .success _ =>
+        return some ()
+      | .fail => do
+        trace[Meta.synthInstance] m!"{tac.name} failed, no backtracking to other instances"
+        return none
+      | .continue =>
+        trace[Meta.synthInstance] m!"{tac.name} did not find an instance, continue to other instances"
+        continue
+
     let instances ← SynthInstance.getInstances mvarType
-    let mctx      ← getMCtx
-    if instances.isEmpty then
-      return none
+    let mctx ← getMCtx
     for inst in instances.reverse do
       let (res, match?) ← withTraceNode `Meta.synthInstance
         (λ _ => withMCtx mctx do return MessageData.withMCtx mctx m!"apply {inst.val} to {← instantiateMVars (← inferType mvar)}") do
@@ -110,12 +108,20 @@ partial def synthInstanceMainCore (mvar : Expr) : MetaM (Option Unit) := do
         return res
     return none
 
+/-- This function should only be directly used by IPM tactic instances
+to initiate recursive searches. -/
+def synthInstanceRecursive (type : Expr) : MetaM (Option Expr) := do
+   let mvar ← mkFreshExprMVar type
+   let some _ ← synthInstanceMainCore mvar | return none
+   return mvar
+
+/-- This function should only be directly used by IPM tactic instances
+to initiate recursive searches. -/
+def synthInstanceRecursiveQ (type : Q(Sort u)) : MetaM (Option Q($type)) := synthInstanceRecursive type
+
 def synthInstanceMain (type : Expr) (_maxResultSize : Nat) : MetaM (Option Expr) :=
   withCurrHeartbeats do
-     let mvar ← mkFreshExprMVar type
-     tryCatchRuntimeEx (do
-       let some _ ← synthInstanceMainCore mvar | return none
-       return mvar)
+     tryCatchRuntimeEx (synthInstanceRecursive type)
        fun ex =>
          if ex.isRuntime then
            throwError "failed to synthesize{indentExpr type}\n{ex.toMessageData}{useDiagnosticMsg}"
@@ -182,3 +188,6 @@ def ipm_synth_elab : Command.CommandElab
         | .some (e, mvars) => do
             logInfo m!"solution: {← inferType e}, new goals: {← mvars.toList.mapM (λ m => do return m!"{Expr.mvar m}: {← m.getType}")}"
   | _ => throwUnsupportedSyntax
+
+initialize
+  registerTraceClass `Meta.synthInstance.tactics (inherited := true)

--- a/Iris/Iris/ProofMode/SynthInstanceAttr.lean
+++ b/Iris/Iris/ProofMode/SynthInstanceAttr.lean
@@ -54,9 +54,17 @@ end IPMBacktrack
 
 section IPMTactic
 
+/-- Result of a tactic registered via the `ipm_tactic_instance` attribute. -/
 inductive SynthTacticResult
+/-- The tactic produced a term `e` solving the goal. No further tactics or
+instances are tried. -/
 | success (e : Expr)
+/-- The tactic does not apply to this goal. The synthesis continues with the
+next tactic, or falls through to regular instance search if no tactics remain. -/
 | continue
+/-- The tactic determined that the goal is unsolvable. The synthesis aborts
+immediately: no further tactics are tried *and* the regular instance search
+is skipped. -/
 | fail
 
 

--- a/Iris/Iris/ProofMode/SynthInstanceAttr.lean
+++ b/Iris/Iris/ProofMode/SynthInstanceAttr.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2026 Michael Sammler. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Sammler
+-/
+module
+
+public import Qq
+public import Iris.BI.Notation
+
+public meta section
+open Lean Elab Tactic Meta Qq
+
+section IPMClasses
+initialize ipmClassesExt :
+    SimpleScopedEnvExtension Name (Std.HashSet Name)  ←
+  registerSimpleScopedEnvExtension {
+    addEntry := fun s n => s.insert n
+    initial := ∅
+  }
+
+syntax (name := ipm_class) "ipm_class" : attr
+
+/-- This attribute should be used for classes that use the special IPM synthInstance below. -/
+initialize registerBuiltinAttribute {
+  name := `ipm_class
+  descr := "proof mode class"
+  add := fun decl _stx _kind =>
+    ipmClassesExt.add decl
+}
+
+end IPMClasses
+
+section IPMBacktrack
+
+initialize ipmBacktrackExt :
+    SimpleScopedEnvExtension Name (Std.HashSet Name)  ←
+  registerSimpleScopedEnvExtension {
+    addEntry := fun s n => s.insert n
+    initial := ∅
+  }
+
+syntax (name := ipm_backtrack) "ipm_backtrack" : attr
+
+/-- This attribute marks instances on which the proof mode synthesis should backtrack. -/
+initialize registerBuiltinAttribute {
+  name := `ipm_backtrack
+  descr := "Enable backtracking for this instance"
+  add := fun decl _stx _kind =>
+    ipmBacktrackExt.add decl
+}
+
+end IPMBacktrack
+
+section IPMTactic
+
+inductive SynthTacticResult
+| success (e : Expr)
+| continue
+| fail
+
+
+@[expose]
+def SynthTactic : Type := Expr → MetaM SynthTacticResult
+
+def SynthTactic.run (tac : SynthTactic) :
+  Expr → MetaM SynthTacticResult := tac
+
+
+structure SynthTacticEntry where
+  tac : SynthTactic
+  prio : Nat
+  name : Name
+instance : BEq SynthTacticEntry where
+  beq _ _ := false
+instance : Inhabited SynthTacticEntry where
+  default := ⟨fun _ _ => return .fail, 0, default⟩
+instance : ToMessageData SynthTacticEntry where
+  toMessageData e := m!"{e.name}:{e.prio}"
+
+structure SynthTacticEntrySerialized where
+  prio : Nat
+  name : Name
+deriving Repr
+instance : BEq SynthTacticEntrySerialized where
+  beq _ _ := false
+instance : Inhabited SynthTacticEntrySerialized where
+  default := ⟨0, default⟩
+
+def SynthTacticEntry.serialize (e : SynthTacticEntry) : SynthTacticEntrySerialized := { prio := e.prio, name := e.name }
+
+unsafe def SynthTacticEntrySerialized.deserialize (e : SynthTacticEntrySerialized) (compile : Bool) : CoreM SynthTacticEntry := do
+  let mut name := e.name
+  let ty := (← getConstInfo e.name).type
+  if ty != .const ``SynthTactic [] then
+    throwError "The tactic should have type SynthTactic."
+  if compile then
+    let d ← getConstInfoDefn e.name
+    compileDecl (.defnDecl d)
+  let tac ← evalConst SynthTactic name
+  return {tac, prio := e.prio, name := e.name}
+
+
+/-- Environment extension for synth tactics -/
+unsafe initialize synthTacticExt :
+    ScopedEnvExtension (SynthTacticEntrySerialized × Array DiscrTree.Key) (SynthTacticEntry × Array DiscrTree.Key) (DiscrTree SynthTacticEntry) ←
+  registerScopedEnvExtension {
+    mkInitial := return {}
+    addEntry := fun dt (n, ks) => dt.insertKeyValue ks n
+    ofOLeanEntry := fun _ (n, ks) => ImportM.runCoreM do return (← n.deserialize (compile:=false), ks)
+    toOLeanEntry := fun (n, ks) => (n.serialize, ks)
+  }
+
+
+private def default_prio : Nat := (eval_prio default)
+
+syntax (name := ipm_tactic_instance) "ipm_tactic_instance" (":" prio)? (ppSpace term),* : attr
+
+unsafe initialize registerBuiltinAttribute {
+  name := `ipm_tactic_instance
+  descr := "tactic instance used by the proof mode instance synthesis"
+  -- we ignore TC failures for BI, they should just create metavariables
+  add := fun decl stx kind => MetaM.run' do Elab.Term.TermElabM.run' (ctx := {ignoreTCFailures := true}) do
+    let prio := if stx[1][1].isMissing then some default_prio else stx[1][1].isNatLit?
+    let .some prio := prio | throwError "unknown priority: {stx[1][1]}"
+
+    let pats ← stx[2].getSepArgs.mapM λ stx => do
+      let stx ← `(iprop($(TSyntax.mk stx)))
+      Term.elabTerm stx none
+
+    let tac ← (SynthTacticEntrySerialized.mk prio decl).deserialize (compile:=true)
+    for pat in pats do
+      let key ← DiscrTree.mkPath pat
+      synthTacticExt.add (tac, key) kind
+}
+
+end IPMTactic

--- a/Iris/Iris/Tests.lean
+++ b/Iris/Iris/Tests.lean
@@ -1,6 +1,7 @@
 module
 
 public import Iris.Tests.Instances
+public import Iris.Tests.InstancesImport
 public import Iris.Tests.Notation
 public import Iris.Tests.Tactics
 public import Iris.Tests.HeapLang

--- a/Iris/Iris/Tests/Instances.lean
+++ b/Iris/Iris/Tests/Instances.lean
@@ -6,12 +6,13 @@ Authors: Michael Sammler
 module
 
 public import Iris.BI
-public import Iris.ProofMode
+public import Iris.ProofMode.SynthInstance
+public import Iris.ProofMode.Instances
 
 @[expose] public section
 
 namespace Iris.Tests
-open BI ProofMode
+open Lean Qq BI ProofMode
 
 /- Test the backtracking of ipm_synth -/
 section backtracking
@@ -63,6 +64,7 @@ info: solution: FromAssumption false InOut.out P1 P1, new goals: []
 ---
 trace: [Meta.synthInstance] ✅️ IPM: FromAssumption false InOut.out P1 P1
   [Meta.synthInstance] ✅️ new goal FromAssumption false InOut.out ?_ P1 => FromAssumption false InOut.out P1 P1
+    [Meta.synthInstance.tactics] []
     [Meta.synthInstance.instances] #[@fromAssumption_exact]
     [Meta.synthInstance] ✅️ apply @fromAssumption_exact to FromAssumption false InOut.out ?_ P1
       [Meta.synthInstance.tryResolve] ✅️ FromAssumption false InOut.out P1 P1 ≟ FromAssumption false InOut.out P1 P1
@@ -90,3 +92,177 @@ set_option pp.mvars false in
 #ipm_synth (FromAssumption false .out _ P1)
 
 end trace
+
+meta section tactics
+
+@[ipm_class]
+class TacticTest [BI PROP] (P : PROP) (Q : outParam PROP) where
+  tactic_test : P ⊢ Q
+
+@[ipm_tactic_instance:high TacticTest _ _]
+def tac_continue : SynthTactic := λ e => do
+  logInfo m!"tac_continue called wit {e}"
+  return .continue
+
+theorem tactic_test_emp [BI PROP] (P : PROP) : TacticTest iprop(emp ∗ P) P := ⟨sep_elim_r⟩
+
+@[ipm_tactic_instance TacticTest iprop(emp ∗ _) _]
+def tac_emp : SynthTactic := λ e => do
+  let_expr TacticTest prop bi P _ := e | return .continue
+  have u := e.getAppFn.constLevels![0]!
+  have prop : Q(Type u) := prop
+  have _bi : Q(BI $prop) := bi
+  let_expr BI.sep _ _ E Q := P | return .continue
+  let_expr BI.emp _ _ := E | return .continue
+  have Q : Q($prop) := Q
+  return .success q(tactic_test_emp $Q)
+
+theorem tactic_test_sep [BI PROP] (P P' Q : PROP) :
+  TacticTest P P' →
+  TacticTest iprop(P ∗ Q) iprop(P' ∗ Q) := λ h => ⟨sep_mono h.1 .rfl⟩
+
+@[ipm_tactic_instance TacticTest iprop(_ ∗ _) _]
+def tac_sep : SynthTactic := λ e => do
+  let_expr TacticTest prop bi S _ := e | return .continue
+  have u := e.getAppFn.constLevels![0]!
+  have prop : Q(Type u) := prop
+  have _bi : Q(BI $prop) := bi
+  let_expr BI.sep _ _ P Q := S | return .continue
+  have P : Q($prop) := P
+  have Q : Q($prop) := Q
+  let P' : Q($prop) ← mkFreshExprMVarQ q($prop)
+  let .some pf ← synthInstanceRecursiveQ q(TacticTest $P $P') | return .continue
+  return .success q(tactic_test_sep $P $P' $Q $pf)
+
+instance tactic_test_all {α} [BI PROP] (P P' : α → PROP)
+  [h : ∀ a, TacticTest (P a) (P' a)] :
+  TacticTest iprop(∀ a, P a) iprop(∀ a, P' a) :=
+  ⟨forall_mono (λ a => (h a).1)⟩
+
+-- Tests failing and multiple patterns
+@[ipm_tactic_instance:low TacticTest iprop(False) _, TacticTest iprop(True) _]
+def tac_fail : SynthTactic := λ _ => return .fail
+
+variable {PROP} [BI PROP] (P : PROP)
+
+/--
+info: tac_continue called wit TacticTest iprop(emp ∗ P) ?_
+---
+info: solution: TacticTest iprop(emp ∗ P) P, new goals: []
+---
+trace: [Meta.synthInstance] ✅️ IPM: TacticTest iprop(emp ∗ P) P
+  [Meta.synthInstance] ✅️ new goal TacticTest iprop(emp ∗ P) ?_ => TacticTest iprop(emp ∗ P) P
+    [Meta.synthInstance.tactics] [Iris.Tests.tac_sep:1000, Iris.Tests.tac_emp:1000, Iris.Tests.tac_continue:10000]
+    [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_continue to TacticTest iprop(emp ∗ P) ?_
+    [Meta.synthInstance] Iris.Tests.tac_continue did not find an instance, continue to other instances
+    [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_emp to TacticTest iprop(emp ∗ P) ?_
+      [Meta.synthInstance] Iris.Tests.tac_emp success: tactic_test_emp P
+  [Meta.synthInstance] result tactic_test_emp P
+-/
+#guard_msgs (substring := true) in
+set_option trace.Meta.synthInstance true in
+set_option pp.mvars false in
+#ipm_synth (TacticTest iprop(emp ∗ P) _)
+
+/--
+info: tac_continue called wit TacticTest iprop((emp ∗ P) ∗ P) ?_
+---
+info: tac_continue called wit TacticTest iprop(emp ∗ P) ?_
+---
+info: solution: TacticTest iprop((emp ∗ P) ∗ P) iprop(P ∗ P), new goals: []
+---
+trace: [Meta.synthInstance] ✅️ IPM: TacticTest iprop((emp ∗ P) ∗ P) iprop(P ∗ P)
+  [Meta.synthInstance] ✅️ new goal TacticTest iprop((emp ∗ P) ∗ P) ?_ => TacticTest iprop((emp ∗ P) ∗ P) iprop(P ∗ P)
+    [Meta.synthInstance.tactics] [Iris.Tests.tac_sep:1000, Iris.Tests.tac_continue:10000]
+    [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_continue to TacticTest iprop((emp ∗ P) ∗ P) ?_
+    [Meta.synthInstance] Iris.Tests.tac_continue did not find an instance, continue to other instances
+    [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_sep to TacticTest iprop((emp ∗ P) ∗ P) ?_
+      [Meta.synthInstance] ✅️ new goal TacticTest iprop(emp ∗ P) ?_ => TacticTest iprop(emp ∗ P) P
+        [Meta.synthInstance.tactics] [Iris.Tests.tac_sep:1000, Iris.Tests.tac_emp:1000, Iris.Tests.tac_continue:10000]
+        [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_continue to TacticTest iprop(emp ∗ P) ?_
+        [Meta.synthInstance] Iris.Tests.tac_continue did not find an instance, continue to other instances
+        [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_emp to TacticTest iprop(emp ∗ P) ?_
+          [Meta.synthInstance] Iris.Tests.tac_emp success: tactic_test_emp P
+      [Meta.synthInstance] Iris.Tests.tac_sep success: tactic_test_sep iprop(emp ∗ P) P P (tactic_test_emp P)
+  [Meta.synthInstance] result tactic_test_sep iprop(emp ∗ P) P P (tactic_test_emp P)
+-/
+#guard_msgs (substring := true) in
+set_option trace.Meta.synthInstance true in
+set_option pp.mvars false in
+#ipm_synth (TacticTest iprop((emp ∗ P) ∗ P) _)
+
+/--
+info: tac_continue called wit TacticTest iprop(∀ a, (emp ∗ ⌜a = 5⌝) ∗ P) ?_
+---
+info: tac_continue called wit TacticTest iprop((emp ∗ ⌜a = 5⌝) ∗ P) (?_ a)
+---
+info: tac_continue called wit TacticTest iprop(emp ∗ ⌜a = 5⌝) ?_
+---
+info: solution: TacticTest iprop(∀ a, (emp ∗ ⌜a = 5⌝) ∗ P) iprop(∀ a, ⌜a = 5⌝ ∗ P), new goals: []
+---
+trace: [Meta.synthInstance] ✅️ IPM: TacticTest iprop(∀ a, (emp ∗ ⌜a = 5⌝) ∗ P) iprop(∀ a, ⌜a = 5⌝ ∗ P)
+  [Meta.synthInstance] ✅️ new goal TacticTest iprop(∀ a, (emp ∗ ⌜a = 5⌝) ∗ P)
+        ?_ => TacticTest iprop(∀ a, (emp ∗ ⌜a = 5⌝) ∗ P) iprop(∀ a, ⌜a = 5⌝ ∗ P)
+    [Meta.synthInstance.tactics] [Iris.Tests.tac_continue:10000]
+    [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_continue to TacticTest iprop(∀ a, (emp ∗ ⌜a = 5⌝) ∗ P) ?_
+    [Meta.synthInstance] Iris.Tests.tac_continue did not find an instance, continue to other instances
+    [Meta.synthInstance.instances] #[@tactic_test_all]
+    [Meta.synthInstance] ✅️ apply @tactic_test_all to TacticTest iprop(∀ a, (emp ∗ ⌜a = 5⌝) ∗ P) ?_
+      [Meta.synthInstance.tryResolve] ✅️ TacticTest iprop(∀ a, (emp ∗ ⌜a = 5⌝) ∗ P)
+            iprop(∀ a, ?_ a) ≟ TacticTest iprop(∀ a, (emp ∗ ⌜a = 5⌝) ∗ P) iprop(∀ a, ?_ a)
+      [Meta.synthInstance] ✅️ switch to normal synthInstance
+        [Meta.synthInstance] ✅️ BI PROP
+          [Meta.synthInstance] ✅️ new goal BI PROP
+            [Meta.synthInstance.instances] #[@Sbi.toBI, inst✝]
+          [Meta.synthInstance.apply] ✅️ apply inst✝ to BI PROP
+            [Meta.synthInstance.tryResolve] ✅️ BI PROP ≟ BI PROP
+            [Meta.synthInstance.answer] ✅️ BI PROP
+          [Meta.synthInstance] result inst✝
+      [Meta.synthInstance] ✅️ new goal ∀ (a : Nat),
+            TacticTest iprop((emp ∗ ⌜a = 5⌝) ∗ P)
+              (?_ a) => ∀ (a : Nat), TacticTest iprop((emp ∗ ⌜a = 5⌝) ∗ P) iprop(⌜a = 5⌝ ∗ P)
+        [Meta.synthInstance.tactics] [Iris.Tests.tac_sep:1000, Iris.Tests.tac_continue:10000]
+        [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_continue to ∀ (a : Nat),
+              TacticTest iprop((emp ∗ ⌜a = 5⌝) ∗ P) (?_ a)
+        [Meta.synthInstance] Iris.Tests.tac_continue did not find an instance, continue to other instances
+        [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_sep to ∀ (a : Nat),
+              TacticTest iprop((emp ∗ ⌜a = 5⌝) ∗ P) (?_ a)
+          [Meta.synthInstance] ✅️ new goal TacticTest iprop(emp ∗ ⌜a = 5⌝)
+                ?_ => TacticTest iprop(emp ∗ ⌜a = 5⌝) iprop(⌜a = 5⌝)
+            [Meta.synthInstance.tactics] [Iris.Tests.tac_sep:1000,
+                 Iris.Tests.tac_emp:1000,
+                 Iris.Tests.tac_continue:10000]
+            [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_continue to TacticTest iprop(emp ∗ ⌜a = 5⌝) ?_
+            [Meta.synthInstance] Iris.Tests.tac_continue did not find an instance, continue to other instances
+            [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_emp to TacticTest iprop(emp ∗ ⌜a = 5⌝) ?_
+              [Meta.synthInstance] Iris.Tests.tac_emp success: tactic_test_emp iprop(⌜a = 5⌝)
+          [Meta.synthInstance] Iris.Tests.tac_sep success: tactic_test_sep iprop(emp ∗ ⌜a = 5⌝) iprop(⌜a = 5⌝) P
+                (tactic_test_emp iprop(⌜a = 5⌝))
+  [Meta.synthInstance] result tactic_test_all (fun a => iprop((emp ∗ ⌜a = 5⌝) ∗ P)) fun a => iprop(⌜a = 5⌝ ∗ P)
+-/
+#guard_msgs (substring := true) in
+set_option trace.Meta.synthInstance true in
+set_option pp.mvars false in
+#ipm_synth (TacticTest iprop(∀ a, (emp ∗ ⌜a = 5⌝) ∗ P) _)
+
+/--
+info: tac_continue called wit TacticTest iprop(True) ?_
+---
+info: None
+---
+trace: [Meta.synthInstance] ❌️ IPM: TacticTest iprop(True) ?_
+  [Meta.synthInstance] ❌️ new goal TacticTest iprop(True) ?_ => TacticTest iprop(True) ?_
+    [Meta.synthInstance.tactics] [Iris.Tests.tac_fail:100, Iris.Tests.tac_continue:10000]
+    [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_continue to TacticTest iprop(True) ?_
+    [Meta.synthInstance] Iris.Tests.tac_continue did not find an instance, continue to other instances
+    [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_fail to TacticTest iprop(True) ?_
+    [Meta.synthInstance] Iris.Tests.tac_fail failed, no backtracking to other instances
+  [Meta.synthInstance] result <not-available>
+-/
+#guard_msgs (substring := true) in
+set_option trace.Meta.synthInstance true in
+set_option pp.mvars false in
+#ipm_synth (TacticTest iprop(True) _)
+
+
+end tactics

--- a/Iris/Iris/Tests/Instances.lean
+++ b/Iris/Iris/Tests/Instances.lean
@@ -101,7 +101,7 @@ class TacticTest [BI PROP] (P : PROP) (Q : outParam PROP) where
 
 @[ipm_tactic_instance:high TacticTest _ _]
 def tac_continue : SynthTactic := λ e => do
-  logInfo m!"tac_continue called wit {e}"
+  logInfo m!"tac_continue called with {e}"
   return .continue
 
 theorem tactic_test_emp [BI PROP] (P : PROP) : TacticTest iprop(emp ∗ P) P := ⟨sep_elim_r⟩
@@ -146,7 +146,7 @@ def tac_fail : SynthTactic := λ _ => return .fail
 variable {PROP} [BI PROP] (P : PROP)
 
 /--
-info: tac_continue called wit TacticTest iprop(emp ∗ P) ?_
+info: tac_continue called with TacticTest iprop(emp ∗ P) ?_
 ---
 info: solution: TacticTest iprop(emp ∗ P) P, new goals: []
 ---
@@ -165,9 +165,9 @@ set_option pp.mvars false in
 #ipm_synth (TacticTest iprop(emp ∗ P) _)
 
 /--
-info: tac_continue called wit TacticTest iprop((emp ∗ P) ∗ P) ?_
+info: tac_continue called with TacticTest iprop((emp ∗ P) ∗ P) ?_
 ---
-info: tac_continue called wit TacticTest iprop(emp ∗ P) ?_
+info: tac_continue called with TacticTest iprop(emp ∗ P) ?_
 ---
 info: solution: TacticTest iprop((emp ∗ P) ∗ P) iprop(P ∗ P), new goals: []
 ---
@@ -192,11 +192,11 @@ set_option pp.mvars false in
 #ipm_synth (TacticTest iprop((emp ∗ P) ∗ P) _)
 
 /--
-info: tac_continue called wit TacticTest iprop(∀ a, (emp ∗ ⌜a = 5⌝) ∗ P) ?_
+info: tac_continue called with TacticTest iprop(∀ a, (emp ∗ ⌜a = 5⌝) ∗ P) ?_
 ---
-info: tac_continue called wit TacticTest iprop((emp ∗ ⌜a = 5⌝) ∗ P) (?_ a)
+info: tac_continue called with TacticTest iprop((emp ∗ ⌜a = 5⌝) ∗ P) (?_ a)
 ---
-info: tac_continue called wit TacticTest iprop(emp ∗ ⌜a = 5⌝) ?_
+info: tac_continue called with TacticTest iprop(emp ∗ ⌜a = 5⌝) ?_
 ---
 info: solution: TacticTest iprop(∀ a, (emp ∗ ⌜a = 5⌝) ∗ P) iprop(∀ a, ⌜a = 5⌝ ∗ P), new goals: []
 ---
@@ -246,7 +246,7 @@ set_option pp.mvars false in
 #ipm_synth (TacticTest iprop(∀ a, (emp ∗ ⌜a = 5⌝) ∗ P) _)
 
 /--
-info: tac_continue called wit TacticTest iprop(True) ?_
+info: tac_continue called with TacticTest iprop(True) ?_
 ---
 info: None
 ---

--- a/Iris/Iris/Tests/InstancesImport.lean
+++ b/Iris/Iris/Tests/InstancesImport.lean
@@ -1,0 +1,30 @@
+/-
+Copyright (c) 2026 Michael Sammler. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Sammler
+-/
+module
+
+import Iris.Tests.Instances
+
+/- This file tests that IPM tactic instances declared in other files are imported and applied correctly. -/
+
+@[expose] public section
+
+namespace Iris.Tests
+open Lean Qq BI ProofMode
+
+variable {PROP} [BI PROP] (P : PROP)
+
+/--
+info: tac_continue called wit TacticTest iprop(∀ x, (emp ∗ P) ∗ P) ?_
+---
+info: tac_continue called wit TacticTest iprop((emp ∗ P) ∗ P) (?_ a)
+---
+info: tac_continue called wit TacticTest iprop(emp ∗ P) ?_
+---
+info: solution: TacticTest iprop(∀ a, (emp ∗ P) ∗ P) iprop(∀ a, P ∗ P), new goals: []
+-/
+#guard_msgs in
+set_option pp.mvars false in
+#ipm_synth (TacticTest iprop(∀ (_ : Nat), (emp ∗ P) ∗ P) _)

--- a/Iris/Iris/Tests/InstancesImport.lean
+++ b/Iris/Iris/Tests/InstancesImport.lean
@@ -17,11 +17,11 @@ open Lean Qq BI ProofMode
 variable {PROP} [BI PROP] (P : PROP)
 
 /--
-info: tac_continue called wit TacticTest iprop(∀ x, (emp ∗ P) ∗ P) ?_
+info: tac_continue called with TacticTest iprop(∀ x, (emp ∗ P) ∗ P) ?_
 ---
-info: tac_continue called wit TacticTest iprop((emp ∗ P) ∗ P) (?_ a)
+info: tac_continue called with TacticTest iprop((emp ∗ P) ∗ P) (?_ a)
 ---
-info: tac_continue called wit TacticTest iprop(emp ∗ P) ?_
+info: tac_continue called with TacticTest iprop(emp ∗ P) ?_
 ---
 info: solution: TacticTest iprop(∀ a, (emp ∗ P) ∗ P) iprop(∀ a, P ∗ P), new goals: []
 -/


### PR DESCRIPTION
## Description
This PR adds the `ipm_tactic_instance` attribute that allows one to extend the IPM typeclass synthesis with custom tactics. These tactics can be mixed with normal instances and can recursively call typeclass synthesis again (see the tests for an example). This feature will be useful to implement `iframe` among other.