### PR TITLE
fix: Change WSat to use identity OFunctor rather than constant 

### DIFF
--- a/Iris/Iris/Algebra/OFE.lean
+++ b/Iris/Iris/Algebra/OFE.lean
@@ -693,6 +693,15 @@ instance oFunctorConstOF [OFE B] : OFunctor (constOF B) where
 instance OFunctor.constOF_contractive [OFE B] : OFunctorContractive (constOF B) where
   map_contractive.1 := by simp [map]
 
+abbrev IdOF : COFE.OFunctorPre := fun _ B _ _ => B
+
+instance IdOF_OFunctor : COFE.OFunctor IdOF where
+  cofe := inferInstance
+  map _ g := g
+  map_ne := ⟨fun _ _ _ _ _ _ hg => hg⟩
+  map_id _ := .rfl
+  map_comp _ _ _ _ _ := .rfl
+
 end COFE
 
 /- Leibniz OFE structure on a type -/
@@ -1051,6 +1060,14 @@ instance [OFunctorContractive F] : OFunctorContractive (LaterOF F) where
   map_contractive.1 H z m := Dist.lt <| by
     have := (OFunctorContractive.map_contractive (F := F)).distLater_dist H
     simp_all only [Dist, DistLater, Function.uncurry, OFunctor.map, laterMap]
+
+instance laterIdOF_contractive : COFE.OFunctorContractive (LaterOF IdOF) where
+    map_contractive.1 := by
+      intro n x y H z
+      simp only [Function.uncurry, COFE.OFunctor.map, laterMap, IdOF]
+      show OFE.DistLater _ _ _
+      intros k Hk
+      exact (H k Hk).2 _
 
 end LaterOF
 

--- a/Iris/Iris/Examples.lean
+++ b/Iris/Iris/Examples.lean
@@ -5,3 +5,4 @@ public import Iris.Examples.Namesets
 public import Iris.Examples.Proofs
 public import Iris.Examples.Resources
 public import Iris.Examples.HeapLang
+public import Iris.Examples.ClosedProofs

--- a/Iris/Iris/Examples/ClosedProofs.lean
+++ b/Iris/Iris/Examples/ClosedProofs.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2026 Sergei Stepanenko. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Iris.ProofMode
+public import Iris.Algebra.IProp
+public import Iris.Algebra.Auth
+public import Iris.Instances.UPred.Instance
+public import Iris.Instances.IProp.Instance
+public import Iris.Instances.Lib.WSat
+public import Iris.Instances.Lib.LaterCredits
+public import Iris.Instances.Lib.Invariants
+public import Iris.Std.HeapInstances
+
+@[expose] public section
+
+namespace Iris.Examples.ClosedProofs
+open Iris.BI COFE HeapView Auth Std.LawfulSet
+
+/-!
+This file shows how to obtain closed (pure Lean) propositions by taking a détour
+through the Iris logic in the presence of circular resources such as invariants.
+
+`GF` is a family of GFunctors that specifies the input functor for IProp. Each slot is
+an indexed functor contributing one resource algebra: the first slot carries `InvMapF` (the
+invariant map, which makes `IProp` self-referential), slots 1–2 carry the invariant
+mask bookkeeping, and slot 3 carries later credits. Additional user resources can be
+added at higher indices together with a matching `GpreS` instance.
+
+`pure_soundness` converts a proof of `⊢ ⌜P⌝` in the Iris logic into the plain Lean
+proposition `P`. The `step_fupdN_soundness_no_lc'` wrapper accounts for the fancy
+update steps required to allocate invariants.
+-/
+section proof
+
+noncomputable def GF : BundledGFunctors := fun n =>
+  match n with
+  | 0  => ⟨InvMapF, by infer_instance⟩
+  | 1  => ⟨constOF (DisjointLeibnizSet CoPset), by infer_instance⟩
+  | 2  => ⟨constOF (DisjointLeibnizSet PosSet), by infer_instance⟩
+  | 3  => ⟨AuthURF (F := PNat) (constOF Credit), by infer_instance⟩
+  | _  => ⟨constOF Unit, by infer_instance⟩
+
+instance : WsatGpreS GF where
+  inv := { τ := 0, transp := by unfold GF; rfl }
+  enabled := { τ := 1, transp := by unfold GF; rfl }
+  disabled := { τ := 2, transp := by unfold GF; rfl }
+
+instance : LcGpreS GF where
+  lc_elem := { τ := 3, transp := by unfold GF; rfl }
+
+instance : InvGpreS GF where
+  toWsatGpreS := inferInstance
+  toLcGpreS := inferInstance
+
+example : True := by
+  apply pure_soundness (PROP := IProp GF)
+  iapply step_fupdN_soundness_no_lc' (m := 0) (n := 1)
+  iintro %_ _
+  simp only [Nat.repeat]
+  icases inv_alloc nroot ⊤ iprop(True) $$ [] with >#Hinv
+  · inext; ipure_intro; simp
+  imod inv_acc ⊤ $$ Hinv with ⟨HP, Hcl⟩
+  · rw [nclose_root]; exact subset_refl
+  imod Hcl $$ HP with HP
+  iapply fupd_mask_intro empty_subset
+  iintro Hcl
+  inext
+  imod Hcl
+  imodintro
+  iintro _
+  iexact HP
+
+end proof
+
+end Iris.Examples.ClosedProofs

--- a/Iris/Iris/Instances/Lib/WSat.lean
+++ b/Iris/Iris/Instances/Lib/WSat.lean
@@ -30,11 +30,15 @@ abbrev PosSet := Std.ExtTreeSet Pos compare
 
 abbrev InvMap (x : Type _) := Std.ExtTreeMap Pos x compare
 
