### PR TITLE
More HeapLang notation

### DIFF
--- a/Iris/Iris/Examples/HeapLang.lean
+++ b/Iris/Iris/Examples/HeapLang.lean
@@ -48,27 +48,27 @@ def minMax : Exp :=
 
 def optionMap : Exp :=
   hl(λ f opt,
-    case: opt
-    | _ => injl(#())
-    | x => injr(f x))
+    match opt with
+    | injl(_) => injl(#())
+    | injr(x) => injr(f x))
 
 def optionGetOrElse : Exp :=
   hl(λ opt default,
-    case: opt
-    | _ => default
-    | x => x)
+    match opt with
+    | injl(_) => default
+    | injr(x) => x)
 
 def listLength : Exp :=
   hl(rec len xs :=
-    case: xs
-    | _ => #0
-    | p => #1 + (len (snd(p))))
+    match xs with
+    | injl(_) => #0
+    | injr(p) => #1 + (len (snd(p))))
 
 def listSum : Exp :=
   hl(rec lsum xs :=
-    case: xs
-    | _ => #0
-    | p => fst(p) + (lsum (snd(p))))
+    match xs with
+    | injl(_) => #0
+    | injr(p) => fst(p) + (lsum (snd(p))))
 
 /-! ## Heap operations -/
 
