### PR TITLE
feat: non-atomic invariants

### DIFF
--- a/Iris/Iris/Algebra/LeibnizSet.lean
+++ b/Iris/Iris/Algebra/LeibnizSet.lean
@@ -27,6 +27,10 @@ inductive DisjointLeibnizSet (S : Type _) where
   | error : DisjointLeibnizSet S
 
 instance : COFE (DisjointLeibnizSet S) := COFE.ofDiscrete _ Eq_Equivalence
+
+instance inst_disjointLeibnizSet_DiscreteE {S : Type _} (x : DisjointLeibnizSet S) :
+    DiscreteE x := ⟨id⟩
+
 instance : Leibniz (DisjointLeibnizSet S) := ⟨id⟩
 
 namespace DisjointLeibnizSet

--- a/Iris/Iris/Instances/Lib/NaInvariants.lean
+++ b/Iris/Iris/Instances/Lib/NaInvariants.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
+Authors: Markus de Medeiros
 -/
 module
 
@@ -15,135 +15,91 @@ public import Iris.Std.CoPset
 
 @[expose] public section
 
-/-! ## Non-atomic ("thread-local") invariants
-Port of `iris/base_logic/lib/na_invariants.v`.
-
-Iris-Rocq's `into_inv_na` / `into_acc_na` proofmode instances are not ported,
-because the Lean proofmode does not yet provide the corresponding `IntoInv` /
-`IntoAcc` classes.
--/
-
 namespace Iris
 
-open BI CMRA OFE Iris Std LawfulSet DisjointLeibnizSet
+open BI CMRA OFE Iris Std LawfulSet DisjointLeibnizSet COFE
 
-/-- The functor underlying a non-atomic invariant pool: products of a coPset
-of enabled tokens and a `PosSet` of currently-held thread-local permissions. -/
-abbrev NaInvF : COFE.OFunctorPre :=
-  ProdOF (COFE.constOF (DisjointLeibnizSet CoPset))
-    (COFE.constOF (DisjointLeibnizSet PosSet))
+abbrev NaInvF : OFunctorPre :=
+  ProdOF (constOF (DisjointLeibnizSet CoPset)) (constOF (DisjointLeibnizSet PosSet))
 
 @[rocq_alias na_invG]
 class NaInvG (GF : BundledGFunctors) where
-  [elemG : ElemG GF NaInvF]
+  inv : ElemG GF NaInvF
 
-attribute [reducible] NaInvG.elemG
-attribute [instance] NaInvG.elemG
+attribute [reducible, instance] NaInvG.inv
 
 @[rocq_alias na_inv_pool_name]
 abbrev NaInvPoolName := GName
 
-/-- Discrete elements of the `DisjointLeibnizSet` CMRA. Needed for `Timeless`
-instances on `iOwn` at this CMRA. -/
-instance DisjointLeibnizSet.instDiscreteE {S : Type _} (x : DisjointLeibnizSet S) :
-    DiscreteE x where
-  discrete h := h
-
-instance NaInvF.instDiscreteE {α β : Type _} (x : DisjointLeibnizSet α) (y : DisjointLeibnizSet β) :
+instance instNaInvF_discreteE {α β : Type _} (x : DisjointLeibnizSet α) (y : DisjointLeibnizSet β) :
     DiscreteE (x, y) :=
-  prod.is_discrete (DisjointLeibnizSet.instDiscreteE _) (DisjointLeibnizSet.instDiscreteE _)
+  prod.is_discrete (inst_disjointLeibnizSet_DiscreteE _) (inst_disjointLeibnizSet_DiscreteE _)
 
-/-- The unit element of the non-atomic-invariants CMRA is core-id. -/
-instance coreId_valid_empty_pair :
-    CMRA.CoreId
-      ((DisjointLeibnizSet.valid (∅ : CoPset), DisjointLeibnizSet.valid (∅ : PosSet))) where
-  core_id := by
-    show CMRA.pcore _ ≡ _
-    rfl
+instance coreId_valid_empty_empty : CoreId ((valid (∅ : CoPset), valid (∅ : PosSet))) where
+  core_id := by rfl
 
-instance isUnit_valid_empty_pair :
-    IsUnit ((DisjointLeibnizSet.valid (∅ : CoPset), DisjointLeibnizSet.valid (∅ : PosSet))) where
+instance isUnit_valid_empty_empty : IsUnit ((valid (∅ : CoPset), valid (∅ : PosSet))) where
   unit_valid := ⟨trivial, trivial⟩
-  unit_left_id := ⟨UCMRA.unit_left_id, UCMRA.unit_left_id⟩
-  pcore_unit := coreId_valid_empty_pair.core_id
+  unit_left_id := ⟨unit_left_id, unit_left_id⟩
+  pcore_unit := coreId_valid_empty_empty.core_id
 
-section defs
+namespace NonAtomicInvariant
 
 variable {GF : BundledGFunctors} [InvGS_gen hlc GF] [W : NaInvG GF]
 
 @[rocq_alias na_own]
-def na_own (p : NaInvPoolName) (E : CoPset) : IProp GF :=
-  iOwn (E := W.elemG) p (DisjointLeibnizSet.valid E, DisjointLeibnizSet.valid ∅)
+def own (p : NaInvPoolName) (E : CoPset) : IProp GF :=
+  iOwn (E := W.inv) p (.valid E, .valid ∅)
 
 @[rocq_alias na_inv]