-abbrev InvMapF := HeapViewURF (F := PNat) (H := InvMap) (AgreeRF (LaterOF IdOF))
+abbrev InvMapF (GF : BundledGFunctors) :=
+  HeapViewURF (F := PNat) (H := InvMap) (AgreeRF (LaterOF (constOF (IProp GF))))
+
+abbrev InvMapR :=
+  HeapViewURF (F := PNat) (H := InvMap) (AgreeRF (LaterOF IdOF))
 
 /-- Wsat inclusion typeclass (`GF` contains the necessary functors for wsat) -/
 class WsatGpreS (GF : BundledGFunctors) where
-  inv : ElemG GF InvMapF
+  inv : ElemG GF (InvMapF GF)
   enabled : ElemG GF (constOF (DisjointLeibnizSet CoPset))
   disabled : ElemG GF (constOF (DisjointLeibnizSet PosSet))
 
@@ -67,7 +71,7 @@ def ownD (S : PosSet) : IProp GF :=
 
 abbrev liftInv (I : InvMap (IProp GF)) := map toAgree (map invariant_unfold I)
 
-abbrev invMap (I : InvMap (IProp GF)) : InvMapF.ap (IProp GF) :=
+abbrev invMap (I : InvMap (IProp GF)) : (InvMapF GF).ap (IProp GF) :=
   Auth (own 1) (liftInv I)
 
 def wsat : IProp GF := iprop(

--- a/Iris/Iris/Instances/Lib/WSat.lean
+++ b/Iris/Iris/Instances/Lib/WSat.lean
@@ -30,15 +30,11 @@ abbrev PosSet := Std.ExtTreeSet Pos compare
 
 abbrev InvMap (x : Type _) := Std.ExtTreeMap Pos x compare
 
-abbrev InvMapF (GF : BundledGFunctors) :=
-  HeapViewURF (F := PNat) (H := InvMap) (AgreeRF (LaterOF (constOF (IProp GF))))
-
-abbrev InvMapR :=
-  HeapViewURF (F := PNat) (H := InvMap) (AgreeRF (LaterOF IdOF))
+abbrev InvMapF := HeapViewURF (F := PNat) (H := InvMap) (AgreeRF (LaterOF IdOF))
 
 /-- Wsat inclusion typeclass (`GF` contains the necessary functors for wsat) -/
 class WsatGpreS (GF : BundledGFunctors) where
-  inv : ElemG GF (InvMapF GF)
+  inv : ElemG GF InvMapF
   enabled : ElemG GF (constOF (DisjointLeibnizSet CoPset))
   disabled : ElemG GF (constOF (DisjointLeibnizSet PosSet))
 
@@ -71,7 +67,7 @@ def ownD (S : PosSet) : IProp GF :=
 
 abbrev liftInv (I : InvMap (IProp GF)) := map toAgree (map invariant_unfold I)
 
-abbrev invMap (I : InvMap (IProp GF)) : (InvMapF GF).ap (IProp GF) :=
+abbrev invMap (I : InvMap (IProp GF)) : InvMapF.ap (IProp GF) :=
   Auth (own 1) (liftInv I)
 
 def wsat : IProp GF := iprop(

--- a/Iris/Iris/Instances/Lib/WSat.lean
+++ b/Iris/Iris/Instances/Lib/WSat.lean
@@ -30,12 +30,11 @@ abbrev PosSet := Std.ExtTreeSet Pos compare
 
 abbrev InvMap (x : Type _) := Std.ExtTreeMap Pos x compare
 
-abbrev InvMapF (GF : BundledGFunctors) :=
-  HeapViewURF (F := PNat) (H := InvMap) (AgreeRF (LaterOF (constOF (IProp GF))))
+abbrev InvMapF := HeapViewURF (F := PNat) (H := InvMap) (AgreeRF (LaterOF IdOF))
 
 /-- Wsat inclusion typeclass (`GF` contains the necessary functors for wsat) -/
 class WsatGpreS (GF : BundledGFunctors) where
-  inv : ElemG GF (InvMapF GF)
+  inv : ElemG GF InvMapF
   enabled : ElemG GF (constOF (DisjointLeibnizSet CoPset))
   disabled : ElemG GF (constOF (DisjointLeibnizSet PosSet))
 
@@ -68,7 +67,7 @@ def ownD (S : PosSet) : IProp GF :=
 
 abbrev liftInv (I : InvMap (IProp GF)) := map toAgree (map invariant_unfold I)
 
-abbrev invMap (I : InvMap (IProp GF)) : (InvMapF GF).ap (IProp GF) :=
+abbrev invMap (I : InvMap (IProp GF)) : InvMapF.ap (IProp GF) :=
   Auth (own 1) (liftInv I)
 
 def wsat : IProp GF := iprop(


### PR DESCRIPTION
Ran into this issue when trying to close off a fully adequacy proof in Approxis: It seems like in Rocq it's not a problem to use `constOF (IProp GF)` in the definition of the `Wsat` functor, but this caused me problems when trying to build a concrete model since then `GF` had to be recursive. To be honest I assumed the functor would be `Id` anyways. 

Not sure exactly how we should go here: the version in this PR deviates from Rocq but seems to work nicely with our existing infrastructure. Alternatively, we could think harder about why the Rocq version works and try to tweak `ElemG` etc. to match. 

Any thoughts about this? Paging @Kaptch specifically