@@ -143,9 +143,9 @@ def listIsEmpty : Exp := hl(λ xs, {listLength} xs ≤ #0)
 
 def listSumIncremented : Exp :=
   hl(rec go xs :=
-    case: xs
-    | _ => #0
-    | p => {increment} (fst(p)) + (go (snd(p))))
+    match xs with
+    | injl(_) => #0
+    | injr(p) => {increment} (fst(p)) + (go (snd(p))))
 
 def casIncrementTwice : Exp :=
   hl(λ l,
@@ -235,11 +235,11 @@ def readCoin : Exp :=
   hl(λ cp,
     let c := fst(cp);
     let p := snd(cp);
-    case: !c
-    | _ => {hl(let r := {nondetBool} #();
+    match !c with
+    | injl(_) => {hl(let r := {nondetBool} #();
                c ← injr(r);
                {Exp.resolve hl(injl(#())) hl(p) hl(r)};
                r)}
-    | b => b)
+    | injr(b) => b)
 
 end Iris.Examples.HeapLang

--- a/Iris/Iris/Examples/HeapLang.lean
+++ b/Iris/Iris/Examples/HeapLang.lean
@@ -49,14 +49,14 @@ def minMax : Exp :=
 def optionMap : Exp :=
   hl(λ f opt,
     match opt with
-    | injl(_) => injl(#())
-    | injr(x) => injr(f x))
+    | none() => none()
+    | some(x) => some(f x))
 
 def optionGetOrElse : Exp :=
   hl(λ opt default,
     match opt with
-    | injl(_) => default
-    | injr(x) => x)
+    | none() => default
+    | some(x) => x)
 
 def listLength : Exp :=
   hl(rec len xs :=

--- a/Iris/Iris/HeapLang/Notation.lean
+++ b/Iris/Iris/HeapLang/Notation.lean
@@ -76,6 +76,9 @@ syntax:50 hl_exp:50 " < " hl_exp:50 : hl_exp
 /-- equality -/
 syntax:50 hl_exp:50 " = " hl_exp:50 : hl_exp
 
+syntax:35 hl_exp:36 "&&" hl_exp:35 : hl_exp
+syntax:30 hl_exp:31 "||" hl_exp:30 : hl_exp
+
 /-- neg -/
 syntax:100 "~" hl_exp:100 : hl_exp
 /-- minus -/
@@ -106,12 +109,21 @@ syntax:100 "fst(" hl_exp ")" : hl_exp
 /-- snd -/
 syntax:100 "snd(" hl_exp ")" : hl_exp
 
-/-- case -/
-syntax:100 "case: " hl_exp:80 " | " binderIdent " => " hl_exp:80 " | " binderIdent " => " hl_exp:80 : hl_exp
+/-- match -/
+syntax:100 "match " hl_exp:80 " with"
+  " | " "injl(" binderIdent ")" " => " hl_exp:80
+  " | " "injr(" binderIdent ")" " => " hl_exp:80 : hl_exp
 /-- injL -/
 syntax:100 "injl(" hl_exp ")" : hl_exp
 /-- injR -/
 syntax:100 "injr(" hl_exp ")" : hl_exp
+
+/-- none and some-/
+syntax:100 "match " hl_exp:80 " with"
+  " | " "none()" " => " hl_exp:80
+  " | " "some(" binderIdent ")" " => " hl_exp:80 : hl_exp
+syntax:100 "none()" : hl_exp
+syntax:100 "some(" hl_exp ")" : hl_exp
 
 /-- heap operations -/
 syntax:100 "allocn(" hl_exp ", " hl_exp ")" : hl_exp
@@ -120,6 +132,7 @@ syntax:100 "free(" hl_exp ")" : hl_exp
 syntax:100 "!" hl_exp:100 : hl_exp
 syntax:15 hl_exp:16 " ← " hl_exp:15 : hl_exp
 syntax:100 "cmpXchg(" hl_exp ", " hl_exp ", " hl_exp ")" : hl_exp
+syntax:100 "cas(" hl_exp ", " hl_exp ", " hl_exp ")" : hl_exp
 syntax:100 "xchg(" hl_exp ", " hl_exp ")" : hl_exp
 syntax:100 "faa(" hl_exp ", " hl_exp ")" : hl_exp
 
@@ -182,6 +195,8 @@ macro_rules
   | `(hl($e1 ≤ $e2)) => `(Exp.binop BinOp.le hl($e1) hl($e2))
   | `(hl($e1 < $e2)) => `(Exp.binop BinOp.lt hl($e1) hl($e2))
   | `(hl($e1 = $e2)) => `(Exp.binop BinOp.eq hl($e1) hl($e2))
+  | `(hl($e1 && $e2)) => `( hl(if $e1 then $e2 else #false) )
+  | `(hl($e1 || $e2)) => `( hl(if $e1 then true else $e2) )
   | `(hl(~$e1)) => `(Exp.unop UnOp.neg hl($e1))
   | `(hl(-$e1)) => `(Exp.unop UnOp.minus hl($e1))
   | `(hl(if $e1 then $e2 else $e3)) => `(Exp.if hl($e1) hl($e2) hl($e3))
@@ -195,15 +210,21 @@ macro_rules
   | `(hl(($e1, $e2, $e3,*))) => `(hl(($e1, ($e2, $e3,*))))
   | `(hl(fst($e1))) => `(Exp.fst hl($e1))
   | `(hl(snd($e1))) => `(Exp.snd hl($e1))
-  | `(hl(case: $e1 | $i2 => $e2 | $i3 => $e3)) => `(Exp.case hl($e1) hl(λ $i2, $e2) hl(λ $i3, $e3))
+  | `(hl(match $e1 with | injl($i2) => $e2 | injr($i3) => $e3)) =>
+    `(Exp.case hl($e1) hl(λ $i2, $e2) hl(λ $i3, $e3))
+  | `(hl(match $e1 with | none() => $e2 | some($i3) => $e3)) =>
+    `(Exp.case hl($e1) hl(λ _, $e2) hl(λ $i3, $e3))
   | `(hl(injl($e1))) => `(Exp.injL hl($e1))
   | `(hl(injr($e1))) => `(Exp.injR hl($e1))
+  | `(hl(none())) => `( hl(injl(#())) )
+  | `(hl(some($e))) => `( hl(injr($e)) )
   | `(hl(allocn($e1, $e2))) => `(Exp.allocN hl($e1) hl($e2))
   | `(hl(ref($e1))) => `(hl(allocn(#1, $e1)))
   | `(hl(free($e1))) => `(Exp.free hl($e1))
   | `(hl(! $e1)) => `(Exp.load hl($e1))
   | `(hl($e1 ← $e2)) => `(Exp.store hl($e1) hl($e2))
   | `(hl(cmpXchg($e1, $e2, $e3))) => `(Exp.cmpXchg hl($e1) hl($e2) hl($e3))
+  | `(hl(cas($e1, $e2, $e3))) => `( hl(snd(cmpXchg($e1, $e2, $e3))) )
   | `(hl(xchg($e1, $e2))) => `(Exp.xchg hl($e1) hl($e2))
   | `(hl(faa($e1, $e2))) => `(Exp.faa hl($e1) hl($e2))
   | `(hl(fork($e1))) => `(Exp.fork hl($e1))
@@ -365,7 +386,8 @@ def unexpInjr : Unexpander
 
 @[app_unexpander Exp.case]
 def unexpCase : Unexpander
-  | `($_ $e1 hl((λ $i2, $e2)) hl((λ $i3, $e3))) => do `(hl(case: $(← unpackHLExp e1) | $i2 => $e2 | $i3 => $e3))
+  | `($_ $e1 hl((λ $i2, $e2)) hl((λ $i3, $e3))) =>
+    do `( hl(match $(← unpackHLExp e1) with | injl($i2) => $e2 | injr($i3) => $e3) )
   | _ => throw ()
 
 partial def unexpRef : Term → UnexpandM Term

--- a/Iris/Iris/HeapLang/Notation.lean
+++ b/Iris/Iris/HeapLang/Notation.lean
@@ -13,6 +13,7 @@ namespace Iris.HeapLang
 open Lean Lean.PrettyPrinter Elab Parser
 
 declare_syntax_cat hl_exp
+declare_syntax_cat hl_match_arm
 declare_syntax_cat hl_val
 
 /-- embedding heaplang expressions into terms -/
@@ -34,6 +35,9 @@ syntax:max "(" hl_val ", " hl_val,+ ")" : hl_val
 syntax:100 "injl(" hl_val ")" : hl_val
 /-- injR -/
 syntax:100 "injr(" hl_val ")" : hl_val
+/-- none and some -/
+syntax:100 "none()" : hl_val
+syntax:100 "some(" hl_val ")" : hl_val
 
 /-- parenthesis -/
 syntax:max "(" hl_exp ")" : hl_exp
@@ -109,21 +113,24 @@ syntax:100 "fst(" hl_exp ")" : hl_exp
 /-- snd -/
 syntax:100 "snd(" hl_exp ")" : hl_exp
 
-/-- match -/
-syntax:100 "match " hl_exp:80 " with"
-  " | " "injl(" binderIdent ")" " => " hl_exp:80
-  " | " "injr(" binderIdent ")" " => " hl_exp:80 : hl_exp
 /-- injL -/
 syntax:100 "injl(" hl_exp ")" : hl_exp
 /-- injR -/
 syntax:100 "injr(" hl_exp ")" : hl_exp
 
-/-- none and some-/
-syntax:100 "match " hl_exp:80 " with"
-  " | " "none()" " => " hl_exp:80
-  " | " "some(" binderIdent ")" " => " hl_exp:80 : hl_exp
+/-- none and some -/
 syntax:100 "none()" : hl_exp
 syntax:100 "some(" hl_exp ")" : hl_exp
+
+/-- match -/
+syntax:100 "match " hl_exp:80 " with"
+  " | " hl_match_arm " => " hl_exp:80
+  " | " hl_match_arm " => " hl_exp:80 : hl_exp
+
+syntax "injl(" binderIdent ")" : hl_match_arm
+syntax "injr(" binderIdent ")" : hl_match_arm
+syntax "some(" binderIdent ")" : hl_match_arm
+syntax "none()" : hl_match_arm
 
 /-- heap operations -/
 syntax:100 "allocn(" hl_exp ", " hl_exp ")" : hl_exp
@@ -172,6 +179,8 @@ macro_rules
   | `(hl_val(($e1, $e2, $e3,*))) => `(hl_val(($e1, ($e2, $e3,*))))
   | `(hl_val(injl($e1))) => `(Val.injL hl_val($e1))
   | `(hl_val(injr($e1))) => `(Val.injR hl_val($e1))
+  | `(hl_val(none())) => `(hl_val(injl(#())))
+  | `(hl_val(some($e))) => `(hl_val(injr($e)))
 
 /-- elaborating expressions -/
 macro_rules
@@ -195,15 +204,15 @@ macro_rules
   | `(hl($e1 ≤ $e2)) => `(Exp.binop BinOp.le hl($e1) hl($e2))
   | `(hl($e1 < $e2)) => `(Exp.binop BinOp.lt hl($e1) hl($e2))
   | `(hl($e1 = $e2)) => `(Exp.binop BinOp.eq hl($e1) hl($e2))
-  | `(hl($e1 && $e2)) => `( hl(if $e1 then $e2 else #false) )
-  | `(hl($e1 || $e2)) => `( hl(if $e1 then true else $e2) )
+  | `(hl($e1 && $e2)) => `(hl(if $e1 then $e2 else #false))
+  | `(hl($e1 || $e2)) => `(hl(if $e1 then #true else $e2))
   | `(hl(~$e1)) => `(Exp.unop UnOp.neg hl($e1))
   | `(hl(-$e1)) => `(Exp.unop UnOp.minus hl($e1))
   | `(hl(if $e1 then $e2 else $e3)) => `(Exp.if hl($e1) hl($e2) hl($e3))
   | `(hl($e1 $e2)) => `(Exp.app hl($e1) hl($e2))
   | `(hl(rec $f $x := $e)) => do `(Exp.rec_ hl_binder($f) hl_binder($x) hl($e))
-  | `(hl(rec $f $x $xs* := $e)) => do `(hl(rec $f $x := λ $xs*, $e))
-  | `(hl(λ $xs*, $e)) => do `(hl(rec _ $xs* := $e))
+  | `(hl(rec $f $x $xs* := $e)) => `(hl(rec $f $x := λ $xs*, $e))
+  | `(hl(λ $xs*, $e)) => `(hl(rec _ $xs* := $e))
   | `(hl($e1; $e2)) => `(hl(let _ := $e1; $e2))
   | `(hl(let $i := $e1; $e2)) => `(hl((λ $i, $e2) $e1))
   | `(hl(($e1, $e2))) => `(Exp.pair hl($e1) hl($e2))
@@ -212,19 +221,26 @@ macro_rules
   | `(hl(snd($e1))) => `(Exp.snd hl($e1))
   | `(hl(match $e1 with | injl($i2) => $e2 | injr($i3) => $e3)) =>
     `(Exp.case hl($e1) hl(λ $i2, $e2) hl(λ $i3, $e3))
+  | `(hl(match $e1 with | injr($i2) => $e2 | injl($i3) => $e3)) =>
+    `(hl(match $e1 with | injl($i3) => $e3 | injr($i2) => $e2))
+  -- TODO: Why does the following not work?
+  -- | `(hl_match_arm | none()) => `(hl_match_arm | injl(_))
+  -- | `(hl_match_arm | some($i)) => `(hl_match_arm | injr($i))
+  | `(hl(match $e1 with | some($i2) => $e2 | none() => $e3)) =>
+    `(hl(match $e1 with | injr($i2) => $e2 | injl(_) => $e3))
   | `(hl(match $e1 with | none() => $e2 | some($i3) => $e3)) =>
-    `(Exp.case hl($e1) hl(λ _, $e2) hl(λ $i3, $e3))
+    `(hl(match $e1 with | injl(_) => $e2 | injr($i3) => $e3))
   | `(hl(injl($e1))) => `(Exp.injL hl($e1))
   | `(hl(injr($e1))) => `(Exp.injR hl($e1))
-  | `(hl(none())) => `( hl(injl(#())) )
-  | `(hl(some($e))) => `( hl(injr($e)) )
+  | `(hl(none())) => `(hl(injl(#())))
+  | `(hl(some($e))) => `(hl(injr($e)))
   | `(hl(allocn($e1, $e2))) => `(Exp.allocN hl($e1) hl($e2))
   | `(hl(ref($e1))) => `(hl(allocn(#1, $e1)))
   | `(hl(free($e1))) => `(Exp.free hl($e1))
   | `(hl(! $e1)) => `(Exp.load hl($e1))
   | `(hl($e1 ← $e2)) => `(Exp.store hl($e1) hl($e2))
   | `(hl(cmpXchg($e1, $e2, $e3))) => `(Exp.cmpXchg hl($e1) hl($e2) hl($e3))
-  | `(hl(cas($e1, $e2, $e3))) => `( hl(snd(cmpXchg($e1, $e2, $e3))) )
+  | `(hl(cas($e1, $e2, $e3))) => `(hl(snd(cmpXchg($e1, $e2, $e3))))
   | `(hl(xchg($e1, $e2))) => `(Exp.xchg hl($e1) hl($e2))
   | `(hl(faa($e1, $e2))) => `(Exp.faa hl($e1) hl($e2))
   | `(hl(fork($e1))) => `(Exp.fork hl($e1))

--- a/Iris/Iris/Tests/HeapLang.lean
+++ b/Iris/Iris/Tests/HeapLang.lean
@@ -180,9 +180,9 @@ set_option pp.explicit true in
 #guard_msgs in
 #check hl(fst(snd((#1, #2, #3))))
 
-/-- info: hl(case: injl(injr(#1)) | _ => #1 | y => #2) : Exp -/
+/-- info: hl(match injl(injr(#1)) with | injl(_) => #1 | injr(y) => #2) : Exp -/
 #guard_msgs in
-#check hl(case: injl(injr(#1)) | _ => #1 | y => #2)
+#check hl(match injl(injr(#1)) with | injl(_) => #1 | injr(y) => #2)
 
 /-- info: hl_val(injl(injr(#1))) : Val -/
 #guard_msgs in

--- a/Iris/Iris/Tests/HeapLang.lean
+++ b/Iris/Iris/Tests/HeapLang.lean
@@ -150,6 +150,13 @@ set_option pp.explicit true in
 #guard_msgs in
 #check hl(if #1 then #2 else #3)
 
+/--
+info: hl(if if a then b else #(BaseLit.bool false) then #(BaseLit.bool true) else
+    if c then d else #(BaseLit.bool false)) : Exp
+-/
+#guard_msgs in
+#check hl(a && b || c && d)
+
 /-- info: hl((#1, #2, #3)) : Exp -/
 #guard_msgs in
 #check hl((#1, #2, #3))
@@ -184,18 +191,35 @@ set_option pp.explicit true in
 #guard_msgs in
 #check hl(match injl(injr(#1)) with | injl(_) => #1 | injr(y) => #2)
 
+/-- info: hl(match injl(injr(#1)) with | injl(y) => #2 | injr(_) => #1) : Exp -/
+#guard_msgs in
+#check hl(match injl(injr(#1)) with | injr(_) => #1 | injl(y) => #2)
+
+/-- info: hl(match injr(injl(#BaseLit.unit)) with | injl(_) => #2 | injr(_) => #1) : Exp -/
+#guard_msgs in
+#check hl(match some(none()) with | some(_) => #1 | none() => #2)
+
+/-- info: hl(match injr(injl(#BaseLit.unit)) with | injl(_) => #1 | injr(x) => #2) : Exp -/
+#guard_msgs in
+#check hl(match some(none()) with | none() => #1 | some(x) => #2)
+
 /-- info: hl_val(injl(injr(#1))) : Val -/
 #guard_msgs in
 #check hl_val(injl(injr(#1)))
+
+/-- info: hl_val(injr(injl(#BaseLit.unit))) : Val -/
+#guard_msgs in
+#check hl_val(some(none()))
 
 
 /--
 info: hl(let x := ref(#0);
     let y := allocn(!x, #0);
-      x ← (!x + #1); fork(cmpXchg(x, #1, #2); xchg(x, #2); faa(x, #4)); assert((!x = #0)); free(x)) : Exp
+      x ← (!x + #1);
+        fork(cmpXchg(x, #1, #2); snd(cmpXchg(x, #1, #2)); xchg(x, #2); faa(x, #4)); assert((!x = #0)); free(x)) : Exp
 -/
 #guard_msgs in
-#check hl(let x := ref(#0); let y := allocn(!x, #0); x ← !x + #1; fork(cmpXchg(x, #1, #2); xchg(x, #2); faa(x, #4)); assert(!x = #0); free(x))
+#check hl(let x := ref(#0); let y := allocn(!x, #0); x ← !x + #1; fork(cmpXchg(x, #1, #2); cas(x, #1, #2); xchg(x, #2); faa(x, #4)); assert(!x = #0); free(x))
 
 /--
 info: (Exp.rec_ Binder.anon (Binder.named "x")


### PR DESCRIPTION
## Description

Add some notation used in iris-tutorial. ~~Also change `case: $e` syntax to `case $e with`.~~

The `case:` notation is replaced with a notation that more closely matches Rocq Iris notation and Lean syntax.

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [ ] I have updated `PORTING.md` as appropriate
* [ ] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