-def na_inv (p : NaInvPoolName) (N : Namespace) (P : IProp GF) : IProp GF :=
+nonrec def inv (p : NaInvPoolName) (N : Namespace) (P : IProp GF) : IProp GF :=
   iprop(∃ i, ⌜i ∈ (↑N : CoPset)⌝ ∧
-        inv N iprop(
-          P ∗ iOwn (E := W.elemG) p (DisjointLeibnizSet.valid ∅, DisjointLeibnizSet.valid {i})
-          ∨ na_own p {i}))
-
-end defs
-
-section proofs
-
-variable {GF : BundledGFunctors} [InvGS_gen hlc GF] [W : NaInvG GF]
+    inv N iprop(P ∗ iOwn (E := W.inv) p (.valid ∅, .valid {i}) ∨ own p {i}))
 
 @[rocq_alias na_own_timeless]
-instance na_own_timeless (p : NaInvPoolName) (E : CoPset) :
-    Timeless (na_own (GF := GF) p E) := by
-  simp only [na_own]
-  infer_instance
+instance instTimeless_own (p : NaInvPoolName) (E : CoPset) : Timeless (own (GF := GF) p E) := by
+  unfold own; infer_instance
 
 @[rocq_alias na_inv_contractive]
-instance na_inv_contractive (p : NaInvPoolName) (N : Namespace) :
-    Contractive (na_inv (GF := GF) p N) where
+instance instContractive_inv (p : NaInvPoolName) (N : Namespace) :
+    Contractive (inv (GF := GF) p N) where
   distLater_dist {n x y} H := by
-    simp only [na_inv]
-    refine exists_ne fun i => ?_
-    refine and_ne.ne .rfl ?_
-    refine Contractive.distLater_dist ?_
-    intro m hm
-    refine or_ne.ne ?_ .rfl
-    exact sep_ne.ne (H _ hm) .rfl
+    refine exists_ne fun i => and_ne.ne .rfl ?_
+    refine Contractive.distLater_dist fun m hm => ?_
+    exact or_ne.ne (sep_ne.ne (H _ hm) .rfl) .rfl
 
 @[rocq_alias na_inv_ne]
-instance na_inv_ne (p : NaInvPoolName) (N : Namespace) :
-    NonExpansive (na_inv (GF := GF) p N) := ne_of_contractive _
+instance instNonExpansive_inv (p : NaInvPoolName) (N : Namespace) : NonExpansive (inv (GF := GF) p N) :=
+  ne_of_contractive _
 
 @[rocq_alias na_inv_persistent]
-instance na_inv_persistent (p : NaInvPoolName) (N : Namespace) (P : IProp GF) :
-    Persistent (na_inv p N P) := by
-  simp only [na_inv]
-  infer_instance
+instance instPersistentInv (p : NaInvPoolName) (N : Namespace) (P : IProp GF) :
+    Persistent (inv p N P) := by
+  unfold inv; infer_instance
 
 @[rocq_alias na_own_empty_persistent]
-instance na_own_empty_persistent (p : NaInvPoolName) :
-    Persistent (na_own (GF := GF) p ∅) := by
-  simp only [na_own]
-  infer_instance
+instance instPersistent_own (p : NaInvPoolName) : Persistent (own (GF := GF) p ∅) := by
+  unfold own; infer_instance
 
 @[rocq_alias na_inv_iff]
-theorem na_inv_iff (p : NaInvPoolName) (N : Namespace) (P Q : IProp GF) :
-    ⊢ na_inv p N P -∗ ▷ □ (P ↔ Q) -∗ na_inv p N Q := by
-  simp only [na_inv]
+nonrec theorem inv_iff {p : NaInvPoolName} {N : Namespace} {P Q : IProp GF} :
+    ⊢ inv p N P -∗ ▷ □ (P ↔ Q) -∗ inv p N Q := by
+  unfold inv
   iintro ⟨%i, %Hin, HI⟩ #HPQ
   iexists i
-  isplit
-  · ipure_intro; assumption
+  isplit; (· ipure_intro; assumption)
   iapply inv_iff $$ HI
   inext; imodintro
-  simp only [BI.iff]
+  unfold BI.iff
   isplit
-  · iintro H
-    icases H with (⟨HP, Ho⟩ | Htok)
+  · iintro (⟨HP, Ho⟩ | Htok)
     · ileft
       isplitr [Ho]
       · icases HPQ with ⟨HPQm, _⟩
         iapply HPQm $$ HP
       · iassumption
     · iright; iassumption
-  · iintro H
-    icases H with (⟨HQ, Ho⟩ | Htok)
+  · iintro (⟨HQ, Ho⟩ | Htok)
     · ileft
       isplitr [Ho]
       · icases HPQ with ⟨_, HQPm⟩
@@ -152,82 +108,58 @@ theorem na_inv_iff (p : NaInvPoolName) (N : Namespace) (P Q : IProp GF) :
     · iright; iassumption
 
 @[rocq_alias na_alloc]
-theorem na_alloc : ⊢@{IProp GF} |==> ∃ p : NaInvPoolName, na_own p ⊤ := by
-  simp only [na_own]
-  exact iOwn_alloc (E := W.elemG)
-    (DisjointLeibnizSet.valid (⊤ : CoPset), DisjointLeibnizSet.valid (∅ : PosSet))
-    ⟨trivial, trivial⟩
+theorem alloc : ⊢@{IProp GF} |==> ∃ p : NaInvPoolName, own p ⊤ :=
+  iOwn_alloc (E := W.inv) (.valid (⊤ : CoPset), .valid (∅ : PosSet)) ⟨trivial, trivial⟩
 
 @[rocq_alias na_own_disjoint]
-theorem na_own_disjoint (p : NaInvPoolName) (E1 E2 : CoPset) :
-    ⊢ na_own (GF := GF) p E1 -∗ na_own p E2 -∗ ⌜E1 ## E2⌝ := by
-  simp only [na_own]
+theorem own_disjoint {p : NaInvPoolName} {E1 E2 : CoPset} :
+    ⊢ own (GF := GF) p E1 -∗ own p E2 -∗ ⌜E1 ## E2⌝ := by
+  unfold own
   iintro H1 H2
