### PR TITLE
refactor: prefer Function.Injective over custom typeclass

### DIFF
--- a/Iris/Iris/Std/Classes.lean
+++ b/Iris/Iris/Std/Classes.lean
@@ -71,8 +71,4 @@ class Disjoint (α : Type u) where
 export Disjoint (disjoint)
 infix:50 " ## " => Disjoint.disjoint
 
-class Injective (f : A -> B) where
-  inj : ∀ (a a' : A), f a = f a' -> a = a'
-export Injective (inj)
-
 end Iris.Std

--- a/Iris/Iris/Std/GenSets.lean
+++ b/Iris/Iris/Std/GenSets.lean
@@ -952,7 +952,7 @@ theorem map_subset {S' : Type _} {B : Type _} [LawfulFiniteSet S' B]
   exists x; exact ⟨hf, h _ hx⟩
 
 theorem toList_map_perm {S' : Type _} {B : Type _} [LawfulFiniteSet S' B]
-    {f : A → B} (s : S) (hinj : Injective f) :
+    {f : A → B} (s : S) (hinj : f.Injective) :
     (toList (map (S' := S') f s)).Perm (List.map f (toList s)) := by
   simp only [map]
   have hnodup : (List.map f (toList s)).Nodup := by

--- a/Iris/Iris/Std/List.lean
+++ b/Iris/Iris/Std/List.lean
@@ -29,7 +29,7 @@ inductive Equiv {α : Type _} (R : α → α → Prop) : List α → List α →
   l.mapIdx (fun i v => (v, (i : Int) + n))
 
 theorem nodup_map_of_injective {B : Type _} {f : A → B} {l : List A}
-    (hinj : Injective f) (hnodup : l.Nodup) : (l.map f).Nodup := by
+    (hinj : f.Injective) (hnodup : l.Nodup) : (l.map f).Nodup := by
   induction l with
   | nil => simp [List.Nodup]
   | cons x xs ih =>
@@ -38,7 +38,7 @@ theorem nodup_map_of_injective {B : Type _} {f : A → B} {l : List A}
     simp only [List.mem_map]
     constructor
     · intro ⟨y, hy, heq⟩
-      cases (hinj.inj _ _ heq.symm)
+      cases (hinj heq.symm)
       exact hnodup.1 hy
     · exact ih hnodup.2
 
@@ -48,7 +48,7 @@ theorem fresh [InfiniteType A] (X : List A) : ∃ a : A, a ∉ X := by
   let Nalloc := X |>.length
   let L := List.range (Nalloc + 1)
   have hnodup : L.map (InfiniteType.enum (T := A)) |>.Nodup :=
-    nodup_map_of_injective ⟨fun _ _ => InfiniteType.enum_inj _ _⟩ List.nodup_range
+    nodup_map_of_injective (fun _ _ => InfiniteType.enum_inj _ _) List.nodup_range
   have hsub : L.map InfiniteType.enum ⊆ X := by
     intro _ ha
     obtain ⟨_, _, rfl⟩ := List.mem_map.mp ha

--- a/Iris/Iris/Std/Namespaces.lean
+++ b/Iris/Iris/Std/Namespaces.lean
@@ -52,9 +52,9 @@ theorem ndot_ne_disjoint [Pos.Countable A] (N : Namespace) {x y : A} (Hxy : x �
   intros p
   simp only [nclose, CoPset.elem_suffixes]
   rintro ⟨⟨qx, Heqx⟩, ⟨qy, Heqy⟩⟩
-  refine Hxy (Pos.encode_inj.inj _ _ ?_)
-  have _ := Pos.flatten_suffix_eq (by simp [ndot]) (Heqx ▸ Heqy)
-  simp_all [ndot]
+  apply Hxy
+  have := Pos.flatten_suffix_eq (by simp [ndot]) (Heqx ▸ Heqy)
+  simpa only [ndot, List.cons.injEq, Pos.encode_inj, Function.Injective.eq_iff, and_true]
 
 theorem ndot_preserve_disjoint_l [Pos.Countable A] {N : Namespace} {E : CoPset} (x : A)
     (Hdisj : ↑N ## E) : ↑(N.@x) ## E :=

--- a/Iris/Iris/Std/Positives.lean
+++ b/Iris/Iris/Std/Positives.lean
@@ -105,7 +105,8 @@ theorem Pos_toNat_pos (a : Pos) : 0 < a.toNat := by
   | xI a' ih => simp [Pos.toNat]
   | xO a' ih => simp [Pos.toNat]; omega
 
-theorem Pos_toNat_inj {a b : Pos} (h : a.toNat = b.toNat) : a = b := by
+theorem Pos_toNat_inj : Pos.toNat.Injective  := by
+  intros a b h
   induction a generalizing b <;> cases b
   all_goals simp [Pos.toNat] at h; grind [Pos_toNat_pos]
 
@@ -118,7 +119,7 @@ match n with
 | 0 => P1
 | (n + 1) => succ (ofNat n)
 
-theorem succ_inj : Function.Injective Pos.succ := by
+theorem succ_inj : Pos.succ.Injective  := by
   have succ_not_xH : ∀ (a : Pos), a.succ ≠ xH := by
     intro a; cases a <;> simp [succ]
   intro a b H
@@ -151,7 +152,7 @@ theorem succ_inj : Function.Injective Pos.succ := by
       apply IH
       rw [H]
 
-theorem Pos_ofNat_inj : Function.Injective Pos.ofNat := by
+theorem Pos_ofNat_inj : Pos.ofNat.Injective := by
   intro a b h
   induction a generalizing b with
   | zero =>
@@ -339,8 +340,8 @@ theorem flatten_suffix (l k : List Pos) : l <:+ k -> ∃ q, flatten k = q ++ fla
   rintro ⟨l', rfl⟩
   exact ⟨_, flatten_app⟩
 
-instance app_inj (p : Pos) : Iris.Std.Injective (.++ p) where
-  inj a a' Heq := by induction p <;> simp_all [HAppend.hAppend, app]
+instance app_inj (p : Pos) : (· ++ p).Injective :=
+  fun a a' Heq => by induction p <;> simp_all [HAppend.hAppend, app]
 
 theorem reverse_involutive p : reverse (reverse p) = p := by
   induction p with
@@ -348,8 +349,8 @@ theorem reverse_involutive p : reverse (reverse p) = p := by
   | xO p IH => rewrite [reverse_x0, reverse_app, IH]; rfl
   | xH => rfl
 
-instance rev_inj : Iris.Std.Injective reverse where
-  inj p q Heq := by
+instance rev_inj : reverse.Injective :=
+  fun p q Heq => by
     rewrite [<- reverse_involutive p, <- reverse_involutive q]
     simp [Heq]
 
@@ -393,19 +394,19 @@ theorem flatten_suffix_eq {p1 p2} {xs ys : List Pos} :
     have Heq : xs = ys := IH (Nat.add_right_cancel Hlen) Hl
     rewrite [Heq, reverse_dup, reverse_dup] at Hl
     refine List.cons_eq_cons.mpr ⟨?_, Heq⟩
-    exact rev_inj.inj _ _ (dup_suffix_eq ((app_inj (flatten ys)).inj _ _ Hl))
+    exact rev_inj (dup_suffix_eq ((app_inj (flatten ys)) Hl))
 
 class Countable (A : Type) where
   encode : A -> Pos
   decode : Pos -> Option A
   decode_encode x : decode (encode x) = some x
 
-instance some_inj {A} : Iris.Std.Injective (@some A) where
-  inj _ _ := by rintro ⟨⟩; rfl
+instance some_inj {A} : (@some A).Injective :=
+  fun _ _ => by rintro ⟨⟩; rfl
 
-instance encode_inj [c : Countable A] : Iris.Std.Injective (c.encode) where
-  inj x _ Hxy := by
-    apply some_inj.inj
+instance encode_inj [c : Countable A] : c.encode.Injective :=
+  fun x _ Hxy => by
+    apply some_inj
     rewrite [<- c.decode_encode x, Hxy, c.decode_encode]
     rfl
 
@@ -438,7 +439,7 @@ instance : Std.LawfulEqOrd Pos where
   eq_of_compare {a b} := by
     simp only [Ord.compare, compare]
     rw [compareOfLessAndEq_eq_eq Nat.le_refl (by grind)]
-    exact Pos_toNat_inj
+    apply Pos_toNat_inj
   compare_self {_} := by
     simp [Ord.compare, Pos.compare, compareOfLessAndEq_eq_eq]
 


### PR DESCRIPTION
## Description
I noticed we recently introduced an `Iris.Std.Injective` typeclass which we can replace with the builtin `Function.Injective` typeclass, since the definitions seem to be pretty much equivalent. I have made this PR since I believe it's better to use the built-in definitions as much as possible.

## Checklist
* [X] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [ ] I have updated `PORTING.md` as appropriate
* [ ] I have added my name to the `authors` section of any appropriate files