-  ihave H := iOwn_op (E := W.elemG) $$ [H1 H2]
+  ihave H := iOwn_op $$ [H1 H2]
   · isplitl [H1] <;> iassumption
   ihave H := iOwn_cmraValid $$ H
-  icases internalCmraValid_discrete (A := NaInvF.ap (IProp GF)) $$ H with %H
+  icases internalCmraValid_discrete $$ H with %H
   ipure_intro
   exact valid_op_iff_disj.mp H.1
 
 @[rocq_alias na_own_union]
-theorem na_own_union (p : NaInvPoolName) (E1 E2 : CoPset) (Hdisj : E1 ## E2) :
-    na_own (GF := GF) p (E1 ∪ E2) ⊣⊢ na_own p E1 ∗ na_own p E2 := by
-  simp only [na_own]
-  have hempty :
-      DisjointLeibnizSet.valid (∅ : PosSet) ≡
-        DisjointLeibnizSet.valid (∅ : PosSet) • DisjointLeibnizSet.valid ∅ := by
-    refine .trans ?_ (disj_op_union (S := PosSet) disjoint_empty_left).symm
-    exact Equiv.of_eq (by simp)
-  have heq : (DisjointLeibnizSet.valid (E1 ∪ E2), DisjointLeibnizSet.valid ∅) ≡
-      ((DisjointLeibnizSet.valid E1, DisjointLeibnizSet.valid ∅) •
-       (DisjointLeibnizSet.valid E2, DisjointLeibnizSet.valid (∅ : PosSet))) :=
-    equiv_prod_ext (disj_op_union Hdisj).symm hempty
+theorem own_union {p : NaInvPoolName} {E1 E2 : CoPset} (Hdisj : E1 ## E2) :
+    own (GF := GF) p (E1 ∪ E2) ⊣⊢ own p E1 ∗ own p E2 := by
   refine .trans ?_ iOwn_op
-  exact BI.equiv_iff.mp (NonExpansive.eqv (f := iOwn (E := W.elemG) p) heq)
+  refine BI.equiv_iff.mp (NonExpansive.eqv (f := iOwn (E := W.inv) p) ?_)
+  refine .symm <| equiv_prod_ext (disj_op_union Hdisj) ?_
+  refine .trans (disj_op_union disjoint_empty_left) ?_
+  exact .of_eq (by simp)
 
 @[rocq_alias na_own_acc]
-theorem na_own_acc (E2 E1 : CoPset) (tid : NaInvPoolName) (Hsub : E2 ⊆ E1) :
-    ⊢ na_own (GF := GF) tid E1 -∗ na_own tid E2 ∗ (na_own tid E2 -∗ na_own tid E1) := by
-  have Heq : E1 = E2 ∪ (E1 \ E2) := by
-    rw [union_comm]; exact diff_subset_decomp Hsub
-  rw [Heq]
+theorem own_acc {E2 E1 : CoPset} {tid : NaInvPoolName} (Hsub : E2 ⊆ E1) :
+    ⊢ own (GF := GF) tid E1 -∗ own tid E2 ∗ (own tid E2 -∗ own tid E1) := by
+  rw [← subset_union_diff Hsub]
   iintro H
-  icases (na_own_union tid E2 (E1 \ E2) disjoint_diff_right).mp $$ H with ⟨H1, H2⟩
+  icases (own_union disjoint_diff_right).mp $$ H with ⟨H1, H2⟩
   isplitl [H1]; iassumption
   iintro H1
-  iapply (na_own_union tid E2 (E1 \ E2) disjoint_diff_right).mpr
+  iapply (own_union disjoint_diff_right).mpr
   isplitl [H1] <;> iassumption
 
 @[rocq_alias na_own_empty]
-theorem na_own_empty (p : NaInvPoolName) : ⊢@{IProp GF} |==> na_own p ∅ := by
-  simp only [na_own]
-  exact iOwn_unit (E := W.elemG)
-    (ε := (DisjointLeibnizSet.valid ∅, DisjointLeibnizSet.valid ∅))
+theorem own_empty (p : NaInvPoolName) : ⊢@{IProp GF} |==> own p ∅ := iOwn_unit (E := W.inv)
 
 @[rocq_alias na_inv_alloc]
-theorem na_inv_alloc (p : NaInvPoolName) (E : CoPset) (N : Namespace) (P : IProp GF) :
-    ⊢ ▷ P ={E}=∗ na_inv p N P := by
+nonrec theorem inv_alloc {p : NaInvPoolName} {E : CoPset} {N : Namespace} {P : IProp GF} :
+    ⊢ ▷ P ={E}=∗ inv p N P := by
   iintro HP
-  imod (iOwn_unit (E := W.elemG) (γ := p)
-      (ε := (DisjointLeibnizSet.valid ∅, DisjointLeibnizSet.valid ∅))) with Hempty
-  have Hupd :
-      ((DisjointLeibnizSet.valid (∅ : CoPset), DisjointLeibnizSet.valid (∅ : PosSet)))
-      ~~>: (fun y : NaInvF.ap (IProp GF) =>
-        ∃ i : Pos, y = (DisjointLeibnizSet.valid ∅, DisjointLeibnizSet.valid {i}) ∧
-          i ∈ (↑N : CoPset)) := by
-    refine UpdateP.prod (α := DisjointLeibnizSet CoPset) (β := DisjointLeibnizSet PosSet)
-      (P := (· = DisjointLeibnizSet.valid ∅))
-      (Q := fun y => ∃ i : Pos, y = DisjointLeibnizSet.valid {i} ∧ i ∈ (↑N : CoPset))
-      (UpdateP.id rfl)
-      (DisjointLeibnizSet.alloc_empty_updateP_strong' (fun Y => fresh_name Y N))
-      (fun a b ha ⟨i, hb, hi⟩ => ⟨i, by simp [ha, hb], hi⟩)
+  imod (iOwn_unit (E := W.inv) (γ := p) (ε := (.valid ∅, .valid ∅))) with Hempty
+  have Hupd : (.valid (∅ : CoPset), .valid (∅ : PosSet)) ~~>:
+      fun y : NaInvF.ap (IProp GF) => ∃ i, y = (.valid ∅, .valid {i}) ∧ i ∈ (↑N : CoPset) :=
+    .prod (P := (· = .valid ∅)) (.id rfl) (alloc_empty_updateP_strong' (fresh_name · N))
+      (fun a b ha ⟨i, hb, hi⟩ => ⟨i, Prod.ext ha hb, hi⟩)
   imod iOwn_updateP Hupd $$ Hempty with ⟨%y, %Hy, Hown⟩
   obtain ⟨i, rfl, Hi⟩ := Hy
-  simp only [na_inv]
-  imod inv_alloc N E iprop(
-    P ∗ iOwn (E := W.elemG) p (DisjointLeibnizSet.valid ∅, DisjointLeibnizSet.valid {i})
-    ∨ na_own p {i}) $$ [HP Hown] with HI
+  unfold inv
+  imod inv_alloc N E iprop( P ∗ iOwn (E := W.inv) p (.valid ∅, .valid {i}) ∨ own p {i}) $$ [HP Hown]
+    with HI
   · inext; ileft; isplitl [HP] <;> iassumption
   imodintro
   iexists i
@@ -236,80 +168,58 @@ theorem na_inv_alloc (p : NaInvPoolName) (E : CoPset) (N : Namespace) (P : IProp
   · iassumption
 
 @[rocq_alias na_inv_acc]
-theorem na_inv_acc (p : NaInvPoolName) (E F : CoPset) (N : Namespace) (P : IProp GF)
+nonrec theorem inv_acc {p : NaInvPoolName} {E F : CoPset} {N : Namespace} {P : IProp GF}
     (HNE : ↑N ⊆ E) (HNF : ↑N ⊆ F) :
-    ⊢ na_inv p N P -∗ na_own p F ={E}=∗
-      ▷ P ∗ na_own p (F \ ↑N) ∗
-      (▷ P ∗ na_own p (F \ ↑N) ={E}=∗ na_own p F) := by
-  simp only [na_inv]
+    ⊢ inv p N P -∗ own p F ={E}=∗ ▷ P ∗ own p (F \ ↑N) ∗ (▷ P ∗ own p (F \ ↑N) ={E}=∗ own p F) := by
+  unfold inv
   iintro #⟨%i, %Hin, Hinv⟩ Htoks
-  -- Split Htoks : na_own p F = na_own p ({i} ∪ (↑N \ {i})) ∗ na_own p (F \ ↑N)
-  have HiN : ({i} : CoPset) ⊆ (↑N : CoPset) := by
-    intro x hx; rw [mem_singleton] at hx; subst hx; exact Hin
-  have HeqN : ↑N = {i} ∪ ((↑N : CoPset) \ {i}) := by
-    rw [union_comm]; exact diff_subset_decomp HiN
-  have HeqF : F = ↑N ∪ (F \ ↑N) := by
-    rw [union_comm]; exact diff_subset_decomp HNF
-  ihave Htoks' : na_own p (↑N ∪ (F \ ↑N)) $$ [Htoks]
-  · rw [← HeqF]; iassumption
-  icases (na_own_union p ↑N (F \ ↑N) disjoint_diff_right).mp $$ Htoks' with ⟨HtokN, HtokRest⟩
-  ihave HtokN' : na_own p ({i} ∪ ((↑N : CoPset) \ {i})) $$ [HtokN]
-  · rw [← HeqN]; iassumption
-  icases (na_own_union p {i} (↑N \ {i}) disjoint_diff_right).mp $$ HtokN' with ⟨Htoki, HtokNdi⟩
-  -- Open the invariant.
+  have HNminusi : ↑N = {i} ∪ ((↑N : CoPset) \ {i}) := by
+    refine (subset_union_diff ?_).symm
+    intro x hx; rw [mem_singleton] at hx; exact hx ▸ Hin
+  icases (own_union disjoint_diff_right).mp $$ [Htoks] with ⟨HtokN, HtokRest⟩
+  · rw [subset_union_diff HNF]
+    iassumption
+  icases (own_union disjoint_diff_right).mp $$ [HtokN] with ⟨Htoki, HtokNdi⟩
+  · rw [← HNminusi]; iassumption
   imod inv_acc _ _ _ HNE $$ Hinv with ⟨Hcontent, Hclose⟩
   icases Hcontent with (⟨HP, >Hdis⟩ | >Htoki2)
-  · -- Left branch: got P and the stored token. Close with Htoki in right branch.
-    ihave Hreturn : iprop(▷ (P ∗ iOwn (E := W.elemG) p
-            (DisjointLeibnizSet.valid ∅, DisjointLeibnizSet.valid {i}) ∨ na_own p {i}))
-        $$ [Htoki]
+  · ihave Hreturn : ▷ (P ∗ iOwn (E := W.inv) p (.valid ∅, .valid {i}) ∨ own p {i}) $$ [Htoki]
     · inext; iright; iassumption
     imod Hclose $$ Hreturn with _
     imodintro
     isplitl [HP]; iassumption
     isplitl [HtokRest]; iassumption
-    -- Returner: user gives back ▷P and na_own p (F \ ↑N). We need to give back na_own p F.
     iintro ⟨HPret, HtokFret⟩
     imod inv_acc _ _ _ HNE $$ Hinv with ⟨Hcontent2, Hclose2⟩
     icases Hcontent2 with (⟨_HPconflict, >Hdis2⟩ | >Htoki_back)
-    · -- Impossible: two copies of own p (ε, {i}) would have disjoint tokens.
-      iexfalso
-      ihave Hbad := iOwn_op (E := W.elemG) $$ [Hdis Hdis2]
+    · iexfalso
+      ihave Hk := iOwn_op (E := W.inv) $$ [Hdis Hdis2]
       · isplitl [Hdis] <;> iassumption
-      ihave Hbad := iOwn_cmraValid $$ Hbad
-      icases internalCmraValid_discrete (A := NaInvF.ap (IProp GF)) $$ Hbad with %Hbad
-      ipure_intro
-      have Hbad2 := DisjointLeibnizSet.valid_op_iff_disj.mp Hbad.2
-      exact Hbad2 i ⟨mem_singleton.mpr rfl, mem_singleton.mpr rfl⟩
-    · -- Good branch: consume Htoki_back, close with (P, Hdis) left branch.
-      ihave Hreturn2 : iprop(▷ (P ∗ iOwn (E := W.elemG) p
-              (DisjointLeibnizSet.valid ∅, DisjointLeibnizSet.valid {i}) ∨ na_own p {i}))
-          $$ [HPret Hdis]
+      ihave Hk := iOwn_cmraValid $$ Hk
+      icases internalCmraValid_discrete $$ Hk with %Hbad
+      have Hk := DisjointLeibnizSet.valid_op_iff_disj.mp Hbad.2
+      exact Hk i ⟨mem_singleton.mpr rfl, mem_singleton.mpr rfl⟩ |>.elim
+    · ihave Hreturn2 : ▷ (P ∗ iOwn (E := W.inv) p (.valid ∅, .valid {i}) ∨ own p {i}) $$ [HPret Hdis]
       · inext; ileft; isplitl [HPret] <;> iassumption
       imod Hclose2 $$ Hreturn2 with _
       imodintro
-      -- Combine Htoki_back, HtokNdi, HtokFret into na_own p F.
-      ihave HtokN_new : na_own p ((↑N : CoPset)) $$ [Htoki_back HtokNdi]
-      · conv => rhs; rw [show (↑N : CoPset) = {i} ∪ (↑N \ {i}) from HeqN]
-        iapply (na_own_union p {i} (↑N \ {i}) disjoint_diff_right).mpr
+      ihave HtokN_new : own p ((↑N : CoPset)) $$ [Htoki_back HtokNdi]
+      · conv => rhs; rw [HNminusi]
+        iapply (own_union disjoint_diff_right).mpr
         isplitl [Htoki_back]
         · iexact Htoki_back
         · iexact HtokNdi
-      conv => rhs; rw [show F = (↑N : CoPset) ∪ (F \ ↑N) from HeqF]
-      iapply (na_own_union p ↑N (F \ ↑N) disjoint_diff_right).mpr
+      conv => rhs; rw [← subset_union_diff HNF]
+      iapply (own_union disjoint_diff_right).mpr
       isplitl [HtokN_new]
       · iexact HtokN_new
       · iexact HtokFret
-  · -- Right branch: two na_own p {i} would contradict disjointness.
-    iexfalso
+  · iexfalso
     ihave Hbad : ⌜({i} : CoPset) ## {i}⌝ $$ [Htoki Htoki2]
-    · ihave Hd1 := na_own_disjoint p {i} {i} $$ Htoki
-      iapply Hd1 $$ Htoki2
+    · iapply own_disjoint $$ Htoki Htoki2
     icases Hbad with %Hbad
     exact Hbad i ⟨mem_singleton.mpr rfl, mem_singleton.mpr rfl⟩ |>.elim
 
-end proofs
-
+end NonAtomicInvariant
 end Iris
-
 end

--- a/Iris/Iris/Instances/Lib/NaInvariants.lean
+++ b/Iris/Iris/Instances/Lib/NaInvariants.lean
@@ -1,0 +1,315 @@
+/-
+Copyright (c) 2026. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
+module
+
+public import Iris.ProofMode
+public import Iris.Instances.IProp.Instance
+public import Iris.Instances.Lib.FUpd
+public import Iris.Instances.Lib.Invariants
+public import Iris.Algebra.LeibnizSet
+public import Iris.Std.Namespaces
+public import Iris.Std.CoPset
+
+@[expose] public section
+
+/-! ## Non-atomic ("thread-local") invariants
+Port of `iris/base_logic/lib/na_invariants.v`.
+
+Iris-Rocq's `into_inv_na` / `into_acc_na` proofmode instances are not ported,
+because the Lean proofmode does not yet provide the corresponding `IntoInv` /
+`IntoAcc` classes.
+-/
+
+namespace Iris
+
+open BI CMRA OFE Iris Std LawfulSet DisjointLeibnizSet
+
+/-- The functor underlying a non-atomic invariant pool: products of a coPset
+of enabled tokens and a `PosSet` of currently-held thread-local permissions. -/
+abbrev NaInvF : COFE.OFunctorPre :=
+  ProdOF (COFE.constOF (DisjointLeibnizSet CoPset))
+    (COFE.constOF (DisjointLeibnizSet PosSet))
+
+@[rocq_alias na_invG]
+class NaInvG (GF : BundledGFunctors) where
+  [elemG : ElemG GF NaInvF]
+
+attribute [reducible] NaInvG.elemG
+attribute [instance] NaInvG.elemG
+
+@[rocq_alias na_inv_pool_name]
+abbrev NaInvPoolName := GName
+
+/-- Discrete elements of the `DisjointLeibnizSet` CMRA. Needed for `Timeless`
+instances on `iOwn` at this CMRA. -/
+instance DisjointLeibnizSet.instDiscreteE {S : Type _} (x : DisjointLeibnizSet S) :
+    DiscreteE x where
+  discrete h := h
+
+instance NaInvF.instDiscreteE {α β : Type _} (x : DisjointLeibnizSet α) (y : DisjointLeibnizSet β) :
+    DiscreteE (x, y) :=
+  prod.is_discrete (DisjointLeibnizSet.instDiscreteE _) (DisjointLeibnizSet.instDiscreteE _)
+
+/-- The unit element of the non-atomic-invariants CMRA is core-id. -/
+instance coreId_valid_empty_pair :
+    CMRA.CoreId
+      ((DisjointLeibnizSet.valid (∅ : CoPset), DisjointLeibnizSet.valid (∅ : PosSet))) where
+  core_id := by
+    show CMRA.pcore _ ≡ _
+    rfl
+
+instance isUnit_valid_empty_pair :
+    IsUnit ((DisjointLeibnizSet.valid (∅ : CoPset), DisjointLeibnizSet.valid (∅ : PosSet))) where
+  unit_valid := ⟨trivial, trivial⟩
+  unit_left_id := ⟨UCMRA.unit_left_id, UCMRA.unit_left_id⟩
+  pcore_unit := coreId_valid_empty_pair.core_id
+
+section defs
+
+variable {GF : BundledGFunctors} [InvGS_gen hlc GF] [W : NaInvG GF]
+
+@[rocq_alias na_own]
+def na_own (p : NaInvPoolName) (E : CoPset) : IProp GF :=
+  iOwn (E := W.elemG) p (DisjointLeibnizSet.valid E, DisjointLeibnizSet.valid ∅)
+
+@[rocq_alias na_inv]
+def na_inv (p : NaInvPoolName) (N : Namespace) (P : IProp GF) : IProp GF :=
+  iprop(∃ i, ⌜i ∈ (↑N : CoPset)⌝ ∧
+        inv N iprop(
+          P ∗ iOwn (E := W.elemG) p (DisjointLeibnizSet.valid ∅, DisjointLeibnizSet.valid {i})
+          ∨ na_own p {i}))
+
+end defs
+
+section proofs
+
+variable {GF : BundledGFunctors} [InvGS_gen hlc GF] [W : NaInvG GF]
+
+@[rocq_alias na_own_timeless]
+instance na_own_timeless (p : NaInvPoolName) (E : CoPset) :
+    Timeless (na_own (GF := GF) p E) := by
+  simp only [na_own]
+  infer_instance
+
+@[rocq_alias na_inv_contractive]
+instance na_inv_contractive (p : NaInvPoolName) (N : Namespace) :
+    Contractive (na_inv (GF := GF) p N) where
+  distLater_dist {n x y} H := by
+    simp only [na_inv]
+    refine exists_ne fun i => ?_
+    refine and_ne.ne .rfl ?_
+    refine Contractive.distLater_dist ?_
+    intro m hm
+    refine or_ne.ne ?_ .rfl
+    exact sep_ne.ne (H _ hm) .rfl
+
+@[rocq_alias na_inv_ne]
+instance na_inv_ne (p : NaInvPoolName) (N : Namespace) :
+    NonExpansive (na_inv (GF := GF) p N) := ne_of_contractive _
+
+@[rocq_alias na_inv_persistent]
+instance na_inv_persistent (p : NaInvPoolName) (N : Namespace) (P : IProp GF) :
+    Persistent (na_inv p N P) := by
+  simp only [na_inv]
+  infer_instance
+
+@[rocq_alias na_own_empty_persistent]
+instance na_own_empty_persistent (p : NaInvPoolName) :
+    Persistent (na_own (GF := GF) p ∅) := by
+  simp only [na_own]
+  infer_instance
+
+@[rocq_alias na_inv_iff]
+theorem na_inv_iff (p : NaInvPoolName) (N : Namespace) (P Q : IProp GF) :
+    ⊢ na_inv p N P -∗ ▷ □ (P ↔ Q) -∗ na_inv p N Q := by
+  simp only [na_inv]
+  iintro ⟨%i, %Hin, HI⟩ #HPQ
+  iexists i
+  isplit
+  · ipure_intro; assumption
+  iapply inv_iff $$ HI
+  inext; imodintro
+  simp only [BI.iff]
+  isplit
+  · iintro H
+    icases H with (⟨HP, Ho⟩ | Htok)
+    · ileft
+      isplitr [Ho]
+      · icases HPQ with ⟨HPQm, _⟩
+        iapply HPQm $$ HP
+      · iassumption
+    · iright; iassumption
+  · iintro H
+    icases H with (⟨HQ, Ho⟩ | Htok)
+    · ileft
+      isplitr [Ho]
+      · icases HPQ with ⟨_, HQPm⟩
+        iapply HQPm $$ HQ
+      · iassumption
+    · iright; iassumption
+
+@[rocq_alias na_alloc]
+theorem na_alloc : ⊢@{IProp GF} |==> ∃ p : NaInvPoolName, na_own p ⊤ := by
+  simp only [na_own]
+  exact iOwn_alloc (E := W.elemG)
+    (DisjointLeibnizSet.valid (⊤ : CoPset), DisjointLeibnizSet.valid (∅ : PosSet))
+    ⟨trivial, trivial⟩
+
+@[rocq_alias na_own_disjoint]
+theorem na_own_disjoint (p : NaInvPoolName) (E1 E2 : CoPset) :
+    ⊢ na_own (GF := GF) p E1 -∗ na_own p E2 -∗ ⌜E1 ## E2⌝ := by
+  simp only [na_own]
+  iintro H1 H2
+  ihave H := iOwn_op (E := W.elemG) $$ [H1 H2]
+  · isplitl [H1] <;> iassumption
+  ihave H := iOwn_cmraValid $$ H
+  icases internalCmraValid_discrete (A := NaInvF.ap (IProp GF)) $$ H with %H
+  ipure_intro
+  exact valid_op_iff_disj.mp H.1
+
+@[rocq_alias na_own_union]
+theorem na_own_union (p : NaInvPoolName) (E1 E2 : CoPset) (Hdisj : E1 ## E2) :
+    na_own (GF := GF) p (E1 ∪ E2) ⊣⊢ na_own p E1 ∗ na_own p E2 := by
+  simp only [na_own]
+  have hempty :
+      DisjointLeibnizSet.valid (∅ : PosSet) ≡
+        DisjointLeibnizSet.valid (∅ : PosSet) • DisjointLeibnizSet.valid ∅ := by
+    refine .trans ?_ (disj_op_union (S := PosSet) disjoint_empty_left).symm
+    exact Equiv.of_eq (by simp)
+  have heq : (DisjointLeibnizSet.valid (E1 ∪ E2), DisjointLeibnizSet.valid ∅) ≡
+      ((DisjointLeibnizSet.valid E1, DisjointLeibnizSet.valid ∅) •
+       (DisjointLeibnizSet.valid E2, DisjointLeibnizSet.valid (∅ : PosSet))) :=
+    equiv_prod_ext (disj_op_union Hdisj).symm hempty
+  refine .trans ?_ iOwn_op
+  exact BI.equiv_iff.mp (NonExpansive.eqv (f := iOwn (E := W.elemG) p) heq)
+
+@[rocq_alias na_own_acc]
+theorem na_own_acc (E2 E1 : CoPset) (tid : NaInvPoolName) (Hsub : E2 ⊆ E1) :
+    ⊢ na_own (GF := GF) tid E1 -∗ na_own tid E2 ∗ (na_own tid E2 -∗ na_own tid E1) := by
+  have Heq : E1 = E2 ∪ (E1 \ E2) := by
+    rw [union_comm]; exact diff_subset_decomp Hsub
+  rw [Heq]
+  iintro H
+  icases (na_own_union tid E2 (E1 \ E2) disjoint_diff_right).mp $$ H with ⟨H1, H2⟩
+  isplitl [H1]; iassumption
+  iintro H1
+  iapply (na_own_union tid E2 (E1 \ E2) disjoint_diff_right).mpr
+  isplitl [H1] <;> iassumption
+
+@[rocq_alias na_own_empty]
+theorem na_own_empty (p : NaInvPoolName) : ⊢@{IProp GF} |==> na_own p ∅ := by
+  simp only [na_own]
+  exact iOwn_unit (E := W.elemG)
+    (ε := (DisjointLeibnizSet.valid ∅, DisjointLeibnizSet.valid ∅))
+
+@[rocq_alias na_inv_alloc]
+theorem na_inv_alloc (p : NaInvPoolName) (E : CoPset) (N : Namespace) (P : IProp GF) :
+    ⊢ ▷ P ={E}=∗ na_inv p N P := by
+  iintro HP
+  imod (iOwn_unit (E := W.elemG) (γ := p)
+      (ε := (DisjointLeibnizSet.valid ∅, DisjointLeibnizSet.valid ∅))) with Hempty
+  have Hupd :
+      ((DisjointLeibnizSet.valid (∅ : CoPset), DisjointLeibnizSet.valid (∅ : PosSet)))
+      ~~>: (fun y : NaInvF.ap (IProp GF) =>
+        ∃ i : Pos, y = (DisjointLeibnizSet.valid ∅, DisjointLeibnizSet.valid {i}) ∧
+          i ∈ (↑N : CoPset)) := by
+    refine UpdateP.prod (α := DisjointLeibnizSet CoPset) (β := DisjointLeibnizSet PosSet)
+      (P := (· = DisjointLeibnizSet.valid ∅))
+      (Q := fun y => ∃ i : Pos, y = DisjointLeibnizSet.valid {i} ∧ i ∈ (↑N : CoPset))
+      (UpdateP.id rfl)
+      (DisjointLeibnizSet.alloc_empty_updateP_strong' (fun Y => fresh_name Y N))
+      (fun a b ha ⟨i, hb, hi⟩ => ⟨i, by simp [ha, hb], hi⟩)
+  imod iOwn_updateP Hupd $$ Hempty with ⟨%y, %Hy, Hown⟩
+  obtain ⟨i, rfl, Hi⟩ := Hy
+  simp only [na_inv]
+  imod inv_alloc N E iprop(
+    P ∗ iOwn (E := W.elemG) p (DisjointLeibnizSet.valid ∅, DisjointLeibnizSet.valid {i})
+    ∨ na_own p {i}) $$ [HP Hown] with HI
+  · inext; ileft; isplitl [HP] <;> iassumption
+  imodintro
+  iexists i
+  isplit
+  · ipure_intro; assumption
+  · iassumption
+
+@[rocq_alias na_inv_acc]
+theorem na_inv_acc (p : NaInvPoolName) (E F : CoPset) (N : Namespace) (P : IProp GF)
+    (HNE : ↑N ⊆ E) (HNF : ↑N ⊆ F) :
+    ⊢ na_inv p N P -∗ na_own p F ={E}=∗
+      ▷ P ∗ na_own p (F \ ↑N) ∗
+      (▷ P ∗ na_own p (F \ ↑N) ={E}=∗ na_own p F) := by
+  simp only [na_inv]
+  iintro #⟨%i, %Hin, Hinv⟩ Htoks
+  -- Split Htoks : na_own p F = na_own p ({i} ∪ (↑N \ {i})) ∗ na_own p (F \ ↑N)
+  have HiN : ({i} : CoPset) ⊆ (↑N : CoPset) := by
+    intro x hx; rw [mem_singleton] at hx; subst hx; exact Hin
+  have HeqN : ↑N = {i} ∪ ((↑N : CoPset) \ {i}) := by
+    rw [union_comm]; exact diff_subset_decomp HiN
+  have HeqF : F = ↑N ∪ (F \ ↑N) := by
+    rw [union_comm]; exact diff_subset_decomp HNF
+  ihave Htoks' : na_own p (↑N ∪ (F \ ↑N)) $$ [Htoks]
+  · rw [← HeqF]; iassumption
+  icases (na_own_union p ↑N (F \ ↑N) disjoint_diff_right).mp $$ Htoks' with ⟨HtokN, HtokRest⟩
+  ihave HtokN' : na_own p ({i} ∪ ((↑N : CoPset) \ {i})) $$ [HtokN]
+  · rw [← HeqN]; iassumption
+  icases (na_own_union p {i} (↑N \ {i}) disjoint_diff_right).mp $$ HtokN' with ⟨Htoki, HtokNdi⟩
+  -- Open the invariant.
+  imod inv_acc _ _ _ HNE $$ Hinv with ⟨Hcontent, Hclose⟩
+  icases Hcontent with (⟨HP, >Hdis⟩ | >Htoki2)
+  · -- Left branch: got P and the stored token. Close with Htoki in right branch.
+    ihave Hreturn : iprop(▷ (P ∗ iOwn (E := W.elemG) p
+            (DisjointLeibnizSet.valid ∅, DisjointLeibnizSet.valid {i}) ∨ na_own p {i}))
+        $$ [Htoki]
+    · inext; iright; iassumption
+    imod Hclose $$ Hreturn with _
+    imodintro
+    isplitl [HP]; iassumption
+    isplitl [HtokRest]; iassumption
+    -- Returner: user gives back ▷P and na_own p (F \ ↑N). We need to give back na_own p F.
+    iintro ⟨HPret, HtokFret⟩
+    imod inv_acc _ _ _ HNE $$ Hinv with ⟨Hcontent2, Hclose2⟩
+    icases Hcontent2 with (⟨_HPconflict, >Hdis2⟩ | >Htoki_back)
+    · -- Impossible: two copies of own p (ε, {i}) would have disjoint tokens.
+      iexfalso
+      ihave Hbad := iOwn_op (E := W.elemG) $$ [Hdis Hdis2]
+      · isplitl [Hdis] <;> iassumption
+      ihave Hbad := iOwn_cmraValid $$ Hbad
+      icases internalCmraValid_discrete (A := NaInvF.ap (IProp GF)) $$ Hbad with %Hbad
+      ipure_intro
+      have Hbad2 := DisjointLeibnizSet.valid_op_iff_disj.mp Hbad.2
+      exact Hbad2 i ⟨mem_singleton.mpr rfl, mem_singleton.mpr rfl⟩
+    · -- Good branch: consume Htoki_back, close with (P, Hdis) left branch.
+      ihave Hreturn2 : iprop(▷ (P ∗ iOwn (E := W.elemG) p
+              (DisjointLeibnizSet.valid ∅, DisjointLeibnizSet.valid {i}) ∨ na_own p {i}))
+          $$ [HPret Hdis]
+      · inext; ileft; isplitl [HPret] <;> iassumption
+      imod Hclose2 $$ Hreturn2 with _
+      imodintro
+      -- Combine Htoki_back, HtokNdi, HtokFret into na_own p F.
+      ihave HtokN_new : na_own p ((↑N : CoPset)) $$ [Htoki_back HtokNdi]
+      · conv => rhs; rw [show (↑N : CoPset) = {i} ∪ (↑N \ {i}) from HeqN]
+        iapply (na_own_union p {i} (↑N \ {i}) disjoint_diff_right).mpr
+        isplitl [Htoki_back]
+        · iexact Htoki_back
+        · iexact HtokNdi
+      conv => rhs; rw [show F = (↑N : CoPset) ∪ (F \ ↑N) from HeqF]
+      iapply (na_own_union p ↑N (F \ ↑N) disjoint_diff_right).mpr
+      isplitl [HtokN_new]
+      · iexact HtokN_new
+      · iexact HtokFret
+  · -- Right branch: two na_own p {i} would contradict disjointness.
+    iexfalso
+    ihave Hbad : ⌜({i} : CoPset) ## {i}⌝ $$ [Htoki Htoki2]
+    · ihave Hd1 := na_own_disjoint p {i} {i} $$ Htoki
+      iapply Hd1 $$ Htoki2
+    icases Hbad with %Hbad
+    exact Hbad i ⟨mem_singleton.mpr rfl, mem_singleton.mpr rfl⟩ |>.elim
+
+end proofs
+
+end Iris
+
+end

--- a/Iris/PORTING.md
+++ b/Iris/PORTING.md
@@ -192,6 +192,8 @@ Some porting tasks will require other tasks as dependencies, the GitHub issues p
 - [ ] `lib/mono_Z.v` (nb. generalize to `MonoNumbers.lean`)
 - [ ] `lib/mono_nat.v` (nb. generalize to `MonoNumbers.lean`)
 - [ ] `lib/na_invariants.v`
+  - [x] Basic construction 
+  - [ ] Proofmode classes
 - [ ] `lib/own.v`
   - Missing: `later_internal_eq_iRes_singleton`
   - [x] Definition


### PR DESCRIPTION
## Description
Non-atomic invariants
Closes #297 

## Checklist
* [ ] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [ ] I have updated `PORTING.md` as appropriate
* [ ] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
