### PR TITLE
feat: iframe tactic and input/output handling for IPM synthesis

### DIFF
--- a/Iris/Iris/Examples/IProp.lean
+++ b/Iris/Iris/Examples/IProp.lean
@@ -41,9 +41,7 @@ example : ⊢ |==> ∃ (γ0 γ1 : GName) (s0 s1 : String),
 
   -- Complete the Iris proof
   iexists γ0, γ1, "string0", "string1"
-  isplitl [Hγ0]
-  · iexact Hγ0
-  · iexact Hγ1
+  iframe
 
 
 end Example1
@@ -165,9 +163,7 @@ example (e e' : Expr) Φ (Hstep : ∀ {s : State}, @step _ _ Value _ (e, s) = (e
   · ipure_intro
     exact Hstep
   · iintro !> !>
-    isplitl [Hs]
-    · iexact Hs
-    · iexact Hspec
+    iframe
 
 /- The pattern of rules for stateful steps, for example, writing to a piece of memory.
    This style of rule applies when ownership over a resource P (eg. k ↦[γ] v) ensures that the state
@@ -183,16 +179,15 @@ example (e e' : Expr) (P P' : IProp GF) Φ
   iright
   iintro %s Hs
   ihave ⟨%s', %Hstep, Hupd⟩ := Hstep s $$ [HP Hs]
-  . isplitl [HP] <;> iassumption
+  . iframe
   iexists e', s'
   isplitr
   · ipure_intro; exact Hstep
   iintro !>
   imod Hupd with ⟨HP', Hs⟩
   iintro !>
-  isplitl [Hs]
-  · iexact Hs
-  · iapply Hspec $$ HP'
+  iframe
+  iapply Hspec $$ HP'
 
 /- Looping programs, by Löb induction -/
 example (e : Expr) Φ (Hloop : ∀ σ : State, step Value (e, σ) = (e, σ)) :
@@ -206,9 +201,7 @@ example (e : Expr) Φ (Hloop : ∀ σ : State, step Value (e, σ) = (e, σ)) :
   isplitr
   · ipure_intro; exact Hloop s
   iintro !> !>
-  isplitl [Hs]
-  · iassumption
-  · iassumption
+  iframe
   · exact true_intro
 
 end Example3

--- a/Iris/Iris/Examples/Proofs.lean
+++ b/Iris/Iris/Examples/Proofs.lean
@@ -23,7 +23,7 @@ theorem proof_example_1 [BI PROP] (P Q R : PROP) (Φ : α → PROP) :
   isplitr
   · iassumption
   isplitl [HP]
-  · iexact HP
+  · iframe
   · iexact HQ
 
 end Iris.Examples

--- a/Iris/Iris/Instances/Lib/FUpd.lean
+++ b/Iris/Iris/Instances/Lib/FUpd.lean
@@ -70,76 +70,56 @@ instance uPred_bi_fupd {GF : BundledGFunctors} [InvGS_gen hlc GF] : BIFUpdate (I
   fupd := uPred_fupd
   subset Hsub := by
     simp only [uPred_fupd]
-    iintro ⟨Hwsat, HE⟩
+    iintro ⟨$, HE⟩
     rw [diff_subset_decomp Hsub]
-    ihave ⟨HE1, HE2⟩ := (ownE_op (disjoint_symm disjoint_diff_right)).mp $$ HE
-    imodintro; imodintro
-    isplitl [Hwsat]; iassumption
-    isplitl [HE2]; iassumption
-    iintro ⟨Hwsat, HE⟩
-    imodintro; imodintro
-    isplitl [Hwsat]; iassumption
-    ihave HE := (ownE_op (disjoint_symm disjoint_diff_right)).mpr $$ [HE1 HE]
-    · isplitl [HE1] <;> iassumption
-    isplitl [HE]; iassumption
-    simp
+    ihave ⟨HE1, $⟩ := (ownE_op (disjoint_symm disjoint_diff_right)).mp $$ HE
+    iintro !> !>
+    iintro ⟨$, HE⟩ !> !>
+    ihave $ := (ownE_op (disjoint_symm disjoint_diff_right)).mpr $$ [$]
   except0 {E1 E2 P} := by
     simp only [uPred_fupd]
     iintro >H; iexact H
   mono H := by
     simp only [uPred_fupd]
     iintro H ⟨Hwsat, HE⟩
-    ihave H := H $$ [Hwsat HE]; isplitl [Hwsat] <;> iassumption
+    ihave H := H $$ [$]
     iapply le_upd_if_mono $$ H
-    iintro >⟨H1, H2, H3⟩; imodintro
-    isplitl [H1]; iassumption
-    isplitl [H2]; iassumption
+    iintro >⟨$, $, H3⟩ !>
     iapply H $$ H3
   trans {_ _ _ _} := by
     simp only [uPred_fupd]
     iintro H ⟨Hwsat, HE⟩
     iapply le_upd_if_trans
-    ihave H := H $$ [Hwsat HE]; isplitl [Hwsat] <;> iassumption
+    ihave H := H $$ [$]
     iapply le_upd_if_mono $$ H
     iintro >⟨H1, H2, H3⟩
-    iapply H3 $$ [H1 H2]; isplitl [H1] <;> iassumption
+    iapply H3 $$ [$]
   mask_frame_r' {_ _ _ _} Hdisj := by
     simp only [uPred_fupd]
     iintro H ⟨Hwsat, HE⟩
     ihave ⟨HE1, HE2⟩ := ownE_op Hdisj $$ HE
-    ihave >H := H $$ [Hwsat HE1]; isplitl [Hwsat] <;> iassumption
+    ihave >H := H $$ [$]
     imodintro
-    imod H with ⟨H1, H2, H3⟩; imodintro
-    ihave ⟨%Hdisj, HE⟩ := ownE_op_iff.mpr $$ [H2 HE2]
-    · isplitl [H2] <;> iassumption
-    isplitl [H1]; iassumption
-    isplitl [HE]; iassumption
+    imod H with ⟨$, H2, H3⟩; imodintro
+    ihave ⟨%Hdisj, $⟩ := ownE_op_iff.mpr $$ [H2 HE2]
+    · iframe
     iapply H3
     ipure_intro; assumption
   frame_r {_ _ _ _} := by
     simp only [uPred_fupd]
     iintro ⟨H, Hx⟩ ⟨Hwsat, HE⟩
-    ispecialize H $$ [Hwsat HE]; isplitl [Hwsat] <;> iassumption
-    ihave H := le_upd_if_frame_r $$ [H Hx]
-    · isplitl [H]
-      · iexact H
-      · iexact Hx
-    imod H with ⟨>⟨H1, H2, H3⟩, H4⟩; imodintro
-    imodintro
-    isplitl [H1]; iassumption
-    isplitl [H2]; iassumption
-    isplitl [H3]; iassumption
-    iassumption
+    ispecialize H $$ [$]
+    ihave H := le_upd_if_frame_r $$ [$H $Hx]
+    imod H with ⟨>⟨$, $, $⟩, $⟩; imodintro
+    ipure_intro; trivial
 
 @[rocq_alias uPred_bi_bupd_fupd]
 instance {GF : BundledGFunctors} [InvGS_gen hlc GF] : BIUpdateFUpdate (IProp GF) where
   fupd_of_bupd {_ _} := by
     iintro H
     simp only [fupd, uPred_fupd]
-    iintro ⟨Hwsat, HE⟩
+    iintro ⟨$, $⟩
     imod H; imodintro; imodintro
-    isplitl [Hwsat]; iassumption
-    isplitl [HE]; iassumption
     iassumption
 
 @[rocq_alias uPred_bi_fupd_sbi_no_lc]
@@ -149,35 +129,26 @@ instance uPred_bi_fupd_plainly_no_lc {GF : BundledGFunctors} [INV : InvGS_gen fa
     simp only [fupd, uPred_fupd, le_upd_if, Bool.false_eq_true, ↓reduceIte]
     iintro ⟨H, Hx⟩ ⟨Hwsat, HE⟩
     ihave #>HP : ◇ ■ P $$ [H Hx Hwsat HE]
-    · imod H $$ Hx [Hwsat HE] with ⟨_, _, H⟩
-      · isplitl [Hwsat] <;> iassumption
-      iexact H
+    · imod H $$ Hx [$] with ⟨_, _, $⟩
     imodintro
-    isplitl [Hwsat]; iassumption
-    isplitl [HE]; iassumption
-    isplitl [HP] <;> iassumption
+    iframe
+    iassumption
   fupd_plainly_later _ P := by
     simp only [fupd, uPred_fupd, le_upd_if, Bool.false_eq_true, ↓reduceIte]
     iintro H ⟨Hwsat, HE⟩
     ihave #HP : ▷ ◇ ■ P $$ [H Hwsat HE]
     · inext
-      imod H $$ [Hwsat HE] with ⟨_, _, H⟩
-      · isplitl [Hwsat] <;> iassumption
-      iexact H
+      imod H $$ [$] with ⟨_, _, $⟩
     imodintro
-    isplitl [Hwsat]; iassumption
-    isplitl [HE]; iassumption
+    iframe
     imodintro; inext; imod HP; imodintro; iassumption
   fupd_plainly_sForall_2 E P := by
     simp only [fupd, uPred_fupd, le_upd_if, Bool.false_eq_true, ↓reduceIte]
     iintro H ⟨Hwsat, HE⟩
     ihave #HP : ◇ ■ sForall P $$ [H Hwsat HE]
-    · imod H $$ [Hwsat HE] with ⟨_, _, H⟩
-      · isplitl [Hwsat] <;> iassumption
-      iexact H
+    · imod H $$ [$] with ⟨_, _, $⟩
     imodintro; imod HP; imodintro
-    isplitl [Hwsat]; iassumption
-    isplitl [HE]; iassumption
+    iframe
     iclear H
     iexact HP
 
@@ -326,14 +297,8 @@ theorem step_fupdN_soundness_lc [InvGpreS GF] (n m : Nat) {P : IProp GF} [Plain 
     simp only [Nat.repeat]
     iintro ⟨⟨Hcr, Hcrs⟩, >H⟩
     imod lc_fupd_elim_later $$ Hcr H with >H
-    -- FIXME: direct iapply doesn't work
-    ihave IH : £ n ∗ (|={∅}▷=>^[n] P) -∗ |={∅}=> P $$ []
-    · refine wand_intro ?_
-      refine sep_elim_r.trans ?_
-      exact IH
-    iapply IH $$ [Hcrs H]
-    isplitl [Hcrs]; iassumption
-    iassumption
+    iapply IH
+    iframe
 
 @[rocq_alias step_fupdN_soundness_gen]
 theorem step_fupdN_soundness_gen [InvGpreS GF] (n m : Nat) {P : IProp GF} [Plain P] hlc :
@@ -395,14 +360,8 @@ theorem step_fupdN_soundness_lc' [InvGpreS GF] (n m : Nat) {P : IProp GF} [Plain
     simp only [Nat.repeat]
     iintro ⟨⟨Hcr, Hcrs⟩, >H⟩
     imod lc_fupd_elim_later $$ Hcr H with >H
-    -- FIXME: direct iapply doesn't work
-    ihave IH : £ n ∗ (|={⊤}[∅]▷=>^[n] P) -∗ |={⊤}=> P $$ []
-    · refine wand_intro ?_
-      refine sep_elim_r.trans ?_
-      exact IH
-    iapply IH $$ [Hcrs H]
-    isplitl [Hcrs]; iassumption
-    iassumption
+    iapply IH
+    iframe
 
 end StepIndexed
 

--- a/Iris/Iris/Instances/Lib/LaterCredits.lean
+++ b/Iris/Iris/Instances/Lib/LaterCredits.lean
@@ -14,7 +14,7 @@ public import Iris.Instances.IProp
 @[expose] public section
 
 /-! ## Later credits
-TODO: missing instances for PM: frame_le_upd, frame_le_upd_if, combine_sep_lc_add, combine_sep_lc_S_l
+TODO: missing instances for PM: combine_sep_lc_add, combine_sep_lc_S_l
 -/
 
 namespace Iris
@@ -407,7 +407,7 @@ instance from_assumption_le_upd {p} {P Q : IProp GF} [h : FromAssumption p ioP P
   from_assumption := h.1.trans le_upd_intro
 
 @[rocq_alias le_upd.from_pure_le_upd]
-instance {P : IProp GF} [H : FromPure a P φ] : FromPure a (le_upd P) φ where
+instance {io} {P : IProp GF} [H : FromPure a P io φ] : FromPure a (le_upd P) io φ where
   from_pure := by
     cases a <;> dsimp
     · iintro H
@@ -440,6 +440,10 @@ instance {P : IProp GF} : ElimModal True p false (le_upd P) P (le_upd Q) (le_upd
       iapply le_upd_bind $$ H2 H1
     · iintro ⟨H1, H2⟩
       iapply le_upd_bind $$ H2 H1
+
+@[rocq_alias le_upd.frame_le_upd]
+instance {p} {P R Q : IProp GF} [hf : Frame p R P Q] : Frame p R (le_upd P) (le_upd Q) where
+  frame := le_upd_frame_l.trans <| le_upd_mono hf.frame
 
 end Internal
 
@@ -551,7 +555,7 @@ instance {b} {p} {P Q : IProp GF} : ElimModal True p false (bupd P) P (le_upd_if
   cases b <;> (simp only [le_upd_if, Bool.false_eq_true, ↓reduceIte]; infer_instance)
 
 @[rocq_alias le_upd_if.from_pure_le_upd_if]
-instance {b} {a} {P : IProp GF} φ [FromPure a P φ] : FromPure a (le_upd_if b P) φ := by
+instance {b} {a} {io} {P : IProp GF} φ [FromPure a P io φ] : FromPure a (le_upd_if b P) io φ := by
   cases b <;> (simp only [le_upd_if, Bool.false_eq_true, ↓reduceIte]; infer_instance)
 
 @[rocq_alias le_upd_if.is_except_0_le_upd_if]
@@ -566,6 +570,10 @@ instance {b} {P : IProp GF} : FromModal True modality_id (le_upd_if b P) (le_upd
 instance {b} {p} {P Q : IProp GF} :
   ElimModal True p false (le_upd_if b P) P (le_upd_if b Q) (le_upd_if b Q) := by
   cases b <;> (simp only [le_upd_if, Bool.false_eq_true, ↓reduceIte]; infer_instance)
+
+@[rocq_alias le_upd_if.frame_le_upd_if]
+instance {p b} {P R Q : IProp GF} [hf : Frame p R P Q] : Frame p R (le_upd_if b P) (le_upd_if b Q) where
+  frame := le_upd_if_frame_l.trans <| le_upd_if_mono hf.frame
 
 @[rocq_alias le_upd_if.from_assumption_le_upd_if]
 instance from_assumption_le_upd_if {p} {P Q : IProp GF} [h : FromAssumption p ioP P Q] : FromAssumption p ioP P (le_upd_if b Q) where

--- a/Iris/Iris/Instances/Lib/LaterCredits.lean
+++ b/Iris/Iris/Instances/Lib/LaterCredits.lean
@@ -407,7 +407,7 @@ instance from_assumption_le_upd {p} {P Q : IProp GF} [h : FromAssumption p ioP P
   from_assumption := h.1.trans le_upd_intro
 
 @[rocq_alias le_upd.from_pure_le_upd]
-instance {io} {P : IProp GF} [H : FromPure a P io φ] : FromPure a (le_upd P) io φ where
+instance {P : IProp GF} [H : FromPure .out a P io φ] : FromPure ioA a (le_upd P) io φ where
   from_pure := by
     cases a <;> dsimp
     · iintro H
@@ -555,7 +555,7 @@ instance {b} {p} {P Q : IProp GF} : ElimModal True p false (bupd P) P (le_upd_if
   cases b <;> (simp only [le_upd_if, Bool.false_eq_true, ↓reduceIte]; infer_instance)
 
 @[rocq_alias le_upd_if.from_pure_le_upd_if]
-instance {b} {a} {io} {P : IProp GF} φ [FromPure a P io φ] : FromPure a (le_upd_if b P) io φ := by
+instance {b} {a} {P : IProp GF} φ [FromPure .out a P io φ] : FromPure ioA a (le_upd_if b P) io φ := by
   cases b <;> (simp only [le_upd_if, Bool.false_eq_true, ↓reduceIte]; infer_instance)
 
 @[rocq_alias le_upd_if.is_except_0_le_upd_if]

--- a/Iris/Iris/Instances/Lib/LaterCredits.lean
+++ b/Iris/Iris/Instances/Lib/LaterCredits.lean
@@ -407,7 +407,7 @@ instance from_assumption_le_upd {p} {P Q : IProp GF} [h : FromAssumption p ioP P
   from_assumption := h.1.trans le_upd_intro
 
 @[rocq_alias le_upd.from_pure_le_upd]
-instance {P : IProp GF} [H : FromPure .out a P io φ] : FromPure ioA a (le_upd P) io φ where
+instance {P : IProp GF} [H : FromPure a P io φ] : FromPure a (le_upd P) io φ where
   from_pure := by
     cases a <;> dsimp
     · iintro H
@@ -555,7 +555,7 @@ instance {b} {p} {P Q : IProp GF} : ElimModal True p false (bupd P) P (le_upd_if
   cases b <;> (simp only [le_upd_if, Bool.false_eq_true, ↓reduceIte]; infer_instance)
 
 @[rocq_alias le_upd_if.from_pure_le_upd_if]
-instance {b} {a} {P : IProp GF} φ [FromPure .out a P io φ] : FromPure ioA a (le_upd_if b P) io φ := by
+instance {b} {a} {P : IProp GF} φ [FromPure a P io φ] : FromPure a (le_upd_if b P) io φ := by
   cases b <;> (simp only [le_upd_if, Bool.false_eq_true, ↓reduceIte]; infer_instance)
 
 @[rocq_alias le_upd_if.is_except_0_le_upd_if]

--- a/Iris/Iris/ProofMode.lean
+++ b/Iris/Iris/ProofMode.lean
@@ -5,6 +5,7 @@ public import Iris.ProofMode.ClassesMake
 public meta import Iris.ProofMode.Display
 public meta import Iris.ProofMode.Expr
 public import Iris.ProofMode.Instances
+public import Iris.ProofMode.InstancesFrame
 public import Iris.ProofMode.InstancesLater
 public import Iris.ProofMode.InstancesMake
 public import Iris.ProofMode.InstancesPlainly

--- a/Iris/Iris/ProofMode/Classes.lean
+++ b/Iris/Iris/ProofMode/Classes.lean
@@ -18,27 +18,18 @@ open Iris.BI
   that have pure preconditions (such as [ElimModal]) -/
 inductive PMError (msg : String) : Prop
 
-/-- [InOut] is used to dynamically determine whether a type class
-parameter is an input or an output. This is important for classes that
-are used with multiple modings, e.g., IntoWand. Instances can match on
-the InOut parameter to avoid accidentially instantiating outputs if
-matching on an input was intended. -/
-inductive InOut where
-  | in
-  | out
-
 inductive AsEmpValid.Direction where
   | into
   | from
 
 @[ipm_class]
-class AsEmpValid (d : AsEmpValid.Direction) (φ : Prop) {PROP : semiOutParam (Type _)} (P : outParam PROP) [semiOutParam (BI PROP)] where
+class AsEmpValid (d : AsEmpValid.Direction) (φ : Prop) (_ : InOut) (PROP : semiOutParam (Type _)) (_ : InOut) (bi : semiOutParam (BI PROP)) (P : outParam PROP) where
   as_emp_valid : (d = .into → φ → ⊢ P) ∧ (d = .from → (⊢ P) → φ)
 
-theorem asEmpValid_1 [BI PROP] (P : PROP) [AsEmpValid .into φ P] : φ → ⊢ P :=
-  AsEmpValid.as_emp_valid.1 rfl
-theorem asEmpValid_2 [BI PROP] (φ : Prop) [AsEmpValid .from φ (P : PROP)] : (⊢ P) → φ :=
-  AsEmpValid.as_emp_valid.2 rfl
+theorem asEmpValid_1 [bi : BI PROP] (P : PROP) [AsEmpValid .into φ .in PROP .in bi P] : φ → ⊢ P :=
+  (AsEmpValid.as_emp_valid .in .in).1 rfl
+theorem asEmpValid_2 [bi : BI PROP] (φ : Prop) [AsEmpValid .from φ .out PROP .out bi P] : (⊢ P) → φ :=
+  (AsEmpValid.as_emp_valid .out .out).2 rfl
 
 /- Depending on the use case, type classes with the prefix `From` or `Into` are used. Type classes
 with the prefix `From` are used to generate one or more propositions *from* which the original
@@ -52,7 +43,7 @@ class FromImp [BI PROP] (P : PROP) (Q1 Q2 : outParam PROP) where
 export FromImp (from_imp)
 
 @[ipm_class]
-class FromWand [BI PROP] (P : PROP) (Q1 Q2 : outParam PROP) where
+class FromWand [BI PROP] (P : PROP) (_ : InOut) (Q1 : semiOutParam PROP) (Q2 : outParam PROP) where
   from_wand : (Q1 -∗ Q2) ⊢ P
 export FromWand (from_wand)
 
@@ -140,7 +131,7 @@ class IntoPure [BI PROP] (P : PROP) (φ : outParam Prop) where
 export IntoPure (into_pure)
 
 @[ipm_class]
-class FromPure [BI PROP] (a : outParam Bool) (P : PROP) (φ : outParam Prop) where
+class FromPure [BI PROP] (a : outParam Bool) (P : PROP) (_ : InOut) (φ : semiOutParam Prop) where
   from_pure : <affine>?a ⌜φ⌝ ⊢ P
 export FromPure (from_pure)
 
@@ -154,9 +145,12 @@ class IntoExcept0 [BI PROP] (P : PROP) (Q : outParam PROP) where
   into_except0 : P ⊢ ◇ Q
 export IntoExcept0 (into_except0)
 
-/-- `FromModal` turns a goal `P : PROP2` into a modality `M : PROP1 → PROP2` applied to `Q : PROP1` under condition `φ`. -/
+/-- `FromModal` turns a goal `P : PROP2` into a modality `M : PROP1 → PROP2` applied to `Q : PROP1` under condition `φ`.
+
+`sel` is an input that can be provided by the user to match on the desired modality to introduce. It needs to be an `outParam` to make Lean happy since `PROP1` is an `outParam`. For the IPM TC synthesis, it needs to be an `uncheckedInParam` since it should match all modalities if the user provides an mvar.
+ -/
 @[ipm_class]
-class FromModal {PROP1 PROP2} [BI PROP1] [BI PROP2] (φ : outParam $ Prop) (M : outParam $ Modality PROP1 PROP2) (sel : semiOutParam PROP1) (P : PROP2) (Q : outParam $ PROP1) where
+class FromModal {PROP1 : outParam (Type _)} {PROP2} [outParam (BI PROP1)] [BI PROP2] (φ : outParam $ Prop) (M : outParam $ Modality PROP1 PROP2) (sel : outParam (uncheckedInParam PROP1)) (P : PROP2) (Q : outParam $ PROP1) where
   from_modal : φ → M.M Q ⊢ P
 export FromModal (from_modal)
 
@@ -165,6 +159,11 @@ export FromModal (from_modal)
 class ElimModal {PROP} [BI PROP] (φ : outParam $ Prop) (p : Bool) (p' : outParam Bool) (P : PROP) (P' : outParam PROP) (Q : PROP) (Q' : outParam PROP) where
   elim_modal : φ → □?p P ∗ (□?p' P' -∗ Q') ⊢ Q
 export ElimModal (elim_modal)
+
+@[ipm_class]
+class Frame {PROP} [BI PROP] (p : Bool) (R P : PROP) (Q : outParam PROP) where
+  frame : □?p R ∗ Q ⊢ P
+export Frame (frame)
 
 
 /-- `IntoLaterN` turns `P` into `▷^[n] Q`.

--- a/Iris/Iris/ProofMode/Classes.lean
+++ b/Iris/Iris/ProofMode/Classes.lean
@@ -133,7 +133,7 @@ class IntoPure {PROP} [BI PROP] (P : PROP) (φ : outParam Prop) where
 export IntoPure (into_pure)
 
 @[ipm_class]
-class FromPure {PROP} [BI PROP] (ioA : InOut) (a : semiOutParam $ Bool) (P : PROP) (ioφ : InOut) (φ : semiOutParam $ Prop) where
+class FromPure {PROP} [BI PROP] (a : outParam $ Bool) (P : PROP) (ioφ : InOut) (φ : semiOutParam $ Prop) where
   from_pure : <affine>?a ⌜φ⌝ ⊢ P
 export FromPure (from_pure)
 

--- a/Iris/Iris/ProofMode/Classes.lean
+++ b/Iris/Iris/ProofMode/Classes.lean
@@ -14,8 +14,10 @@ public import Iris.ProofMode.Modalities
 namespace Iris.ProofMode
 open Iris.BI
 
-/-- [PMError] is used as precondition on "failing" instances of typeclasses
-  that have pure preconditions (such as [ElimModal]) -/
+/--
+[PMError] is used as precondition on "failing" instances of typeclasses that
+have pure preconditions (such as [ElimModal])
+-/
 inductive PMError (msg : String) : Prop
 
 inductive AsEmpValid.Direction where
@@ -23,13 +25,14 @@ inductive AsEmpValid.Direction where
   | from
 
 @[ipm_class]
-class AsEmpValid (d : AsEmpValid.Direction) (φ : Prop) (_ : InOut) (PROP : semiOutParam (Type _)) (_ : InOut) (bi : semiOutParam (BI PROP)) (P : outParam PROP) where
+class AsEmpValid (d : AsEmpValid.Direction) (φ : Prop) (_ : InOut) (PROP : semiOutParam $ Type _)
+(_ : InOut) (bi : semiOutParam $ BI PROP) (P : outParam $ PROP) where
   as_emp_valid : (d = .into → φ → ⊢ P) ∧ (d = .from → (⊢ P) → φ)
 
-theorem asEmpValid_1 [bi : BI PROP] (P : PROP) [AsEmpValid .into φ .in PROP .in bi P] : φ → ⊢ P :=
-  (AsEmpValid.as_emp_valid .in .in).1 rfl
-theorem asEmpValid_2 [bi : BI PROP] (φ : Prop) [AsEmpValid .from φ .out PROP .out bi P] : (⊢ P) → φ :=
-  (AsEmpValid.as_emp_valid .out .out).2 rfl
+theorem asEmpValid_1 {PROP} [bi : BI PROP] {φ : Prop} (P : PROP) [AsEmpValid .into φ .in PROP .in bi P]
+: φ → ⊢ P := (AsEmpValid.as_emp_valid .in .in).1 rfl
+theorem asEmpValid_2 {PROP} [bi : BI PROP] {P: PROP} (φ : Prop) [AsEmpValid .from φ .out PROP .out bi P]
+: (⊢ P) → φ := (AsEmpValid.as_emp_valid .out .out).2 rfl
 
 /- Depending on the use case, type classes with the prefix `From` or `Into` are used. Type classes
 with the prefix `From` are used to generate one or more propositions *from* which the original
@@ -38,147 +41,153 @@ proposition can be derived. Type classes with the prefix `Into` are used to gene
 used to indicate that certain propositions should be intuitionistic. -/
 
 @[ipm_class]
-class FromImp [BI PROP] (P : PROP) (Q1 Q2 : outParam PROP) where
+class FromImp {PROP} [BI PROP] (P : PROP) (Q1 Q2 : outParam $ PROP) where
   from_imp : (Q1 → Q2) ⊢ P
 export FromImp (from_imp)
 
 @[ipm_class]
-class FromWand [BI PROP] (P : PROP) (_ : InOut) (Q1 : semiOutParam PROP) (Q2 : outParam PROP) where
+class FromWand {PROP} [BI PROP] (P : PROP) (_ : InOut) (Q1 : semiOutParam PROP) (Q2 : outParam $ PROP) where
   from_wand : (Q1 -∗ Q2) ⊢ P
 export FromWand (from_wand)
 
 @[ipm_class]
-class IntoWand [BI PROP] (p q : Bool) (R : PROP)
+class IntoWand {PROP} [BI PROP] (p q : Bool) (R : PROP)
   (ioP : InOut) (P : semiOutParam PROP)
   (ioQ : InOut) (Q : semiOutParam PROP) where
   into_wand : □?p R ⊢ □?q P -∗ Q
 export IntoWand (into_wand)
 
 @[ipm_class]
-class FromForall [BI PROP] (P : PROP) {α : outParam (Sort _)} (Ψ : outParam <| α → PROP) where
+class FromForall {PROP} [BI PROP] (P : PROP) {α : outParam (Sort _)} (Ψ : outParam <| α → PROP) where
   from_forall : (∀ x, Ψ x) ⊢ P
 export FromForall (from_forall)
 
 @[ipm_class]
-class IntoForall [BI PROP] (P : PROP) {α : outParam (Sort _)} (Φ : outParam <| α → PROP) where
+class IntoForall {PROP} [BI PROP] (P : PROP) {α : outParam (Sort _)} (Φ : outParam <| α → PROP) where
   into_forall : P ⊢ ∀ x, Φ x
 export IntoForall (into_forall)
 
 @[ipm_class]
-class FromExists [BI PROP] (P : PROP) {α : outParam (Sort _)} (Φ : outParam <| α → PROP) where
+class FromExists {PROP} [BI PROP] (P : PROP) {α : outParam (Sort _)} (Φ : outParam <| α → PROP) where
   from_exists : (∃ x, Φ x) ⊢ P
 export FromExists (from_exists)
 
 @[ipm_class]
-class IntoExists [BI PROP] (P : PROP) {α : outParam (Sort _)} (Φ : outParam <| α → PROP) where
+class IntoExists {PROP} [BI PROP] (P : PROP) {α : outParam (Sort _)} (Φ : outParam <| α → PROP) where
   into_exists : P ⊢ ∃ x, Φ x
 export IntoExists (into_exists)
 
 @[ipm_class]
-class FromAnd [BI PROP] (P : PROP) (Q1 Q2 : outParam PROP) where
+class FromAnd {PROP} [BI PROP] (P : PROP) (Q1 Q2 : outParam $ PROP) where
   from_and : Q1 ∧ Q2 ⊢ P
 export FromAnd (from_and)
 
 @[ipm_class]
-class IntoAnd (p : Bool) [BI PROP] (P : PROP) (Q1 Q2 : outParam PROP) where
+class IntoAnd {PROP} [BI PROP] (p : Bool) (P : PROP) (Q1 Q2 : outParam $ PROP) where
   into_and : □?p P ⊢ □?p (Q1 ∧ Q2)
 export IntoAnd (into_and)
 
 @[ipm_class]
-class FromSep [BI PROP] (P : PROP) (Q1 Q2 : outParam PROP) where
+class FromSep {PROP} [BI PROP] (P : PROP) (Q1 Q2 : outParam $ PROP) where
   from_sep : Q1 ∗ Q2 ⊢ P
 export FromSep (from_sep)
 
 @[ipm_class]
-class IntoSep [BI PROP] (P : PROP) (Q1 Q2 : outParam PROP) where
+class IntoSep {PROP} [BI PROP] (P : PROP) (Q1 Q2 : outParam $ PROP) where
   into_sep : P ⊢ Q1 ∗ Q2
 export IntoSep (into_sep)
 
 @[ipm_class]
-class FromOr [BI PROP] (P : PROP) (Q1 Q2 : outParam PROP) where
+class FromOr {PROP} [BI PROP] (P : PROP) (Q1 Q2 : outParam $ PROP) where
   from_or : Q1 ∨ Q2 ⊢ P
 export FromOr (from_or)
 
 @[ipm_class]
-class IntoOr [BI PROP] (P : PROP) (Q1 Q2 : outParam PROP) where
+class IntoOr {PROP} [BI PROP] (P : PROP) (Q1 Q2 : outParam $ PROP) where
   into_or : P ⊢ Q1 ∨ Q2
 export IntoOr (into_or)
 
-
 @[ipm_class]
-class IntoPersistently (p : Bool) [BI PROP] (P : PROP) (Q : outParam PROP) where
+class IntoPersistently {PROP} [BI PROP] (p : Bool) (P : PROP) (Q : outParam $ PROP) where
   into_persistently : <pers>?p P ⊢ <pers> Q
 export IntoPersistently (into_persistently)
 
 @[ipm_class]
-class FromAffinely [BI PROP] (P : outParam PROP) (Q : PROP) (p : Bool := true) where
+class FromAffinely {PROP} [BI PROP] (P : outParam $ PROP) (Q : PROP) (p : Bool := true) where
   from_affinely : <affine>?p Q ⊢ P
 export FromAffinely (from_affinely)
 
 @[ipm_class]
-class IntoAbsorbingly [BI PROP] (P : outParam PROP) (Q : PROP) where
+class IntoAbsorbingly {PROP} [BI PROP] (P : outParam $ PROP) (Q : PROP) where
   into_absorbingly : P ⊢ <absorb> Q
 export IntoAbsorbingly (into_absorbingly)
 
 @[ipm_class]
-class FromAssumption (p : Bool) [BI PROP] (ioP : InOut) (P : semiOutParam PROP) (Q : PROP) where
+class FromAssumption {PROP} [BI PROP] (p : Bool) (ioP : InOut) (P : semiOutParam $ PROP) (Q : PROP) where
   from_assumption : □?p P ⊢ Q
 export FromAssumption (from_assumption)
 
 @[ipm_class]
-class IntoPure [BI PROP] (P : PROP) (φ : outParam Prop) where
+class IntoPure {PROP} [BI PROP] (P : PROP) (φ : outParam Prop) where
   into_pure : P ⊢ ⌜φ⌝
 export IntoPure (into_pure)
 
 @[ipm_class]
-class FromPure [BI PROP] (a : outParam Bool) (P : PROP) (_ : InOut) (φ : semiOutParam Prop) where
+class FromPure {PROP} [BI PROP] (ioA : InOut) (a : semiOutParam $ Bool) (P : PROP) (ioφ : InOut) (φ : semiOutParam $ Prop) where
   from_pure : <affine>?a ⌜φ⌝ ⊢ P
 export FromPure (from_pure)
 
 @[ipm_class]
-class IsExcept0 [BI PROP] (Q : PROP) where
+class IsExcept0 {PROP} [BI PROP] (Q : PROP) where
   is_except0 : ◇ Q ⊢ Q
 export IsExcept0 (is_except0)
 
 @[ipm_class]
-class IntoExcept0 [BI PROP] (P : PROP) (Q : outParam PROP) where
+class IntoExcept0 {PROP} [BI PROP] (P : PROP) (Q : outParam $ PROP) where
   into_except0 : P ⊢ ◇ Q
 export IntoExcept0 (into_except0)
 
-/-- `FromModal` turns a goal `P : PROP2` into a modality `M : PROP1 → PROP2` applied to `Q : PROP1` under condition `φ`.
+/--
+`FromModal` turns a goal `P : PROP2` into a modality `M : PROP1 → PROP2` applied to `Q : PROP1`
+under condition `φ`.
 
-`sel` is an input that can be provided by the user to match on the desired modality to introduce. It needs to be an `outParam` to make Lean happy since `PROP1` is an `outParam`. For the IPM TC synthesis, it needs to be an `uncheckedInParam` since it should match all modalities if the user provides an mvar.
- -/
+`sel` is an input that can be provided by the user to match on the desired modality to introduce.
+It needs to be an `outParam` to make Lean happy since `PROP1` is an `outParam`.
+For the IPM TC synthesis, it needs to be an `uncheckedInParam` since it should match all modalities
+if the user provides an mvar.
+-/
 @[ipm_class]
-class FromModal {PROP1 : outParam (Type _)} {PROP2} [outParam (BI PROP1)] [BI PROP2] (φ : outParam $ Prop) (M : outParam $ Modality PROP1 PROP2) (sel : outParam (uncheckedInParam PROP1)) (P : PROP2) (Q : outParam $ PROP1) where
+class FromModal {PROP1 : outParam $ Type _} {PROP2} [outParam $ BI PROP1] [BI PROP2] (φ : outParam $ Prop)
+    (M : outParam $ Modality PROP1 PROP2) (sel : outParam <| uncheckedInParam $ PROP1) (P : PROP2)
+    (Q : outParam $ PROP1) where
   from_modal : φ → M.M Q ⊢ P
 export FromModal (from_modal)
 
 /-- `ElimModal` turns `□?p P` into `□?p' P'` and `Q` into `Q'` under condition `φ`. -/
 @[ipm_class]
-class ElimModal {PROP} [BI PROP] (φ : outParam $ Prop) (p : Bool) (p' : outParam Bool) (P : PROP) (P' : outParam PROP) (Q : PROP) (Q' : outParam PROP) where
+class ElimModal {PROP} [BI PROP] (φ : outParam $ Prop) (p : Bool) (p' : outParam $ Bool) (P : PROP)
+    (P' : outParam $ PROP) (Q : PROP) (Q' : outParam $ PROP) where
   elim_modal : φ → □?p P ∗ (□?p' P' -∗ Q') ⊢ Q
 export ElimModal (elim_modal)
 
 @[ipm_class]
-class Frame {PROP} [BI PROP] (p : Bool) (R P : PROP) (Q : outParam PROP) where
+class Frame {PROP} [BI PROP] (p : Bool) (R P : PROP) (Q : outParam $ PROP) where
   frame : □?p R ∗ Q ⊢ P
 export Frame (frame)
 
+/--
+`IntoLaterN` turns `P` into `▷^[n] Q`.
+The Boolean [only_head] indicates whether laters should only be stripped in head position or also below
+other logical connectives. For [inext] it should strip laters below other logical connectives,
+but this should not happen while framing.
 
-/-- `IntoLaterN` turns `P` into `▷^[n] Q`.
-The Boolean [only_head] indicates whether laters should only be stripped in
-head position or also below other logical connectives. For [inext] it should
-strip laters below other logical connectives, but this should not happen while
-framing.
-
-The Rocq version uses an `MaybeIntoLaterN` typeclass that avoids unfolding definitions
-for searches that do not make progress. But this is not necessary in Lean since Lean
-TC synthesis does not unfold definitions by default.
+The Rocq version uses an `MaybeIntoLaterN` typeclass that avoids unfolding definitions for searches
+that do not make progress. But this is not necessary in Lean since Lean TC synthesis does not unfold
+definitions by default.
 
 This classes is deliberately not an `ipm_class` to use the more efficient TC synthesis.
 -/
-class IntoLaterN [BI PROP] (only_head : Bool) (n : Nat) (P : PROP) (Q : outParam PROP) where
+class IntoLaterN {PROP} [BI PROP] (only_head : Bool) (n : Nat) (P : PROP) (Q : outParam $ PROP) where
   into_laterN : P ⊢ ▷^[n] Q
 export IntoLaterN (into_laterN)
 

--- a/Iris/Iris/ProofMode/ClassesMake.lean
+++ b/Iris/Iris/ProofMode/ClassesMake.lean
@@ -13,27 +13,80 @@ public meta import Iris.ProofMode.SynthInstance
 namespace Iris.ProofMode
 open Iris.BI
 
+/-- Aliases for [Affine] and [Absorbing], but the instances are severely
+restricted. They only inspect the top-level symbol or check if the whole BI
+is affine. -/
+@[rocq_alias QuickAffine]
+class QuickAffine [BI PROP] (P : PROP) where
+  quick_affine : Affine P
+export QuickAffine (quick_affine)
+@[rocq_alias QuickAbsorbing]
+class QuickAbsorbing [BI PROP] (P : PROP) where
+  quick_absorbing : Absorbing P
+export QuickAbsorbing (quick_absorbing)
+
+/-- The class [MakeSep P Q PQ] is used to compute `PQ := P ∗ Q`. -/
+@[ipm_class, rocq_alias MakeSep, rocq_alias KnownLMakeSep, rocq_alias KnownRMakeSep]
+class MakeSep [BI PROP] (P Q : PROP) (PQ : outParam PROP) where
+  make_sep : P ∗ Q ⊣⊢ PQ
+export MakeSep (make_sep)
+
+/-- The class [MakeAnd P Q PQ] is used to compute `PQ := P ∧ Q`. -/
+@[ipm_class, rocq_alias MakeAnd, rocq_alias KnownLMakeAnd, rocq_alias KnownRMakeAnd]
+class MakeAnd [BI PROP] (P Q : PROP) (PQ : outParam PROP) where
+  make_and : P ∧ Q ⊣⊢ PQ
+export MakeAnd (make_and)
+
+/-- The class [MakeOr P Q PQ] is used to compute `PQ := P ∨ Q`. -/
+@[ipm_class, rocq_alias MakeOr, rocq_alias KnownLMakeOr, rocq_alias KnownRMakeOr]
+class MakeOr [BI PROP] (P Q : PROP) (PQ : outParam PROP) where
+  make_or : P ∨ Q ⊣⊢ PQ
+export MakeOr (make_or)
+
 /-- The class [MakeAffinely P Q] is used to compute `Q := <affine> P`. -/
+@[ipm_class, rocq_alias MakeAffinely, rocq_alias KnownMakeAffinely]
 class MakeAffinely [BI PROP] (P : PROP) (Q : outParam PROP) where
   make_affinely : <affine> P ⊣⊢ Q
 export MakeAffinely (make_affinely)
 
 /-- The class [MakeIntuitionistically P Q] is used to compute `Q := □ P`. -/
+@[ipm_class, rocq_alias MakeIntuitionistically, rocq_alias KnownMakeIntuitionistically]
 class MakeIntuitionistically [BI PROP] (P : PROP) (Q : outParam PROP) where
   make_intuitionistically : □ P ⊣⊢ Q
 export MakeIntuitionistically (make_intuitionistically)
 
 /-- The class [MakeAbsorbingly P Q] is used to compute `Q := <absorb> P`. -/
+@[ipm_class, rocq_alias MakeAbsorbingly, rocq_alias KnownMakeAbsorbingly]
 class MakeAbsorbingly [BI PROP] (P : PROP) (Q : outParam PROP) where
   make_absorbingly : <absorb> P ⊣⊢ Q
 export MakeAbsorbingly (make_absorbingly)
 
 /-- The class [MakePersistently P Q] is used to compute `Q := <pers> P`. -/
+@[ipm_class, rocq_alias MakePersistently, rocq_alias KnownMakePersistently]
 class MakePersistently [BI PROP] (P : PROP) (Q : outParam PROP) where
   make_persistently : <pers> P ⊣⊢ Q
 export MakePersistently (make_persistently)
 
 /-- The class [MakeLaterN n P Q] is used to compute `lP := ▷^n P`. -/
+@[ipm_class, rocq_alias MakeLaterN, rocq_alias KnownMakeLaterN]
 class MakeLaterN [BI PROP] (n : Nat) (P : PROP) (lP : outParam PROP) where
   make_laterN : ▷^[n] P ⊣⊢ lP
 export MakeLaterN (make_laterN)
+
+/-- The class [MakeExcept0 P Q] is used to compute `Q := ◇ P`. -/
+@[ipm_class, rocq_alias MakeExcept0, rocq_alias KnownMakeExcept0]
+class MakeExcept0 [BI PROP] (P : PROP) (Q : outParam PROP) where
+  make_except0 : ◇ P ⊣⊢ Q
+export MakeExcept0 (make_except0)
+
+/-- The class [MakeBUpd P Q] is used to compute `Q := |==> P`. -/
+@[ipm_class]
+class MakeBUpd [BI PROP] [BIUpdate PROP] (P : PROP) (Q : outParam PROP) where
+  make_bupd : (|==> P) ⊣⊢ Q
+export MakeBUpd (make_bupd)
+
+/-- The class [MakeFUpd E1 E2 P Q] is used to compute `Q := |={E1, E2}=> P`. -/
+@[ipm_class]
+class MakeFUpd [BI PROP] [BIFUpdate PROP] (E1 E2 : CoPset) (P : PROP) (Q : outParam PROP) where
+  make_fupd : (|={E1,E2}=> P) ⊣⊢ Q
+export MakeFUpd (make_fupd)

--- a/Iris/Iris/ProofMode/ClassesMake.lean
+++ b/Iris/Iris/ProofMode/ClassesMake.lean
@@ -17,76 +17,76 @@ open Iris.BI
 restricted. They only inspect the top-level symbol or check if the whole BI
 is affine. -/
 @[rocq_alias QuickAffine]
-class QuickAffine [BI PROP] (P : PROP) where
+class QuickAffine {PROP} [BI PROP] (P : PROP) where
   quick_affine : Affine P
 export QuickAffine (quick_affine)
 @[rocq_alias QuickAbsorbing]
-class QuickAbsorbing [BI PROP] (P : PROP) where
+class QuickAbsorbing {PROP} [BI PROP] (P : PROP) where
   quick_absorbing : Absorbing P
 export QuickAbsorbing (quick_absorbing)
 
 /-- The class [MakeSep P Q PQ] is used to compute `PQ := P ∗ Q`. -/
 @[ipm_class, rocq_alias MakeSep, rocq_alias KnownLMakeSep, rocq_alias KnownRMakeSep]
-class MakeSep [BI PROP] (P Q : PROP) (PQ : outParam PROP) where
+class MakeSep {PROP} [BI PROP] (P Q : PROP) (PQ : outParam $ PROP) where
   make_sep : P ∗ Q ⊣⊢ PQ
 export MakeSep (make_sep)
 
 /-- The class [MakeAnd P Q PQ] is used to compute `PQ := P ∧ Q`. -/
 @[ipm_class, rocq_alias MakeAnd, rocq_alias KnownLMakeAnd, rocq_alias KnownRMakeAnd]
-class MakeAnd [BI PROP] (P Q : PROP) (PQ : outParam PROP) where
+class MakeAnd {PROP} [BI PROP] (P Q : PROP) (PQ : outParam $ PROP) where
   make_and : P ∧ Q ⊣⊢ PQ
 export MakeAnd (make_and)
 
 /-- The class [MakeOr P Q PQ] is used to compute `PQ := P ∨ Q`. -/
 @[ipm_class, rocq_alias MakeOr, rocq_alias KnownLMakeOr, rocq_alias KnownRMakeOr]
-class MakeOr [BI PROP] (P Q : PROP) (PQ : outParam PROP) where
+class MakeOr {PROP} [BI PROP] (P Q : PROP) (PQ : outParam $ PROP) where
   make_or : P ∨ Q ⊣⊢ PQ
 export MakeOr (make_or)
 
 /-- The class [MakeAffinely P Q] is used to compute `Q := <affine> P`. -/
 @[ipm_class, rocq_alias MakeAffinely, rocq_alias KnownMakeAffinely]
-class MakeAffinely [BI PROP] (P : PROP) (Q : outParam PROP) where
+class MakeAffinely {PROP} [BI PROP] (P : PROP) (Q : outParam $ PROP) where
   make_affinely : <affine> P ⊣⊢ Q
 export MakeAffinely (make_affinely)
 
 /-- The class [MakeIntuitionistically P Q] is used to compute `Q := □ P`. -/
 @[ipm_class, rocq_alias MakeIntuitionistically, rocq_alias KnownMakeIntuitionistically]
-class MakeIntuitionistically [BI PROP] (P : PROP) (Q : outParam PROP) where
+class MakeIntuitionistically {PROP} [BI PROP] (P : PROP) (Q : outParam $ PROP) where
   make_intuitionistically : □ P ⊣⊢ Q
 export MakeIntuitionistically (make_intuitionistically)
 
 /-- The class [MakeAbsorbingly P Q] is used to compute `Q := <absorb> P`. -/
 @[ipm_class, rocq_alias MakeAbsorbingly, rocq_alias KnownMakeAbsorbingly]
-class MakeAbsorbingly [BI PROP] (P : PROP) (Q : outParam PROP) where
+class MakeAbsorbingly {PROP} [BI PROP] (P : PROP) (Q : outParam $ PROP) where
   make_absorbingly : <absorb> P ⊣⊢ Q
 export MakeAbsorbingly (make_absorbingly)
 
 /-- The class [MakePersistently P Q] is used to compute `Q := <pers> P`. -/
 @[ipm_class, rocq_alias MakePersistently, rocq_alias KnownMakePersistently]
-class MakePersistently [BI PROP] (P : PROP) (Q : outParam PROP) where
+class MakePersistently {PROP} [BI PROP] (P : PROP) (Q : outParam $ PROP) where
   make_persistently : <pers> P ⊣⊢ Q
 export MakePersistently (make_persistently)
 
 /-- The class [MakeLaterN n P Q] is used to compute `lP := ▷^n P`. -/
 @[ipm_class, rocq_alias MakeLaterN, rocq_alias KnownMakeLaterN]
-class MakeLaterN [BI PROP] (n : Nat) (P : PROP) (lP : outParam PROP) where
+class MakeLaterN {PROP} [BI PROP] (n : Nat) (P : PROP) (lP : outParam $ PROP) where
   make_laterN : ▷^[n] P ⊣⊢ lP
 export MakeLaterN (make_laterN)
 
 /-- The class [MakeExcept0 P Q] is used to compute `Q := ◇ P`. -/
 @[ipm_class, rocq_alias MakeExcept0, rocq_alias KnownMakeExcept0]
-class MakeExcept0 [BI PROP] (P : PROP) (Q : outParam PROP) where
+class MakeExcept0 {PROP} [BI PROP] (P : PROP) (Q : outParam $ PROP) where
   make_except0 : ◇ P ⊣⊢ Q
 export MakeExcept0 (make_except0)
 
 /-- The class [MakeBUpd P Q] is used to compute `Q := |==> P`. -/
 @[ipm_class]
-class MakeBUpd [BI PROP] [BIUpdate PROP] (P : PROP) (Q : outParam PROP) where
+class MakeBUpd {PROP} [BI PROP] [BIUpdate PROP] (P : PROP) (Q : outParam $ PROP) where
   make_bupd : (|==> P) ⊣⊢ Q
 export MakeBUpd (make_bupd)
 
 /-- The class [MakeFUpd E1 E2 P Q] is used to compute `Q := |={E1, E2}=> P`. -/
 @[ipm_class]
-class MakeFUpd [BI PROP] [BIFUpdate PROP] (E1 E2 : CoPset) (P : PROP) (Q : outParam PROP) where
+class MakeFUpd {PROP} [BI PROP] [BIFUpdate PROP] (E1 E2 : CoPset) (P : PROP) (Q : outParam $ PROP) where
   make_fupd : (|={E1,E2}=> P) ⊣⊢ Q
 export MakeFUpd (make_fupd)

--- a/Iris/Iris/ProofMode/Instances.lean
+++ b/Iris/Iris/ProofMode/Instances.lean
@@ -19,22 +19,23 @@ open Iris.BI Iris.Std
 -- AsEmpValid
 @[rocq_alias as_emp_valid_emp_valid]
 instance (priority := default + 10) asEmpValidEmpValid
-    [BI PROP] d (P : PROP) : AsEmpValid d (⊢ P) P := ⟨by simp⟩
+    [bi : BI PROP] d (P : PROP) :
+    AsEmpValid d (⊢ P) io1 PROP io2 bi P := ⟨by simp⟩
 
 @[rocq_alias as_emp_valid_entails]
-instance asEmpValid_entails [BI PROP] d (P Q : PROP) : AsEmpValid d (P ⊢ Q) iprop(P -∗ Q) where
+instance asEmpValid_entails [bi : BI PROP] d (P Q : PROP) : AsEmpValid d (P ⊢ Q) io1 PROP io2 bi iprop(P -∗ Q) where
   as_emp_valid := ⟨λ _ => entails_wand, λ _ => wand_entails⟩
 
-instance asEmpValid_bientails [BI PROP] (P Q : PROP) : AsEmpValid d (P ⊣⊢ Q) iprop(P ∗-∗ Q) where
+instance asEmpValid_bientails [bi : BI PROP] (P Q : PROP) : AsEmpValid d (P ⊣⊢ Q) io1 PROP io2 bi iprop(P ∗-∗ Q) where
   as_emp_valid := ⟨λ _ => equiv_wandIff, λ _ => wandIff_equiv⟩
 
 @[rocq_alias as_emp_valid_equiv]
-instance asEmpValid_equiv [BI PROP] (P Q : PROP) : AsEmpValid d (P ≡ Q) iprop(P ∗-∗ Q) where
+instance asEmpValid_equiv [bi : BI PROP] (P Q : PROP) : AsEmpValid d (P ≡ Q) io1 PROP io2 bi iprop(P ∗-∗ Q) where
   as_emp_valid := ⟨λ _ h => equiv_wandIff (equiv_iff.1 h), λ _ h => (equiv_iff.2 (wandIff_equiv h))⟩
 
 @[rocq_alias as_emp_valid_forall]
-instance asEmpValid_forall {α} [BI PROP] (Φ : α → Prop) (P : α → PROP)
-  [hP : ∀ x, AsEmpValid d (Φ x) iprop(P x)] : AsEmpValid d (∀ x, Φ x) iprop(∀ x, P x) where
+instance asEmpValid_forall {α} [bi : BI PROP] (Φ : α → Prop) (P : α → PROP)
+  [hP : ∀ x, AsEmpValid d (Φ x) io1 PROP io2 bi iprop(P x)] : AsEmpValid d (∀ x, Φ x) io1 PROP io2 bi iprop(∀ x, P x) where
   as_emp_valid := ⟨λ hd h => forall_intro λ x => (hP x).1.1 hd (h x), λ hd h x => (hP x).1.2 hd $ h.trans (forall_elim x)⟩
 
 -- FromImp
@@ -43,7 +44,7 @@ instance fromImp_imp [BI PROP] (P1 P2 : PROP) : FromImp iprop(P1 → P2) P1 P2 :
 
 -- FromWand
 @[rocq_alias from_wand_wand]
-instance fromWand_wand [BI PROP] (P1 P2 : PROP) : FromWand iprop(P1 -∗ P2) P1 P2 := ⟨.rfl⟩
+instance fromWand_wand [BI PROP] io (P1 P2 : PROP) : FromWand iprop(P1 -∗ P2) io P1 P2 := ⟨.rfl⟩
 
 -- IntoWand
 #rocq_ignore into_wand_wand' "IntoWand' is not used in Lean"
@@ -165,9 +166,9 @@ instance intoForall_persistently [BI PROP] [BIPersistentlyForall PROP] (P : PROP
     [h : IntoForall P Φ] : IntoForall iprop(<pers> P) (fun a => iprop(<pers> (Φ a))) where
   into_forall := (persistently_mono h.1).trans persistently_forall_1
 
-@[rocq_alias into_forall_wand_pure]
+@[ipm_backtrack, rocq_alias into_forall_wand_pure]
 instance intoForall_wand_pure [BI PROP] (P Q : PROP) Φ
-    [h : FromPure a P Φ] : IntoForall iprop(P -∗ Q) (fun _ : Φ => Q) where
+    [h : FromPure a P .out Φ] : IntoForall iprop(P -∗ Q) (fun _ : Φ => Q) where
   into_forall := forall_intro λ hΦ =>
     emp_sep.2.trans <| (sep_mono_l <|
       (affinelyIf_emp.mpr.trans (affinelyIf_mono (pure_intro hΦ))).trans
@@ -389,7 +390,7 @@ instance (priority := default + 10) fromSep_persistently [BI PROP] (P Q1 Q2 : PR
 
 -- AndIntoSep
 @[ipm_class, rocq_alias AndIntoSep]
-class inductive AndIntoSep [BI PROP] : PROP → PROP → PROP → PROP → Prop
+class inductive AndIntoSep [BI PROP] : PROP → outParam PROP → PROP → outParam PROP → Prop
   | affine (P Q Q' : PROP) [Affine P] [h : FromAffinely Q' Q] : AndIntoSep P P Q Q'
   | affinely (P Q : PROP) : AndIntoSep P iprop(<affine> P) Q Q
 
@@ -657,7 +658,7 @@ instance intoPure_pure_or (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
 
 @[rocq_alias into_pure_pure_impl]
 instance intoPure_pure_imp (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
-    [h1 : FromPure false P1 φ1] [h2 : IntoPure P2 φ2] : IntoPure iprop(P1 → P2) (φ1 → φ2) where
+    [h1 : FromPure false P1 .out φ1] [h2 : IntoPure P2 φ2] : IntoPure iprop(P1 → P2) (φ1 → φ2) where
   into_pure := (imp_mono h1.1 h2.1).trans pure_imp.2
 
 @[rocq_alias into_pure_exist]
@@ -692,51 +693,51 @@ instance intoPure_persistently [BI PROP] (P : PROP) (φ : Prop)
 
 -- FromPure
 @[rocq_alias from_pure_emp]
-instance fromPure_emp [BI PROP] : FromPure (PROP := PROP) true emp True where
+instance fromPure_emp {io} [BI PROP] : FromPure (PROP := PROP) true emp io True where
   from_pure := affinely_true.1
 
 @[rocq_alias from_pure_pure]
-instance fromPure_pure [BI PROP] (φ : Prop) : FromPure (PROP := PROP) false iprop(⌜φ⌝) φ := ⟨.rfl⟩
+instance fromPure_pure {io} [BI PROP] (φ : Prop) : FromPure (PROP := PROP) false iprop(⌜φ⌝) io φ := ⟨.rfl⟩
 
 @[rocq_alias from_pure_pure_and]
-instance fromPure_pure_and (a1 a2 : Bool) (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
-    [h1 : FromPure a1 P1 φ1] [h2 : FromPure a2 P2 φ2] :
-    FromPure (a1 || a2) iprop(P1 ∧ P2) (φ1 ∧ φ2) where
+instance fromPure_pure_and {io} (a1 a2 : Bool) (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
+    [h1 : FromPure a1 P1 io φ1] [h2 : FromPure a2 P2 io φ2] :
+    FromPure (a1 || a2) iprop(P1 ∧ P2) io (φ1 ∧ φ2) where
   from_pure := (affinelyIf_mono pure_and.2).trans <| affinelyIf_and.1.trans <| by
     refine and_mono ((affinelyIf_flag_mono ?_).trans h1.1) ((affinelyIf_flag_mono ?_).trans h2.1)
       <;> simp_all
 
 @[rocq_alias from_pure_pure_or]
-instance fromPure_pure_or (a1 a2 : Bool) (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
-    [h1 : FromPure a1 P1 φ1] [h2 : FromPure a2 P2 φ2] :
-    FromPure (a1 || a2) iprop(P1 ∨ P2) (φ1 ∨ φ2) where
+instance fromPure_pure_or {io} (a1 a2 : Bool) (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
+    [h1 : FromPure a1 P1 io φ1] [h2 : FromPure a2 P2 io φ2] :
+    FromPure (a1 || a2) iprop(P1 ∨ P2) io (φ1 ∨ φ2) where
   from_pure := (affinelyIf_mono pure_or.2).trans <| affinelyIf_or.1.trans <| by
     refine or_mono ((affinelyIf_flag_mono ?_).trans h1.1) ((affinelyIf_flag_mono ?_).trans h2.1)
       <;> simp_all
 
 @[rocq_alias from_pure_pure_impl]
-instance fromPure_pure_imp (a : Bool) (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
-    [h1 : IntoPure P1 φ1] [h2 : FromPure a P2 φ2] : FromPure a iprop(P1 → P2) (φ1 → φ2) where
+instance fromPure_pure_imp {io} (a : Bool) (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
+    [h1 : IntoPure P1 φ1] [h2 : FromPure a P2 io φ2] : FromPure a iprop(P1 → P2) io (φ1 → φ2) where
   from_pure := (affinelyIf_mono pure_imp.1).trans <|
     (BI.imp_intro <| affinelyIf_and_l.1.trans (affinelyIf_mono imp_elim_l)).trans <|
     imp_mono h1.1 h2.1
 
 @[rocq_alias from_pure_exist]
-instance fromPure_exists (a : Bool) [BI PROP] (Φ : α → PROP) (φ : α → Prop)
-    [h : ∀ x, FromPure a iprop(Φ x) (φ x)] : FromPure a iprop(∃ x, Φ x) (∃ x, φ x) where
+instance fromPure_exists {io} (a : Bool) [BI PROP] (Φ : α → PROP) (φ : α → Prop)
+    [h : ∀ x, FromPure a iprop(Φ x) io (φ x)] : FromPure a iprop(∃ x, Φ x) io (∃ x, φ x) where
   from_pure := (affinelyIf_mono pure_exists.2).trans <|
     affinelyIf_exists.1.trans (exists_mono fun x => (h x).1)
 
 @[rocq_alias from_pure_forall]
-instance fromPure_forall (a : Bool) [BI PROP] (Φ : α → PROP) (φ : α → Prop)
-    [h : ∀ x, FromPure a iprop(Φ x) (φ x)] : FromPure a iprop(∀ x, Φ x) (∀ x, φ x) where
+instance fromPure_forall {io} (a : Bool) [BI PROP] (Φ : α → PROP) (φ : α → Prop)
+    [h : ∀ x, FromPure a iprop(Φ x) io (φ x)] : FromPure a iprop(∀ x, Φ x) io (∀ x, φ x) where
   from_pure := (affinelyIf_mono pure_forall.1).trans <|
     affinelyIf_forall_1.trans (forall_mono fun x => (h x).1)
 
 @[rocq_alias from_pure_pure_sep_true]
-instance fromPure_pure_sep_true (a1 a2 : Bool) (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
-    [h1 : FromPure a1 P1 φ1] [h2 : FromPure a2 P2 φ2] :
-    FromPure (a1 && a2) iprop(P1 ∗ P2) (φ1 ∧ φ2) where
+instance fromPure_pure_sep_true {io} (a1 a2 : Bool) (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
+    [h1 : FromPure a1 P1 io φ1] [h2 : FromPure a2 P2 io φ2] :
+    FromPure (a1 && a2) iprop(P1 ∗ P2) io (φ1 ∧ φ2) where
   from_pure := by
     refine (affinelyIf_mono pure_and.2).trans <| Entails.trans ?_ (sep_mono h1.1 h2.1)
     exact match a1, a2 with
@@ -747,37 +748,37 @@ instance fromPure_pure_sep_true (a1 a2 : Bool) (φ1 φ2 : Prop) [BI PROP] (P1 P2
 
 -- from_pure_pure_wand in Rocq is split into fromPure_pure_wand_true and fromPure_pure_wand_false in Lean
 @[rocq_alias from_pure_pure_wand]
-instance fromPure_pure_wand_true (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
-    [h1 : IntoPure P1 φ1] [h2 : FromPure true P2 φ2] [Affine P1] :
-    FromPure true iprop(P1 -∗ P2) (φ1 → φ2) where
+instance fromPure_pure_wand_true {io} (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
+    [h1 : IntoPure P1 φ1] [h2 : FromPure true P2 io φ2] [Affine P1] :
+    FromPure true iprop(P1 -∗ P2) io (φ1 → φ2) where
   from_pure := by
     refine (wand_intro ?_).trans (wand_mono_r h2.1)
     refine persistent_and_affinely_sep_l.2.trans <|
       (and_mono_r (affine_affinely P1).2).trans <|
       affinely_and_r.1.trans <| affinely_mono <| (and_mono pure_imp.1 h1.1).trans imp_elim_l
 
-instance fromPure_pure_wand_false (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
-    [h1 : IntoPure P1 φ1] [h2 : FromPure false P2 φ2] :
-    FromPure false iprop(P1 -∗ P2) (φ1 → φ2) where
+instance fromPure_pure_wand_false {io} (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
+    [h1 : IntoPure P1 φ1] [h2 : FromPure false P2 io φ2] :
+    FromPure false iprop(P1 -∗ P2) io (φ1 → φ2) where
   from_pure := by
     refine (wand_intro ?_).trans (wand_mono_r h2.1)
     dsimp; exact IntoPure.into_pure.trans <| pure_mono (And.elim id)
 
 set_option synthInstance.checkSynthOrder false in
 @[rocq_alias from_pure_persistently]
-instance fromPure_persistently [BI PROP] (P : PROP) (a : Bool) (φ : Prop)
-    [h : FromPure true P φ] : FromPure a iprop(<pers> P) φ where
+instance fromPure_persistently {io} [BI PROP] (P : PROP) (a : Bool) (φ : Prop)
+    [h : FromPure true P io φ] : FromPure a iprop(<pers> P) io φ where
   from_pure := affinelyIf_elim.trans <| persistently_pure.2.trans <|
     persistently_affinely.2.trans <| persistently_mono h.1
 
 @[rocq_alias from_pure_affinely_true]
-instance fromPure_affinely_true (a : Bool) [BI PROP] (P : PROP) (φ : Prop)
-    [h : FromPure a P φ] : FromPure true iprop(<affine> P) φ where
+instance fromPure_affinely_true {io} (a : Bool) [BI PROP] (P : PROP) (φ : Prop)
+    [h : FromPure a P io φ] : FromPure true iprop(<affine> P) io φ where
   from_pure := affinely_idem.2.trans <| affinely_mono <| affinely_affinelyIf.trans h.1
 
 @[rocq_alias from_pure_intuitionistically_true]
-instance fromPure_intuitionistically_true (a : Bool) [BI PROP] (P : PROP) (φ : Prop)
-    [h : FromPure a P φ] : FromPure true iprop(□ P) φ where
+instance fromPure_intuitionistically_true {io} (a : Bool) [BI PROP] (P : PROP) (φ : Prop)
+    [h : FromPure a P io φ] : FromPure true iprop(□ P) io φ where
   from_pure :=
     (intuitionistically_of_intuitionistic (P := iprop(<affine> ⌜φ⌝))).2.trans <|
     (intuitionistically_mono <| affinely_idem.2.trans <|
@@ -785,8 +786,8 @@ instance fromPure_intuitionistically_true (a : Bool) [BI PROP] (P : PROP) (φ : 
     intuitionistically_affinely.1.trans <| intuitionistically_mono h.1
 
 @[rocq_alias from_pure_absorbingly]
-instance fromPure_absorbingly (a : Bool) [BI PROP] (P : PROP) (φ : Prop)
-    [h : FromPure a P φ] : FromPure false iprop(<absorb> P) φ where
+instance fromPure_absorbingly {io} (a : Bool) [BI PROP] (P : PROP) (φ : Prop)
+    [h : FromPure a P io φ] : FromPure false iprop(<absorb> P) io φ where
   from_pure := absorbingly_affinely_intro_of_persistent.trans <|
     absorbingly_mono <| affinely_affinelyIf.trans h.1
 

--- a/Iris/Iris/ProofMode/Instances.lean
+++ b/Iris/Iris/ProofMode/Instances.lean
@@ -173,7 +173,7 @@ instance intoForall_persistently [BI PROP] [BIPersistentlyForall PROP] (P : PROP
 
 @[ipm_backtrack, rocq_alias into_forall_wand_pure]
 instance intoForall_wand_pure [BI PROP] (P Q : PROP) Φ
-    [h : FromPure .out a P .out Φ] : IntoForall iprop(P -∗ Q) (fun _ : Φ => Q) where
+    [h : FromPure a P .out Φ] : IntoForall iprop(P -∗ Q) (fun _ : Φ => Q) where
   into_forall := forall_intro λ hΦ =>
     emp_sep.2.trans <| (sep_mono_l <|
       (affinelyIf_emp.mpr.trans (affinelyIf_mono (pure_intro hΦ))).trans
@@ -663,8 +663,11 @@ instance intoPure_pure_or (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
 
 @[rocq_alias into_pure_pure_impl]
 instance intoPure_pure_imp (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
-    [h1 : FromPure .in false P1 .out φ1] [h2 : IntoPure P2 φ2] : IntoPure iprop(P1 → P2) (φ1 → φ2) where
-  into_pure := (imp_mono h1.1 h2.1).trans pure_imp.2
+    [h1 : FromPure a P1 .out φ1] [or : TCOr (TCEq a false) (BIAffine PROP)] [h2 : IntoPure P2 φ2] : IntoPure iprop(P1 → P2) (φ1 → φ2) where
+  into_pure := (imp_mono h1.1 h2.1).trans <| match a, or with
+    | false, _ => pure_imp.2
+    | true, TCOr.r => (imp_mono_l (affine_affinely _).2).trans pure_imp.2
+    | true, TCOr.l (t:=heq) => nomatch heq
 
 @[rocq_alias into_pure_exist]
 instance intoPure_exists [BI PROP] (Φ : α → PROP) (φ : α → Prop)
@@ -698,51 +701,51 @@ instance intoPure_persistently [BI PROP] (P : PROP) (φ : Prop)
 
 -- FromPure
 @[rocq_alias from_pure_emp]
-instance fromPure_emp [BI PROP] : FromPure (PROP := PROP) ioA true emp ioφ True where
+instance fromPure_emp [BI PROP] : FromPure (PROP := PROP) true emp ioφ True where
   from_pure := affinely_true.1
 
 @[rocq_alias from_pure_pure]
-instance fromPure_pure [BI PROP] (φ : Prop) : FromPure (PROP := PROP) ioA false iprop(⌜φ⌝) ioφ φ := ⟨.rfl⟩
+instance fromPure_pure [BI PROP] (φ : Prop) : FromPure (PROP := PROP) false iprop(⌜φ⌝) ioφ φ := ⟨.rfl⟩
 
 @[rocq_alias from_pure_pure_and]
 instance fromPure_pure_and (a1 a2 : Bool) (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
-    [h1 : FromPure .out a1 P1 io φ1] [h2 : FromPure .out a2 P2 io φ2] :
-    FromPure ioA (a1 || a2) iprop(P1 ∧ P2) io (φ1 ∧ φ2) where
+    [h1 : FromPure a1 P1 io φ1] [h2 : FromPure a2 P2 io φ2] :
+    FromPure (a1 || a2) iprop(P1 ∧ P2) io (φ1 ∧ φ2) where
   from_pure := (affinelyIf_mono pure_and.2).trans <| affinelyIf_and.1.trans <| by
     refine and_mono ((affinelyIf_flag_mono ?_).trans h1.1) ((affinelyIf_flag_mono ?_).trans h2.1)
       <;> simp_all
 
 @[rocq_alias from_pure_pure_or]
 instance fromPure_pure_or (a1 a2 : Bool) (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
-    [h1 : FromPure .out a1 P1 io φ1] [h2 : FromPure .out a2 P2 io φ2] :
-    FromPure ioA (a1 || a2) iprop(P1 ∨ P2) io (φ1 ∨ φ2) where
+    [h1 : FromPure a1 P1 io φ1] [h2 : FromPure a2 P2 io φ2] :
+    FromPure (a1 || a2) iprop(P1 ∨ P2) io (φ1 ∨ φ2) where
   from_pure := (affinelyIf_mono pure_or.2).trans <| affinelyIf_or.1.trans <| by
     refine or_mono ((affinelyIf_flag_mono ?_).trans h1.1) ((affinelyIf_flag_mono ?_).trans h2.1)
       <;> simp_all
 
 @[rocq_alias from_pure_pure_impl]
 instance fromPure_pure_imp (a : Bool) (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
-    [h1 : IntoPure P1 φ1] [h2 : FromPure .out a P2 io φ2] : FromPure ioA a iprop(P1 → P2) io (φ1 → φ2) where
+    [h1 : IntoPure P1 φ1] [h2 : FromPure a P2 io φ2] : FromPure a iprop(P1 → P2) io (φ1 → φ2) where
   from_pure := (affinelyIf_mono pure_imp.1).trans <|
     (BI.imp_intro <| affinelyIf_and_l.1.trans (affinelyIf_mono imp_elim_l)).trans <|
     imp_mono h1.1 h2.1
 
 @[rocq_alias from_pure_exist]
 instance fromPure_exists (a : Bool) [BI PROP] (Φ : α → PROP) (φ : α → Prop)
-    [h : ∀ x, FromPure .out a iprop(Φ x) io (φ x)] : FromPure ioA a iprop(∃ x, Φ x) io (∃ x, φ x) where
+    [h : ∀ x, FromPure a iprop(Φ x) io (φ x)] : FromPure a iprop(∃ x, Φ x) io (∃ x, φ x) where
   from_pure := (affinelyIf_mono pure_exists.2).trans <|
     affinelyIf_exists.1.trans (exists_mono fun x => (h x).1)
 
 @[rocq_alias from_pure_forall]
 instance fromPure_forall (a : Bool) [BI PROP] (Φ : α → PROP) (φ : α → Prop)
-    [h : ∀ x, FromPure .out a iprop(Φ x) io (φ x)] : FromPure ioA a iprop(∀ x, Φ x) io (∀ x, φ x) where
+    [h : ∀ x, FromPure a iprop(Φ x) io (φ x)] : FromPure a iprop(∀ x, Φ x) io (∀ x, φ x) where
   from_pure := (affinelyIf_mono pure_forall.1).trans <|
     affinelyIf_forall_1.trans (forall_mono fun x => (h x).1)
 
 @[rocq_alias from_pure_pure_sep_true]
 instance fromPure_pure_sep_true (a1 a2 : Bool) (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
-    [h1 : FromPure .out a1 P1 io φ1] [h2 : FromPure .out a2 P2 io φ2] :
-    FromPure ioA (a1 && a2) iprop(P1 ∗ P2) io (φ1 ∧ φ2) where
+    [h1 : FromPure a1 P1 io φ1] [h2 : FromPure a2 P2 io φ2] :
+    FromPure (a1 && a2) iprop(P1 ∗ P2) io (φ1 ∧ φ2) where
   from_pure := by
     refine (affinelyIf_mono pure_and.2).trans <| Entails.trans ?_ (sep_mono h1.1 h2.1)
     exact match a1, a2 with
@@ -751,39 +754,34 @@ instance fromPure_pure_sep_true (a1 a2 : Bool) (φ1 φ2 : Prop) [BI PROP] (P1 P2
     | true, false => persistent_and_affinely_sep_l.1
     | true, true => affinely_and.1.trans persistent_and_sep_1
 
--- from_pure_pure_wand in Rocq is split into fromPure_pure_wand_true and fromPure_pure_wand_false in Lean
 @[rocq_alias from_pure_pure_wand]
-instance fromPure_pure_wand_true (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
-    [h1 : IntoPure P1 φ1] [h2 : FromPure .in true P2 io φ2] [Affine P1] :
-    FromPure ioA true iprop(P1 -∗ P2) io (φ1 → φ2) where
-  from_pure := by
-    refine (wand_intro ?_).trans (wand_mono_r h2.1)
-    refine persistent_and_affinely_sep_l.2.trans <|
-      (and_mono_r (affine_affinely P1).2).trans <|
-      affinely_and_r.1.trans <| affinely_mono <| (and_mono pure_imp.1 h1.1).trans imp_elim_l
+instance fromPure_pure_wand (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
+    [h1 : IntoPure P1 φ1] [h2 : FromPure a P2 io φ2] [or : TCOr (TCEq a false) (Affine P1)] :
+    FromPure a iprop(P1 -∗ P2) io (φ1 → φ2) where
+  from_pure := match a, or, h2 with
+    | false, _, h2 => pure_wand_2.trans (wand_mono h1.1 h2.1)
+    | true, TCOr.r, h2 =>
+        (wand_intro <|
+            persistent_and_affinely_sep_l.2.trans <|
+            (and_mono_r (affine_affinely P1).2).trans <|
+            affinely_and_r.1.trans <| affinely_mono <| (and_mono pure_imp.1 h1.1).trans imp_elim_l
+          ).trans (wand_mono_r h2.1)
+    | true, .l (t := h_teq), _ => nomatch h_teq
 
-instance fromPure_pure_wand_false (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
-    [h1 : IntoPure P1 φ1] [h2 : FromPure .in false P2 io φ2] :
-    FromPure ioA false iprop(P1 -∗ P2) io (φ1 → φ2) where
-  from_pure := by
-    refine (wand_intro ?_).trans (wand_mono_r h2.1)
-    dsimp; exact IntoPure.into_pure.trans <| pure_mono (And.elim id)
-
-set_option synthInstance.checkSynthOrder false in
 @[rocq_alias from_pure_persistently]
 instance fromPure_persistently [BI PROP] (P : PROP) (a : Bool) (φ : Prop)
-    [h : FromPure .in true P io φ] : FromPure ioA a iprop(<pers> P) io φ where
+    [h : FromPure a P io φ] : FromPure false iprop(<pers> P) io φ where
   from_pure := affinelyIf_elim.trans <| persistently_pure.2.trans <|
-    persistently_affinely.2.trans <| persistently_mono h.1
+    persistently_affinely.2.trans <| persistently_mono <| affinely_affinelyIf.trans h.1
 
 @[rocq_alias from_pure_affinely_true]
 instance fromPure_affinely_true (a : Bool) [BI PROP] (P : PROP) (φ : Prop)
-    [h : FromPure .out a P io φ] : FromPure ioA true iprop(<affine> P) io φ where
+    [h : FromPure a P io φ] : FromPure true iprop(<affine> P) io φ where
   from_pure := affinely_idem.2.trans <| affinely_mono <| affinely_affinelyIf.trans h.1
 
 @[rocq_alias from_pure_intuitionistically_true]
-instance fromPure_intuitionistically_true {ioA io} (a : Bool) [BI PROP] (P : PROP) (φ : Prop)
-    [h : FromPure .out a P io φ] : FromPure ioA true iprop(□ P) io φ where
+instance fromPure_intuitionistically_true (a : Bool) [BI PROP] (P : PROP) (φ : Prop)
+    [h : FromPure a P io φ] : FromPure true iprop(□ P) io φ where
   from_pure :=
     (intuitionistically_of_intuitionistic (P := iprop(<affine> ⌜φ⌝))).2.trans <|
     (intuitionistically_mono <| affinely_idem.2.trans <|
@@ -791,8 +789,8 @@ instance fromPure_intuitionistically_true {ioA io} (a : Bool) [BI PROP] (P : PRO
     intuitionistically_affinely.1.trans <| intuitionistically_mono h.1
 
 @[rocq_alias from_pure_absorbingly]
-instance fromPure_absorbingly {ioA io} (a : Bool) [BI PROP] (P : PROP) (φ : Prop)
-    [h : FromPure .out a P io φ] : FromPure ioA false iprop(<absorb> P) io φ where
+instance fromPure_absorbingly (a : Bool) [BI PROP] (P : PROP) (φ : Prop)
+    [h : FromPure a P io φ] : FromPure false iprop(<absorb> P) io φ where
   from_pure := absorbingly_affinely_intro_of_persistent.trans <|
     absorbingly_mono <| affinely_affinelyIf.trans h.1
 

--- a/Iris/Iris/ProofMode/Instances.lean
+++ b/Iris/Iris/ProofMode/Instances.lean
@@ -23,20 +23,25 @@ instance (priority := default + 10) asEmpValidEmpValid
     AsEmpValid d (⊢ P) io1 PROP io2 bi P := ⟨by simp⟩
 
 @[rocq_alias as_emp_valid_entails]
-instance asEmpValid_entails [bi : BI PROP] d (P Q : PROP) : AsEmpValid d (P ⊢ Q) io1 PROP io2 bi iprop(P -∗ Q) where
+instance asEmpValid_entails [bi : BI PROP] d (P Q : PROP)
+: AsEmpValid d (P ⊢ Q) io1 PROP io2 bi iprop(P -∗ Q) where
   as_emp_valid := ⟨λ _ => entails_wand, λ _ => wand_entails⟩
 
-instance asEmpValid_bientails [bi : BI PROP] (P Q : PROP) : AsEmpValid d (P ⊣⊢ Q) io1 PROP io2 bi iprop(P ∗-∗ Q) where
+instance asEmpValid_bientails [bi : BI PROP] (P Q : PROP)
+: AsEmpValid d (P ⊣⊢ Q) io1 PROP io2 bi iprop(P ∗-∗ Q) where
   as_emp_valid := ⟨λ _ => equiv_wandIff, λ _ => wandIff_equiv⟩
 
 @[rocq_alias as_emp_valid_equiv]
-instance asEmpValid_equiv [bi : BI PROP] (P Q : PROP) : AsEmpValid d (P ≡ Q) io1 PROP io2 bi iprop(P ∗-∗ Q) where
+instance asEmpValid_equiv [bi : BI PROP] (P Q : PROP)
+: AsEmpValid d (P ≡ Q) io1 PROP io2 bi iprop(P ∗-∗ Q) where
   as_emp_valid := ⟨λ _ h => equiv_wandIff (equiv_iff.1 h), λ _ h => (equiv_iff.2 (wandIff_equiv h))⟩
 
 @[rocq_alias as_emp_valid_forall]
 instance asEmpValid_forall {α} [bi : BI PROP] (Φ : α → Prop) (P : α → PROP)
-  [hP : ∀ x, AsEmpValid d (Φ x) io1 PROP io2 bi iprop(P x)] : AsEmpValid d (∀ x, Φ x) io1 PROP io2 bi iprop(∀ x, P x) where
-  as_emp_valid := ⟨λ hd h => forall_intro λ x => (hP x).1.1 hd (h x), λ hd h x => (hP x).1.2 hd $ h.trans (forall_elim x)⟩
+  [hP : ∀ x, AsEmpValid d (Φ x) io1 PROP io2 bi iprop(P x)]
+: AsEmpValid d (∀ x, Φ x) io1 PROP io2 bi iprop(∀ x, P x) where
+  as_emp_valid := ⟨λ hd h => forall_intro λ x => (hP x).1.1 hd (h x),
+                   λ hd h x => (hP x).1.2 hd $ h.trans (forall_elim x)⟩
 
 -- FromImp
 @[rocq_alias from_impl_impl]
@@ -44,65 +49,65 @@ instance fromImp_imp [BI PROP] (P1 P2 : PROP) : FromImp iprop(P1 → P2) P1 P2 :
 
 -- FromWand
 @[rocq_alias from_wand_wand]
-instance fromWand_wand [BI PROP] io (P1 P2 : PROP) : FromWand iprop(P1 -∗ P2) io P1 P2 := ⟨.rfl⟩
+instance fromWand_wand [BI PROP] (P1 P2 : PROP) : FromWand iprop(P1 -∗ P2) io P1 P2 := ⟨.rfl⟩
 
 -- IntoWand
 #rocq_ignore into_wand_wand' "IntoWand' is not used in Lean"
 #rocq_ignore into_wand_impl' "IntoWand' is not used in Lean"
 #rocq_ignore into_wand_wandM' "IntoWand' is not used in Lean"
 
-instance intoWand_wand (p q : Bool) [BI PROP] ioP ioQ (P Q P' : PROP) [h : FromAssumption q ioP P P'] :
+instance intoWand_wand (p q : Bool) [BI PROP] (P Q P' : PROP) [h : FromAssumption q ioP P P'] :
     IntoWand p q iprop(P' -∗ Q) ioP P ioQ Q where
   into_wand := (intuitionisticallyIf_mono <| wand_mono_l h.1).trans intuitionisticallyIf_elim
 
-instance intoWand_imp_false [BI PROP] ioP ioQ (P Q P' : PROP) [Absorbing P'] [Absorbing iprop(P' → Q)]
+instance intoWand_imp_false [BI PROP] (P Q P' : PROP) [Absorbing P'] [Absorbing iprop(P' → Q)]
     [h : FromAssumption b ioP P P'] : IntoWand false b iprop(P' → Q) ioP P ioQ Q where
   into_wand := wand_intro <| (sep_mono_r h.1).trans <| by dsimp; exact sep_and.trans imp_elim_l
 
-instance intoWand_imp_true [BI PROP] ioP ioQ (P Q P' : PROP) [Affine P']
+instance intoWand_imp_true [BI PROP] (P Q P' : PROP) [Affine P']
     [h : FromAssumption b ioP P P'] : IntoWand true b iprop(P' → Q) ioP P ioQ Q where
   into_wand := wand_intro <| (sep_mono_r h.1).trans <| by
     dsimp; exact sep_and.trans <| imp_elim intuitionistically_elim
 
 @[ipm_backtrack, rocq_alias into_wand_and_l]
-instance intoWand_and_l (p q : Bool) [BI PROP] ioP ioQ (R1 R2 P' Q' : PROP)
+instance intoWand_and_l (p q : Bool) [BI PROP] (R1 R2 P' Q' : PROP)
     [h : IntoWand p q R1 ioP P' ioQ Q'] : IntoWand p q iprop(R1 ∧ R2) ioP P' ioQ Q' where
   into_wand := (intuitionisticallyIf_mono and_elim_l).trans h.1
 
 @[ipm_backtrack, rocq_alias into_wand_and_r]
-instance intoWand_and_r (p q : Bool) [BI PROP] ioP ioQ (R1 R2 P' Q' : PROP)
+instance intoWand_and_r (p q : Bool) [BI PROP] (R1 R2 P' Q' : PROP)
     [h : IntoWand p q R2 ioP P' ioQ Q'] : IntoWand p q iprop(R1 ∧ R2) ioP P' ioQ Q' where
   into_wand := (intuitionisticallyIf_mono and_elim_r).trans h.1
 
-instance intoWand_wandIff (p q : Bool) [BI PROP] ioP ioQ (R1 R2 P' Q' : PROP)
+instance intoWand_wandIff (p q : Bool) [BI PROP] (R1 R2 P' Q' : PROP)
     [h : IntoWand p q iprop((R1 -∗ R2) ∧ (R2 -∗ R1)) ioP P' ioQ Q'] : IntoWand p q iprop(R1 ∗-∗ R2) ioP P' ioQ Q' := h
 
 -- The set_option is ok since this is an instance for an IPM class and thus can create mvars.
 set_option synthInstance.checkSynthOrder false in
 @[rocq_alias into_wand_forall]
-instance intoWand_forall (p q : Bool) [BI PROP] (Φ : α → PROP) ioP ioQ (P Q : PROP) (x : α)
+instance intoWand_forall (p q : Bool) [BI PROP] (Φ : α → PROP) (P Q : PROP) (x : α)
     [h : IntoWand p q (Φ x) ioP P ioQ Q] : IntoWand p q iprop(∀ x, Φ x) ioP P ioQ Q where
   into_wand := (intuitionisticallyIf_mono <| BI.forall_elim x).trans h.1
 
 @[rocq_alias into_wand_affine]
-instance intoWand_affinely (p q : Bool) [BI PROP] ioP ioQ (R P Q : PROP) [h : IntoWand p q R ioP P ioQ Q] :
+instance intoWand_affinely (p q : Bool) [BI PROP] (R P Q : PROP) [h : IntoWand p q R ioP P ioQ Q] :
     IntoWand p q iprop(<affine> R) ioP iprop(<affine> P) ioQ iprop(<affine> Q) where
   into_wand := wand_intro <|
     (sep_congr intuitionisticallyIf_affinely intuitionisticallyIf_affinely).1.trans <|
     affinely_sep_2.trans <| affinely_mono <| wand_elim h.1
 
 @[rocq_alias into_wand_intuitionistically]
-instance intoWand_intuitionistically (p q : Bool) [BI PROP] ioP ioQ (R P Q : PROP)
+instance intoWand_intuitionistically (p q : Bool) [BI PROP] (R P Q : PROP)
     [h : IntoWand true q R ioP P ioQ Q] : IntoWand p q iprop(□ R) ioP P ioQ Q where
   into_wand := (intuitionisticallyIf_mono h.1).trans intuitionisticallyIf_elim
 
 @[rocq_alias into_wand_persistently_true]
-instance intoWand_persistently_true (q : Bool) [BI PROP] ioP ioQ (R P Q : PROP)
+instance intoWand_persistently_true (q : Bool) [BI PROP] (R P Q : PROP)
     [h : IntoWand true q R ioP P ioQ Q] : IntoWand true q iprop(<pers> R) ioP P ioQ Q where
   into_wand := intuitionistically_persistently.1.trans h.1
 
 @[rocq_alias into_wand_persistently_false]
-instance intoWand_persistently_false (q : Bool) [BI PROP] ioP ioQ (R P Q : PROP) [Absorbing R]
+instance intoWand_persistently_false (q : Bool) [BI PROP] (R P Q : PROP) [Absorbing R]
     [h : IntoWand false q R ioP P ioQ Q] : IntoWand false q iprop(<pers> R) ioP P ioQ Q where
   into_wand := persistently_elim.trans h.1
 
@@ -168,7 +173,7 @@ instance intoForall_persistently [BI PROP] [BIPersistentlyForall PROP] (P : PROP
 
 @[ipm_backtrack, rocq_alias into_forall_wand_pure]
 instance intoForall_wand_pure [BI PROP] (P Q : PROP) Φ
-    [h : FromPure a P .out Φ] : IntoForall iprop(P -∗ Q) (fun _ : Φ => Q) where
+    [h : FromPure .out a P .out Φ] : IntoForall iprop(P -∗ Q) (fun _ : Φ => Q) where
   into_forall := forall_intro λ hΦ =>
     emp_sep.2.trans <| (sep_mono_l <|
       (affinelyIf_emp.mpr.trans (affinelyIf_mono (pure_intro hΦ))).trans
@@ -390,7 +395,7 @@ instance (priority := default + 10) fromSep_persistently [BI PROP] (P Q1 Q2 : PR
 
 -- AndIntoSep
 @[ipm_class, rocq_alias AndIntoSep]
-class inductive AndIntoSep [BI PROP] : PROP → outParam PROP → PROP → outParam PROP → Prop
+class inductive AndIntoSep {PROP} [BI PROP] : PROP → outParam PROP → PROP → outParam PROP → Prop
   | affine (P Q Q' : PROP) [Affine P] [h : FromAffinely Q' Q] : AndIntoSep P P Q Q'
   | affinely (P Q : PROP) : AndIntoSep P iprop(<affine> P) Q Q
 
@@ -658,7 +663,7 @@ instance intoPure_pure_or (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
 
 @[rocq_alias into_pure_pure_impl]
 instance intoPure_pure_imp (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
-    [h1 : FromPure false P1 .out φ1] [h2 : IntoPure P2 φ2] : IntoPure iprop(P1 → P2) (φ1 → φ2) where
+    [h1 : FromPure .in false P1 .out φ1] [h2 : IntoPure P2 φ2] : IntoPure iprop(P1 → P2) (φ1 → φ2) where
   into_pure := (imp_mono h1.1 h2.1).trans pure_imp.2
 
 @[rocq_alias into_pure_exist]
@@ -693,51 +698,51 @@ instance intoPure_persistently [BI PROP] (P : PROP) (φ : Prop)
 
 -- FromPure
 @[rocq_alias from_pure_emp]
-instance fromPure_emp {io} [BI PROP] : FromPure (PROP := PROP) true emp io True where
+instance fromPure_emp [BI PROP] : FromPure (PROP := PROP) ioA true emp ioφ True where
   from_pure := affinely_true.1
 
 @[rocq_alias from_pure_pure]
-instance fromPure_pure {io} [BI PROP] (φ : Prop) : FromPure (PROP := PROP) false iprop(⌜φ⌝) io φ := ⟨.rfl⟩
+instance fromPure_pure [BI PROP] (φ : Prop) : FromPure (PROP := PROP) ioA false iprop(⌜φ⌝) ioφ φ := ⟨.rfl⟩
 
 @[rocq_alias from_pure_pure_and]
-instance fromPure_pure_and {io} (a1 a2 : Bool) (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
-    [h1 : FromPure a1 P1 io φ1] [h2 : FromPure a2 P2 io φ2] :
-    FromPure (a1 || a2) iprop(P1 ∧ P2) io (φ1 ∧ φ2) where
+instance fromPure_pure_and (a1 a2 : Bool) (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
+    [h1 : FromPure .out a1 P1 io φ1] [h2 : FromPure .out a2 P2 io φ2] :
+    FromPure ioA (a1 || a2) iprop(P1 ∧ P2) io (φ1 ∧ φ2) where
   from_pure := (affinelyIf_mono pure_and.2).trans <| affinelyIf_and.1.trans <| by
     refine and_mono ((affinelyIf_flag_mono ?_).trans h1.1) ((affinelyIf_flag_mono ?_).trans h2.1)
       <;> simp_all
 
 @[rocq_alias from_pure_pure_or]
-instance fromPure_pure_or {io} (a1 a2 : Bool) (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
-    [h1 : FromPure a1 P1 io φ1] [h2 : FromPure a2 P2 io φ2] :
-    FromPure (a1 || a2) iprop(P1 ∨ P2) io (φ1 ∨ φ2) where
+instance fromPure_pure_or (a1 a2 : Bool) (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
+    [h1 : FromPure .out a1 P1 io φ1] [h2 : FromPure .out a2 P2 io φ2] :
+    FromPure ioA (a1 || a2) iprop(P1 ∨ P2) io (φ1 ∨ φ2) where
   from_pure := (affinelyIf_mono pure_or.2).trans <| affinelyIf_or.1.trans <| by
     refine or_mono ((affinelyIf_flag_mono ?_).trans h1.1) ((affinelyIf_flag_mono ?_).trans h2.1)
       <;> simp_all
 
 @[rocq_alias from_pure_pure_impl]
-instance fromPure_pure_imp {io} (a : Bool) (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
-    [h1 : IntoPure P1 φ1] [h2 : FromPure a P2 io φ2] : FromPure a iprop(P1 → P2) io (φ1 → φ2) where
+instance fromPure_pure_imp (a : Bool) (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
+    [h1 : IntoPure P1 φ1] [h2 : FromPure .out a P2 io φ2] : FromPure ioA a iprop(P1 → P2) io (φ1 → φ2) where
   from_pure := (affinelyIf_mono pure_imp.1).trans <|
     (BI.imp_intro <| affinelyIf_and_l.1.trans (affinelyIf_mono imp_elim_l)).trans <|
     imp_mono h1.1 h2.1
 
 @[rocq_alias from_pure_exist]
-instance fromPure_exists {io} (a : Bool) [BI PROP] (Φ : α → PROP) (φ : α → Prop)
-    [h : ∀ x, FromPure a iprop(Φ x) io (φ x)] : FromPure a iprop(∃ x, Φ x) io (∃ x, φ x) where
+instance fromPure_exists (a : Bool) [BI PROP] (Φ : α → PROP) (φ : α → Prop)
+    [h : ∀ x, FromPure .out a iprop(Φ x) io (φ x)] : FromPure ioA a iprop(∃ x, Φ x) io (∃ x, φ x) where
   from_pure := (affinelyIf_mono pure_exists.2).trans <|
     affinelyIf_exists.1.trans (exists_mono fun x => (h x).1)
 
 @[rocq_alias from_pure_forall]
-instance fromPure_forall {io} (a : Bool) [BI PROP] (Φ : α → PROP) (φ : α → Prop)
-    [h : ∀ x, FromPure a iprop(Φ x) io (φ x)] : FromPure a iprop(∀ x, Φ x) io (∀ x, φ x) where
+instance fromPure_forall (a : Bool) [BI PROP] (Φ : α → PROP) (φ : α → Prop)
+    [h : ∀ x, FromPure .out a iprop(Φ x) io (φ x)] : FromPure ioA a iprop(∀ x, Φ x) io (∀ x, φ x) where
   from_pure := (affinelyIf_mono pure_forall.1).trans <|
     affinelyIf_forall_1.trans (forall_mono fun x => (h x).1)
 
 @[rocq_alias from_pure_pure_sep_true]
-instance fromPure_pure_sep_true {io} (a1 a2 : Bool) (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
-    [h1 : FromPure a1 P1 io φ1] [h2 : FromPure a2 P2 io φ2] :
-    FromPure (a1 && a2) iprop(P1 ∗ P2) io (φ1 ∧ φ2) where
+instance fromPure_pure_sep_true (a1 a2 : Bool) (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
+    [h1 : FromPure .out a1 P1 io φ1] [h2 : FromPure .out a2 P2 io φ2] :
+    FromPure ioA (a1 && a2) iprop(P1 ∗ P2) io (φ1 ∧ φ2) where
   from_pure := by
     refine (affinelyIf_mono pure_and.2).trans <| Entails.trans ?_ (sep_mono h1.1 h2.1)
     exact match a1, a2 with
@@ -748,37 +753,37 @@ instance fromPure_pure_sep_true {io} (a1 a2 : Bool) (φ1 φ2 : Prop) [BI PROP] (
 
 -- from_pure_pure_wand in Rocq is split into fromPure_pure_wand_true and fromPure_pure_wand_false in Lean
 @[rocq_alias from_pure_pure_wand]
-instance fromPure_pure_wand_true {io} (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
-    [h1 : IntoPure P1 φ1] [h2 : FromPure true P2 io φ2] [Affine P1] :
-    FromPure true iprop(P1 -∗ P2) io (φ1 → φ2) where
+instance fromPure_pure_wand_true (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
+    [h1 : IntoPure P1 φ1] [h2 : FromPure .in true P2 io φ2] [Affine P1] :
+    FromPure ioA true iprop(P1 -∗ P2) io (φ1 → φ2) where
   from_pure := by
     refine (wand_intro ?_).trans (wand_mono_r h2.1)
     refine persistent_and_affinely_sep_l.2.trans <|
       (and_mono_r (affine_affinely P1).2).trans <|
       affinely_and_r.1.trans <| affinely_mono <| (and_mono pure_imp.1 h1.1).trans imp_elim_l
 
-instance fromPure_pure_wand_false {io} (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
-    [h1 : IntoPure P1 φ1] [h2 : FromPure false P2 io φ2] :
-    FromPure false iprop(P1 -∗ P2) io (φ1 → φ2) where
+instance fromPure_pure_wand_false (φ1 φ2 : Prop) [BI PROP] (P1 P2 : PROP)
+    [h1 : IntoPure P1 φ1] [h2 : FromPure .in false P2 io φ2] :
+    FromPure ioA false iprop(P1 -∗ P2) io (φ1 → φ2) where
   from_pure := by
     refine (wand_intro ?_).trans (wand_mono_r h2.1)
     dsimp; exact IntoPure.into_pure.trans <| pure_mono (And.elim id)
 
 set_option synthInstance.checkSynthOrder false in
 @[rocq_alias from_pure_persistently]
-instance fromPure_persistently {io} [BI PROP] (P : PROP) (a : Bool) (φ : Prop)
-    [h : FromPure true P io φ] : FromPure a iprop(<pers> P) io φ where
+instance fromPure_persistently [BI PROP] (P : PROP) (a : Bool) (φ : Prop)
+    [h : FromPure .in true P io φ] : FromPure ioA a iprop(<pers> P) io φ where
   from_pure := affinelyIf_elim.trans <| persistently_pure.2.trans <|
     persistently_affinely.2.trans <| persistently_mono h.1
 
 @[rocq_alias from_pure_affinely_true]
-instance fromPure_affinely_true {io} (a : Bool) [BI PROP] (P : PROP) (φ : Prop)
-    [h : FromPure a P io φ] : FromPure true iprop(<affine> P) io φ where
+instance fromPure_affinely_true (a : Bool) [BI PROP] (P : PROP) (φ : Prop)
+    [h : FromPure .out a P io φ] : FromPure ioA true iprop(<affine> P) io φ where
   from_pure := affinely_idem.2.trans <| affinely_mono <| affinely_affinelyIf.trans h.1
 
 @[rocq_alias from_pure_intuitionistically_true]
-instance fromPure_intuitionistically_true {io} (a : Bool) [BI PROP] (P : PROP) (φ : Prop)
-    [h : FromPure a P io φ] : FromPure true iprop(□ P) io φ where
+instance fromPure_intuitionistically_true {ioA io} (a : Bool) [BI PROP] (P : PROP) (φ : Prop)
+    [h : FromPure .out a P io φ] : FromPure ioA true iprop(□ P) io φ where
   from_pure :=
     (intuitionistically_of_intuitionistic (P := iprop(<affine> ⌜φ⌝))).2.trans <|
     (intuitionistically_mono <| affinely_idem.2.trans <|
@@ -786,8 +791,8 @@ instance fromPure_intuitionistically_true {io} (a : Bool) [BI PROP] (P : PROP) (
     intuitionistically_affinely.1.trans <| intuitionistically_mono h.1
 
 @[rocq_alias from_pure_absorbingly]
-instance fromPure_absorbingly {io} (a : Bool) [BI PROP] (P : PROP) (φ : Prop)
-    [h : FromPure a P io φ] : FromPure false iprop(<absorb> P) io φ where
+instance fromPure_absorbingly {ioA io} (a : Bool) [BI PROP] (P : PROP) (φ : Prop)
+    [h : FromPure .out a P io φ] : FromPure ioA false iprop(<absorb> P) io φ where
   from_pure := absorbingly_affinely_intro_of_persistent.trans <|
     absorbingly_mono <| affinely_affinelyIf.trans h.1
 

--- a/Iris/Iris/ProofMode/InstancesFrame.lean
+++ b/Iris/Iris/ProofMode/InstancesFrame.lean
@@ -1,0 +1,347 @@
+/-
+Copyright (c) 2026 Michael Sammler. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Sammler
+-/
+module
+
+public import Iris.BI
+public import Iris.ProofMode.Classes
+public import Iris.ProofMode.ClassesMake
+public meta import Iris.ProofMode.Expr
+public import Iris.Std.TC
+
+@[expose] public section
+
+namespace Iris.ProofMode
+open Qq Iris.BI Iris.Std
+
+/- When framing [R] against itself, we leave [True] if possible since it is a weaker goal. Otherwise we leave [emp].
+Only if all those options fail, we start decomposing [R]. -/
+@[ipm_backtrack, rocq_alias frame_here_absorbing]
+instance (priority := high + 10) frame_here_absorbing [BI PROP] p (R : PROP) [QuickAbsorbing R] : Frame p R R iprop(True) where
+  frame := sep_comm.1.trans <| (sep_mono_r intuitionisticallyIf_elim).trans quick_absorbing.absorbing
+
+@[ipm_backtrack, rocq_alias frame_here]
+instance (priority := high + 5) frame_here [BI PROP] p (R : PROP) : Frame p R R iprop(emp) where
+  frame := sep_emp.1.trans intuitionisticallyIf_elim
+
+@[ipm_backtrack, rocq_alias frame_affinely_here_absorbing]
+instance (priority := high + 10) frame_affinely_here_absorbing [BI PROP] p (R : PROP) [QuickAbsorbing R] : Frame p iprop(<affine> R) R iprop(True) where
+  frame := sep_comm.1.trans <| (sep_mono_r (intuitionisticallyIf_elim.trans affinely_elim)).trans quick_absorbing.absorbing
+
+@[ipm_backtrack, rocq_alias frame_affinely_here]
+instance (priority := high + 10) frame_affinely_here [BI PROP] p (R : PROP) : Frame p iprop(<affine> R) R iprop(emp) where
+  frame := sep_emp.1.trans (intuitionisticallyIf_elim.trans affinely_elim)
+
+@[ipm_backtrack, rocq_alias frame_here_pure_persistent]
+instance frame_here_pure_persistent [BI PROP] {a : Bool} {φ : Prop} {Q : PROP}
+    [FromPure a Q .in φ] : Frame true iprop(⌜φ⌝) Q iprop(emp) where
+  frame :=
+    have h : □?true iprop(⌜φ⌝) ∗ emp ⊢ □ iprop(⌜φ⌝) := sep_emp.1
+    h.trans (affinely_of_intuitionistically.trans (affinely_affinelyIf.trans (from_pure .in)))
+
+@[ipm_backtrack, rocq_alias frame_here_pure]
+instance frame_here_pure [BI PROP] {a : Bool} {φ : Prop} {Q : PROP}
+    [h1 : FromPure a Q .in φ] [hor : TCOr (TCEq a false) (BIAffine PROP)] :
+    Frame false iprop(⌜φ⌝) Q iprop(emp) where
+  frame :=
+    sep_emp.1.trans <|
+    match hor with
+    | @TCOr.l _ _ heq => by cases heq; refine h1.1
+    | TCOr.r => (affinely_intro .rfl).trans <| affinely_affinelyIf.trans h1.1
+
+@[ipm_backtrack, rocq_alias frame_wand]
+instance frame_wand [BI PROP] p (R P1 P2 Q2 : PROP)
+    [h : Frame p R P2 Q2] : Frame p R iprop(P1 -∗ P2) iprop(P1 -∗ Q2) where
+  frame := wand_intro <| sep_assoc.1.trans <| (sep_mono_r wand_elim_l).trans h.frame
+
+@[ipm_backtrack, rocq_alias frame_affinely]
+instance frame_affinely [BI PROP] p (R P Q Q' : PROP)
+    [hor : TCOr (TCEq p true) (QuickAffine R)]
+    [h1 : Frame p R P Q] [h2 : MakeAffinely Q Q'] :
+    Frame p R iprop(<affine> P) Q' where
+  frame :=
+    let h_aff : Affine iprop(□?p R) := match hor with
+      | @TCOr.l _ _ heq => by cases heq; exact inferInstance
+      | @TCOr.r _ _ hq => by have := hq.quick_affine; exact inferInstance
+    (sep_mono_r h2.make_affinely.2).trans <|
+    (sep_mono_l (affine_affinely _).symm.1).trans <|
+    affinely_sep_2.trans <|
+    affinely_mono h1.frame
+
+@[ipm_backtrack, rocq_alias frame_intuitionistically]
+instance frame_intuitionistically [BI PROP] (R P Q Q' : PROP)
+    [h1 : Frame true R P Q] [h2 : MakeIntuitionistically Q Q'] :
+    Frame true R iprop(□ P) Q' where
+  frame :=
+    (sep_mono_r h2.make_intuitionistically.2).trans <|
+    (sep_mono_l intuitionistically_idem.2).trans <|
+    intuitionistically_sep_2.trans <|
+    intuitionistically_mono h1.frame
+
+@[ipm_backtrack, rocq_alias frame_absorbingly]
+instance frame_absorbingly [BI PROP] p (R P Q Q' : PROP)
+    [h1 : Frame p R P Q] [h2 : MakeAbsorbingly Q Q'] :
+    Frame p R iprop(<absorb> P) Q' where
+  frame :=
+    (sep_mono_r h2.make_absorbingly.2).trans <|
+    absorbingly_sep_r.1.trans <|
+    absorbingly_mono h1.frame
+
+@[ipm_backtrack, rocq_alias frame_persistently]
+instance frame_persistently [BI PROP] (R P Q Q' : PROP)
+    [h1 : Frame true R P Q] [h2 : MakePersistently Q Q'] :
+    Frame true R iprop(<pers> P) Q' where
+  frame :=
+    (sep_mono_r h2.make_persistently.2).trans <|
+    (sep_mono_l persistent).trans <|
+    persistently_sep_2.trans <|
+    persistently_mono h1.frame
+
+@[ipm_backtrack, rocq_alias frame_forall]
+instance frame_forall {α} [BI PROP] p R (Φ Ψ : α → PROP)
+-- TODO: add FrameInstantiateExistDisabled to the premise once supported
+    [h : ∀ a, Frame p R (Φ a) (Ψ a)] :
+    Frame p R iprop(∀ x, Φ x) iprop(∀ x, Ψ x) where
+  frame := forall_intro λ a => (sep_mono_r (forall_elim a)).trans (h a).1
+
+@[ipm_backtrack, rocq_alias frame_impl_persistent]
+instance frame_impl_persistent [BI PROP] (R P1 P2 Q2 : PROP)
+    [h : Frame true R P2 Q2] : Frame true R iprop(P1 → P2) iprop(P1 → Q2) where
+  frame := imp_intro <|
+    (and_mono_l persistently_and_intuitionistically_sep_l.2).trans <|
+    and_assoc.1.trans <|
+    (and_mono_r (and_comm.1.trans imp_elim_r)).trans <|
+    persistently_and_intuitionistically_sep_l.1.trans h.frame
+
+/- You may wonder why this uses [Persistent] and not [QuickPersistent].
+The reason is that [QuickPersistent] is not needed anywhere else, and
+even without [QuickPersistent], this instance avoids quadratic complexity:
+we usually use the [Quick*] classes to not traverse the same term over and over
+again, but here [P1] is encountered at most once. It is hence not worth adding
+a new typeclass just for this extremely rarely used instance. -/
+@[ipm_backtrack, rocq_alias frame_impl]
+instance frame_impl [BI PROP] (R P1 P2 Q2 : PROP)
+    [hp : Persistent P1] [ha : QuickAbsorbing P1]
+    [h : Frame false R P2 Q2] : Frame false R iprop(P1 → P2) iprop(P1 → Q2) where
+  frame :=
+    have : Absorbing P1 := ha.quick_absorbing
+    imp_intro <|
+      persistent_and_affinely_sep_r.1.trans <|
+      sep_assoc.1.trans <|
+      (sep_mono_r (sep_comm.1.trans (persistent_and_affinely_sep_l.2.trans imp_elim_r))).trans <|
+      h.frame
+
+@[ipm_backtrack, rocq_alias frame_later]
+instance frame_later [BI PROP] p (R R' P Q Q' : PROP)
+    [h1 : IntoLaterN true 1 R' R] [h2 : Frame p R P Q] [h3 : MakeLaterN 1 Q Q'] :
+    Frame p R' iprop(▷ P) Q' where
+  frame :=
+    (sep_mono_r h3.make_laterN.2).trans <|
+    (sep_mono_l ((intuitionisticallyIf_mono h1.into_laterN).trans later_intuitionisticallyIf_2)).trans <|
+    later_sep.2.trans <|
+    later_mono h2.frame
+
+@[ipm_backtrack, rocq_alias frame_laterN]
+instance frame_laterN [BI PROP] p n (R R' P Q Q' : PROP)
+    [h1 : IntoLaterN true n R' R] [h2 : Frame p R P Q] [h3 : MakeLaterN n Q Q'] :
+    Frame p R' iprop(▷^[n] P) Q' where
+  frame :=
+    (sep_mono_r h3.make_laterN.2).trans <|
+    (sep_mono_l ((intuitionisticallyIf_mono h1.into_laterN).trans (laterN_intuitionisticallyIf_2 n))).trans <|
+    (laterN_sep n).2.trans <|
+    laterN_mono n h2.frame
+
+@[ipm_backtrack, rocq_alias frame_bupd]
+instance frame_bupd [BI PROP] [BIUpdate PROP] p (R P Q Q' : PROP)
+    [h : Frame p R P Q] [h2 : MakeBUpd Q Q'] : Frame p R iprop(|==> P) Q' where
+  frame := (sep_mono .rfl h2.1.2).trans <| bupd_frame_l.trans (BIUpdate.mono h.frame)
+
+@[ipm_backtrack, rocq_alias frame_fupd]
+instance frame_fupd [BI PROP] [BIFUpdate PROP] p (E1 E2 : CoPset) (R P Q Q' : PROP)
+    [h : Frame p R P Q] [h2 : MakeFUpd E1 E2 Q Q'] : Frame p R iprop(|={E1,E2}=> P) Q' where
+  frame := (sep_mono .rfl h2.1.2).trans <| fupd_frame_l.trans (BIFUpdate.mono h.frame)
+
+@[ipm_backtrack, rocq_alias frame_except_0]
+instance frame_except_0 [BI PROP] p (R P Q Q' : PROP)
+    [h1 : Frame p R P Q] [h2 : MakeExcept0 Q Q'] : Frame p R iprop(◇ P) Q' where
+  frame :=
+    (sep_mono_r h2.make_except0.2).trans <|
+    (sep_mono_l except0_intro).trans <|
+    except0_sep.2.trans <|
+    except0_mono h1.frame
+
+
+section tactic_theorems
+
+@[rocq_alias maybe_frame_default_persistent]
+theorem maybeFrame_default_persistent [BI PROP] (R P : PROP) :
+  Frame true R P P where
+  frame := sep_elim_r
+
+@[rocq_alias maybe_frame_default]
+theorem maybeFrame_default [BI PROP] (R P : PROP)
+  [h : TCOr (Affine R) (Absorbing P)]:
+  Frame false R P P where
+  frame := by simp only [intuitionisticallyIf_false']; exact sep_elim_r
+
+@[rocq_alias frame_sep_persistent_l]
+theorem frame_sep_both [BI PROP] (R P1 P2 Q1 Q2 Q' : PROP)
+  [h1 : Frame true R P1 Q1] [h2 : Frame true R P2 Q2] [MakeSep Q1 Q2 Q'] :
+  Frame true R iprop(P1 ∗ P2) Q' where
+  frame := (sep_mono_r make_sep.2).trans <|
+    (sep_mono_l intuitionistically_sep_idem.2).trans <|
+    sep_sep_sep_comm.1.trans <|
+    sep_mono h1.frame h2.frame
+
+@[rocq_alias frame_sep_l]
+theorem frame_sep_l [BI PROP] p (R P1 P2 Q Q' : PROP)
+  [h1 : Frame p R P1 Q] [h2 : MakeSep Q P2 Q'] :
+  Frame p R iprop(P1 ∗ P2) Q' where
+  frame := (sep_mono_r make_sep.2).trans <|
+    sep_assoc.2.trans <|
+    sep_mono_l h1.frame
+
+@[rocq_alias frame_sep_r]
+theorem frame_sep_r [BI PROP] p (R P1 P2 Q Q' : PROP)
+  [h1 : Frame p R P2 Q] [h2 : MakeSep P1 Q Q'] :
+  Frame p R iprop(P1 ∗ P2) Q' where
+  frame :=(sep_mono_r make_sep.2).trans <|
+    sep_left_comm.1.trans <|
+    sep_mono_r h1.frame
+
+@[rocq_alias frame_and]
+theorem frame_and [BI PROP] p (R P1 P2 Q1 Q2 Q' : PROP)
+  [h1 : Frame p R P1 Q1] [h2 : Frame p R P2 Q2] [h3 : MakeAnd Q1 Q2 Q'] :
+  Frame p R iprop(P1 ∧ P2) Q' where
+  frame := and_intro
+    ((sep_mono_r (h3.make_and.2.trans and_elim_l)).trans h1.frame)
+    ((sep_mono_r (h3.make_and.2.trans and_elim_r)).trans h2.frame)
+
+@[rocq_alias frame_or_spatial, rocq_alias frame_or_persistent]
+theorem frame_or [BI PROP] p (R P1 P2 Q1 Q2 Q' : PROP)
+  [h1 : Frame p R P1 Q1] [h2 : Frame p R P2 Q2] [h3 : MakeOr Q1 Q2 Q'] :
+  Frame p R iprop(P1 ∨ P2) Q' where
+  frame :=
+    (sep_mono_r h3.make_or.2).trans <|
+    sep_or_l.1.trans <|
+    or_mono h1.frame h2.frame
+
+end tactic_theorems
+
+meta section tactics
+open Lean
+
+/-- corresponds to the MaybeFrame typeclass in Rocq -/
+@[rocq_alias MaybeFrame']
+def maybeFrame {prop : Q(Type u)} {bi : Q(BI $prop)} (p : Q(Bool))
+  (R P Q : Q($prop)) (f : Option Q(Frame $p $R $P $Q)) :
+  MetaM (Option Q(Frame $p $R $P $Q)) := do
+  if let some f := f then return some f
+  match matchBool p with
+  | .inl _ =>
+    Q.mvarId!.assign P
+    have : $Q =Q $P := ⟨⟩
+    return some (q(maybeFrame_default_persistent $R $P))
+  | .inr _ =>
+    let .some _ ← trySynthInstanceQ q(TCOr (Affine $R) (Absorbing $P))
+      | return none
+    Q.mvarId!.assign P
+    have : $Q =Q $P := ⟨⟩
+    return some (q(maybeFrame_default $R $P))
+
+@[ipm_tactic_instance Frame _ _ iprop(_ ∗ _) _]
+def frameSep : SynthTactic := λ e => do
+  let_expr Frame prop bi p R P _ := e | return .continue
+  have u := e.getAppFn.constLevels![0]!
+  have prop : Q(Type u) := prop
+  have _bi : Q(BI $prop) := bi
+  have p : Q(Bool) := p
+  have R : Q($prop) := R
+  let_expr BI.sep _ _ P1 P2 := P | return .continue
+  have P1 : Q($prop) := P1
+  have P2 : Q($prop) := P2
+  let Q1 : Q($prop) ← mkFreshExprMVarQ q($prop)
+  if let .some _ ← synthInstanceRecursiveQ q(Frame $p $R $P1 $Q1) then
+    -- if the hyp is persistent, also try to frame it in P2
+    if let .inl _ := matchBool p then
+      let Q2 : Q($prop) ← mkFreshExprMVarQ q($prop)
+      if let .some _ ← synthInstanceRecursiveQ q(Frame $p $R $P2 $Q2) then
+        let Q' : Q($prop) ← mkFreshExprMVarQ q($prop)
+        let .some _ ← synthInstanceRecursiveQ q(MakeSep $Q1 $Q2 $Q') |
+          throwError "MakeSep should always succeed"
+        return .success q(frame_sep_both $R $P1 $P2 $Q1 $Q2 $Q')
+    let Q' : Q($prop) ← mkFreshExprMVarQ q($prop)
+    let .some _ ← synthInstanceRecursiveQ q(MakeSep $Q1 $P2 $Q') |
+      throwError "MakeSep should always succeed"
+    return .success q(frame_sep_l $p $R $P1 $P2 $Q1 $Q')
+  else
+    let Q2 : Q($prop) ← mkFreshExprMVarQ q($prop)
+    let .some _ ← synthInstanceRecursiveQ q(Frame $p $R $P2 $Q2) |
+      return .continue
+    let Q' : Q($prop) ← mkFreshExprMVarQ q($prop)
+    let .some _ ← synthInstanceRecursiveQ q(MakeSep $P1 $Q2 $Q') |
+      throwError "MakeSep should always succeed"
+    return .success q(frame_sep_r $p $R $P1 $P2 $Q2 $Q')
+
+@[ipm_tactic_instance Frame _ _ iprop(_ ∧ _) _]
+def frameAnd : SynthTactic := λ e => do
+  let_expr Frame prop bi p R P _ := e | return .continue
+  have u := e.getAppFn.constLevels![0]!
+  have prop : Q(Type u) := prop
+  have _bi : Q(BI $prop) := bi
+  have p : Q(Bool) := p
+  have R : Q($prop) := R
+  let_expr BI.and _ _ P1 P2 := P | return .continue
+  have P1 : Q($prop) := P1
+  have P2 : Q($prop) := P2
+  let Q1 : Q($prop) ← mkFreshExprMVarQ q($prop)
+  let f1 ← synthInstanceRecursiveQ q(Frame $p $R $P1 $Q1)
+  let Q2 : Q($prop) ← mkFreshExprMVarQ q($prop)
+  let f2 ← synthInstanceRecursiveQ q(Frame $p $R $P2 $Q2)
+  if f1.isNone && f2.isNone then return .continue
+  let .some _ ← maybeFrame p R P1 Q1 f1 | return .continue
+  let .some _ ← maybeFrame p R P2 Q2 f2 | return .continue
+  let Q' : Q($prop) ← mkFreshExprMVarQ q($prop)
+  let .some _ ← synthInstanceRecursiveQ q(MakeAnd $Q1 $Q2 $Q') |
+    throwError "MakeAnd should always succeed"
+  return .success q(frame_and $p $R $P1 $P2 $Q1 $Q2 $Q')
+
+def isBITrue (e : Expr) : Bool :=
+  let_expr BI.pure _ _ P := e | false
+  let_expr True := P | false
+  true
+
+@[ipm_tactic_instance Frame _ _ iprop(_ ∨ _) _]
+def frameOr : SynthTactic := λ e => do
+  let_expr Frame prop bi p R P _ := e | return .continue
+  have u := e.getAppFn.constLevels![0]!
+  have prop : Q(Type u) := prop
+  have _bi : Q(BI $prop) := bi
+  have p : Q(Bool) := p
+  have R : Q($prop) := R
+  let_expr BI.or _ _ P1 P2 := P | return .continue
+  have P1 : Q($prop) := P1
+  have P2 : Q($prop) := P2
+  let Q1 : Q($prop) ← mkFreshExprMVarQ q($prop)
+  let f1 ← synthInstanceRecursiveQ q(Frame $p $R $P1 $Q1)
+  let Q2 : Q($prop) ← mkFreshExprMVarQ q($prop)
+  let f2 ← synthInstanceRecursiveQ q(Frame $p $R $P2 $Q2)
+  let Q1 : Q($prop) ← instantiateMVars Q1
+  let Q2 : Q($prop) ← instantiateMVars Q2
+  -- if no side made progress, framing fails
+  if f1.isNone && f2.isNone then return .continue
+  -- framing succeeds
+  if isTrue p -- if the assumption is persistent (since we can reuse it)
+     || (f1.isSome && f2.isSome) -- or if both sides made progress
+     || (f1.isSome && isBITrue Q1) -- or if the left side was changed to True
+     || (f2.isSome && isBITrue Q2) -- or if the right side was changed to True
+     then
+    let .some _ ← maybeFrame p R P1 Q1 f1 | return .continue
+    let .some _ ← maybeFrame p R P2 Q2 f2 | return .continue
+    let Q' : Q($prop) ← mkFreshExprMVarQ q($prop)
+    let .some _ ← synthInstanceRecursiveQ q(MakeOr $Q1 $Q2 $Q') |
+      throwError "MakeOr should always succeed"
+    return .success q(frame_or $p $R $P1 $P2 $Q1 $Q2 $Q')
+  return .continue

--- a/Iris/Iris/ProofMode/InstancesFrame.lean
+++ b/Iris/Iris/ProofMode/InstancesFrame.lean
@@ -43,14 +43,14 @@ instance (priority := high + 10) frame_affinely_here [BI PROP] p (R : PROP) :
 
 @[ipm_backtrack, rocq_alias frame_here_pure_persistent]
 instance frame_here_pure_persistent [BI PROP] {a : Bool} {φ : Prop} {Q : PROP}
-    [hfp : FromPure .out a Q .in φ] : Frame true iprop(⌜φ⌝) Q iprop(emp) where
+    [hfp : FromPure a Q .in φ] : Frame true iprop(⌜φ⌝) Q iprop(emp) where
   frame :=
     have h : □?true iprop(⌜φ⌝) ∗ emp ⊢ □ iprop(⌜φ⌝) := sep_emp.1
     h.trans (affinely_of_intuitionistically.trans (affinely_affinelyIf.trans hfp.1))
 
 @[ipm_backtrack, rocq_alias frame_here_pure]
 instance frame_here_pure [BI PROP] {a : Bool} {φ : Prop} {Q : PROP}
-    [h1 : FromPure .out a Q .in φ] [hor : TCOr (TCEq a false) (BIAffine PROP)] :
+    [h1 : FromPure a Q .in φ] [hor : TCOr (TCEq a false) (BIAffine PROP)] :
     Frame false iprop(⌜φ⌝) Q iprop(emp) where
   frame :=
     sep_emp.1.trans <|

--- a/Iris/Iris/ProofMode/InstancesFrame.lean
+++ b/Iris/Iris/ProofMode/InstancesFrame.lean
@@ -16,10 +16,13 @@ public import Iris.Std.TC
 namespace Iris.ProofMode
 open Qq Iris.BI Iris.Std
 
-/- When framing [R] against itself, we leave [True] if possible since it is a weaker goal. Otherwise we leave [emp].
-Only if all those options fail, we start decomposing [R]. -/
+/-
+When framing [R] against itself, we leave [True] if possible since it is a weaker goal.
+Otherwise we leave [emp]. Only if all those options fail, we start decomposing [R].
+-/
 @[ipm_backtrack, rocq_alias frame_here_absorbing]
-instance (priority := high + 10) frame_here_absorbing [BI PROP] p (R : PROP) [QuickAbsorbing R] : Frame p R R iprop(True) where
+instance (priority := high + 10) frame_here_absorbing [BI PROP] p (R : PROP) [QuickAbsorbing R] :
+    Frame p R R iprop(True) where
   frame := sep_comm.1.trans <| (sep_mono_r intuitionisticallyIf_elim).trans quick_absorbing.absorbing
 
 @[ipm_backtrack, rocq_alias frame_here]
@@ -27,23 +30,27 @@ instance (priority := high + 5) frame_here [BI PROP] p (R : PROP) : Frame p R R 
   frame := sep_emp.1.trans intuitionisticallyIf_elim
 
 @[ipm_backtrack, rocq_alias frame_affinely_here_absorbing]
-instance (priority := high + 10) frame_affinely_here_absorbing [BI PROP] p (R : PROP) [QuickAbsorbing R] : Frame p iprop(<affine> R) R iprop(True) where
-  frame := sep_comm.1.trans <| (sep_mono_r (intuitionisticallyIf_elim.trans affinely_elim)).trans quick_absorbing.absorbing
+instance (priority := high + 10) frame_affinely_here_absorbing [BI PROP] p (R : PROP)
+    [QuickAbsorbing R] : Frame p iprop(<affine> R) R iprop(True) where
+  frame :=
+    sep_comm.1.trans <|
+    (sep_mono_r (intuitionisticallyIf_elim.trans affinely_elim)).trans quick_absorbing.absorbing
 
 @[ipm_backtrack, rocq_alias frame_affinely_here]
-instance (priority := high + 10) frame_affinely_here [BI PROP] p (R : PROP) : Frame p iprop(<affine> R) R iprop(emp) where
+instance (priority := high + 10) frame_affinely_here [BI PROP] p (R : PROP) :
+    Frame p iprop(<affine> R) R iprop(emp) where
   frame := sep_emp.1.trans (intuitionisticallyIf_elim.trans affinely_elim)
 
 @[ipm_backtrack, rocq_alias frame_here_pure_persistent]
 instance frame_here_pure_persistent [BI PROP] {a : Bool} {φ : Prop} {Q : PROP}
-    [FromPure a Q .in φ] : Frame true iprop(⌜φ⌝) Q iprop(emp) where
+    [hfp : FromPure .out a Q .in φ] : Frame true iprop(⌜φ⌝) Q iprop(emp) where
   frame :=
     have h : □?true iprop(⌜φ⌝) ∗ emp ⊢ □ iprop(⌜φ⌝) := sep_emp.1
-    h.trans (affinely_of_intuitionistically.trans (affinely_affinelyIf.trans (from_pure .in)))
+    h.trans (affinely_of_intuitionistically.trans (affinely_affinelyIf.trans hfp.1))
 
 @[ipm_backtrack, rocq_alias frame_here_pure]
 instance frame_here_pure [BI PROP] {a : Bool} {φ : Prop} {Q : PROP}
-    [h1 : FromPure a Q .in φ] [hor : TCOr (TCEq a false) (BIAffine PROP)] :
+    [h1 : FromPure .out a Q .in φ] [hor : TCOr (TCEq a false) (BIAffine PROP)] :
     Frame false iprop(⌜φ⌝) Q iprop(emp) where
   frame :=
     sep_emp.1.trans <|
@@ -115,12 +122,13 @@ instance frame_impl_persistent [BI PROP] (R P1 P2 Q2 : PROP)
     (and_mono_r (and_comm.1.trans imp_elim_r)).trans <|
     persistently_and_intuitionistically_sep_l.1.trans h.frame
 
-/- You may wonder why this uses [Persistent] and not [QuickPersistent].
-The reason is that [QuickPersistent] is not needed anywhere else, and
-even without [QuickPersistent], this instance avoids quadratic complexity:
-we usually use the [Quick*] classes to not traverse the same term over and over
-again, but here [P1] is encountered at most once. It is hence not worth adding
-a new typeclass just for this extremely rarely used instance. -/
+/-
+You may wonder why this uses [Persistent] and not [QuickPersistent].
+The reason is that [QuickPersistent] is not needed anywhere else, and even without [QuickPersistent],
+this instance avoids quadratic complexity: we usually use the [Quick*] classes to not traverse the
+same term over and over again, but here [P1] is encountered at most once. It is hence not worth adding
+a new typeclass just for this extremely rarely used instance.
+-/
 @[ipm_backtrack, rocq_alias frame_impl]
 instance frame_impl [BI PROP] (R P1 P2 Q2 : PROP)
     [hp : Persistent P1] [ha : QuickAbsorbing P1]
@@ -236,7 +244,7 @@ open Lean
 /-- corresponds to the MaybeFrame typeclass in Rocq -/
 @[rocq_alias MaybeFrame']
 def maybeFrame {prop : Q(Type u)} {bi : Q(BI $prop)} (p : Q(Bool))
-  (R P Q : Q($prop)) (f : Option Q(Frame $p $R $P $Q)) :
+    (R P Q : Q($prop)) (f : Option Q(Frame $p $R $P $Q)) :
   MetaM (Option Q(Frame $p $R $P $Q)) := do
   if let some f := f then return some f
   match matchBool p with
@@ -337,7 +345,7 @@ def frameOr : SynthTactic := λ e => do
      || (f1.isSome && f2.isSome) -- or if both sides made progress
      || (f1.isSome && isBITrue Q1) -- or if the left side was changed to True
      || (f2.isSome && isBITrue Q2) -- or if the right side was changed to True
-     then
+  then
     let .some _ ← maybeFrame p R P1 Q1 f1 | return .continue
     let .some _ ← maybeFrame p R P2 Q2 f2 | return .continue
     let Q' : Q($prop) ← mkFreshExprMVarQ q($prop)

--- a/Iris/Iris/ProofMode/InstancesLater.lean
+++ b/Iris/Iris/ProofMode/InstancesLater.lean
@@ -37,18 +37,18 @@ instance fromAssumption_except0 [BI PROP] (p : Bool) ioP (P Q : PROP)
 /-- FromPure -/
 
 @[rocq_alias from_pure_later]
-instance fromPure_later [BI PROP] (a : Bool) (P : PROP) (φ : Prop)
-    [h : FromPure a P φ] : FromPure a iprop(▷ P) φ where
+instance fromPure_later {io} [BI PROP] (a : Bool) (P : PROP) (φ : Prop)
+    [h : FromPure a P io φ] : FromPure a iprop(▷ P) io φ where
   from_pure := h.1.trans later_intro
 
 @[rocq_alias from_pure_laterN]
-instance fromPure_laterN [BI PROP] (a : Bool) (n : Nat) (P : PROP) (φ : Prop)
-    [h : FromPure a P φ] : FromPure a iprop(▷^[n] P) φ where
+instance fromPure_laterN {io} [BI PROP] (a : Bool) (n : Nat) (P : PROP) (φ : Prop)
+    [h : FromPure a P io φ] : FromPure a iprop(▷^[n] P) io φ where
   from_pure := h.1.trans (laterN_intro n)
 
 @[rocq_alias from_pure_except_0]
-instance fromPure_except0 [BI PROP] (a : Bool) (P : PROP) (φ : Prop)
-    [h : FromPure a P φ] : FromPure a iprop(◇ P) φ where
+instance fromPure_except0 {io} [BI PROP] (a : Bool) (P : PROP) (φ : Prop)
+    [h : FromPure a P io φ] : FromPure a iprop(◇ P) io φ where
   from_pure := h.1.trans except0_intro
 
 /-- IntoWand -/

--- a/Iris/Iris/ProofMode/InstancesLater.lean
+++ b/Iris/Iris/ProofMode/InstancesLater.lean
@@ -38,17 +38,17 @@ instance fromAssumption_except0 [BI PROP] (p : Bool) (P Q : PROP)
 
 @[rocq_alias from_pure_later]
 instance fromPure_later [BI PROP] (a : Bool) (P : PROP) (φ : Prop)
-    [h : FromPure .out a P io φ] : FromPure ioA a iprop(▷ P) io φ where
+    [h : FromPure a P io φ] : FromPure a iprop(▷ P) io φ where
   from_pure := h.1.trans later_intro
 
 @[rocq_alias from_pure_laterN]
 instance fromPure_laterN [BI PROP] (a : Bool) (n : Nat) (P : PROP) (φ : Prop)
-    [h : FromPure .out a P io φ] : FromPure ioA a iprop(▷^[n] P) io φ where
+    [h : FromPure a P io φ] : FromPure a iprop(▷^[n] P) io φ where
   from_pure := h.1.trans (laterN_intro n)
 
 @[rocq_alias from_pure_except_0]
 instance fromPure_except0 [BI PROP] (a : Bool) (P : PROP) (φ : Prop)
-    [h : FromPure .out a P io φ] : FromPure ioA a iprop(◇ P) io φ where
+    [h : FromPure a P io φ] : FromPure a iprop(◇ P) io φ where
   from_pure := h.1.trans except0_intro
 
 /-- IntoWand -/

--- a/Iris/Iris/ProofMode/InstancesLater.lean
+++ b/Iris/Iris/ProofMode/InstancesLater.lean
@@ -19,17 +19,17 @@ open Iris.BI Iris.Std
 /-- FromAssumption -/
 
 @[rocq_alias from_assumption_later]
-instance fromAssumption_later [BI PROP] (p : Bool) ioP (P Q : PROP)
+instance fromAssumption_later [BI PROP] (p : Bool) (P Q : PROP)
     [h : FromAssumption p ioP P Q] : FromAssumption p ioP P iprop(▷ Q) where
   from_assumption := h.1.trans later_intro
 
 @[rocq_alias from_assumption_laterN]
-instance fromAssumption_laterN [BI PROP] n (p : Bool) ioP (P Q : PROP)
+instance fromAssumption_laterN [BI PROP] n (p : Bool) (P Q : PROP)
     [h : FromAssumption p ioP P Q] : FromAssumption p ioP P iprop(▷^[n] Q) where
   from_assumption := h.1.trans (laterN_intro n)
 
 @[rocq_alias from_assumption_except_0]
-instance fromAssumption_except0 [BI PROP] (p : Bool) ioP (P Q : PROP)
+instance fromAssumption_except0 [BI PROP] (p : Bool) (P Q : PROP)
     [h : FromAssumption p ioP P Q] : FromAssumption p ioP P iprop(◇ Q) where
   from_assumption := h.1.trans except0_intro
 
@@ -37,44 +37,44 @@ instance fromAssumption_except0 [BI PROP] (p : Bool) ioP (P Q : PROP)
 /-- FromPure -/
 
 @[rocq_alias from_pure_later]
-instance fromPure_later {io} [BI PROP] (a : Bool) (P : PROP) (φ : Prop)
-    [h : FromPure a P io φ] : FromPure a iprop(▷ P) io φ where
+instance fromPure_later [BI PROP] (a : Bool) (P : PROP) (φ : Prop)
+    [h : FromPure .out a P io φ] : FromPure ioA a iprop(▷ P) io φ where
   from_pure := h.1.trans later_intro
 
 @[rocq_alias from_pure_laterN]
-instance fromPure_laterN {io} [BI PROP] (a : Bool) (n : Nat) (P : PROP) (φ : Prop)
-    [h : FromPure a P io φ] : FromPure a iprop(▷^[n] P) io φ where
+instance fromPure_laterN [BI PROP] (a : Bool) (n : Nat) (P : PROP) (φ : Prop)
+    [h : FromPure .out a P io φ] : FromPure ioA a iprop(▷^[n] P) io φ where
   from_pure := h.1.trans (laterN_intro n)
 
 @[rocq_alias from_pure_except_0]
-instance fromPure_except0 {io} [BI PROP] (a : Bool) (P : PROP) (φ : Prop)
-    [h : FromPure a P io φ] : FromPure a iprop(◇ P) io φ where
+instance fromPure_except0 [BI PROP] (a : Bool) (P : PROP) (φ : Prop)
+    [h : FromPure .out a P io φ] : FromPure ioA a iprop(◇ P) io φ where
   from_pure := h.1.trans except0_intro
 
 /-- IntoWand -/
 
 @[rocq_alias into_wand_later]
-instance intoWand_later [BI PROP] (p q : Bool) ioP ioQ (R P Q : PROP)
+instance intoWand_later [BI PROP] (p q : Bool) (R P Q : PROP)
     [h : IntoWand p q R ioP P ioQ Q] : IntoWand p q iprop(▷ R) ioP iprop(▷ P) ioQ iprop(▷ Q) where
   into_wand := later_intuitionisticallyIf_2.trans <|
     (later_mono h.1).trans <| later_wand.trans <| wand_mono later_intuitionisticallyIf_2 .rfl
 
 #rocq_ignore into_wand_later_args "IntoWand' is not used in Lean"
 -- TODO: see if this is necessary. It is an instance for IntoWand' in Rocq
--- instance intoWand_later_args [BI PROP] (p q : Bool) ioP ioQ (R P Q : PROP)
+-- instance intoWand_later_args [BI PROP] (p q : Bool) (R P Q : PROP)
 --     [h : IntoWand p q R ioP P ioQ Q] : IntoWand p q R ioP iprop(▷ P) ioQ iprop(▷ Q) where
 --   into_wand := (intuitionisticallyIf_mono later_intro).trans <| later_intuitionisticallyIf_2.trans <|
 --     (later_mono h.1).trans <| later_wand.trans <| wand_mono later_intuitionisticallyIf_2 .rfl
 
 @[rocq_alias into_wand_laterN]
-instance intoWand_laterN [BI PROP] (n : Nat) (p q : Bool) ioP ioQ (R P Q : PROP)
+instance intoWand_laterN [BI PROP] (n : Nat) (p q : Bool) (R P Q : PROP)
     [h : IntoWand p q R ioP P ioQ Q] : IntoWand p q iprop(▷^[n] R) ioP iprop(▷^[n] P) ioQ iprop(▷^[n] Q) where
   into_wand := (laterN_intuitionisticallyIf_2 n).trans <|
     (laterN_mono n h.1).trans <| (laterN_wand n).trans <| wand_mono (laterN_intuitionisticallyIf_2 n) .rfl
 
 #rocq_ignore into_wand_laterN_args "IntoWand' is not used in Lean"
 -- TODO: see if this is necessary. It is an instance for IntoWand' in Rocq
--- instance intoWand_laterN_args [BI PROP] (n : Nat) (p q : Bool) ioP ioQ (R P Q : PROP)
+-- instance intoWand_laterN_args [BI PROP] (n : Nat) (p q : Bool) (R P Q : PROP)
 --     [h : IntoWand p q R ioP P ioQ Q] : IntoWand p q R ioP iprop(▷^[n] P) ioQ iprop(▷^[n] Q) where
 --   into_wand := (intuitionisticallyIf_mono (laterN_intro n)).trans <| (laterN_intuitionisticallyIf_2 n).trans <|
 --     (laterN_mono n h.1).trans <| (laterN_wand n).trans <| wand_mono (laterN_intuitionisticallyIf_2 n) .rfl
@@ -125,13 +125,15 @@ instance intoAnd_later [BI PROP] (p : Bool) (P Q1 Q2 : PROP)
 instance intoAnd_laterN [BI PROP] (n : Nat) (p : Bool) (P Q1 Q2 : PROP)
     [h : IntoAnd p P Q1 Q2] : IntoAnd p iprop(▷^[n] P) iprop(▷^[n] Q1) iprop(▷^[n] Q2) where
   into_and := intuitionisticallyIf_intro' <|
-    (laterN_intuitionisticallyIf_2 n).trans <| (laterN_mono n <| h.1.trans intuitionisticallyIf_elim).trans (laterN_and n).1
+    (laterN_intuitionisticallyIf_2 n).trans <|
+    (laterN_mono n <| h.1.trans intuitionisticallyIf_elim).trans (laterN_and n).1
 
 @[rocq_alias into_and_except_0]
 instance intoAnd_except0 [BI PROP] (p : Bool) (P Q1 Q2 : PROP)
     [h : IntoAnd p P Q1 Q2] : IntoAnd p iprop(◇ P) iprop(◇ Q1) iprop(◇ Q2) where
   into_and := intuitionisticallyIf_intro' <|
-    except0_intuitionisticallyIf_2.trans <| (except0_mono <| h.1.trans intuitionisticallyIf_elim).trans except0_and.1
+    except0_intuitionisticallyIf_2.trans <|
+    (except0_mono <| h.1.trans intuitionisticallyIf_elim).trans except0_and.1
 
 /-- IntoSep -/
 

--- a/Iris/Iris/ProofMode/InstancesMake.lean
+++ b/Iris/Iris/ProofMode/InstancesMake.lean
@@ -13,60 +13,207 @@ public import Iris.ProofMode.ClassesMake
 namespace Iris.ProofMode
 open Iris.BI
 
+/- For classes that are not ipm_classes (like QuickAffine and QuickAbsorbing), the BIAffine
+  instances must have a higher priority than the instances that match on the proposition
+  since if the proposition P is a meta variable, instances that try to match on it will generate an
+  IsDefEqStuck exception, which aborts the typeclass search completely. -/
+
+/- QuickAffine -/
+@[rocq_alias bi_affine_quick_affine]
+instance (priority := default + 10) quickAffine_biAffine [BI PROP] (P : PROP) [BIAffine PROP] :
+  QuickAffine P where
+  quick_affine := inferInstance
+
+@[rocq_alias False_quick_affine]
+instance quickAffine_False [BI PROP] :
+  QuickAffine (PROP:=PROP) iprop(False) where
+  quick_affine := inferInstance
+
+@[rocq_alias emp_quick_affine]
+instance quickAffine_emp [BI PROP] :
+  QuickAffine (PROP:=PROP) iprop(emp) where
+  quick_affine := inferInstance
+
+@[rocq_alias affinely_quick_affine]
+instance quickAffine_affinely [BI PROP] (P : PROP) :
+  QuickAffine iprop(<affine> P) where
+  quick_affine := inferInstance
+
+@[rocq_alias intuitionistically_quick_affine]
+instance quickAffine_intuitionistically [BI PROP] (P : PROP) :
+  QuickAffine iprop(□ P) where
+  quick_affine := inferInstance
+
+/- QuickAbsorbing -/
+@[rocq_alias bi_affine_quick_absorbing]
+instance (priority := default + 10) quickAbsorbing_biAffine [BI PROP] (P : PROP) [BIAffine PROP] :
+  QuickAbsorbing P where
+  quick_absorbing := inferInstance
+
+@[rocq_alias pure_quick_absorbing]
+instance quickAbsorbing_pure [BI PROP] (P : Prop) :
+  QuickAbsorbing (PROP:=PROP) iprop(⌜P⌝) where
+  quick_absorbing := inferInstance
+
+@[rocq_alias absorbingly_quick_absorbing]
+instance quickAbsorbing_absorbingly [BI PROP] (P : PROP) :
+  QuickAbsorbing iprop(<absorb> P) where
+  quick_absorbing := inferInstance
+
+@[rocq_alias persistently_quick_absorbing]
+instance quickAbsorbing_persistently [BI PROP] (P : PROP) :
+  QuickAbsorbing iprop(<pers> P) where
+  quick_absorbing := inferInstance
+
+/- MakeSep -/
+
+@[rocq_alias make_sep_emp_l]
+instance makeSep_emp_l [BI PROP] (P : PROP) : MakeSep iprop(emp) P P where
+  make_sep := emp_sep
+
+@[rocq_alias make_sep_emp_r]
+instance makeSep_emp_r [BI PROP] (P : PROP) : MakeSep P iprop(emp) P where
+  make_sep := sep_emp
+
+@[ipm_backtrack, rocq_alias make_sep_true_l]
+instance makeSep_true_l [BI PROP] (P : PROP) [h : QuickAbsorbing P] : MakeSep iprop(True) P P where
+  make_sep := have := h.1; true_sep
+
+@[ipm_backtrack, rocq_alias make_sep_true_r]
+instance makeSep_true_r [BI PROP] (P : PROP) [h : QuickAbsorbing P] : MakeSep P iprop(True) P where
+  make_sep := have := h.1; sep_true
+
+@[rocq_alias make_sep_default]
+instance (priority:=low) makeSep_default [BI PROP] (P Q : PROP) : MakeSep P Q iprop(P ∗ Q) where
+  make_sep := .rfl
+
+/- MakeAnd -/
+
+@[rocq_alias make_and_true_l]
+instance makeAnd_true_l [BI PROP] (P : PROP) : MakeAnd iprop(True) P P where
+  make_and := true_and
+
+@[rocq_alias make_and_true_r]
+instance makeAnd_true_r [BI PROP] (P : PROP) : MakeAnd P iprop(True) P where
+  make_and := and_true
+
+@[ipm_backtrack, rocq_alias make_and_emp_l]
+instance makeAnd_emp_l [BI PROP] (P : PROP) [h : QuickAffine P] : MakeAnd iprop(emp) P P where
+  make_and := have := h.1; emp_and
+
+@[ipm_backtrack, rocq_alias make_and_emp_r]
+instance makeAnd_emp_r [BI PROP] (P : PROP) [h : QuickAffine P] : MakeAnd P iprop(emp) P where
+  make_and := have := h.1; and_emp
+
+@[rocq_alias make_and_false_l]
+instance makeAnd_false_l [BI PROP] (P : PROP) : MakeAnd iprop(False) P iprop(False) where
+  make_and := false_and
+
+@[rocq_alias make_and_false_r]
+instance makeAnd_false_r [BI PROP] (P : PROP) : MakeAnd P iprop(False) iprop(False) where
+  make_and := and_false
+
+@[rocq_alias make_and_default]
+instance (priority:=low) makeAnd_default [BI PROP] (P Q : PROP) : MakeAnd P Q iprop(P ∧ Q) where
+  make_and := .rfl
+
+/- MakeOr -/
+
+@[rocq_alias make_or_true_l]
+instance makeOr_true_l [BI PROP] (P : PROP) : MakeOr iprop(True) P iprop(True) where
+  make_or := true_or
+
+@[rocq_alias make_or_true_r]
+instance makeOr_true_r [BI PROP] (P : PROP) : MakeOr P iprop(True) iprop(True) where
+  make_or := or_true
+
+@[ipm_backtrack, rocq_alias make_or_emp_l]
+instance makeOr_emp_l [BI PROP] (P : PROP) [h : QuickAffine P] : MakeOr iprop(emp) P iprop(emp) where
+  make_or := have := h.1; emp_or
+
+@[ipm_backtrack, rocq_alias make_or_emp_r]
+instance makeOr_emp_r [BI PROP] (P : PROP) [h : QuickAffine P] : MakeOr P iprop(emp) iprop(emp) where
+  make_or := have := h.1; or_emp
+
+@[rocq_alias make_or_false_l]
+instance makeOr_false_l [BI PROP] (P : PROP) : MakeOr iprop(False) P P where
+  make_or := false_or
+
+@[rocq_alias make_or_false_r]
+instance makeOr_false_r [BI PROP] (P : PROP) : MakeOr P iprop(False) P where
+  make_or := or_false
+
+@[rocq_alias make_or_default]
+instance (priority:=low) makeOr_default [BI PROP] (P Q : PROP) : MakeOr P Q iprop(P ∨ Q) where
+  make_or := .rfl
+
 /- MakeAffinely -/
 
+@[ipm_backtrack, rocq_alias make_affinely_affine]
 instance (priority := high) makeAffinely_affine [BI PROP] (P : PROP) [Affine P] :
     MakeAffinely P P where
   make_affinely := affine_affinely P
 
+@[rocq_alias make_affinely_True]
 instance makeAffinely_True [BI PROP] :
     MakeAffinely (PROP := PROP) iprop(True) iprop(emp) where
   make_affinely := affinely_true
 
+@[rocq_alias make_affinely_default]
 instance (priority := low) makeAffinely_default [BI PROP] (P : PROP) :
     MakeAffinely P iprop(<affine> P) where
   make_affinely := .rfl
 
 /- MakeAbsorbingly -/
+@[ipm_backtrack, rocq_alias make_absorbingly_absorbing]
 instance (priority := high) makeAbsorbingly_absorbing [BI PROP] (P : PROP) [Absorbing P] :
     MakeAbsorbingly P P where
   make_absorbingly := absorbing_absorbingly
 
+@[rocq_alias make_absorbingly_emp]
 instance makeAbsorbingly_emp [BI PROP] :
     MakeAbsorbingly (PROP := PROP) iprop(emp) iprop(True) where
   make_absorbingly := absorbingly_emp
 
+@[rocq_alias make_absorbingly_default]
 instance (priority := low) makeAbsorbingly_default [BI PROP] (P : PROP) :
     MakeAbsorbingly P iprop(<absorb> P) where
   make_absorbingly := .rfl
 
 /- MakePersistently -/
+@[rocq_alias make_persistently_emp]
 instance (priority := high) makePersistently_emp [BI PROP] :
     MakePersistently (PROP := PROP) iprop(emp) iprop(True) where
   make_persistently := persistently_emp
 
+@[rocq_alias make_persistently_True]
 instance (priority := high) makePersistently_True [BI PROP] :
     MakePersistently (PROP := PROP) iprop(True) iprop(True) where
   make_persistently := persistently_true
 
+@[rocq_alias make_persistently_default]
 instance (priority := low) makePersistently_default [BI PROP] (P : PROP) :
     MakePersistently P iprop(<pers> P) where
   make_persistently := .rfl
 
 /- MakeIntuitionistically -/
 
+@[rocq_alias make_intuitionistically_emp]
 instance (priority := high) makeIntuitionistically_emp [BI PROP] :
     MakeIntuitionistically (PROP := PROP) iprop(emp) iprop(emp) where
   make_intuitionistically := intuitionistically_emp
 
+@[ipm_backtrack, rocq_alias make_intuitionistically_True_affine]
 instance (priority := high) makeIntuitionistically_True_affine [BI PROP] [BIAffine PROP] :
     MakeIntuitionistically (PROP := PROP) iprop(True) iprop(True) where
   make_intuitionistically := intuitionistically_true.trans true_emp.symm
 
+@[rocq_alias make_intuitionistically_True]
 instance makeIntuitionistically_True [BI PROP] :
     MakeIntuitionistically (PROP := PROP) iprop(True) iprop(emp) where
   make_intuitionistically := intuitionistically_true
 
+@[rocq_alias make_intuitionistically_default]
 instance (priority := low) makeIntuitionistically_default [BI PROP] (P : PROP) :
     MakeIntuitionistically P iprop(□ P) where
   make_intuitionistically := .rfl
@@ -79,14 +226,49 @@ instance makeLaterN_0 [BI PROP] (P : PROP) : MakeLaterN 0 P P where
 instance makeLaterN_1 [BI PROP] (P : PROP) : MakeLaterN 1 P iprop(▷ P) where
   make_laterN := .rfl
 
+@[rocq_alias make_laterN_default]
 instance (priority := low) makeLaterN_default [BI PROP] n (P : PROP) :
     MakeLaterN n P iprop(▷^[n] P) where
   make_laterN := .rfl
 
+@[rocq_alias make_laterN_true]
 instance (priority := high) makeLaterN_True [BI PROP] n :
     MakeLaterN (PROP:=PROP) n iprop(True) iprop(True) where
   make_laterN := laterN_true n
 
+@[ipm_backtrack, rocq_alias make_laterN_emp]
 instance (priority := high) makeLaterN_emp [BI PROP] [BIAffine PROP] n :
     MakeLaterN (PROP:=PROP) n iprop(emp) iprop(emp) where
   make_laterN := laterN_emp n
+
+/- MakeExcept0 -/
+
+@[rocq_alias make_except_0_True]
+instance makeExcept0_True [BI PROP] :
+    MakeExcept0 (PROP:=PROP) iprop(True) iprop(True) where
+  make_except0 := except0_true
+
+@[rocq_alias make_except_0_default]
+instance (priority := low) makeExcept0_default [BI PROP] (P : PROP) :
+    MakeExcept0 P iprop(◇ P) where
+  make_except0 := .rfl
+
+/- MakeBUpd -/
+
+instance makeBUpd_True [BI PROP] [BIUpdate PROP] :
+    MakeBUpd (PROP:=PROP) iprop(True) iprop(True) where
+  make_bupd := ⟨true_intro, BIUpdate.intro⟩
+
+instance (priority := low) makeBUpd_default [BI PROP] [BIUpdate PROP] (P : PROP) :
+    MakeBUpd P iprop(|==> P) where
+  make_bupd := .rfl
+
+/- MakeFUpd -/
+
+instance makeFUpd_True [BI PROP] [BIFUpdate PROP] E :
+    MakeFUpd (PROP:=PROP) E E iprop(True) iprop(True) where
+  make_fupd := ⟨true_intro, fupd_intro⟩
+
+instance (priority := low) makeFUpd_default [BI PROP] [BIFUpdate PROP] E1 E2 (P : PROP) :
+    MakeFUpd E1 E2 P iprop(|={E1, E2}=> P) where
+  make_fupd := .rfl

--- a/Iris/Iris/ProofMode/InstancesPlainly.lean
+++ b/Iris/Iris/ProofMode/InstancesPlainly.lean
@@ -31,8 +31,8 @@ instance fromAssumption_plainly_l_false [Sbi PROP] [BIAffine PROP] (P Q : PROP)
 /-- FromPure -/
 
 @[rocq_alias from_pure_plainly]
-instance fromPure_plainly [Sbi PROP] (P : PROP) (φ : Prop)
-    [h : FromPure false P φ] : FromPure false iprop(■ P) φ where
+instance fromPure_plainly {io} [Sbi PROP] (P : PROP) (φ : Prop)
+    [h : FromPure false P io φ] : FromPure false iprop(■ P) io φ where
   from_pure := plainly_pure.2.trans (plainly_mono h.1)
 
 /-- IntoPure -/

--- a/Iris/Iris/ProofMode/InstancesPlainly.lean
+++ b/Iris/Iris/ProofMode/InstancesPlainly.lean
@@ -31,8 +31,8 @@ instance fromAssumption_plainly_l_false [Sbi PROP] [BIAffine PROP] (P Q : PROP)
 /-- FromPure -/
 
 @[rocq_alias from_pure_plainly]
-instance fromPure_plainly {io} [Sbi PROP] (P : PROP) (φ : Prop)
-    [h : FromPure false P io φ] : FromPure false iprop(■ P) io φ where
+instance fromPure_plainly [Sbi PROP] (P : PROP) (φ : Prop)
+    [h : FromPure .in false P io φ] : FromPure ioA false iprop(■ P) io φ where
   from_pure := plainly_pure.2.trans (plainly_mono h.1)
 
 /-- IntoPure -/

--- a/Iris/Iris/ProofMode/InstancesPlainly.lean
+++ b/Iris/Iris/ProofMode/InstancesPlainly.lean
@@ -32,8 +32,8 @@ instance fromAssumption_plainly_l_false [Sbi PROP] [BIAffine PROP] (P Q : PROP)
 
 @[rocq_alias from_pure_plainly]
 instance fromPure_plainly [Sbi PROP] (P : PROP) (φ : Prop)
-    [h : FromPure .in false P io φ] : FromPure ioA false iprop(■ P) io φ where
-  from_pure := plainly_pure.2.trans (plainly_mono h.1)
+    [h : FromPure a P io φ] : FromPure false iprop(■ P) io φ where
+  from_pure := plainly_pure.2.trans (plainly_affinely_elim.2.trans (plainly_mono (affinely_affinelyIf.trans h.1)))
 
 /-- IntoPure -/
 

--- a/Iris/Iris/ProofMode/InstancesUpdates.lean
+++ b/Iris/Iris/ProofMode/InstancesUpdates.lean
@@ -25,8 +25,8 @@ instance fromAssumption_bupd p ioP (P Q : PROP)
   from_assumption := h.1.trans BIUpdate.intro
 
 @[rocq_alias from_pure_bupd]
-instance fromPure_bupd (a : Bool) (P : PROP) (φ : Prop)
-    [h : FromPure a P φ] : FromPure a iprop(|==> P) φ where
+instance fromPure_bupd {io} (a : Bool) (P : PROP) (φ : Prop)
+    [h : FromPure a P io φ] : FromPure a iprop(|==> P) io φ where
   from_pure := h.1.trans BIUpdate.intro
 
 @[rocq_alias into_wand_bupd]
@@ -117,8 +117,8 @@ instance fromAssumption_fupd E p ioP (P Q : PROP)
   from_assumption := h.from_assumption.trans BIUpdateFUpdate.fupd_of_bupd
 
 @[rocq_alias from_pure_fupd]
-instance fromPure_fupd E a (P : PROP) (φ : Prop)
-    [h : FromPure a P φ] : FromPure a iprop(|={E}=> P) φ where
+instance fromPure_fupd io E a (P : PROP) (φ : Prop)
+    [h : FromPure a P io φ] : FromPure a iprop(|={E}=> P) io φ where
   from_pure := h.from_pure.trans <| fupd_intro
 
 @[rocq_alias into_wand_fupd]

--- a/Iris/Iris/ProofMode/InstancesUpdates.lean
+++ b/Iris/Iris/ProofMode/InstancesUpdates.lean
@@ -26,7 +26,7 @@ instance fromAssumption_bupd p ioP (P Q : PROP)
 
 @[rocq_alias from_pure_bupd]
 instance fromPure_bupd (a : Bool) (P : PROP) (φ : Prop)
-    [h : FromPure .out a P io φ] : FromPure ioA a iprop(|==> P) io φ where
+    [h : FromPure a P io φ] : FromPure a iprop(|==> P) io φ where
   from_pure := h.1.trans BIUpdate.intro
 
 @[rocq_alias into_wand_bupd]
@@ -118,7 +118,7 @@ instance fromAssumption_fupd E p ioP (P Q : PROP)
 
 @[rocq_alias from_pure_fupd]
 instance fromPure_fupd E a (P : PROP) (φ : Prop)
-    [h : FromPure .out a P io φ] : FromPure ioA a iprop(|={E}=> P) io φ where
+    [h : FromPure a P io φ] : FromPure a iprop(|={E}=> P) io φ where
   from_pure := h.from_pure.trans <| fupd_intro
 
 @[rocq_alias into_wand_fupd]

--- a/Iris/Iris/ProofMode/InstancesUpdates.lean
+++ b/Iris/Iris/ProofMode/InstancesUpdates.lean
@@ -25,8 +25,8 @@ instance fromAssumption_bupd p ioP (P Q : PROP)
   from_assumption := h.1.trans BIUpdate.intro
 
 @[rocq_alias from_pure_bupd]
-instance fromPure_bupd {io} (a : Bool) (P : PROP) (φ : Prop)
-    [h : FromPure a P io φ] : FromPure a iprop(|==> P) io φ where
+instance fromPure_bupd (a : Bool) (P : PROP) (φ : Prop)
+    [h : FromPure .out a P io φ] : FromPure ioA a iprop(|==> P) io φ where
   from_pure := h.1.trans BIUpdate.intro
 
 @[rocq_alias into_wand_bupd]
@@ -117,8 +117,8 @@ instance fromAssumption_fupd E p ioP (P Q : PROP)
   from_assumption := h.from_assumption.trans BIUpdateFUpdate.fupd_of_bupd
 
 @[rocq_alias from_pure_fupd]
-instance fromPure_fupd io E a (P : PROP) (φ : Prop)
-    [h : FromPure a P io φ] : FromPure a iprop(|={E}=> P) io φ where
+instance fromPure_fupd E a (P : PROP) (φ : Prop)
+    [h : FromPure .out a P io φ] : FromPure ioA a iprop(|={E}=> P) io φ where
   from_pure := h.from_pure.trans <| fupd_intro
 
 @[rocq_alias into_wand_fupd]

--- a/Iris/Iris/ProofMode/Patterns/CasesPattern.lean
+++ b/Iris/Iris/ProofMode/Patterns/CasesPattern.lean
@@ -16,6 +16,7 @@ declare_syntax_cat icasesPat
 syntax icasesPatAlts := sepBy1(icasesPat, " | ")
 syntax binderIdent : icasesPat
 syntax "-" : icasesPat
+syntax "$" : icasesPat
 syntax "⟨" icasesPatAlts,* "⟩" : icasesPat
 syntax "(" icasesPatAlts ")" : icasesPat
 syntax "%" binderIdent : icasesPat
@@ -28,6 +29,7 @@ syntax ">" icasesPat : icasesPat
 inductive iCasesPat
   | one (name : TSyntax ``binderIdent)
   | clear
+  | frame
   | conjunction (args : List iCasesPat)
   | disjunction (args : List iCasesPat)
   | pure           (pat : TSyntax ``binderIdent)
@@ -44,6 +46,7 @@ where
   go : TSyntax `icasesPat → Option iCasesPat
   | `(icasesPat| $name:binderIdent) => some <| .one name
   | `(icasesPat| -) => some <| .clear
+  | `(icasesPat| $) => some <| .frame
   | `(icasesPat| ⟨$[$args],*⟩) => args.mapM goAlts |>.map (.conjunction ·.toList)
   | `(icasesPat| %$pat:binderIdent) => some <| .pure pat
   | `(icasesPat| #$pat) => go pat |>.map .intuitionistic

--- a/Iris/Iris/ProofMode/Patterns/SelPattern.lean
+++ b/Iris/Iris/ProofMode/Patterns/SelPattern.lean
@@ -46,19 +46,22 @@ partial def SelPat.parse (pats : TSyntaxArray `selPat) : MacroM (List SelPat) :=
 
 public meta section
 
-abbrev SelTarget := Name ⊕ FVarId
+structure SelTarget where
+  target : Name ⊕ FVarId
+  /- Was this target specified explicitly or is it from a glob like ∗? -/
+  explicit : Bool
 
 /-- Resolve selection patterns to concrete proofmode hypotheses (`.inl`) and Lean locals (`.inr`). -/
 def SelPat.resolveOne (hyps : Hyps bi e) : SelPat → ProofModeM (List SelTarget)
   | .ident name =>
-      return [.inl (← hyps.findWithInfo name)]
+      return [⟨.inl (← hyps.findWithInfo name), true⟩]
   | .leanIdent name => do
       let ldecl ← getLocalDeclFromUserName name.getId
-      return [.inr ldecl.fvarId]
+      return [⟨.inr ldecl.fvarId, true⟩]
   | .intuitionistic =>
-      return hyps.intuitionisticUniqs.map .inl
+      return hyps.intuitionisticUniqs.map (⟨.inl ·, false⟩)
   | .spatial =>
-      return hyps.spatialUniqs.map .inl
+      return hyps.spatialUniqs.map (⟨.inl ·, false⟩)
   | .pure => do
       -- `%` selects user-facing Lean pure assumptions, so we keep only `Prop` hypotheses.
       let mut hyps := #[]
@@ -67,12 +70,13 @@ def SelPat.resolveOne (hyps : Hyps bi e) : SelPat → ProofModeM (List SelTarget
           continue
         if ! (← isProp ldecl.type) then
           continue
-        hyps := hyps.push (.inr ldecl.fvarId)
+        hyps := hyps.push (⟨.inr ldecl.fvarId, false⟩)
       return hyps.toList
 
 def SelPat.resolve (hyps : Hyps bi e) (pats : List SelPat) :
     ProofModeM (List SelTarget) := do
-  return (← pats.flatMapM (SelPat.resolveOne hyps)).eraseDups
+  -- we want to remove duplicates and if an pattern is first explicitly specified and then non-explicitly, we want to remove the non-explicit version (but not the other way around)
+  return (← pats.flatMapM (SelPat.resolveOne hyps)).eraseDupsBy (λ snd fst => snd.target == fst.target && (fst.explicit == snd.explicit || fst.explicit))
 
 end
 

--- a/Iris/Iris/ProofMode/Patterns/SelPattern.lean
+++ b/Iris/Iris/ProofMode/Patterns/SelPattern.lean
@@ -75,8 +75,10 @@ def SelPat.resolveOne (hyps : Hyps bi e) : SelPat → ProofModeM (List SelTarget
 
 def SelPat.resolve (hyps : Hyps bi e) (pats : List SelPat) :
     ProofModeM (List SelTarget) := do
-  -- we want to remove duplicates and if an pattern is first explicitly specified and then non-explicitly, we want to remove the non-explicit version (but not the other way around)
-  return (← pats.flatMapM (SelPat.resolveOne hyps)).eraseDupsBy (λ snd fst => snd.target == fst.target && (fst.explicit == snd.explicit || fst.explicit))
+  -- we want to remove duplicates; and if an pattern is first explicitly specified and then non-explicitly,
+  -- we want to remove the non-explicit version (but not the other way around)
+  return (← pats.flatMapM (SelPat.resolveOne hyps)).eraseDupsBy
+    (λ snd fst => snd.target == fst.target && (fst.explicit == snd.explicit || fst.explicit))
 
 end
 

--- a/Iris/Iris/ProofMode/Patterns/SelPattern.lean
+++ b/Iris/Iris/ProofMode/Patterns/SelPattern.lean
@@ -46,19 +46,22 @@ partial def SelPat.parse (pats : TSyntaxArray `selPat) : MacroM (List SelPat) :=
 
 public meta section
 
-abbrev SelTarget := IVarId ⊕ FVarId
+structure SelTarget where
+  target : IVarId ⊕ FVarId
+  /- Was this target specified explicitly or is it from a glob like ∗? -/
+  explicit : Bool
 
 /-- Resolve selection patterns to concrete proofmode hypotheses (`.inl`) and Lean locals (`.inr`). -/
 def SelPat.resolveOne (hyps : Hyps bi e) : SelPat → ProofModeM (List SelTarget)
   | .ident name =>
-      return [.inl (← hyps.findWithInfo name)]
+      return [⟨.inl (← hyps.findWithInfo name), true⟩]
   | .leanIdent name => do
       let ldecl ← getLocalDeclFromUserName name.getId
-      return [.inr ldecl.fvarId]
+      return [⟨.inr ldecl.fvarId, true⟩]
   | .intuitionistic =>
-      return hyps.intuitionisticIVarIds.map .inl
+      return hyps.intuitionisticIVarIds.map (⟨.inl ·, false⟩)
   | .spatial =>
-      return hyps.spatialIVarIds.map .inl
+      return hyps.spatialIVarIds.map (⟨.inl ·, false⟩)
   | .pure => do
       -- `%` selects user-facing Lean pure assumptions, so we keep only `Prop` hypotheses.
       let mut hyps := #[]
@@ -67,12 +70,13 @@ def SelPat.resolveOne (hyps : Hyps bi e) : SelPat → ProofModeM (List SelTarget
           continue
         if ! (← isProp ldecl.type) then
           continue
-        hyps := hyps.push (.inr ldecl.fvarId)
+        hyps := hyps.push (⟨.inr ldecl.fvarId, false⟩)
       return hyps.toList
 
 def SelPat.resolve (hyps : Hyps bi e) (pats : List SelPat) :
     ProofModeM (List SelTarget) := do
-  return (← pats.flatMapM (SelPat.resolveOne hyps)).eraseDups
+  -- we want to remove duplicates and if an pattern is first explicitly specified and then non-explicitly, we want to remove the non-explicit version (but not the other way around)
+  return (← pats.flatMapM (SelPat.resolveOne hyps)).eraseDupsBy (λ snd fst => snd.target == fst.target && (fst.explicit == snd.explicit || fst.explicit))
 
 end
 

--- a/Iris/Iris/ProofMode/Patterns/SpecPattern.lean
+++ b/Iris/Iris/ProofMode/Patterns/SpecPattern.lean
@@ -1,28 +1,76 @@
 /-
 Copyright (c) 2025 Oliver Soeser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Oliver Soeser, Zongyuan Liu
+Authors: Oliver Soeser, Zongyuan Liu, Yunsong Yang, Michael Sammler
 -/
 module
+
+public import Lean.Syntax
+meta import Iris.Std.RocqPorting
 
 @[expose] public section
 
 namespace Iris.ProofMode
 open Lean
 
+declare_syntax_cat frameIdent
+syntax ident : frameIdent
+-- We actually don't want to add the following since it would allow a space between $ and ident.
+-- Instead we rely on the fact that Lean allows $x as an identifier, denoting an antiquotation
+-- syntax "$" ident : frameIdent
+
 declare_syntax_cat specPat
 
 syntax ident : specPat
 syntax "%" term:max : specPat
-syntax "[" ident* "]" optional(" as " ident) : specPat
+syntax "[" frameIdent* "]" optional(" as " ident) : specPat
+syntax "[" "-" frameIdent* "]" optional(" as " ident) : specPat
+syntax "[>" frameIdent* "]" optional(" as " ident) : specPat
+syntax "[>" "-" frameIdent* "]" optional(" as " ident) : specPat
+syntax "[#" frameIdent* "]" optional(" as " ident) : specPat
+syntax "[" "$" "]" : specPat
+syntax "[#" "$" "]" : specPat
+
+@[rocq_alias goal_kind]
+inductive SpecGoalKind
+  | spatial
+  -- TODO: implement
+  | modal
+  -- TODO: implement
+  | intuitionistic
+  deriving Repr, Inhabited, BEq
+
+@[rocq_alias spec_goal]
+structure SpecGoal where
+  kind : SpecGoalKind
+  negate : Bool
+  frame : List Ident
+  hyps : List Ident
+deriving Repr, Inhabited
 
 -- see https://gitlab.mpi-sws.org/iris/iris/-/blob/master/iris/proofmode/spec_patterns.v?ref_type=heads#L15
+@[rocq_alias spec_pat]
 inductive SpecPat
   | ident (name : Ident)
   | pure (t : Term)
-  | goal (names : List Ident) (goalName : Name)
+  | goal (goal : SpecGoal) (goalName : Name)
+  | autoframe (goal : SpecGoalKind)
   deriving Repr, Inhabited
 
+#rocq_ignore spec_pat.stack_item "Not necessary in Lean"
+#rocq_ignore spec_pat.parse_go "Not necessary in Lean"
+#rocq_ignore spec_pat.close "Not necessary in Lean"
+#rocq_ignore spec_pat.close_ident "Not necessary in Lean"
+
+partial def FrameIdent.parse : TSyntax `frameIdent → (Ident ⊕ Ident)
+  | `(frameIdent| $name:ident) => .inl name
+  | e =>
+    -- Antiquotations start with $, so if we find one, it is a framing assumption
+    if e.raw.isAntiquot then
+      .inr ⟨e.raw.getAntiquotTerm⟩
+    else .inl default -- should not happen
+
+@[rocq_alias spec_pat.parse]
 partial def SpecPat.parse (pat : Syntax) : MacroM SpecPat := do
   match go ⟨← expandMacros pat⟩ with
   | none => Macro.throwUnsupported
@@ -31,8 +79,36 @@ where
   go : TSyntax `specPat → Option SpecPat
   | `(specPat| $name:ident) => some <| .ident name
   | `(specPat| % $term:term) => some <| .pure term
-  | `(specPat| [$[$names:ident]*]) => some <| .goal names.toList .anonymous
-  | `(specPat| [$[$names:ident]*] as $goal:ident) => match goal.raw with
-    | .ident _ _ val _ => some <| .goal names.toList val
-    | _ => none
+  | `(specPat| [$[$names:frameIdent]*]) =>
+    let (hyps, frame) := names.toList.partitionMap FrameIdent.parse;
+    some <| .goal {kind := .spatial, negate := false, frame, hyps } .anonymous
+  | `(specPat| [$[$names:frameIdent]*] as $goal:ident) =>
+    let (hyps, frame) := names.toList.partitionMap FrameIdent.parse;
+    some <| .goal {kind := .spatial, negate := false, frame, hyps } goal.getId
+  | `(specPat| [- $[$names:frameIdent]*]) =>
+    let (hyps, frame) := names.toList.partitionMap FrameIdent.parse;
+    some <| .goal {kind := .spatial, negate := true, frame, hyps } .anonymous
+  | `(specPat| [- $[$names:frameIdent]*] as $goal:ident) =>
+    let (hyps, frame) := names.toList.partitionMap FrameIdent.parse;
+    some <| .goal {kind := .spatial, negate := true, frame, hyps } goal.getId
+  | `(specPat| [> $[$names:frameIdent]*]) =>
+    let (hyps, frame) := names.toList.partitionMap FrameIdent.parse;
+    some <| .goal {kind := .modal, negate := false, frame, hyps } .anonymous
+  | `(specPat| [> $[$names:frameIdent]*] as $goal:ident) =>
+    let (hyps, frame) := names.toList.partitionMap FrameIdent.parse;
+    some <| .goal {kind := .modal, negate := false, frame, hyps } goal.getId
+  | `(specPat| [> - $[$names:frameIdent]*]) =>
+    let (hyps, frame) := names.toList.partitionMap FrameIdent.parse;
+    some <| .goal {kind := .modal, negate := true, frame, hyps } .anonymous
+  | `(specPat| [> - $[$names:frameIdent]*] as $goal:ident) =>
+    let (hyps, frame) := names.toList.partitionMap FrameIdent.parse;
+    some <| .goal {kind := .modal, negate := true, frame, hyps } goal.getId
+  | `(specPat| [# $[$names:frameIdent]*]) =>
+    let (hyps, frame) := names.toList.partitionMap FrameIdent.parse;
+    some <| .goal {kind := .intuitionistic, negate := false, frame, hyps } .anonymous
+  | `(specPat| [# $[$names:frameIdent]*] as $goal:ident) =>
+    let (hyps, frame) := names.toList.partitionMap FrameIdent.parse;
+    some <| .goal {kind := .intuitionistic, negate := false, frame, hyps } goal.getId
+  | `(specPat| [$]) => some <| .autoframe .spatial
+  | `(specPat| [# $]) => some <| .autoframe .intuitionistic
   | _ => none

--- a/Iris/Iris/ProofMode/Patterns/SpecPattern.lean
+++ b/Iris/Iris/ProofMode/Patterns/SpecPattern.lean
@@ -62,7 +62,7 @@ inductive SpecPat
 #rocq_ignore spec_pat.close "Not necessary in Lean"
 #rocq_ignore spec_pat.close_ident "Not necessary in Lean"
 
-partial def FrameIdent.parse : TSyntax `frameIdent → (Ident ⊕ Ident)
+def FrameIdent.parse : TSyntax `frameIdent → (Ident ⊕ Ident)
   | `(frameIdent| $name:ident) => .inl name
   | e =>
     -- Antiquotations start with $, so if we find one, it is a framing assumption
@@ -71,7 +71,7 @@ partial def FrameIdent.parse : TSyntax `frameIdent → (Ident ⊕ Ident)
     else .inl default -- should not happen
 
 @[rocq_alias spec_pat.parse]
-partial def SpecPat.parse (pat : Syntax) : MacroM SpecPat := do
+def SpecPat.parse (pat : Syntax) : MacroM SpecPat := do
   match go ⟨← expandMacros pat⟩ with
   | none => Macro.throwUnsupported
   | some pat => return pat

--- a/Iris/Iris/ProofMode/ProofModeM.lean
+++ b/Iris/Iris/ProofMode/ProofModeM.lean
@@ -96,7 +96,7 @@ def startProofMode (mvar : MVarId) : MetaM (MVarId × IrisGoal) := mvar.withCont
   let prop ← mkFreshExprMVarQ q(Type u)
   let P ← mkFreshExprMVarQ q($prop)
   let bi ← mkFreshExprMVarQ q(BI $prop)
-  let .some (_, mvars) ← ProofMode.trySynthInstanceQ q(AsEmpValid .from $goal $P) | throwError "istart: {goal} is not an emp valid"
+  let .some (_, mvars) ← ProofMode.trySynthInstanceQ q(AsEmpValid .from $goal .out $prop .out $bi $P) | throwError "istart: {goal} is not an emp valid"
   if !mvars.isEmpty then throwError "istart does not support creating mvars"
 
   let irisGoal := { u, prop, bi, hyps := .mkEmp bi, goal := P, .. }

--- a/Iris/Iris/ProofMode/ProofModeM.lean
+++ b/Iris/Iris/ProofMode/ProofModeM.lean
@@ -96,7 +96,8 @@ def startProofMode (mvar : MVarId) : MetaM (MVarId × IrisGoal) := mvar.withCont
   let prop ← mkFreshExprMVarQ q(Type u)
   let P ← mkFreshExprMVarQ q($prop)
   let bi ← mkFreshExprMVarQ q(BI $prop)
-  let .some (_, mvars) ← ProofMode.trySynthInstanceQ q(AsEmpValid .from $goal .out $prop .out $bi $P) | throwError "istart: {goal} is not an emp valid"
+  let .some (_, mvars) ← ProofMode.trySynthInstanceQ q(AsEmpValid .from $goal .out $prop .out $bi $P)
+    | throwError "istart: {goal} is not an emp valid"
   if !mvars.isEmpty then throwError "istart does not support creating mvars"
 
   let irisGoal := { u, prop, bi, hyps := .mkEmp bi, goal := P, .. }

--- a/Iris/Iris/ProofMode/SynthInstance.lean
+++ b/Iris/Iris/ProofMode/SynthInstance.lean
@@ -13,8 +13,14 @@ public meta section
 
 /-
 This file implements a custom typeclass synthesis algorithm that is used for the proof mode typeclasses.
+This custom typeclass synthesis is closer to Rocq typeclass search than Lean typeclass synthesis.
 This is necessary since proof mode typeclasses need to be able to instantiate and create new mvars, but the
 standard typeclass synthesis does not support this.
+
+Another problem with standard typeclass synthesis in Lean is that an mvar in an input position creates an IsDefEqStuck exception
+when matches against an instances with a term in the input position. This IsDefEqStuck exception completely terminates the synthesis
+without trying other instances. This creates problems for example for the `Make...` typeclasses that want to treat such cases as a
+normal matching failure that should not prevent other instances from matching.
 
 See also https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/Issues.20with.20typeclasses.20in.20the.20proof.20mode/with/563410548 for discussion.
 
@@ -27,6 +33,9 @@ the IPM synthesis needs to be explicitly invoked via the functions in this file.
 
 The `ipm_backtrack` attribute on an instance tells the IPM synthesis to backtrack if instance instance can be applied, but
 its preconditions fail to synthesize. This is not enabled by default to avoid accidental exponential blow-ups.
+
+The `ipm_tactic_instance` attribute on a function of type `SynthTactic` declares a tactic that is used to solve synthesis problems for
+a given pattern. These tactics can call ipm synthesis recursively. See Tests/Instances.lean for examples.
 
 The `InOut` type in Classes.lean is used to dynamically determine, which parameters are inputs and which are outputs. IPM synthesis
 ignores `outParam` and `semiOutParam` annotations, but it is still recommended to add these annotations as documentation.
@@ -45,14 +54,13 @@ partial def synthInstanceMainCore (mvar : Expr) : MetaM (Option Unit) := do
     let backtrackSet := ipmBacktrackExt.getState (← getEnv)
     let mvarType  ← inferType mvar
     let mvarType  ← instantiateMVars mvarType
-    let bodyConstName ← forallTelescopeReducing mvarType fun _ typeBody => do
-      let typeBody ← whnf typeBody
-      return typeBody.getAppFn.constName
-    if !(ipmClassesExt.getState (← getEnv)).contains bodyConstName then
+    let some mvarInputs ← checkIPMSynthParams mvarType |
       return ← withTraceNode `Meta.synthInstance (λ _ => return m!"switch to normal synthInstance") do
-        let some e ← synthInstance? mvarType | return none
+        let .some e ← trySynthInstance mvarType | return none
         mvar.mvarId!.assign e
         return some ()
+    if mvarInputs.size != 0 then
+      trace[Meta.synthInstance.mvarInputs] m!"mvar inputs of {mvarType}: {mvarInputs}"
 
     let mctx0 ← getMCtx
     withTraceNode `Meta.synthInstance (λ _ => return m!"new goal {MessageData.withMCtx mctx0 m!"{mvarType}"} => {mvarType}") do
@@ -93,6 +101,14 @@ partial def synthInstanceMainCore (mvar : Expr) : MetaM (Option Unit) := do
     let instances ← SynthInstance.getInstances mvarType
     let mctx ← getMCtx
     for inst in instances.reverse do
+      -- check that all mvar inputs are also mvars in the instance
+      if mvarInputs.size != 0 then
+        let instType ← inferType inst.val
+        let instTypeArgs := instType.getForallBody.getAppArgs
+        if mvarInputs.any (λ i => !instTypeArgs[i]!.isBVar) then
+          trace[Meta.synthInstance] "skipping {inst.val} since it matches on an input mvar"
+          continue
+
       let (res, match?) ← withTraceNode `Meta.synthInstance
         (λ _ => withMCtx mctx do return MessageData.withMCtx mctx m!"apply {inst.val} to {← instantiateMVars (← inferType mvar)}") do
         setMCtx mctx
@@ -111,9 +127,15 @@ partial def synthInstanceMainCore (mvar : Expr) : MetaM (Option Unit) := do
 /-- This function should only be directly used by IPM tactic instances
 to initiate recursive searches. -/
 def synthInstanceRecursive (type : Expr) : MetaM (Option Expr) := do
+   let mctx ← getMCtx
    let mvar ← mkFreshExprMVar type
-   let some _ ← synthInstanceMainCore mvar | return none
-   return mvar
+   let res ← try
+       synthInstanceMainCore mvar
+     catch ex => setMCtx mctx; throw ex
+   if res.isSome then
+     return mvar
+   setMCtx mctx
+   return none
 
 /-- This function should only be directly used by IPM tactic instances
 to initiate recursive searches. -/
@@ -190,4 +212,5 @@ def ipm_synth_elab : Command.CommandElab
   | _ => throwUnsupportedSyntax
 
 initialize
+  registerTraceClass `Meta.synthInstance.mvarInputs (inherited := true)
   registerTraceClass `Meta.synthInstance.tactics (inherited := true)

--- a/Iris/Iris/ProofMode/SynthInstance.lean
+++ b/Iris/Iris/ProofMode/SynthInstance.lean
@@ -52,7 +52,7 @@ def MessageData.withMCtx (mctx : MetavarContext) (d : MessageData) : MessageData
                                                  opts := ctx.opts} d
 
 /-- Needed to print the correct emoji with `withTraceNode` -/
-private instance : ExceptToTraceResult ε (Option α × Bool) where
+private local instance : ExceptToTraceResult ε (Option α × Bool) where
   toTraceResult
     | .error _        => .error
     | .ok (some _, _) => .success

--- a/Iris/Iris/ProofMode/SynthInstance.lean
+++ b/Iris/Iris/ProofMode/SynthInstance.lean
@@ -17,28 +17,29 @@ This custom typeclass synthesis is closer to Rocq typeclass search than Lean typ
 This is necessary since proof mode typeclasses need to be able to instantiate and create new mvars, but the
 standard typeclass synthesis does not support this.
 
-Another problem with standard typeclass synthesis in Lean is that an mvar in an input position creates an IsDefEqStuck exception
-when matches against an instances with a term in the input position. This IsDefEqStuck exception completely terminates the synthesis
-without trying other instances. This creates problems for example for the `Make...` typeclasses that want to treat such cases as a
+Another problem with standard typeclass synthesis in Lean is that an mvar in an input position creates
+an `IsDefEqStuck` exception when matches against an instances with a term in the input position.
+This `IsDefEqStuck` exception completely terminates the synthesis without trying other instances.
+This creates problems for example for the `Make...` typeclasses that want to treat such cases as a
 normal matching failure that should not prevent other instances from matching.
 
 See also https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/Issues.20with.20typeclasses.20in.20the.20proof.20mode/with/563410548 for discussion.
 
 In addition to the synthInstance family of functions, we provide the following attributes and annotations:
 
-The `ipm_class` attribute marks that a class should use the IPM synthesis defined in this file. For all other classes,
-the IPM synthesis falls back to standard synthesis, enabling one to use standard type classes as parameters for IPM type classes.
-Note that IPM synthesis is *not* triggered automatically for holes where the class is marked with `ipm_class`. Instead,
-the IPM synthesis needs to be explicitly invoked via the functions in this file.
+The `ipm_class` attribute marks that a class should use the IPM synthesis defined in this file.
+For all other classes, the IPM synthesis falls back to standard synthesis, enabling one to use standard
+type classes as parameters for IPM type classes. Note that IPM synthesis is *not* triggered automatically
+for holes where the class is marked with `ipm_class`. Instead, the IPM synthesis needs to be explicitly
+invoked via the functions in this file.
 
-The `ipm_backtrack` attribute on an instance tells the IPM synthesis to backtrack if instance instance can be applied, but
-its preconditions fail to synthesize. This is not enabled by default to avoid accidental exponential blow-ups.
+The `ipm_backtrack` attribute on an instance tells the IPM synthesis to backtrack if instance
+can be applied, but its preconditions fail to synthesize. This is not enabled by default to avoid
+accidental exponential blow-ups.
 
-The `ipm_tactic_instance` attribute on a function of type `SynthTactic` declares a tactic that is used to solve synthesis problems for
-a given pattern. These tactics can call ipm synthesis recursively. See Tests/Instances.lean for examples.
-
-The `InOut` type in Classes.lean is used to dynamically determine, which parameters are inputs and which are outputs. IPM synthesis
-ignores `outParam` and `semiOutParam` annotations, but it is still recommended to add these annotations as documentation.
+The `ipm_tactic_instance` attribute on a function of type `SynthTactic` declares a tactic that is used
+to solve synthesis problems for a given pattern. These tactics can call IPM synthesis recursively.
+See Tests/Instances.lean for examples.
 
 The `#imp_synth` command allows testing ipm synthesis, similar to the `#synth` command.
 -/
@@ -47,7 +48,15 @@ namespace Iris.ProofMode
 open Lean Elab Tactic Meta Qq BI Std
 
 def MessageData.withMCtx (mctx : MetavarContext) (d : MessageData) : MessageData :=
-  .lazy λ ctx => return MessageData.withContext {env := ctx.env, mctx := mctx, lctx := ctx.lctx, opts := ctx.opts} d
+  .lazy λ ctx => return MessageData.withContext {env := ctx.env, mctx := mctx, lctx := ctx.lctx,
+                                                 opts := ctx.opts} d
+
+/-- Needed to print the correct emoji with `withTraceNode` -/
+private instance : ExceptToTraceResult ε (Option α × Bool) where
+  toTraceResult
+    | .error _        => .error
+    | .ok (some _, _) => .success
+    | .ok (none,   _) => .failure
 
 partial def synthInstanceMainCore (mvar : Expr) : MetaM (Option Unit) := do
   withIncRecDepth do
@@ -63,7 +72,8 @@ partial def synthInstanceMainCore (mvar : Expr) : MetaM (Option Unit) := do
       trace[Meta.synthInstance.mvarInputs] m!"mvar inputs of {mvarType}: {mvarInputs}"
 
     let mctx0 ← getMCtx
-    withTraceNode `Meta.synthInstance (λ _ => return m!"new goal {MessageData.withMCtx mctx0 m!"{mvarType}"} => {mvarType}") do
+    withTraceNode `Meta.synthInstance
+      (λ _ => return m!"new goal {MessageData.withMCtx mctx0 m!"{mvarType}"} => {mvarType}") do
 
     -- first tactics and then instances. We cannot interleave them
     -- since we don't know the priorities of the instances.
@@ -75,7 +85,8 @@ partial def synthInstanceMainCore (mvar : Expr) : MetaM (Option Unit) := do
     let mctx ← getMCtx
     for tac in tactics.reverse do
       let res ← withTraceNode `Meta.synthInstance
-        (λ _ => withMCtx mctx do return MessageData.withMCtx mctx m!"apply tactic {tac.name} to {← instantiateMVars (← inferType mvar)}") do
+        (λ _ => withMCtx mctx do return MessageData.withMCtx mctx m!"apply tactic {tac.name} to \
+        {← instantiateMVars (← inferType mvar)}") do
         setMCtx mctx
         forallTelescopeReducing mvarType fun xs mvarTypeBody => do
           let res ← tac.tac.run mvarTypeBody
@@ -83,7 +94,8 @@ partial def synthInstanceMainCore (mvar : Expr) : MetaM (Option Unit) := do
           | .success instVal =>
             trace[Meta.synthInstance] m!"{tac.name} success: {instVal}"
             let mut instType ← inferType instVal
-            let .true ← isDefEq mvarTypeBody instType | throwError "{tac.name} produced an ill-typed term: {instVal}"
+            let .true ← isDefEq mvarTypeBody instType
+              | throwError "{tac.name} produced an ill-typed term: {instVal}"
             let instVal ← mkLambdaFVars xs instVal (etaReduce := true)
             let .true ← isDefEq mvar instVal | throwError "{tac.name} produced an ill-typed term: {instVal}"
             return .success default
@@ -110,9 +122,11 @@ partial def synthInstanceMainCore (mvar : Expr) : MetaM (Option Unit) := do
           continue
 
       let (res, match?) ← withTraceNode `Meta.synthInstance
-        (λ _ => withMCtx mctx do return MessageData.withMCtx mctx m!"apply {inst.val} to {← instantiateMVars (← inferType mvar)}") do
+        (λ _ => withMCtx mctx do return MessageData.withMCtx mctx m!"apply {inst.val} to \
+        {← instantiateMVars (← inferType mvar)}") do
         setMCtx mctx
-        let some (mctx', subgoals) ← withAssignableSyntheticOpaque (SynthInstance.tryResolve mvar inst) | return (none, false)
+        let some (mctx', subgoals) ← withAssignableSyntheticOpaque (SynthInstance.tryResolve mvar inst)
+          | return (none, false)
         setMCtx mctx'
         for g in subgoals do
           let some _ ← synthInstanceMainCore g | return (none, true)
@@ -124,8 +138,7 @@ partial def synthInstanceMainCore (mvar : Expr) : MetaM (Option Unit) := do
         return res
     return none
 
-/-- This function should only be directly used by IPM tactic instances
-to initiate recursive searches. -/
+/-- This function should only be directly used by IPM tactic instances to initiate recursive searches. -/
 def synthInstanceRecursive (type : Expr) : MetaM (Option Expr) := do
    let mctx ← getMCtx
    let mvar ← mkFreshExprMVar type
@@ -137,8 +150,7 @@ def synthInstanceRecursive (type : Expr) : MetaM (Option Expr) := do
    setMCtx mctx
    return none
 
-/-- This function should only be directly used by IPM tactic instances
-to initiate recursive searches. -/
+/-- This function should only be directly used by IPM tactic instances to initiate recursive searches. -/
 def synthInstanceRecursiveQ (type : Q(Sort u)) : MetaM (Option Q($type)) := synthInstanceRecursive type
 
 def synthInstanceMain (type : Expr) (_maxResultSize : Nat) : MetaM (Option Expr) :=
@@ -156,7 +168,8 @@ def synthInstanceCore? (type : Expr) (maxResultSize? : Option Nat := none) : Met
   withTraceNode `Meta.synthInstance
     (λ _ => return m!"IPM: {← instantiateMVars type}") do
   withConfig (fun config => { config with isDefEqStuckEx := true, transparency := TransparencyMode.instances,
-                                          foApprox := true, ctxApprox := true, constApprox := false, univApprox := false }) do
+                                          foApprox := true, ctxApprox := true, constApprox := false,
+                                          univApprox := false }) do
   withInTypeClassResolution do
     let type ← instantiateMVars type
     -- TODO: if it becomes necessary, run whnf under the ∀ quantifiers of type
@@ -164,16 +177,21 @@ def synthInstanceCore? (type : Expr) (maxResultSize? : Option Nat := none) : Met
     -- TODO: if it becomes necessary, create mvars for outParams
     -- let normType ← preprocessOutParam type
     let normType := type
-    -- key point: we don't create a new MCtxDepth here such that we can instantiate and create mvars
+    -- key point: we don't create a new `MCtxDepth` here such that we can instantiate and create mvars
     let result? ← synthInstanceMain normType maxResultSize
     trace[Meta.synthInstance] "result {result?}"
     return result?
 
-protected def synthInstance? (type : Expr) (maxResultSize? : Option Nat := none) : MetaM (Option (Expr × Std.HashSet MVarId)) := do profileitM Exception "typeclass inference IPM" (← getOptions) (decl := type.getAppFn.constName?.getD .anonymous) do
+protected def synthInstance? (type : Expr) (maxResultSize? : Option Nat := none)
+: MetaM (Option (Expr × Std.HashSet MVarId)) := do
+  profileitM Exception "typeclass inference IPM" (← getOptions)
+    (decl := type.getAppFn.constName?.getD .anonymous) do
   -- we can be sure that e only depends on the mvars that actually appear in e
-  (← synthInstanceCore? type maxResultSize?).mapM λ e => do let e ← instantiateMVars e; return (e, ← e.getMVarDependencies)
+  (← synthInstanceCore? type maxResultSize?).mapM
+    λ e => do let e ← instantiateMVars e; return (e, ← e.getMVarDependencies)
 
-protected def trySynthInstance (type : Expr) (maxResultSize? : Option Nat := none) : MetaM (LOption (Expr × Std.HashSet MVarId)) := do
+protected def trySynthInstance (type : Expr) (maxResultSize? : Option Nat := none)
+: MetaM (LOption (Expr × Std.HashSet MVarId)) := do
   catchInternalId isDefEqStuckExceptionId
     (toLOptionM <| ProofMode.synthInstance? type maxResultSize?)
     (fun _ => pure LOption.undef)
@@ -187,7 +205,8 @@ protected def synthInstance (type : Expr) (maxResultSize? : Option Nat := none) 
       | none        => do _ ← throwFailedToSynthesize type; unreachable!)
     (fun _ => do _ ← throwFailedToSynthesize type; unreachable!)
 
-/- It is recommended to use ProofModeM.trySynthInstanceQ and ProofModeM.synthInstanceQ that automatically handle the newly spawed goals. -/
+/- It is recommended to use ProofModeM.trySynthInstanceQ and ProofModeM.synthInstanceQ that
+automatically handle the newly spawed goals. -/
 
 protected def trySynthInstanceQ (α : Q(Sort u)) : MetaM (LOption (Q($α) × Std.HashSet MVarId)) :=
   ProofMode.trySynthInstance α
@@ -208,7 +227,8 @@ def ipm_synth_elab : Command.CommandElab
         | .undef => logInfo "Undefined"
         | .none => logInfo "None"
         | .some (e, mvars) => do
-            logInfo m!"solution: {← inferType e}, new goals: {← mvars.toList.mapM (λ m => do return m!"{Expr.mvar m}: {← m.getType}")}"
+            logInfo m!"solution: {← inferType e}, new goals: \
+            {← mvars.toList.mapM (λ m => do return m!"{Expr.mvar m}: {← m.getType}")}"
   | _ => throwUnsupportedSyntax
 
 initialize

--- a/Iris/Iris/ProofMode/SynthInstanceAttr.lean
+++ b/Iris/Iris/ProofMode/SynthInstanceAttr.lean
@@ -9,24 +9,172 @@ public import Qq
 public import Iris.BI.Notation
 
 public meta section
+
+namespace Iris.ProofMode
 open Lean Elab Tactic Meta Qq
 
+/-- [InOut] is used to dynamically determine whether a type class
+parameter is an input or an output. This is important for classes that
+are used with multiple modings, e.g., IntoWand. Instances can match on
+the InOut parameter to avoid accidentially instantiating outputs if
+matching on an input was intended. -/
+inductive InOut where
+  | in
+  | out
+
+/-- Marker for an unchecked input parameter. -/
+@[reducible, expose]
+def uncheckedInParam (α : Sort u) : Sort u := α
+
+/-- Return `true` if `e` is of the form `uncheckedInParam _` or `outParam (uncheckedInParam _)`. The second case is necessary for `FromModal`. -/
+def isUncheckedInParam (e : Expr) : Bool :=
+  e.isAppOfArity ``uncheckedInParam 1 || (e.isOutParam && e.appArg!.isAppOfArity ``uncheckedInParam 1)
+
+/--
+The parameters of a class declared with `ipm_class` are categorized into the following categories:
+
+1. in: This is the default for a parameter when not annotated in another way.
+2. out: These are parameters marked with `outParam`. These parameters must be mvars when starting typeclass search.
+3. semiOut: These are parameters marked with `semiOutParam`. The preceding parameter must be of type `InOut`. The value of the `InOut` parameter decides whether the `semiOut` parameter is treated as an input or an output.
+4. uncheckedIn: These are parameters marked with `uncheckedInParam`. These behave like `in` parameters, but allow mvars to match terms (see below).
+5. inout: Parameters of type `InOut`, must appear before semiOut parameters (see above).
+
+The following constraints apply to the parameters:
+(In the following, semiOut parameters are treated as inputs if the preceding `InOut` is `in` and as outputs if the `InOut` is `out`.)
+1. semiOut parameters must have a preceding `InOut` parameter.
+2. For each synthesis problem, all output parameters must be mvars.
+3. When an input parameter is a mvar, it is not considered to match an instance which does not have an mvar at the top-level. This is to prevent accidentally instantiating mvars. Note that this only applies for mvars the top-level (matching the behavior of Hint Mode : ! in Rocq), since this is the simplest version to implement and catches most (all?) of the cases.
+This check 3 is omitted for `uncheckedIn` parameters.
+ -/
+inductive ParamKind
+  | in
+  | out
+  | semiOut
+  | uncheckedIn
+  | inout
+deriving Inhabited
+
+instance : ToString ParamKind where
+  toString
+    | .in => "in"
+    | .out => "out"
+    | .semiOut => "semiOut"
+    | .uncheckedIn => "uncheckedIn"
+    | .inout => "inout"
+
 section IPMClasses
+structure ClassEntry where
+  name      : Name
+  /--
+  Parameter kinds of class.
+  For example, for class
+  ```
+  class FromModal {PROP1 : outParam (Type _)} {PROP2} [outParam (BI PROP1)] [BI PROP2] (φ : outParam $ Prop) (M : outParam $ Modality PROP1 PROP2) (sel : outParam (uncheckedInParam PROP1)) (P : PROP2) (Q : outParam $ PROP1) where
+  from_modal : φ → M.M Q ⊢ P
+  ```
+  `params := #[out, in, out, in, out, out, uncheckedIn, in, out]`
+  -/
+  params : Array ParamKind
+
+structure ClassState where
+  paramMap : SMap Name (Array ParamKind) := SMap.empty
+  deriving Inhabited
+
+namespace ClassState
+
+def addEntry (s : ClassState) (entry : ClassEntry) : ClassState :=
+  { s with
+    paramMap := s.paramMap.insert entry.name entry.params }
+
+/--
+Switch the state into persistent mode. We switch to this mode after
+we read all imported .olean files.
+Recall that we use a `SMap` for implementing the state.
+-/
+def switch (s : ClassState) : ClassState :=
+  { s with
+    paramMap := s.paramMap.switch }
+
+end ClassState
+
+
 initialize ipmClassesExt :
-    SimpleScopedEnvExtension Name (Std.HashSet Name)  ←
-  registerSimpleScopedEnvExtension {
-    addEntry := fun s n => s.insert n
-    initial := ∅
+    SimplePersistentEnvExtension ClassEntry ClassState ←
+  registerSimplePersistentEnvExtension {
+    addEntryFn := ClassState.addEntry
+    addImportedFn := fun es => (mkStateFromImportedEntries ClassState.addEntry {} es).switch
   }
+
+private def getIPMParamKinds? (env : Environment) (declName : Name) : Option (Array ParamKind) :=
+  (ipmClassesExt.getState env).paramMap.find? declName
+
+private partial def computeParamKinds (params : Array ParamKind) (wasInOut : Bool) (type : Expr) : Except MessageData (Array ParamKind) :=
+  match type with
+  | .forallE _ d b _ =>
+    if wasInOut then
+      if d.isSemiOutParam then
+        computeParamKinds (params.push .semiOut) false b
+      else
+        Except.error m!"invalid ipm_class, parameter #{params.size} is a `InOut` that is not followed by a `semiOutParam`"
+    else
+      -- we need to check this before outParam since `outParam (uncheckedInParam _)` should be an `uncheckedInParam`
+      if isUncheckedInParam d then
+        computeParamKinds (params.push .uncheckedIn) false b
+      else if d.isOutParam then
+        computeParamKinds (params.push .out) false b
+      else if d.isSemiOutParam then
+        Except.error m!"invalid ipm_class, parameter #{params.size+1} is a `semiOutParam` that is not preceded by an `InOut`"
+      else if d.isAppOfArity ``InOut 0 then
+        computeParamKinds (params.push .inout) true b
+      else
+        computeParamKinds (params.push .in) false b
+  | _ => return params
+
+def checkIPMSynthParams (type : Expr) : MetaM (Option (Array Nat)) := do
+  forallTelescopeReducing type fun _ typeBody => do
+    let typeBody ← whnf typeBody
+    let name := typeBody.getAppFn.constName
+    let .some params := getIPMParamKinds? (← getEnv) name | return none
+    let args := typeBody.getAppArgs
+    if args.size != params.size then
+      throwError "mismatched number of arguments"
+    let mut inoutIsIn := false
+    let mut mvarInputs := #[]
+    for i in 0...args.size do
+      let param := params[i]!
+      let arg := args[i]!
+      let param := if param matches .semiOut then
+          if inoutIsIn then .in else .out
+        else param
+      match param with
+      | .uncheckedIn => pure ()
+      | .in => if arg.getAppFn.isMVar then mvarInputs := mvarInputs.push i
+      | .out => if !arg.getAppFn.isMVar then throwError "parameter #{i} {arg} of {type} is an out parameter that is not an mvar"
+      | .inout =>
+        if arg.isAppOfArity ``InOut.in 0 then
+          inoutIsIn := true
+        else if arg.isAppOfArity ``InOut.out 0 then
+          inoutIsIn := false
+        else
+          throwError "parameter #{i} {arg} of {type} is an inout parameter that is not .in nor .out"
+      | .semiOut => unreachable!
+    return some mvarInputs
 
 syntax (name := ipm_class) "ipm_class" : attr
 
-/-- This attribute should be used for classes that use the special IPM synthInstance below. -/
+/-- This attribute should be used for classes that use the special IPM synthInstance. -/
 initialize registerBuiltinAttribute {
   name := `ipm_class
   descr := "proof mode class"
-  add := fun decl _stx _kind =>
-    ipmClassesExt.add decl
+  add := fun declName stx kind => do
+    let env ← getEnv
+    let some decl := env.find? declName
+      | throwError "unknown declaration '{declName}'"
+    unless kind == AttributeKind.global do throwAttrMustBeGlobal `ipm_class kind
+    let params ← ofExcept <| computeParamKinds #[] false decl.type
+    trace[Meta.synthInstance.ipmParamKinds] m!"IPM params of {declName}: {params}"
+    let env := ipmClassesExt.addEntry env {name := declName, params}
+    setEnv env
 }
 
 end IPMClasses
@@ -143,3 +291,6 @@ unsafe initialize registerBuiltinAttribute {
 }
 
 end IPMTactic
+
+initialize
+  registerTraceClass `Meta.synthInstance.ipmParamKinds (inherited := true)

--- a/Iris/Iris/ProofMode/SynthInstanceAttr.lean
+++ b/Iris/Iris/ProofMode/SynthInstanceAttr.lean
@@ -13,11 +13,10 @@ public meta section
 namespace Iris.ProofMode
 open Lean Elab Tactic Meta Qq
 
-/-- [InOut] is used to dynamically determine whether a type class
-parameter is an input or an output. This is important for classes that
-are used with multiple modings, e.g., IntoWand. Instances can match on
-the InOut parameter to avoid accidentially instantiating outputs if
-matching on an input was intended. -/
+/-- [InOut] is used to dynamically determine whether a type class parameter is an input or an output.
+This is important for classes that are used with multiple modings, e.g., IntoWand. Instances can match on
+the InOut parameter to avoid accidentially instantiating outputs if matching on an input was intended.
+-/
 inductive InOut where
   | in
   | out
@@ -26,7 +25,10 @@ inductive InOut where
 @[reducible, expose]
 def uncheckedInParam (α : Sort u) : Sort u := α
 
-/-- Return `true` if `e` is of the form `uncheckedInParam _` or `outParam (uncheckedInParam _)`. The second case is necessary for `FromModal`. -/
+/--
+Return `true` if `e` is of the form `uncheckedInParam _` or `outParam (uncheckedInParam _)`.
+The second case is necessary for `FromModal`.
+-/
 def isUncheckedInParam (e : Expr) : Bool :=
   e.isAppOfArity ``uncheckedInParam 1 || (e.isOutParam && e.appArg!.isAppOfArity ``uncheckedInParam 1)
 
@@ -34,16 +36,24 @@ def isUncheckedInParam (e : Expr) : Bool :=
 The parameters of a class declared with `ipm_class` are categorized into the following categories:
 
 1. in: This is the default for a parameter when not annotated in another way.
-2. out: These are parameters marked with `outParam`. These parameters must be mvars when starting typeclass search.
-3. semiOut: These are parameters marked with `semiOutParam`. The preceding parameter must be of type `InOut`. The value of the `InOut` parameter decides whether the `semiOut` parameter is treated as an input or an output.
-4. uncheckedIn: These are parameters marked with `uncheckedInParam`. These behave like `in` parameters, but allow mvars to match terms (see below).
+2. out: These are parameters marked with `outParam`. These parameters must be mvars when starting
+   typeclass search.
+3. semiOut: These are parameters marked with `semiOutParam`. The preceding parameter must be of type `InOut`.
+   The value of the `InOut` parameter decides whether the `semiOut` parameter is treated as an input
+   or an output.
+4. uncheckedIn: These are parameters marked with `uncheckedInParam`. These behave like `in` parameters,
+   but allow mvars to match terms (see below).
 5. inout: Parameters of type `InOut`, must appear before semiOut parameters (see above).
 
 The following constraints apply to the parameters:
-(In the following, semiOut parameters are treated as inputs if the preceding `InOut` is `in` and as outputs if the `InOut` is `out`.)
+(In the following, semiOut parameters are treated as inputs if the preceding `InOut` is `in` and as
+outputs if the `InOut` is `out`.)
 1. semiOut parameters must have a preceding `InOut` parameter.
 2. For each synthesis problem, all output parameters must be mvars.
-3. When an input parameter is a mvar, it is not considered to match an instance which does not have an mvar at the top-level. This is to prevent accidentally instantiating mvars. Note that this only applies for mvars the top-level (matching the behavior of Hint Mode : ! in Rocq), since this is the simplest version to implement and catches most (all?) of the cases.
+3. When an input parameter is a mvar, it is not considered to match an instance which does not have
+an mvar at the top-level. This is to prevent accidentally instantiating mvars. Note that this only
+applies for mvars the top-level (matching the behavior of Hint Mode : ! in Rocq), since this is the
+simplest version to implement and catches most (all?) of the cases.
 This check 3 is omitted for `uncheckedIn` parameters.
  -/
 inductive ParamKind
@@ -69,7 +79,9 @@ structure ClassEntry where
   Parameter kinds of class.
   For example, for class
   ```
-  class FromModal {PROP1 : outParam (Type _)} {PROP2} [outParam (BI PROP1)] [BI PROP2] (φ : outParam $ Prop) (M : outParam $ Modality PROP1 PROP2) (sel : outParam (uncheckedInParam PROP1)) (P : PROP2) (Q : outParam $ PROP1) where
+  class FromModal {PROP1 : outParam (Type _)} {PROP2} [outParam (BI PROP1)] [BI PROP2]
+    (φ : outParam $ Prop) (M : outParam $ Modality PROP1 PROP2) (sel : outParam (uncheckedInParam PROP1))
+    (P : PROP2) (Q : outParam $ PROP1) where
   from_modal : φ → M.M Q ⊢ P
   ```
   `params := #[out, in, out, in, out, out, uncheckedIn, in, out]`
@@ -87,8 +99,7 @@ def addEntry (s : ClassState) (entry : ClassEntry) : ClassState :=
     paramMap := s.paramMap.insert entry.name entry.params }
 
 /--
-Switch the state into persistent mode. We switch to this mode after
-we read all imported .olean files.
+Switch the state into persistent mode. We switch to this mode after we read all imported .olean files.
 Recall that we use a `SMap` for implementing the state.
 -/
 def switch (s : ClassState) : ClassState :=
@@ -108,28 +119,40 @@ initialize ipmClassesExt :
 private def getIPMParamKinds? (env : Environment) (declName : Name) : Option (Array ParamKind) :=
   (ipmClassesExt.getState env).paramMap.find? declName
 
-private partial def computeParamKinds (params : Array ParamKind) (wasInOut : Bool) (type : Expr) : Except MessageData (Array ParamKind) :=
+private partial def computeParamKinds (params : Array ParamKind) (wasInOut : Bool) (type : Expr) :
+Except MessageData (Array ParamKind) :=
   match type with
   | .forallE _ d b _ =>
     if wasInOut then
       if d.isSemiOutParam then
         computeParamKinds (params.push .semiOut) false b
       else
-        Except.error m!"invalid ipm_class, parameter #{params.size} is a `InOut` that is not followed by a `semiOutParam`"
+        Except.error m!"invalid ipm_class, parameter #{params.size} is a `InOut` that is not followed \
+        by a `semiOutParam`"
     else
-      -- we need to check this before outParam since `outParam (uncheckedInParam _)` should be an `uncheckedInParam`
+      -- we need to check this before outParam since `outParam (uncheckedInParam _)` should be
+      -- an `uncheckedInParam`
       if isUncheckedInParam d then
         computeParamKinds (params.push .uncheckedIn) false b
       else if d.isOutParam then
         computeParamKinds (params.push .out) false b
       else if d.isSemiOutParam then
-        Except.error m!"invalid ipm_class, parameter #{params.size+1} is a `semiOutParam` that is not preceded by an `InOut`"
+        Except.error m!"invalid ipm_class, parameter #{params.size+1} is a `semiOutParam` that is \
+        not preceded by an `InOut`"
       else if d.isAppOfArity ``InOut 0 then
         computeParamKinds (params.push .inout) true b
       else
         computeParamKinds (params.push .in) false b
   | _ => return params
 
+/--
+Check that `type` is a valid IPM synthesis goal.
+Returns `none` if the  goal is not registered with `ipm_class`.
+Returns `some idxs`, where `idxs` is a list of the positions of input parameters whose argument has
+an mvar at the top-level. These are the inputs that, per constraint 3 of `ParamKind`, must only match
+instances which themselves have an mvar at the top-level for that parameter. `uncheckedIn` parameters
+are skipped.
+-/
 def checkIPMSynthParams (type : Expr) : MetaM (Option (Array Nat)) := do
   forallTelescopeReducing type fun _ typeBody => do
     let typeBody ← whnf typeBody
@@ -149,7 +172,8 @@ def checkIPMSynthParams (type : Expr) : MetaM (Option (Array Nat)) := do
       match param with
       | .uncheckedIn => pure ()
       | .in => if arg.getAppFn.isMVar then mvarInputs := mvarInputs.push i
-      | .out => if !arg.getAppFn.isMVar then throwError "parameter #{i} {arg} of {type} is an out parameter that is not an mvar"
+      | .out => if !arg.getAppFn.isMVar then
+        throwError "parameter #{i} {arg} of {type} is an out parameter that is not an mvar"
       | .inout =>
         if arg.isAppOfArity ``InOut.in 0 then
           inoutIsIn := true
@@ -215,6 +239,13 @@ immediately: no further tactics are tried *and* the regular instance search
 is skipped. -/
 | fail
 
+/-- Needed to print the correct emoji with `withTraceNode` -/
+instance : ExceptToTraceResult ε SynthTacticResult where
+  toTraceResult
+    | .error _              => .error
+    | .ok (.success _)      => .success
+    | .ok .fail             => .failure
+    | .ok .continue         => .failure
 
 @[expose]
 def SynthTactic : Type := Expr → MetaM SynthTacticResult
@@ -243,9 +274,11 @@ instance : BEq SynthTacticEntrySerialized where
 instance : Inhabited SynthTacticEntrySerialized where
   default := ⟨0, default⟩
 
-def SynthTacticEntry.serialize (e : SynthTacticEntry) : SynthTacticEntrySerialized := { prio := e.prio, name := e.name }
+def SynthTacticEntry.serialize (e : SynthTacticEntry) : SynthTacticEntrySerialized :=
+  { prio := e.prio, name := e.name }
 
-unsafe def SynthTacticEntrySerialized.deserialize (e : SynthTacticEntrySerialized) (compile : Bool) : CoreM SynthTacticEntry := do
+unsafe def SynthTacticEntrySerialized.deserialize (e : SynthTacticEntrySerialized) (compile : Bool)
+  : CoreM SynthTacticEntry := do
   let mut name := e.name
   let ty := (← getConstInfo e.name).type
   if ty != .const ``SynthTactic [] then
@@ -258,8 +291,8 @@ unsafe def SynthTacticEntrySerialized.deserialize (e : SynthTacticEntrySerialize
 
 
 /-- Environment extension for synth tactics -/
-unsafe initialize synthTacticExt :
-    ScopedEnvExtension (SynthTacticEntrySerialized × Array DiscrTree.Key) (SynthTacticEntry × Array DiscrTree.Key) (DiscrTree SynthTacticEntry) ←
+unsafe initialize synthTacticExt : ScopedEnvExtension (SynthTacticEntrySerialized × Array DiscrTree.Key)
+  (SynthTacticEntry × Array DiscrTree.Key) (DiscrTree SynthTacticEntry) ←
   registerScopedEnvExtension {
     mkInitial := return {}
     addEntry := fun dt (n, ks) => dt.insertKeyValue ks n

--- a/Iris/Iris/ProofMode/SynthInstanceAttr.lean
+++ b/Iris/Iris/ProofMode/SynthInstanceAttr.lean
@@ -55,6 +55,9 @@ an mvar at the top-level. This is to prevent accidentally instantiating mvars. N
 applies for mvars the top-level (matching the behavior of Hint Mode : ! in Rocq), since this is the
 simplest version to implement and catches most (all?) of the cases.
 This check 3 is omitted for `uncheckedIn` parameters.
+
+(We are reusing `outParam` and `semiOutParam` from the Lean TC infrastructure since this gives us
+checking synthesis order checking, which is useful (though not perfect).)
  -/
 inductive ParamKind
   | in

--- a/Iris/Iris/ProofMode/Tactics.lean
+++ b/Iris/Iris/ProofMode/Tactics.lean
@@ -9,6 +9,7 @@ public meta import Iris.ProofMode.Tactics.Clear
 public meta import Iris.ProofMode.Tactics.Exact
 public meta import Iris.ProofMode.Tactics.ExFalso
 public meta import Iris.ProofMode.Tactics.Exists
+public meta import Iris.ProofMode.Tactics.Frame
 public meta import Iris.ProofMode.Tactics.Have
 public meta import Iris.ProofMode.Tactics.Intro
 public meta import Iris.ProofMode.Tactics.LeftRight

--- a/Iris/Iris/ProofMode/Tactics/Apply.lean
+++ b/Iris/Iris/ProofMode/Tactics/Apply.lean
@@ -42,7 +42,7 @@ private partial def iApplyCore {prop : Q(Type u)} {bi : Q(BI $prop)} {e} (hyps :
      return q(apply $pf)
 
   -- otherwise, if `A` has the form `?P -∗ ?B`, create a subgoal for `P` and continue with ?B
-  let some ⟨_, hyps', pb, B, pf⟩ ← try? <| iSpecializeCore hyps p A [.goal [] .anonymous]
+  let some ⟨_, hyps', pb, B, pf⟩ ← try? <| iSpecializeCore hyps p A [.goal {kind := .spatial, negate := false, frame := [], hyps := []} .anonymous]
     | throwError m!"iapply: cannot apply {A} to {goal}"
   let pf' ← iApplyCore hyps' pb B goal
   return q($(pf).trans $pf')

--- a/Iris/Iris/ProofMode/Tactics/Apply.lean
+++ b/Iris/Iris/ProofMode/Tactics/Apply.lean
@@ -34,7 +34,8 @@ Apply a hypothesis `A` to the `goal` by eliminating the wands recursively
 ## Returns
 The proof of `hyps ∗ □?p A ⊢ goal`
 -/
-private partial def iApplyCore {prop : Q(Type u)} {bi : Q(BI $prop)} {e} (hyps : Hyps bi e) (p : Q(Bool)) (A : Q($prop)) (goal : Q($prop)) : ProofModeM Q($e ∗ □?$p $A ⊢ $goal) := do
+private partial def iApplyCore {prop : Q(Type u)} {bi : Q(BI $prop)} {e} (hyps : Hyps bi e) (p : Q(Bool))
+(A : Q($prop)) (goal : Q($prop)) : ProofModeM Q($e ∗ □?$p $A ⊢ $goal) := do
   let B ← mkFreshExprMVarQ q($prop)
   -- if `A := ?B -∗ goal`, add `B` as a new subgoal and conclude `goal`
   if let some _ ← ProofModeM.trySynthInstanceQ q(IntoWand $p false $A .out $B .in $goal) then
@@ -42,7 +43,8 @@ private partial def iApplyCore {prop : Q(Type u)} {bi : Q(BI $prop)} {e} (hyps :
      return q(apply $pf)
 
   -- otherwise, if `A` has the form `?P -∗ ?B`, create a subgoal for `P` and continue with ?B
-  let some ⟨_, hyps', pb, B, pf⟩ ← try? <| iSpecializeCore hyps p A [.goal {kind := .spatial, negate := false, frame := [], hyps := []} .anonymous]
+  let some ⟨_, hyps', pb, B, pf⟩ ← try? <| iSpecializeCore hyps p A
+    [.goal {kind := .spatial, negate := false, frame := [], hyps := []} .anonymous]
     | throwError m!"iapply: cannot apply {A} to {goal}"
   let pf' ← iApplyCore hyps' pb B goal
   return q($(pf).trans $pf')

--- a/Iris/Iris/ProofMode/Tactics/Cases.lean
+++ b/Iris/Iris/ProofMode/Tactics/Cases.lean
@@ -12,6 +12,7 @@ public meta import Iris.ProofMode.Tactics.Pure
 public meta import Iris.ProofMode.Tactics.Clear
 public meta import Iris.ProofMode.Tactics.Basic
 public meta import Iris.ProofMode.Tactics.HaveCore
+public meta import Iris.ProofMode.Tactics.Frame
 
 namespace Iris.ProofMode
 
@@ -116,10 +117,10 @@ private def iCasesSep {prop : Q(Type u)} (bi : Q(BI $prop))
     let goal' := q(iprop(□ $A2 -∗ $goal))
     let pf ← k1 hyps goal' A1 fun hyps goal' => do
       let goal'' ← mkFreshExprMVarQ q($prop)
-      let .some _ ← ProofModeM.trySynthInstanceQ q(FromWand $goal' iprop(□ $A2) $goal'')
+      let .some _ ← ProofModeM.trySynthInstanceQ q(FromWand $goal' .in iprop(□ $A2) $goal'')
         | throwError "icases: internal error: {goal'} is not a wand"
       let pf ← k2 hyps goal'' A2 k
-      return q((wand_intro $pf).trans from_wand)
+      return q((wand_intro $pf).trans (from_wand .in (Q1:=iprop(□ $A2))))
     return q(and_elim_intuitionistic $pf)
   | .inr _ =>
     let .some _ ← ProofModeM.trySynthInstanceQ q(IntoSep $A $A1 $A2)
@@ -127,10 +128,10 @@ private def iCasesSep {prop : Q(Type u)} (bi : Q(BI $prop))
     let goal' := q(iprop($A2 -∗ $goal))
     let pf ← k1 hyps goal' A1 fun hyps goal' => do
       let goal'' ← mkFreshExprMVarQ q($prop)
-      let .some _ ← ProofModeM.trySynthInstanceQ q(FromWand $goal' $A2 $goal'')
+      let .some _ ← ProofModeM.trySynthInstanceQ q(FromWand $goal' .in $A2 $goal'')
         | throwError "icases: internal error: {goal'} is not a wand"
       let pf ← k2 hyps goal'' A2 k
-      return q((wand_intro $pf).trans from_wand)
+      return q((wand_intro $pf).trans (from_wand .in (Q1:=$A2)))
     return q(sep_elim_spatial (A := $A) $pf)
 
 /-- Destruct a disjunction hypothesis [A] into two cases and continue separately on each branch. -/
@@ -190,7 +191,7 @@ A proof of `hyps ∗ □?p A ⊢ goal`.
 -/
 partial def iCasesCore {P} (hyps : Hyps bi P) (goal : Q($prop)) (pat : iCasesPat)
     (p : Q(Bool)) (A : Q($prop))
-    (k : ∀ {P}, Hyps bi P → (goal' : Q($prop)) → ProofModeM Q($P ⊢ $goal)) :
+    (k : ∀ {P}, Hyps bi P → (goal' : Q($prop)) → ProofModeM Q($P ⊢ $goal')) :
     ProofModeM (Q($P ∗ □?$p $A ⊢ $goal)) :=
   match pat with
   | .one name => do
@@ -205,6 +206,11 @@ partial def iCasesCore {P} (hyps : Hyps bi P) (goal : Q($prop)) (pat : iCasesPat
   | .clear => do
     let pf ← iClearCore bi q(iprop($P ∗ □?$p $A)) P p A goal q(.rfl)
     pure q($pf $(← k hyps goal))
+
+  | .frame => do
+    let ⟨uniq, hyps'⟩ ← Hyps.addWithInfo bi (← `(binderIdent | _)) p A hyps
+    let res ← iFrame bi _ hyps' goal [⟨.inl uniq, true⟩]
+    res.finish @k
 
   | .conjunction [arg] | .disjunction [arg] => iCasesCore hyps goal arg p A @k
 

--- a/Iris/Iris/ProofMode/Tactics/Cases.lean
+++ b/Iris/Iris/ProofMode/Tactics/Cases.lean
@@ -145,7 +145,10 @@ private def iCasesOr {prop : Q(Type u)} (bi : Q(BI $prop))
     | throwError "icases: {A} is not a disjunction"
   return q(or_elim' $(← k1 A1) $(← k2 A2))
 
-/-- Destruct a persistent hypothesis [A] by turning it into an explicit [□ B] and continuing with the persistent body. -/
+/--
+Destruct a persistent hypothesis [A] by turning it into an explicit [□ B] and continuing with
+the persistent body.
+-/
 private def iCasesIntuitionistic {prop : Q(Type u)} (_bi : Q(BI $prop))
     (p : Q(Bool)) (P A goal : Q($prop))
     (k : (B : Q($prop)) → ProofModeM Q($P ∗ □ $B ⊢ $goal)) :
@@ -161,7 +164,10 @@ private def iCasesIntuitionistic {prop : Q(Type u)} (_bi : Q(BI $prop))
       | throwError "icases: {A} not affine and the goal not absorbing"
     return q(intuitionistic_elim_spatial (A := $A) $(← k B))
 
-/-- Destruct an affine/spatial hypothesis [A] by removing the affinely wrapper and continuing with the spatial body. -/
+/--
+Destruct an affine/spatial hypothesis [A] by removing the affinely wrapper and continuing with
+the spatial body.
+-/
 private def iCasesSpatial {prop : Q(Type u)} (_bi : Q(BI $prop))
     (p : Q(Bool)) (P A goal : Q($prop))
     (k : (B : Q($prop)) → ProofModeM Q($P ∗ $B ⊢ $goal)) :
@@ -218,9 +224,8 @@ partial def iCasesCore {P} (hyps : Hyps bi P) (goal : Q($prop)) (pat : iCasesPat
 
   | .conjunction [] => iCasesEmptyConj bi hyps p A goal
 
-  -- pure conjunctions are always handled as existentials. There is
-  -- intoExist_and_pure and intoExist_sep_pure to make this work as
-  -- expected for pure assertions that are not explicit existentials.
+  -- pure conjunctions are always handled as existentials. There is `intoExist_and_pure` and
+  -- `intoExist_sep_pure` to make this work as expected for pure assertions that are not explicit existentials.
   | .conjunction (.pure arg :: args) => do
     iCasesExists bi arg p P A goal (iCasesCore hyps goal (.conjunction args) p · k)
   | .conjunction (arg :: args) => do
@@ -256,8 +261,10 @@ elab "icases" keep:("+keep")? colGt pmt:pmTerm "with" colGt pat:icasesPat : tact
   let pat ← liftMacroM <| iCasesPat.parse pat
   ProofModeM.runTactic λ mvar { bi, goal, hyps, .. } => do
 
-  -- We keep the persistent hypothesis if it is required by the user (+keep is set by ihave) or if we perform specialization
-  let ⟨_, hyps, p, A, pf⟩ ← iHave hyps pmt (keep.isSome || pmt.is_nontrivial) (try_dup_context := pat.should_try_dup_context)
+  -- We keep the persistent hypothesis if it is required by the user (+keep is set by ihave)
+  -- or if we perform specialization
+  let ⟨_, hyps, p, A, pf⟩ ← iHave hyps pmt (keep.isSome || pmt.is_nontrivial)
+    (try_dup_context := pat.should_try_dup_context)
 
   -- process pattern
   let pf2 ← iCasesCore bi hyps goal pat p A λ hyps goal => addBIGoal hyps goal

--- a/Iris/Iris/ProofMode/Tactics/Cases.lean
+++ b/Iris/Iris/ProofMode/Tactics/Cases.lean
@@ -12,6 +12,7 @@ public meta import Iris.ProofMode.Tactics.Pure
 public meta import Iris.ProofMode.Tactics.Clear
 public meta import Iris.ProofMode.Tactics.Basic
 public meta import Iris.ProofMode.Tactics.HaveCore
+public meta import Iris.ProofMode.Tactics.Frame
 
 namespace Iris.ProofMode
 
@@ -116,10 +117,10 @@ private def iCasesSep {prop : Q(Type u)} (bi : Q(BI $prop))
     let goal' := q(iprop(□ $A2 -∗ $goal))
     let pf ← k1 hyps goal' A1 fun hyps goal' => do
       let goal'' ← mkFreshExprMVarQ q($prop)
-      let .some _ ← ProofModeM.trySynthInstanceQ q(FromWand $goal' iprop(□ $A2) $goal'')
+      let .some _ ← ProofModeM.trySynthInstanceQ q(FromWand $goal' .in iprop(□ $A2) $goal'')
         | throwError "icases: internal error: {goal'} is not a wand"
       let pf ← k2 hyps goal'' A2 k
-      return q((wand_intro $pf).trans from_wand)
+      return q((wand_intro $pf).trans (from_wand .in (Q1:=iprop(□ $A2))))
     return q(and_elim_intuitionistic $pf)
   | .inr _ =>
     let .some _ ← ProofModeM.trySynthInstanceQ q(IntoSep $A $A1 $A2)
@@ -127,10 +128,10 @@ private def iCasesSep {prop : Q(Type u)} (bi : Q(BI $prop))
     let goal' := q(iprop($A2 -∗ $goal))
     let pf ← k1 hyps goal' A1 fun hyps goal' => do
       let goal'' ← mkFreshExprMVarQ q($prop)
-      let .some _ ← ProofModeM.trySynthInstanceQ q(FromWand $goal' $A2 $goal'')
+      let .some _ ← ProofModeM.trySynthInstanceQ q(FromWand $goal' .in $A2 $goal'')
         | throwError "icases: internal error: {goal'} is not a wand"
       let pf ← k2 hyps goal'' A2 k
-      return q((wand_intro $pf).trans from_wand)
+      return q((wand_intro $pf).trans (from_wand .in (Q1:=$A2)))
     return q(sep_elim_spatial (A := $A) $pf)
 
 /-- Destruct a disjunction hypothesis [A] into two cases and continue separately on each branch. -/
@@ -190,7 +191,7 @@ A proof of `hyps ∗ □?p A ⊢ goal`.
 -/
 partial def iCasesCore {P} (hyps : Hyps bi P) (goal : Q($prop)) (pat : iCasesPat)
     (p : Q(Bool)) (A : Q($prop))
-    (k : ∀ {P}, Hyps bi P → (goal' : Q($prop)) → ProofModeM Q($P ⊢ $goal)) :
+    (k : ∀ {P}, Hyps bi P → (goal' : Q($prop)) → ProofModeM Q($P ⊢ $goal')) :
     ProofModeM (Q($P ∗ □?$p $A ⊢ $goal)) :=
   match pat with
   | .one name => do
@@ -205,6 +206,11 @@ partial def iCasesCore {P} (hyps : Hyps bi P) (goal : Q($prop)) (pat : iCasesPat
   | .clear => do
     let pf ← iClearCore bi q(iprop($P ∗ □?$p $A)) P p A goal q(.rfl)
     pure q($pf $(← k hyps goal))
+
+  | .frame => do
+    let ⟨ivar, hyps'⟩ ← Hyps.addWithInfo bi (← `(binderIdent | _)) p A hyps
+    let res ← iFrame bi _ hyps' goal [⟨.inl ivar, true⟩]
+    res.finish @k
 
   | .conjunction [arg] | .disjunction [arg] => iCasesCore hyps goal arg p A @k
 

--- a/Iris/Iris/ProofMode/Tactics/Clear.lean
+++ b/Iris/Iris/ProofMode/Tactics/Clear.lean
@@ -52,7 +52,7 @@ elab "iclear" pats:(colGt selPat)+ : tactic => do
   let pats ← liftMacroM <| SelPat.parse pats
 
   ProofModeM.runTactic λ mvar { e, hyps, goal, .. } => do
-  let (uniqs, fvars) := (← SelPat.resolve hyps pats).partitionMap id
+  let (uniqs, fvars) := (← SelPat.resolve hyps pats).partitionMap (·.target)
 
   -- Clear the selected Iris hypotheses first, updating the proof-mode context and proof term.
   let mut st : ClearState e goal := { e, hyps, pf := q(fun h => h) }

--- a/Iris/Iris/ProofMode/Tactics/Clear.lean
+++ b/Iris/Iris/ProofMode/Tactics/Clear.lean
@@ -52,7 +52,7 @@ elab "iclear" pats:(colGt selPat)+ : tactic => do
   let pats ← liftMacroM <| SelPat.parse pats
 
   ProofModeM.runTactic λ mvar { e, hyps, goal, .. } => do
-  let (ivars, fvars) := (← SelPat.resolve hyps pats).partitionMap id
+  let (ivars, fvars) := (← SelPat.resolve hyps pats).partitionMap (·.target)
 
   -- Clear the selected Iris hypotheses first, updating the proof-mode context and proof term.
   let mut st : ClearState e goal := { e, hyps, pf := q(fun h => h) }

--- a/Iris/Iris/ProofMode/Tactics/Frame.lean
+++ b/Iris/Iris/ProofMode/Tactics/Frame.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2026 Michael Sammler. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Sammler
+-/
+module
+
+import Iris.BI
+import Iris.ProofMode.Classes
+public meta import Iris.ProofMode.Patterns.SelPattern
+public meta import Iris.ProofMode.Tactics.Basic
+
+namespace Iris.ProofMode
+
+public section
+open BI
+
+theorem frame_init [BI PROP] {e goal : PROP} :
+    e ⊢ e ∗ (goal -∗ goal) :=
+  sep_emp.2.trans (sep_mono_r (wand_intro emp_sep.1))
+
+theorem frame_hyp [BI PROP] {p} {e e' origE goal goal' origGoal R : PROP}
+    (h1 : origE ⊢ e ∗ (goal -∗ origGoal))
+    [h2 : Frame p R goal goal']
+    (h3 : e ⊣⊢ e' ∗ □?p R) :
+    origE ⊢ e' ∗ (goal' -∗ origGoal) :=
+  h1.trans <| (sep_mono_l h3.1).trans <| sep_assoc.1.trans <|
+  sep_mono_r (wand_intro (sep_assoc.1.trans <| (sep_mono_r sep_comm.1).trans <|
+    sep_assoc.2.trans <| (sep_mono_l h2.frame).trans wand_elim_r))
+
+theorem frame_pure [BI PROP] {origE e goal goal' origGoal : PROP} (φ : Prop)
+    (h1 : origE ⊢ e ∗ (goal -∗ origGoal))
+    [h2 : Frame true iprop(⌜φ⌝) goal goal'] (h : φ) :
+    origE ⊢ e ∗ (goal' -∗ origGoal) :=
+  have h_box : emp ⊢ □?true iprop(⌜φ⌝) := affinely_intro ((pure_intro h).trans persistent)
+  h1.trans <| sep_mono_r <| wand_intro <|
+    emp_sep.2.trans <| (sep_mono_l h_box).trans <|
+    (sep_mono_r sep_comm.1).trans <| sep_assoc.2.trans <|
+    (sep_mono_l h2.frame).trans wand_elim_r
+
+theorem frame_finish [BI PROP] {e origE goal origGoal : PROP}
+    (h1 : origE ⊢ e ∗ (goal -∗ origGoal)) (h2 : e ⊢ goal) :
+    origE ⊢ origGoal :=
+  h1.trans ((sep_mono_l h2).trans wand_elim_r)
+
+theorem frame_true_done [BI PROP] (P : PROP) : P ⊢ True :=
+  pure_intro .intro
+
+theorem frame_finish_close_true [BI PROP] {e origE origGoal : PROP}
+    (h1 : origE ⊢ e ∗ (True -∗ origGoal)) :
+    origE ⊢ e ∗ origGoal := h1.trans (sep_mono_r <| true_sep_2.trans wand_elim_r)
+
+theorem frame_finish_close_emp [BI PROP] {e origE origGoal : PROP}
+    (h1 : origE ⊢ e ∗ (emp -∗ origGoal)) :
+    origE ⊢ e ∗ origGoal := h1.trans (sep_mono_r <| emp_sep.2.trans wand_elim_r)
+
+public meta section
+open Lean Elab Tactic Meta Qq Std
+
+structure FrameResult {u} {prop : Q(Type u)} (bi : Q(BI $prop)) (origE origGoal : Q($prop)) where
+  (progress : Bool) (e : Q($prop)) (hyps : Hyps bi e) (goal : Q($prop))
+  pf : Q($origE ⊢ $e ∗ ($goal -∗ $origGoal))
+
+private def FrameResult.step {u prop bi origE origGoal} :
+    @FrameResult u prop bi origE origGoal → SelTarget →
+    ProofModeM (FrameResult bi origE origGoal)
+    | st@{progress:= _, e:=_, hyps, goal, pf}, {explicit, target := .inl uniq} => do
+      let ⟨e', hyps', _, out', p, _, hrem⟩ := hyps.remove false uniq
+      let goal' ← mkFreshExprMVarQ q($prop)
+      if let .some _ ← ProofModeM.trySynthInstanceQ q(Frame $p $out' $goal $goal') then
+        return ⟨true, e', hyps', goal', q(frame_hyp $pf $hrem)⟩
+      if explicit then
+         throwError "iframe: cannot frame {out'}"
+      else
+        return st
+    | st@{progress:= _, e, hyps, goal, pf}, {explicit, target := .inr fvar} => do
+      let ty ← fvar.getType
+      if ! (← Meta.isProp ty) then
+        throwError "iframe: {← fvar.getUserName} is not a Prop"
+      have φ : Q(Prop) := ty
+      have t : Q($φ) := Expr.fvar fvar
+      let goal' ← mkFreshExprMVarQ q($prop)
+      if let .some _ ← ProofModeM.trySynthInstanceQ q(Frame true iprop(⌜$φ⌝) $goal $goal') then
+        return ⟨true, e, hyps, goal', q(frame_pure $φ $pf $t)⟩
+      if explicit then
+        throwError "iframe: cannot frame ⌜{φ}⌝"
+      else
+        return st
+
+def iFrame {prop : Q(Type u)} (bi : Q(BI $prop)) (e : Q($prop))
+    (hyps : Hyps bi e) (goal : Q($prop)) (sels : List SelTarget) :
+    ProofModeM (FrameResult bi e goal) := do
+  let mut st : FrameResult bi e goal := { progress := false, e, hyps, goal, pf := q(frame_init) }
+  for sel in sels do st ← st.step sel
+  return st
+
+/-- FrameResult.finish turns a FrameResult into a proof of the original goal given a function k that
+  handles the subgoal remaining after framing. This function k might not be called if the framing
+  made the goal trivial. -/
+def FrameResult.finish {u prop bi origE origGoal} (res : @FrameResult u prop bi origE origGoal)
+  (k : ∀ {e}, Hyps bi e → (goal : Q($prop)) → ProofModeM Q($e ⊢ $goal)) :
+  ProofModeM Q($origE ⊢ $origGoal) := do
+  let {progress, e, hyps, goal, pf} := res
+  if !progress then
+    return q(frame_finish $pf $(← k hyps goal))
+  -- try closing the goal for emp or True without calling k
+  match goal with
+  | ~q(iprop(emp)) =>
+    if let .some _ ← trySynthInstanceQ q(Affine $e) then
+      return q(frame_finish $pf (affine (P := $e)))
+    else
+      return q(frame_finish $pf $(← k hyps goal))
+    | ~q(iprop(True)) =>
+      return q(frame_finish $pf (frame_true_done $e))
+    | _ => return q(frame_finish $pf $(← k hyps goal))
+
+/-- FrameResult.finishClose check that the original goal was fully solved by framing and gives it
+  back with the remaining hypotheses. -/
+def FrameResult.finishClose {u prop bi origE origGoal} (res : @FrameResult u prop bi origE origGoal) :
+  ProofModeM ((e : Q($prop)) × (_ : Hyps bi e) × Q($origE ⊢ $e ∗ $origGoal)) := do
+  let {progress, e, hyps, goal, pf} := res
+  if !progress then
+    throwError "iframe: cannot solve {origGoal} by framing"
+  -- try closing the goal for emp or True without calling k
+  match goal with
+  | ~q(iprop(emp)) =>
+    return ⟨e, hyps, q(frame_finish_close_emp $pf)⟩
+  | ~q(iprop(True)) =>
+    return ⟨e, hyps, q(frame_finish_close_true $pf)⟩
+  | _ => throwError "iframe: cannot solve {origGoal} by framing"
+
+
+elab "iframe" pats:(colGt selPat)+ : tactic => do
+  let pats ← liftMacroM <| SelPat.parse pats
+
+  ProofModeM.runTactic λ mvar { bi, e, hyps, goal, .. } => do
+  let pats ← SelPat.resolve hyps pats
+
+  let res ← iFrame bi e hyps goal pats
+  mvar.assign (← res.finish (addBIGoal · ·))
+
+macro "iframe" : tactic => `(tactic | iframe ∗)

--- a/Iris/Iris/ProofMode/Tactics/Frame.lean
+++ b/Iris/Iris/ProofMode/Tactics/Frame.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2026 Michael Sammler. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Sammler
+-/
+module
+
+import Iris.BI
+import Iris.ProofMode.Classes
+public meta import Iris.ProofMode.Patterns.SelPattern
+public meta import Iris.ProofMode.Tactics.Basic
+
+namespace Iris.ProofMode
+
+public section
+open BI
+
+theorem frame_init [BI PROP] {e goal : PROP} :
+    e ⊢ e ∗ (goal -∗ goal) :=
+  sep_emp.2.trans (sep_mono_r (wand_intro emp_sep.1))
+
+theorem frame_hyp [BI PROP] {p} {e e' origE goal goal' origGoal R : PROP}
+    (h1 : origE ⊢ e ∗ (goal -∗ origGoal))
+    [h2 : Frame p R goal goal']
+    (h3 : e ⊣⊢ e' ∗ □?p R) :
+    origE ⊢ e' ∗ (goal' -∗ origGoal) :=
+  h1.trans <| (sep_mono_l h3.1).trans <| sep_assoc.1.trans <|
+  sep_mono_r (wand_intro (sep_assoc.1.trans <| (sep_mono_r sep_comm.1).trans <|
+    sep_assoc.2.trans <| (sep_mono_l h2.frame).trans wand_elim_r))
+
+theorem frame_pure [BI PROP] {origE e goal goal' origGoal : PROP} (φ : Prop)
+    (h1 : origE ⊢ e ∗ (goal -∗ origGoal))
+    [h2 : Frame true iprop(⌜φ⌝) goal goal'] (h : φ) :
+    origE ⊢ e ∗ (goal' -∗ origGoal) :=
+  have h_box : emp ⊢ □?true iprop(⌜φ⌝) := affinely_intro ((pure_intro h).trans persistent)
+  h1.trans <| sep_mono_r <| wand_intro <|
+    emp_sep.2.trans <| (sep_mono_l h_box).trans <|
+    (sep_mono_r sep_comm.1).trans <| sep_assoc.2.trans <|
+    (sep_mono_l h2.frame).trans wand_elim_r
+
+theorem frame_finish [BI PROP] {e origE goal origGoal : PROP}
+    (h1 : origE ⊢ e ∗ (goal -∗ origGoal)) (h2 : e ⊢ goal) :
+    origE ⊢ origGoal :=
+  h1.trans ((sep_mono_l h2).trans wand_elim_r)
+
+theorem frame_true_done [BI PROP] (P : PROP) : P ⊢ True :=
+  pure_intro .intro
+
+theorem frame_finish_close_true [BI PROP] {e origE origGoal : PROP}
+    (h1 : origE ⊢ e ∗ (True -∗ origGoal)) :
+    origE ⊢ e ∗ origGoal := h1.trans (sep_mono_r <| true_sep_2.trans wand_elim_r)
+
+theorem frame_finish_close_emp [BI PROP] {e origE origGoal : PROP}
+    (h1 : origE ⊢ e ∗ (emp -∗ origGoal)) :
+    origE ⊢ e ∗ origGoal := h1.trans (sep_mono_r <| emp_sep.2.trans wand_elim_r)
+
+public meta section
+open Lean Elab Tactic Meta Qq Std
+
+structure FrameResult {u} {prop : Q(Type u)} (bi : Q(BI $prop)) (origE origGoal : Q($prop)) where
+  (progress : Bool) (e : Q($prop)) (hyps : Hyps bi e) (goal : Q($prop))
+  pf : Q($origE ⊢ $e ∗ ($goal -∗ $origGoal))
+
+private def FrameResult.step {u prop bi origE origGoal} :
+    @FrameResult u prop bi origE origGoal → SelTarget →
+    ProofModeM (FrameResult bi origE origGoal)
+    | st@{progress:= _, e:=_, hyps, goal, pf}, {explicit, target := .inl ivar} => do
+      let ⟨e', hyps', _, out', p, _, hrem⟩ := hyps.remove false ivar
+      let goal' ← mkFreshExprMVarQ q($prop)
+      if let .some _ ← ProofModeM.trySynthInstanceQ q(Frame $p $out' $goal $goal') then
+        return ⟨true, e', hyps', goal', q(frame_hyp $pf $hrem)⟩
+      if explicit then
+         throwError "iframe: cannot frame {out'}"
+      else
+        return st
+    | st@{progress:= _, e, hyps, goal, pf}, {explicit, target := .inr fvar} => do
+      let ty ← fvar.getType
+      if ! (← Meta.isProp ty) then
+        throwError "iframe: {← fvar.getUserName} is not a Prop"
+      have φ : Q(Prop) := ty
+      have t : Q($φ) := Expr.fvar fvar
+      let goal' ← mkFreshExprMVarQ q($prop)
+      if let .some _ ← ProofModeM.trySynthInstanceQ q(Frame true iprop(⌜$φ⌝) $goal $goal') then
+        return ⟨true, e, hyps, goal', q(frame_pure $φ $pf $t)⟩
+      if explicit then
+        throwError "iframe: cannot frame ⌜{φ}⌝"
+      else
+        return st
+
+def iFrame {prop : Q(Type u)} (bi : Q(BI $prop)) (e : Q($prop))
+    (hyps : Hyps bi e) (goal : Q($prop)) (sels : List SelTarget) :
+    ProofModeM (FrameResult bi e goal) := do
+  let mut st : FrameResult bi e goal := { progress := false, e, hyps, goal, pf := q(frame_init) }
+  for sel in sels do st ← st.step sel
+  return st
+
+/-- FrameResult.finish turns a FrameResult into a proof of the original goal given a function k that
+  handles the subgoal remaining after framing. This function k might not be called if the framing
+  made the goal trivial. -/
+def FrameResult.finish {u prop bi origE origGoal} (res : @FrameResult u prop bi origE origGoal)
+  (k : ∀ {e}, Hyps bi e → (goal : Q($prop)) → ProofModeM Q($e ⊢ $goal)) :
+  ProofModeM Q($origE ⊢ $origGoal) := do
+  let {progress, e, hyps, goal, pf} := res
+  if !progress then
+    return q(frame_finish $pf $(← k hyps goal))
+  -- try closing the goal for emp or True without calling k
+  match goal with
+  | ~q(iprop(emp)) =>
+    if let .some _ ← trySynthInstanceQ q(Affine $e) then
+      return q(frame_finish $pf (affine (P := $e)))
+    else
+      return q(frame_finish $pf $(← k hyps goal))
+    | ~q(iprop(True)) =>
+      return q(frame_finish $pf (frame_true_done $e))
+    | _ => return q(frame_finish $pf $(← k hyps goal))
+
+/-- FrameResult.finishClose check that the original goal was fully solved by framing and gives it
+  back with the remaining hypotheses. -/
+def FrameResult.finishClose {u prop bi origE origGoal} (res : @FrameResult u prop bi origE origGoal) :
+  ProofModeM ((e : Q($prop)) × (_ : Hyps bi e) × Q($origE ⊢ $e ∗ $origGoal)) := do
+  let {progress, e, hyps, goal, pf} := res
+  if !progress then
+    throwError "iframe: cannot solve {origGoal} by framing"
+  -- try closing the goal for emp or True without calling k
+  match goal with
+  | ~q(iprop(emp)) =>
+    return ⟨e, hyps, q(frame_finish_close_emp $pf)⟩
+  | ~q(iprop(True)) =>
+    return ⟨e, hyps, q(frame_finish_close_true $pf)⟩
+  | _ => throwError "iframe: cannot solve {origGoal} by framing"
+
+
+elab "iframe" pats:(colGt selPat)+ : tactic => do
+  let pats ← liftMacroM <| SelPat.parse pats
+
+  ProofModeM.runTactic λ mvar { bi, e, hyps, goal, .. } => do
+  let pats ← SelPat.resolve hyps pats
+
+  let res ← iFrame bi e hyps goal pats
+  mvar.assign (← res.finish (addBIGoal · ·))
+
+macro "iframe" : tactic => `(tactic | iframe ∗)

--- a/Iris/Iris/ProofMode/Tactics/Frame.lean
+++ b/Iris/Iris/ProofMode/Tactics/Frame.lean
@@ -62,30 +62,29 @@ structure FrameResult {u} {prop : Q(Type u)} (bi : Q(BI $prop)) (origE origGoal 
   pf : Q($origE ⊢ $e ∗ ($goal -∗ $origGoal))
 
 private def FrameResult.step {u prop bi origE origGoal} :
-    @FrameResult u prop bi origE origGoal → SelTarget →
-    ProofModeM (FrameResult bi origE origGoal)
-    | st@{progress:= _, e:=_, hyps, goal, pf}, {explicit, target := .inl ivar} => do
-      let ⟨e', hyps', _, out', p, _, hrem⟩ := hyps.remove false ivar
-      let goal' ← mkFreshExprMVarQ q($prop)
-      if let .some _ ← ProofModeM.trySynthInstanceQ q(Frame $p $out' $goal $goal') then
-        return ⟨true, e', hyps', goal', q(frame_hyp $pf $hrem)⟩
-      if explicit then
-         throwError "iframe: cannot frame {out'}"
-      else
-        return st
-    | st@{progress:= _, e, hyps, goal, pf}, {explicit, target := .inr fvar} => do
-      let ty ← fvar.getType
-      if ! (← Meta.isProp ty) then
-        throwError "iframe: {← fvar.getUserName} is not a Prop"
-      have φ : Q(Prop) := ty
-      have t : Q($φ) := Expr.fvar fvar
-      let goal' ← mkFreshExprMVarQ q($prop)
-      if let .some _ ← ProofModeM.trySynthInstanceQ q(Frame true iprop(⌜$φ⌝) $goal $goal') then
-        return ⟨true, e, hyps, goal', q(frame_pure $φ $pf $t)⟩
-      if explicit then
-        throwError "iframe: cannot frame ⌜{φ}⌝"
-      else
-        return st
+    @FrameResult u prop bi origE origGoal → SelTarget → ProofModeM (FrameResult bi origE origGoal)
+  | st@{hyps, goal, pf, ..}, {explicit, target := .inl ivar} => do
+    let ⟨e', hyps', _, out', p, _, hrem⟩ := hyps.remove false ivar
+    let goal' ← mkFreshExprMVarQ q($prop)
+    if let .some _ ← ProofModeM.trySynthInstanceQ q(Frame $p $out' $goal $goal') then
+      return ⟨true, e', hyps', goal', q(frame_hyp $pf $hrem)⟩
+    if explicit then
+      throwError "iframe: cannot frame {out'}"
+    else
+      return st
+  | st@{e, hyps, goal, pf, ..}, {explicit, target := .inr fvar} => do
+    let ty ← fvar.getType
+    if ! (← Meta.isProp ty) then
+      throwError "iframe: {← fvar.getUserName} is not a Prop"
+    have φ : Q(Prop) := ty
+    have t : Q($φ) := Expr.fvar fvar
+    let goal' ← mkFreshExprMVarQ q($prop)
+    if let .some _ ← ProofModeM.trySynthInstanceQ q(Frame true iprop(⌜$φ⌝) $goal $goal') then
+      return ⟨true, e, hyps, goal', q(frame_pure $φ $pf $t)⟩
+    if explicit then
+      throwError "iframe: cannot frame ⌜{φ}⌝"
+    else
+      return st
 
 def iFrame {prop : Q(Type u)} (bi : Q(BI $prop)) (e : Q($prop))
     (hyps : Hyps bi e) (goal : Q($prop)) (sels : List SelTarget) :
@@ -98,8 +97,8 @@ def iFrame {prop : Q(Type u)} (bi : Q(BI $prop)) (e : Q($prop))
   handles the subgoal remaining after framing. This function k might not be called if the framing
   made the goal trivial. -/
 def FrameResult.finish {u prop bi origE origGoal} (res : @FrameResult u prop bi origE origGoal)
-  (k : ∀ {e}, Hyps bi e → (goal : Q($prop)) → ProofModeM Q($e ⊢ $goal)) :
-  ProofModeM Q($origE ⊢ $origGoal) := do
+    (k : ∀ {e}, Hyps bi e → (goal : Q($prop)) → ProofModeM Q($e ⊢ $goal)) :
+    ProofModeM Q($origE ⊢ $origGoal) := do
   let {progress, e, hyps, goal, pf} := res
   if !progress then
     return q(frame_finish $pf $(← k hyps goal))
@@ -110,11 +109,11 @@ def FrameResult.finish {u prop bi origE origGoal} (res : @FrameResult u prop bi 
       return q(frame_finish $pf (affine (P := $e)))
     else
       return q(frame_finish $pf $(← k hyps goal))
-    | ~q(iprop(True)) =>
+  | ~q(iprop(True)) =>
       return q(frame_finish $pf (frame_true_done $e))
-    | _ => return q(frame_finish $pf $(← k hyps goal))
+  | _ => return q(frame_finish $pf $(← k hyps goal))
 
-/-- FrameResult.finishClose check that the original goal was fully solved by framing and gives it
+/-- FrameResult.finishClose checks that the original goal was fully solved by framing and gives it
   back with the remaining hypotheses. -/
 def FrameResult.finishClose {u prop bi origE origGoal} (res : @FrameResult u prop bi origE origGoal) :
   ProofModeM ((e : Q($prop)) × (_ : Hyps bi e) × Q($origE ⊢ $e ∗ $origGoal)) := do

--- a/Iris/Iris/ProofMode/Tactics/HaveCore.lean
+++ b/Iris/Iris/ProofMode/Tactics/HaveCore.lean
@@ -23,8 +23,8 @@ namespace Iris.ProofMode
 public section
 open BI
 
-theorem have_asEmpValid [BI PROP] {φ} {P Q : PROP}
-    [h1 : AsEmpValid .into φ P] (h : φ) : Q ⊢ Q ∗ □ P :=
+theorem have_asEmpValid [bi : BI PROP] {φ} {P Q : PROP}
+    [h1 : AsEmpValid .into φ .in PROP .in bi P] (h : φ) : Q ⊢ Q ∗ □ P :=
   sep_emp.2.trans (sep_mono_r $ intuitionistically_emp.2.trans (intuitionistically_mono (asEmpValid_1 _ h)))
 
 public meta section
@@ -80,7 +80,7 @@ private def iHaveCore {e} (hyps : @Hyps u prop bi e)
     have val : Q($ty) := val
 
     let hyp ← mkFreshExprMVarQ q($prop)
-    let some _ ← ProofModeM.trySynthInstanceQ q(AsEmpValid .into $ty $hyp)
+    let some _ ← ProofModeM.trySynthInstanceQ q(AsEmpValid .into $ty .in $prop .in $bi $hyp)
       | throwError m!"ihave: {ty} is not an entailment"
 
     return ⟨_, hyps, q(true), hyp, q(have_asEmpValid $val)⟩

--- a/Iris/Iris/ProofMode/Tactics/HaveCore.lean
+++ b/Iris/Iris/ProofMode/Tactics/HaveCore.lean
@@ -66,7 +66,8 @@ private def iHaveCore {e} (hyps : @Hyps u prop bi e)
     let otherMVarIds := otherMVarIds.filter (!newMVarIds.contains ·)
 
     -- If the new mvars have type class assumption that could not be solved, register them such
-    -- that they are tried to be solved again at the end of `ProofModeM.runTactic` (using Term.synthesizeSyntheticMVarsNoPostponing)
+    -- that they are tried to be solved again at the end of `ProofModeM.runTactic`
+    -- (using `Term.synthesizeSyntheticMVarsNoPostponing`)
     for mvar in newMVars do
       if (← isSyntheticMVar mvar) && !(← mvar.mvarId!.isAssignedOrDelayedAssigned) then
         Term.registerSyntheticMVarWithCurrRef mvar.mvarId! (.typeClass .none)

--- a/Iris/Iris/ProofMode/Tactics/Intro.lean
+++ b/Iris/Iris/ProofMode/Tactics/Intro.lean
@@ -27,9 +27,9 @@ theorem imp_intro_intuitionistic [BI PROP] {P Q A1 A2 B : PROP}
   exact (and_mono_r inst.1).trans <| persistently_and_intuitionistically_sep_r.1.trans h
 
 theorem wand_intro_intuitionistic [BI PROP] {P Q A1 A2 B : PROP}
-    [FromWand Q A1 A2] [inst : IntoPersistently false A1 B] [or : TCOr (Affine A1) (Absorbing A2)]
+    [FromWand Q .out A1 A2] [inst : IntoPersistently false A1 B] [or : TCOr (Affine A1) (Absorbing A2)]
     (h : P ∗ □ B ⊢ A2) : P ⊢ Q := by
-  refine (wand_intro ?_).trans from_wand
+  refine (wand_intro ?_).trans (from_wand .out (Q1:=A1))
   exact match or with
   | TCOr.l => (sep_mono_r <| (affine_affinely A1).2.trans (affinely_mono inst.1)).trans h
   | TCOr.r => (sep_mono_r <| inst.1.trans absorbingly_intuitionistically.2).trans <|
@@ -47,7 +47,7 @@ theorem imp_intro_spatial [BI PROP] {P Q A1 A2 B : PROP}
     persistently_and_intuitionistically_sep_l.1.trans <| sep_mono_l intuitionistically_elim
 
 theorem wand_intro_spatial [BI PROP] {P Q A1 A2 : PROP}
-    [FromWand Q A1 A2] (h : P ∗ A1 ⊢ A2) : P ⊢ Q := (wand_intro h).trans from_wand
+    [FromWand Q .out A1 A2] (h : P ∗ A1 ⊢ A2) : P ⊢ Q := (wand_intro h).trans (from_wand .out (Q1:=A1))
 
 public meta section
 open Lean Elab Tactic Meta Qq BI Std
@@ -91,14 +91,14 @@ private partial def iIntroCore {prop : Q(Type u)} {bi : Q(BI $prop)}
       let pf ← iCasesCore bi hyps A2 pat q(true) B (iIntroCore · · pats)
       return q(imp_intro_intuitionistic (Q := $Q) $pf)
     | .intuitionistic pat, none =>
-      let .some _ ← ProofModeM.trySynthInstanceQ q(FromWand $Q $A1 $A2)
+      let .some _ ← ProofModeM.trySynthInstanceQ q(FromWand $Q .out $A1 $A2)
         | throwError "iintro: {Q} not a wand"
       let .some _ ← ProofModeM.trySynthInstanceQ q(IntoPersistently false $A1 $B)
         | throwError "iintro: {A1} not persistent"
       let .some _ ← trySynthInstanceQ q(TCOr (Affine $A1) (Absorbing $A2))
         | throwError "iintro: {A1} not affine and the goal not absorbing"
       let pf ← iCasesCore bi hyps A2 pat q(true) B (iIntroCore · · pats)
-      return q(wand_intro_intuitionistic (Q := $Q) $pf)
+      return q(wand_intro_intuitionistic (A1 := $A1) (Q := $Q) $pf)
     | _, some _ =>
       -- should always succeed
       let _ ← ProofModeM.synthInstanceQ q(FromAffinely $B $A1)
@@ -107,10 +107,10 @@ private partial def iIntroCore {prop : Q(Type u)} {bi : Q(BI $prop)}
       let pf ← iCasesCore bi hyps A2 pat q(false) B (iIntroCore · · pats)
       return q(imp_intro_spatial (Q := $Q) $pf)
     | _, none =>
-      let .some _ ← ProofModeM.trySynthInstanceQ q(FromWand $Q $A1 $A2)
+      let .some _ ← ProofModeM.trySynthInstanceQ q(FromWand $Q .out $A1 $A2)
         | throwError "iintro: {Q} not a wand"
       let pf ← iCasesCore bi hyps A2 pat q(false) A1 (iIntroCore · · pats)
-      return q(wand_intro_spatial (Q := $Q) $pf)
+      return q(wand_intro_spatial (A1 := $A1) (Q := $Q) $pf)
 
 
 elab "iintro" pats:(colGt introPat)* : tactic => do

--- a/Iris/Iris/ProofMode/Tactics/ModIntro.lean
+++ b/Iris/Iris/ProofMode/Tactics/ModIntro.lean
@@ -59,7 +59,7 @@ theorem modaction_sep [BI PROP1] [bi2: BI PROP2] {elhs erhs elhs' erhs'} {M : Mo
 
 theorem modintro [BI PROP1] [BI PROP2] {e e'} {Φ M sel} {P : PROP2} {Q : PROP1} [FromModal Φ M sel P Q]
   (h1 : e ⊢ M.M e') (h2 : e' ⊢ Q) (hΦ : Φ) : e ⊢ P :=
-    (h1.trans (M.mono h2)).trans (from_modal sel hΦ)
+    (h1.trans (M.mono h2)).trans (from_modal hΦ)
 
 public meta section
 open Lean Elab Tactic Meta

--- a/Iris/Iris/ProofMode/Tactics/ModIntro.lean
+++ b/Iris/Iris/ProofMode/Tactics/ModIntro.lean
@@ -21,20 +21,20 @@ inductive ModalityActionQ (PROP1 : Q(Type u)) (PROP2 : Q(Type u)) : Type where
 | clear
 | id
 
-theorem modaction_forall [BI PROP] {p P} (M : Modality PROP PROP) {C} (h : M.action p = .forall C) (hC : C P)
-  : □?p P ⊢ M.M iprop(□?p P) := by
+theorem modaction_forall [BI PROP] {p P} (M : Modality PROP PROP) {C} (h : M.action p = .forall C)
+(hC : C P) : □?p P ⊢ M.M iprop(□?p P) := by
     have hs := M.spec p
     rw [h] at hs
     apply (hs _ hC)
 
-theorem modaction_transform [BI PROP1] [BI PROP2] {p P Q} (M : Modality PROP1 PROP2) {C} (h : M.action p = .transform C) (hC : C P Q)
-  : □?p P ⊢ M.M iprop(□?p Q) := by
+theorem modaction_transform [BI PROP1] [BI PROP2] {p P Q} (M : Modality PROP1 PROP2) {C}
+(h : M.action p = .transform C) (hC : C P Q) : □?p P ⊢ M.M iprop(□?p Q) := by
     have hs := M.spec p
     rw [h] at hs
     apply (hs _ _ hC)
 
-theorem modaction_clear [BI PROP1] [BI PROP2] {p P} (M : Modality PROP1 PROP2) (h : M.action p = .clear)
-  : □?p P ⊢ M.M emp :=
+theorem modaction_clear [BI PROP1] [BI PROP2] {p P} (M : Modality PROP1 PROP2)
+(h : M.action p = .clear) : □?p P ⊢ M.M emp :=
   match p, h  with
   | true, _ => affine.trans M.emp
   | false, h => by
@@ -49,16 +49,19 @@ theorem modaction_id [BI PROP] {p P} (M : Modality PROP PROP) (h : M.action p = 
     apply hs
 
 theorem modaction_sep_emp_l [BI PROP1] [bi2: BI PROP2] {elhs erhs erhs'} {M : Modality PROP1 PROP2}
-  (h1 : elhs ⊢ M.M emp) (h2 : erhs ⊢ M.M erhs') : elhs ∗ erhs ⊢ M.M iprop(erhs') := (sep_mono h1 h2).trans $ M.sep.trans (M.mono emp_sep.1)
+  (h1 : elhs ⊢ M.M emp) (h2 : erhs ⊢ M.M erhs') : elhs ∗ erhs ⊢ M.M iprop(erhs') :=
+  (sep_mono h1 h2).trans $ M.sep.trans (M.mono emp_sep.1)
 
 theorem modaction_sep_emp_r [BI PROP1] [bi2: BI PROP2] {elhs elhs' erhs} {M : Modality PROP1 PROP2}
-  (h1 : elhs ⊢ M.M elhs') (h2 : erhs ⊢ M.M emp) : elhs ∗ erhs ⊢ M.M iprop(elhs') := (sep_mono h1 h2).trans $ M.sep.trans (M.mono sep_emp.1)
+  (h1 : elhs ⊢ M.M elhs') (h2 : erhs ⊢ M.M emp) : elhs ∗ erhs ⊢ M.M iprop(elhs') :=
+  (sep_mono h1 h2).trans $ M.sep.trans (M.mono sep_emp.1)
 
 theorem modaction_sep [BI PROP1] [bi2: BI PROP2] {elhs erhs elhs' erhs'} {M : Modality PROP1 PROP2}
-  (h1 : elhs ⊢ M.M elhs') (h2 : erhs ⊢ M.M erhs') : elhs ∗ erhs ⊢ M.M iprop(elhs' ∗ erhs') := (sep_mono h1 h2).trans M.sep
+  (h1 : elhs ⊢ M.M elhs') (h2 : erhs ⊢ M.M erhs') : elhs ∗ erhs ⊢ M.M iprop(elhs' ∗ erhs') :=
+  (sep_mono h1 h2).trans M.sep
 
-theorem modintro [BI PROP1] [BI PROP2] {e e'} {Φ M sel} {P : PROP2} {Q : PROP1} [FromModal Φ M sel P Q]
-  (h1 : e ⊢ M.M e') (h2 : e' ⊢ Q) (hΦ : Φ) : e ⊢ P :=
+theorem modintro [BI PROP1] [BI PROP2] {e e'} {Φ M sel} {P : PROP2} {Q : PROP1}
+[FromModal Φ M sel P Q] (h1 : e ⊢ M.M e') (h2 : e' ⊢ Q) (hΦ : Φ) : e ⊢ P :=
     (h1.trans (M.mono h2)).trans (from_modal hΦ)
 
 public meta section
@@ -111,7 +114,8 @@ private def iModAction {prop1 : Q(Type u)} {bi1 : Q(BI $prop1)} {bi2} {e}
       let ty' ← mkFreshExprMVarQ q($prop1)
       let .some hC ← trySynthInstanceQ q($C $ty $ty')
         | throwError "imodintro: cannot transform hypothesis {name} : {ty} with {C}"
-      have heq : Q(@ModalityAction.transform $prop1 $prop2 $C = .transform $C) := q(Eq.refl (ModalityAction.transform $C))
+      have heq : Q(@ModalityAction.transform $prop1 $prop2 $C = .transform $C) :=
+        q(Eq.refl (ModalityAction.transform $C))
       have heq : Q($(M).action $p = .transform $C) := heq
       return ⟨_, .mkHyp bi1 name ivar p ty', q(modaction_transform $M $heq $hC)⟩
     | .clear =>

--- a/Iris/Iris/ProofMode/Tactics/Pure.lean
+++ b/Iris/Iris/ProofMode/Tactics/Pure.lean
@@ -72,11 +72,11 @@ elab "iemp_intro" : tactic => do
   mvar.assign q(affine (P := $e))
 
 theorem pure_intro_affine [BI PROP] {Q : PROP} {φ : Prop}
-    [h : FromPure true Q φ] [Affine P] (hφ : φ) : P ⊢ Q :=
+    [h : FromPure true Q .out φ] [Affine P] (hφ : φ) : P ⊢ Q :=
   (affine.trans (eq_true hφ ▸ affinely_true.2)).trans h.1
 
 theorem pure_intro_spatial [BI PROP] {Q : PROP} {φ : Prop}
-    [h : FromPure false Q φ] (hφ : φ) : P ⊢ Q :=
+    [h : FromPure false Q .out φ] (hφ : φ) : P ⊢ Q :=
   (pure_intro hφ).trans h.1
 
 elab "ipure_intro" : tactic => do
@@ -84,7 +84,7 @@ elab "ipure_intro" : tactic => do
 
   let b : Q(Bool) ← mkFreshExprMVarQ q(Bool)
   let φ : Q(Prop) ← mkFreshExprMVarQ q(Prop)
-  let .some _ ← ProofModeM.trySynthInstanceQ q(FromPure $b $goal $φ)
+  let .some _ ← ProofModeM.trySynthInstanceQ q(FromPure $b $goal .out $φ)
     | throwError "ipure_intro: {goal} is not pure"
   let m : Q($φ) ← mkFreshExprMVar (← instantiateMVars φ)
   addMVarGoal m.mvarId!

--- a/Iris/Iris/ProofMode/Tactics/Pure.lean
+++ b/Iris/Iris/ProofMode/Tactics/Pure.lean
@@ -72,11 +72,11 @@ elab "iemp_intro" : tactic => do
   mvar.assign q(affine (P := $e))
 
 theorem pure_intro_affine [BI PROP] {Q : PROP} {φ : Prop}
-    (h : FromPure .out true Q .out φ) [Affine P] (hφ : φ) : P ⊢ Q :=
+    (h : FromPure true Q .out φ) [Affine P] (hφ : φ) : P ⊢ Q :=
   (affine.trans (eq_true hφ ▸ affinely_true.2)).trans h.1
 
 theorem pure_intro_spatial [BI PROP] {Q : PROP} {φ : Prop}
-    (h : FromPure .out false Q .out φ) (hφ : φ) : P ⊢ Q :=
+    (h : FromPure false Q .out φ) (hφ : φ) : P ⊢ Q :=
   (pure_intro hφ).trans h.1
 
 elab "ipure_intro" : tactic => do
@@ -84,7 +84,7 @@ elab "ipure_intro" : tactic => do
 
   let b : Q(Bool) ← mkFreshExprMVarQ q(Bool)
   let φ : Q(Prop) ← mkFreshExprMVarQ q(Prop)
-  let .some h ← ProofModeM.trySynthInstanceQ q(FromPure .out $b $goal .out $φ)
+  let .some h ← ProofModeM.trySynthInstanceQ q(FromPure $b $goal .out $φ)
     | throwError "ipure_intro: {goal} is not pure"
   let m : Q($φ) ← mkFreshExprMVar (← instantiateMVars φ)
   addMVarGoal m.mvarId!

--- a/Iris/Iris/ProofMode/Tactics/Pure.lean
+++ b/Iris/Iris/ProofMode/Tactics/Pure.lean
@@ -72,11 +72,11 @@ elab "iemp_intro" : tactic => do
   mvar.assign q(affine (P := $e))
 
 theorem pure_intro_affine [BI PROP] {Q : PROP} {φ : Prop}
-    [h : FromPure true Q .out φ] [Affine P] (hφ : φ) : P ⊢ Q :=
+    (h : FromPure .out true Q .out φ) [Affine P] (hφ : φ) : P ⊢ Q :=
   (affine.trans (eq_true hφ ▸ affinely_true.2)).trans h.1
 
 theorem pure_intro_spatial [BI PROP] {Q : PROP} {φ : Prop}
-    [h : FromPure false Q .out φ] (hφ : φ) : P ⊢ Q :=
+    (h : FromPure .out false Q .out φ) (hφ : φ) : P ⊢ Q :=
   (pure_intro hφ).trans h.1
 
 elab "ipure_intro" : tactic => do
@@ -84,7 +84,7 @@ elab "ipure_intro" : tactic => do
 
   let b : Q(Bool) ← mkFreshExprMVarQ q(Bool)
   let φ : Q(Prop) ← mkFreshExprMVarQ q(Prop)
-  let .some _ ← ProofModeM.trySynthInstanceQ q(FromPure $b $goal .out $φ)
+  let .some h ← ProofModeM.trySynthInstanceQ q(FromPure .out $b $goal .out $φ)
     | throwError "ipure_intro: {goal} is not pure"
   let m : Q($φ) ← mkFreshExprMVar (← instantiateMVars φ)
   addMVarGoal m.mvarId!
@@ -94,9 +94,9 @@ elab "ipure_intro" : tactic => do
     have : $b =Q true := ⟨⟩
     let .some _ ← trySynthInstanceQ q(Affine $e)
       | throwError "ipure_intro: context is not affine"
-    mvar.assign q(pure_intro_affine (P := $e) (Q := $goal) $m)
+    mvar.assign q(pure_intro_affine (P := $e) (Q := $goal) $h $m)
   | .const ``false _ =>
     have : $b =Q false := ⟨⟩
-    mvar.assign q(pure_intro_spatial (P := $e) (Q := $goal) $m)
+    mvar.assign q(pure_intro_spatial (P := $e) (Q := $goal) $h $m)
   -- the following indicates a bug in the typeclass instances that generate b
   | _ => throwError "ipure_intro: bug in typeclass instances, cannot reduce {b} to true or false"

--- a/Iris/Iris/ProofMode/Tactics/Revert.lean
+++ b/Iris/Iris/ProofMode/Tactics/Revert.lean
@@ -96,7 +96,7 @@ elab "irevert" pats:(colGt selPat)+ : tactic => do
     let targets ← SelPat.resolve hyps pats
     let init : RevertState e goal := { e, hyps, goal, pf := q(id) }
     let st ← targets.reverse.foldlM (init := init) fun st target => do
-      match target with
+      match target.target with
       | .inl uniq => st.revertProofModeHyp uniq
       | .inr fvar => st.revertLeanHyp fvar
 

--- a/Iris/Iris/ProofMode/Tactics/Revert.lean
+++ b/Iris/Iris/ProofMode/Tactics/Revert.lean
@@ -96,7 +96,7 @@ elab "irevert" pats:(colGt selPat)+ : tactic => do
     let targets ← SelPat.resolve hyps pats
     let init : RevertState e goal := { e, hyps, goal, pf := q(id) }
     let st ← targets.reverse.foldlM (init := init) fun st target => do
-      match target with
+      match target.target with
       | .inl ivar => st.revertProofModeHyp ivar
       | .inr fvar => st.revertLeanHyp fvar
 

--- a/Iris/Iris/ProofMode/Tactics/Specialize.lean
+++ b/Iris/Iris/ProofMode/Tactics/Specialize.lean
@@ -8,6 +8,7 @@ module
 public meta import Iris.ProofMode.Patterns.ProofModeTerm
 public meta import Iris.ProofMode.Patterns.CasesPattern
 public meta import Iris.ProofMode.Tactics.Basic
+public meta import Iris.ProofMode.Tactics.Frame
 
 namespace Iris.ProofMode
 
@@ -32,6 +33,12 @@ theorem specialize_wand_subgoal [BI PROP] {q : Bool} {A1 A2 A3 A4 Q P1 : PROP} P
     [inst : IntoWand q false Q .out P1 .out P2] : A1 ⊢ A3 ∗ P2 := by
   refine h1.trans <| (sep_mono_l h2.1).trans <| sep_assoc.1.trans (sep_mono_r ((sep_mono_l h3).trans ?_))
   exact (sep_mono_r inst.1).trans wand_elim_r
+
+theorem specialize_wand_autoframe [BI PROP] {q : Bool} {A1 A2 A3 Q P1 : PROP} P2
+     (h1 : A1 ⊢ A2 ∗ □?q Q) (h2 : A2 ⊢ A3 ∗ P1)
+     [inst : IntoWand q false Q .out P1 .out P2] : A1 ⊢ A3 ∗ P2 :=
+  h1.trans <| (sep_mono_l h2).trans <| sep_assoc.1.trans
+    (sep_mono_r ((sep_mono_r inst.into_wand).trans wand_elim_r))
 
 theorem specialize_forall [BI PROP] {p : Bool} {A1 A2 P : PROP} {α : Sort _} {Φ : α → PROP}
     [inst : IntoForall P Φ] (h : A1 ⊢ A2 ∗ □?p P) (a : α) : A1 ⊢ A2 ∗ □?p (Φ a) := by
@@ -80,18 +87,41 @@ private def processWand :
     let newMVarIds ← getMVarsNoDelayed x
     for mvar in newMVarIds do addMVarGoal mvar
     return { e, hyps, p, out := out', pf := q(specialize_forall $pf $x) }
-  | { hyps, p, out, pf, .. }, .goal ns g => do
+  | { hyps, p, out, pf, .. }, .goal {kind, negate, frame:=f, hyps := hs} g => do
+    if kind != .spatial then
+      -- TODO
+      throwError "ispecialize: only spatial kind is supported at the moment"
     let mut uniqs : NameSet := {}
-    for name in ns do
+    for name in hs do
       uniqs := uniqs.insert (← hyps.findWithInfo name)
-    let ⟨el', _, hypsl', hypsr', h'⟩ := Hyps.split bi (λ _ uniq => uniqs.contains uniq) hyps
+    let mut frameUniqs : List Name := []
+    for name in f do
+      let uniq ← hyps.findWithInfo name
+      frameUniqs := uniq :: frameUniqs
+      if uniqs.contains uniq then
+        throwError "ispecialize: {name} used twice"
+    frameUniqs := frameUniqs.reverse
+    let ⟨el', _, hypsl', hypsr', pf'⟩ := Hyps.split bi (λ _ uniq => (negate ^^ uniqs.contains uniq) || frameUniqs.contains uniq) hyps
     let out₁ ← mkFreshExprMVarQ prop
     let out₂ ← mkFreshExprMVarQ prop
     let some _ ← ProofModeM.trySynthInstanceQ q(IntoWand $p false $out .out $out₁ .out $out₂)
       | throwError m!"ispecialize: {out} is not a wand"
-    let pf' ← addBIGoal hypsr' out₁ g
-    let pf := q(specialize_wand_subgoal $out₂ $pf $h' $pf')
+    let res ← iFrame bi _ hypsr' out₁ (frameUniqs.map (⟨.inl ·, true⟩))
+    let pf'' ← res.finish (addBIGoal · · g)
+    let pf := q(specialize_wand_subgoal $out₂ $pf $pf' $pf'')
     return { e := el', hyps := hypsl', p := q(false), out := out₂, pf }
+
+  | { hyps, p, out, pf, .. }, .autoframe kind => do
+    if kind != .spatial then
+      -- TODO
+      throwError "ispecialize: only spatial kind is supported at the moment"
+    let out₁ ← mkFreshExprMVarQ prop
+    let out₂ ← mkFreshExprMVarQ prop
+    let some _ ← ProofModeM.trySynthInstanceQ q(IntoWand $p false $out .out $out₁ .out $out₂)
+      | throwError m!"ispecialize: {out} is not a wand"
+    let res ← iFrame bi _ hyps out₁ (← SelPat.resolve hyps [.spatial, .intuitionistic])
+    let ⟨_, hyps', pf'⟩ ← res.finishClose
+    return { e := _, hyps := hyps', p := q(false), out := out₂, pf := q(specialize_wand_autoframe $out₂ $pf $pf') }
 
 /-- `iCasesPat.should_try_dup_context` determines when iSpecializeCore should try to duplicate the separation context.
 The duplication only works if the conclusion of the specialization is persistent.

--- a/Iris/Iris/ProofMode/Tactics/Specialize.lean
+++ b/Iris/Iris/ProofMode/Tactics/Specialize.lean
@@ -87,7 +87,7 @@ private def processWand :
     let newMVarIds ← getMVarsNoDelayed x
     for mvar in newMVarIds do addMVarGoal mvar
     return { e, hyps, p, out := out', pf := q(specialize_forall $pf $x) }
-  | { hyps, p, out, pf, .. }, .goal {kind, negate, frame:=f, hyps := hs} g => do
+  | { hyps, p, out, pf, .. }, .goal {kind, negate, frame := f, hyps := hs} g => do
     if kind != .spatial then
       -- TODO
       throwError "ispecialize: only spatial kind is supported at the moment"
@@ -101,7 +101,8 @@ private def processWand :
       if ivars.contains ivar then
         throwError "ispecialize: {name} used twice"
     frameIVars := frameIVars.reverse
-    let ⟨el', _, hypsl', hypsr', pf'⟩ := Hyps.split bi (λ _ ivar => (negate ^^ ivars.contains ivar) || frameIVars.contains ivar) hyps
+    let ⟨el', _, hypsl', hypsr', pf'⟩ := Hyps.split bi
+      (λ _ ivar => (negate ^^ ivars.contains ivar) || frameIVars.contains ivar) hyps
     let out₁ ← mkFreshExprMVarQ prop
     let out₂ ← mkFreshExprMVarQ prop
     let some _ ← ProofModeM.trySynthInstanceQ q(IntoWand $p false $out .out $out₁ .out $out₂)

--- a/Iris/Iris/ProofMode/Tactics/Specialize.lean
+++ b/Iris/Iris/ProofMode/Tactics/Specialize.lean
@@ -8,6 +8,7 @@ module
 public meta import Iris.ProofMode.Patterns.ProofModeTerm
 public meta import Iris.ProofMode.Patterns.CasesPattern
 public meta import Iris.ProofMode.Tactics.Basic
+public meta import Iris.ProofMode.Tactics.Frame
 
 namespace Iris.ProofMode
 
@@ -32,6 +33,12 @@ theorem specialize_wand_subgoal [BI PROP] {q : Bool} {A1 A2 A3 A4 Q P1 : PROP} P
     [inst : IntoWand q false Q .out P1 .out P2] : A1 ⊢ A3 ∗ P2 := by
   refine h1.trans <| (sep_mono_l h2.1).trans <| sep_assoc.1.trans (sep_mono_r ((sep_mono_l h3).trans ?_))
   exact (sep_mono_r inst.1).trans wand_elim_r
+
+theorem specialize_wand_autoframe [BI PROP] {q : Bool} {A1 A2 A3 Q P1 : PROP} P2
+     (h1 : A1 ⊢ A2 ∗ □?q Q) (h2 : A2 ⊢ A3 ∗ P1)
+     [inst : IntoWand q false Q .out P1 .out P2] : A1 ⊢ A3 ∗ P2 :=
+  h1.trans <| (sep_mono_l h2).trans <| sep_assoc.1.trans
+    (sep_mono_r ((sep_mono_r inst.into_wand).trans wand_elim_r))
 
 theorem specialize_forall [BI PROP] {p : Bool} {A1 A2 P : PROP} {α : Sort _} {Φ : α → PROP}
     [inst : IntoForall P Φ] (h : A1 ⊢ A2 ∗ □?p P) (a : α) : A1 ⊢ A2 ∗ □?p (Φ a) := by
@@ -80,18 +87,41 @@ private def processWand :
     let newMVarIds ← getMVarsNoDelayed x
     for mvar in newMVarIds do addMVarGoal mvar
     return { e, hyps, p, out := out', pf := q(specialize_forall $pf $x) }
-  | { hyps, p, out, pf, .. }, .goal ns g => do
+  | { hyps, p, out, pf, .. }, .goal {kind, negate, frame:=f, hyps := hs} g => do
+    if kind != .spatial then
+      -- TODO
+      throwError "ispecialize: only spatial kind is supported at the moment"
     let mut ivars : IVarIdSet := {}
-    for name in ns do
+    for name in hs do
       ivars := ivars.insert (← hyps.findWithInfo name)
-    let ⟨el', _, hypsl', hypsr', h'⟩ := Hyps.split bi (λ _ ivar => ivars.contains ivar) hyps
+    let mut frameIVars : List IVarId := []
+    for name in f do
+      let ivar ← hyps.findWithInfo name
+      frameIVars := ivar :: frameIVars
+      if ivars.contains ivar then
+        throwError "ispecialize: {name} used twice"
+    frameIVars := frameIVars.reverse
+    let ⟨el', _, hypsl', hypsr', pf'⟩ := Hyps.split bi (λ _ ivar => (negate ^^ ivars.contains ivar) || frameIVars.contains ivar) hyps
     let out₁ ← mkFreshExprMVarQ prop
     let out₂ ← mkFreshExprMVarQ prop
     let some _ ← ProofModeM.trySynthInstanceQ q(IntoWand $p false $out .out $out₁ .out $out₂)
       | throwError m!"ispecialize: {out} is not a wand"
-    let pf' ← addBIGoal hypsr' out₁ g
-    let pf := q(specialize_wand_subgoal $out₂ $pf $h' $pf')
+    let res ← iFrame bi _ hypsr' out₁ (frameIVars.map (⟨.inl ·, true⟩))
+    let pf'' ← res.finish (addBIGoal · · g)
+    let pf := q(specialize_wand_subgoal $out₂ $pf $pf' $pf'')
     return { e := el', hyps := hypsl', p := q(false), out := out₂, pf }
+
+  | { hyps, p, out, pf, .. }, .autoframe kind => do
+    if kind != .spatial then
+      -- TODO
+      throwError "ispecialize: only spatial kind is supported at the moment"
+    let out₁ ← mkFreshExprMVarQ prop
+    let out₂ ← mkFreshExprMVarQ prop
+    let some _ ← ProofModeM.trySynthInstanceQ q(IntoWand $p false $out .out $out₁ .out $out₂)
+      | throwError m!"ispecialize: {out} is not a wand"
+    let res ← iFrame bi _ hyps out₁ (← SelPat.resolve hyps [.spatial, .intuitionistic])
+    let ⟨_, hyps', pf'⟩ ← res.finishClose
+    return { e := _, hyps := hyps', p := q(false), out := out₂, pf := q(specialize_wand_autoframe $out₂ $pf $pf') }
 
 /-- `iCasesPat.should_try_dup_context` determines when iSpecializeCore should try to duplicate the separation context.
 The duplication only works if the conclusion of the specialization is persistent.

--- a/Iris/Iris/Std/TC.lean
+++ b/Iris/Iris/Std/TC.lean
@@ -32,6 +32,13 @@ instance [t : T] : TCOr T U := @TCOr.l T U t
 instance [u : U] : TCOr T U := @TCOr.r T U u
 
 
+/-- Type class version of `Eq`, i.e. a type class that has an instance exactly when `a = b`. -/
+class inductive TCEq {α : Sort _} (a : α) : α → Prop
+  | refl : TCEq a a
+
+instance {α : Sort _} {a : α} : TCEq a a := TCEq.refl
+
+
 /-- Type class version of `Ite`, i.e. a type class for which an instance exists if the boolean
 condition is `true` and an instance of `T` is present or the condition is `false` and an instance
 of `U` is present.

--- a/Iris/Iris/Std/TC.lean
+++ b/Iris/Iris/Std/TC.lean
@@ -32,7 +32,7 @@ instance [t : T] : TCOr T U := @TCOr.l T U t
 instance [u : U] : TCOr T U := @TCOr.r T U u
 
 
-/-- Type class version of `Eq`, i.e. a type class that has an instance exactly when `a = b`. -/
+/-- Type class version of `Eq`. `TCEq a b` has an instance exactly when `a = b`. -/
 class inductive TCEq {α : Sort _} (a : α) : α → Prop
   | refl : TCEq a a
 

--- a/Iris/Iris/Tests/Instances.lean
+++ b/Iris/Iris/Tests/Instances.lean
@@ -8,11 +8,43 @@ module
 public import Iris.BI
 public import Iris.ProofMode.SynthInstance
 public import Iris.ProofMode.Instances
+public import Iris.ProofMode.InstancesMake
 
 @[expose] public section
 
 namespace Iris.Tests
 open Lean Qq BI ProofMode
+
+/- Tests the mvar handling of synth and ipm_synth -/
+section mvars
+variable (PROP : Type u) [BI PROP]
+
+set_option pp.mvars false
+
+/-- info: None -/
+#guard_msgs in
+#ipm_synth QuickAbsorbing (PROP:=PROP) _
+
+-- check that ipm_synth does not accidentally instantiate input mvars
+/-- info: solution: MakeSep iprop(True) ?_ iprop(True ∗ ?_), new goals: [?_: PROP] -/
+#guard_msgs in
+#ipm_synth MakeSep (PROP:=PROP) iprop(True) _ _
+
+/-- info: solution: MakeIntuitionistically ?_ iprop(□ ?_), new goals: [?_: PROP] -/
+#guard_msgs in
+#ipm_synth MakeIntuitionistically (PROP:=PROP) _ _
+
+variable [BIAffine PROP]
+
+/-- info: solution: QuickAbsorbing ?_, new goals: [?_: PROP] -/
+#guard_msgs in
+#ipm_synth QuickAbsorbing (PROP:=PROP) _
+
+/-- info: solution: MakeSep iprop(True) ?_ ?_, new goals: [?_: PROP] -/
+#guard_msgs in
+#ipm_synth MakeSep (PROP:=PROP) iprop(True) _ _
+
+end mvars
 
 /- Test the backtracking of ipm_synth -/
 section backtracking
@@ -262,7 +294,7 @@ trace: [Meta.synthInstance] ❌️ IPM: TacticTest iprop(True) ?_
 #guard_msgs (substring := true) in
 set_option trace.Meta.synthInstance true in
 set_option pp.mvars false in
-#ipm_synth (TacticTest iprop(True) _)
+#ipm_synth (TacticTest (PROP:=PROP) iprop(True) _)
 
 
 end tactics

--- a/Iris/Iris/Tests/Instances.lean
+++ b/Iris/Iris/Tests/Instances.lean
@@ -185,7 +185,7 @@ info: solution: TacticTest iprop(emp ∗ P) P, new goals: []
 trace: [Meta.synthInstance] ✅️ IPM: TacticTest iprop(emp ∗ P) P
   [Meta.synthInstance] ✅️ new goal TacticTest iprop(emp ∗ P) ?_ => TacticTest iprop(emp ∗ P) P
     [Meta.synthInstance.tactics] [Iris.Tests.tac_sep:1000, Iris.Tests.tac_emp:1000, Iris.Tests.tac_continue:10000]
-    [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_continue to TacticTest iprop(emp ∗ P) ?_
+    [Meta.synthInstance] ❌️ apply tactic Iris.Tests.tac_continue to TacticTest iprop(emp ∗ P) ?_
     [Meta.synthInstance] Iris.Tests.tac_continue did not find an instance, continue to other instances
     [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_emp to TacticTest iprop(emp ∗ P) ?_
       [Meta.synthInstance] Iris.Tests.tac_emp success: tactic_test_emp P
@@ -206,12 +206,12 @@ info: solution: TacticTest iprop((emp ∗ P) ∗ P) iprop(P ∗ P), new goals: [
 trace: [Meta.synthInstance] ✅️ IPM: TacticTest iprop((emp ∗ P) ∗ P) iprop(P ∗ P)
   [Meta.synthInstance] ✅️ new goal TacticTest iprop((emp ∗ P) ∗ P) ?_ => TacticTest iprop((emp ∗ P) ∗ P) iprop(P ∗ P)
     [Meta.synthInstance.tactics] [Iris.Tests.tac_sep:1000, Iris.Tests.tac_continue:10000]
-    [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_continue to TacticTest iprop((emp ∗ P) ∗ P) ?_
+    [Meta.synthInstance] ❌️ apply tactic Iris.Tests.tac_continue to TacticTest iprop((emp ∗ P) ∗ P) ?_
     [Meta.synthInstance] Iris.Tests.tac_continue did not find an instance, continue to other instances
     [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_sep to TacticTest iprop((emp ∗ P) ∗ P) ?_
       [Meta.synthInstance] ✅️ new goal TacticTest iprop(emp ∗ P) ?_ => TacticTest iprop(emp ∗ P) P
         [Meta.synthInstance.tactics] [Iris.Tests.tac_sep:1000, Iris.Tests.tac_emp:1000, Iris.Tests.tac_continue:10000]
-        [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_continue to TacticTest iprop(emp ∗ P) ?_
+        [Meta.synthInstance] ❌️ apply tactic Iris.Tests.tac_continue to TacticTest iprop(emp ∗ P) ?_
         [Meta.synthInstance] Iris.Tests.tac_continue did not find an instance, continue to other instances
         [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_emp to TacticTest iprop(emp ∗ P) ?_
           [Meta.synthInstance] Iris.Tests.tac_emp success: tactic_test_emp P
@@ -236,7 +236,7 @@ trace: [Meta.synthInstance] ✅️ IPM: TacticTest iprop(∀ a, (emp ∗ ⌜a = 
   [Meta.synthInstance] ✅️ new goal TacticTest iprop(∀ a, (emp ∗ ⌜a = 5⌝) ∗ P)
         ?_ => TacticTest iprop(∀ a, (emp ∗ ⌜a = 5⌝) ∗ P) iprop(∀ a, ⌜a = 5⌝ ∗ P)
     [Meta.synthInstance.tactics] [Iris.Tests.tac_continue:10000]
-    [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_continue to TacticTest iprop(∀ a, (emp ∗ ⌜a = 5⌝) ∗ P) ?_
+    [Meta.synthInstance] ❌️ apply tactic Iris.Tests.tac_continue to TacticTest iprop(∀ a, (emp ∗ ⌜a = 5⌝) ∗ P) ?_
     [Meta.synthInstance] Iris.Tests.tac_continue did not find an instance, continue to other instances
     [Meta.synthInstance.instances] #[@tactic_test_all]
     [Meta.synthInstance] ✅️ apply @tactic_test_all to TacticTest iprop(∀ a, (emp ∗ ⌜a = 5⌝) ∗ P) ?_
@@ -254,7 +254,7 @@ trace: [Meta.synthInstance] ✅️ IPM: TacticTest iprop(∀ a, (emp ∗ ⌜a = 
             TacticTest iprop((emp ∗ ⌜a = 5⌝) ∗ P)
               (?_ a) => ∀ (a : Nat), TacticTest iprop((emp ∗ ⌜a = 5⌝) ∗ P) iprop(⌜a = 5⌝ ∗ P)
         [Meta.synthInstance.tactics] [Iris.Tests.tac_sep:1000, Iris.Tests.tac_continue:10000]
-        [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_continue to ∀ (a : Nat),
+        [Meta.synthInstance] ❌️ apply tactic Iris.Tests.tac_continue to ∀ (a : Nat),
               TacticTest iprop((emp ∗ ⌜a = 5⌝) ∗ P) (?_ a)
         [Meta.synthInstance] Iris.Tests.tac_continue did not find an instance, continue to other instances
         [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_sep to ∀ (a : Nat),
@@ -264,7 +264,7 @@ trace: [Meta.synthInstance] ✅️ IPM: TacticTest iprop(∀ a, (emp ∗ ⌜a = 
             [Meta.synthInstance.tactics] [Iris.Tests.tac_sep:1000,
                  Iris.Tests.tac_emp:1000,
                  Iris.Tests.tac_continue:10000]
-            [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_continue to TacticTest iprop(emp ∗ ⌜a = 5⌝) ?_
+            [Meta.synthInstance] ❌️ apply tactic Iris.Tests.tac_continue to TacticTest iprop(emp ∗ ⌜a = 5⌝) ?_
             [Meta.synthInstance] Iris.Tests.tac_continue did not find an instance, continue to other instances
             [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_emp to TacticTest iprop(emp ∗ ⌜a = 5⌝) ?_
               [Meta.synthInstance] Iris.Tests.tac_emp success: tactic_test_emp iprop(⌜a = 5⌝)
@@ -285,9 +285,9 @@ info: None
 trace: [Meta.synthInstance] ❌️ IPM: TacticTest iprop(True) ?_
   [Meta.synthInstance] ❌️ new goal TacticTest iprop(True) ?_ => TacticTest iprop(True) ?_
     [Meta.synthInstance.tactics] [Iris.Tests.tac_fail:100, Iris.Tests.tac_continue:10000]
-    [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_continue to TacticTest iprop(True) ?_
+    [Meta.synthInstance] ❌️ apply tactic Iris.Tests.tac_continue to TacticTest iprop(True) ?_
     [Meta.synthInstance] Iris.Tests.tac_continue did not find an instance, continue to other instances
-    [Meta.synthInstance] ✅️ apply tactic Iris.Tests.tac_fail to TacticTest iprop(True) ?_
+    [Meta.synthInstance] ❌️ apply tactic Iris.Tests.tac_fail to TacticTest iprop(True) ?_
     [Meta.synthInstance] Iris.Tests.tac_fail failed, no backtracking to other instances
   [Meta.synthInstance] result <not-available>
 -/

--- a/Iris/Iris/Tests/Tactics.lean
+++ b/Iris/Iris/Tests/Tactics.lean
@@ -1011,6 +1011,42 @@ example [BI PROP] (Q : PROP) : P ⊢ (⌜True⌝ -∗ P -∗ ⌜True⌝ -∗ Q) 
   case G => iexact HP
   iexact HPQ
 
+/-- Tests `ispecialize` with negated subgoal -/
+example [BI PROP] (Q : PROP) : P ⊢ R -∗ (P -∗ R -∗ Q) -∗ Q := by
+  iintro HP HR HPQ
+  ispecialize HPQ $$ [- HR] [-]
+  . iexact HP
+  . iexact HR
+  iexact HPQ
+
+/-- Tests `ispecialize` with framing subgoal -/
+example [BI PROP] (Q : PROP) : P ⊢ P -∗ R -∗ (P ∗ P -∗ R -∗ Q) -∗ Q := by
+  iintro HP1 HP2 HR HPQ
+  ispecialize HPQ $$ [$HP1 HP2] [-]
+  . iexact HP2
+  . iexact HR
+  iexact HPQ
+
+/-- Tests `ispecialize` with negated framing subgoal -/
+example [BI PROP] (Q : PROP) : P ⊢ P -∗ R -∗ (P ∗ P -∗ R -∗ Q) -∗ Q := by
+  iintro HP1 HP2 HR HPQ
+  ispecialize HPQ $$ [- $HP1 HR] [-]
+  . iexact HP2
+  . iexact HR
+  iexact HPQ
+
+/- Tests `ispecialize` with autoframe -/
+example [BI PROP] (Q : PROP) : P ⊢ (P -∗ Q) -∗ Q := by
+  iintro HP HPQ
+  ispecialize HPQ $$ [$]
+  iexact HPQ
+
+/-- Tests `ispecialize` with more complex autoframe -/
+example [BI PROP] (Q : PROP) : P ⊢ P -∗ R -∗ (P ∗ P -∗ R -∗ Q) -∗ Q := by
+  iintro HP1 HP2 HR HPQ
+  ispecialize HPQ $$ [$] [$]
+  iexact HPQ
+
 /-- Tests `ispecialize` with intuitionistic wand -/
 example [BI PROP] (Q : PROP) : □ P ⊢ □ (P -∗ Q) -∗ □ Q := by
   iintro #HP #HPQ
@@ -1259,6 +1295,18 @@ example [BI PROP] (P Q : PROP) : ⊢ P -∗ <affine> Q -∗ P := by
   iintro HQ
   icases HQ with -
   iexact HP
+
+/-- Tests `icases` to frame hypothesis -/
+example [BI PROP] (P : PROP) : ⊢ P -∗ P := by
+  iintro HP
+  icases HP with $
+
+/-- Tests `icases` to frame persistent hypothesis -/
+example [BI PROP] (P Q : PROP) : ⊢ □ P -∗ (P -∗ Q) -∗ P ∗ Q := by
+  iintro #HP Hwand
+  icases HP with $
+  iapply Hwand
+  iframe #
 
 /-- Tests `icases` with nested conjunction -/
 example [BI PROP] (Q : PROP) : □ (P1 ∧ P2 ∧ Q) ⊢ Q := by
@@ -1900,3 +1948,170 @@ example [BI PROP] (P : PROP) : P ⊢ P := by
   inext
 
 end inext
+
+section iframe
+
+/- Tests basic `iframe` -/
+example [BI PROP] (P : PROP) : P ⊢ P := by
+  iintro HP
+  iframe HP
+
+/- Tests `iframe` not closing goal with non-affine assumption -/
+/--
+error: unsolved goals
+PROP : Type u_1
+inst✝ : BI PROP
+P Q : PROP
+⊢ ⏎
+  ∗HQ : Q
+  ⊢ emp
+-/
+#guard_msgs in
+example [BI PROP] (P Q : PROP) : P ∗ Q ⊢ P := by
+  iintro ⟨HP, HQ⟩
+  iframe HP
+
+/- Tests `iframe` closing goal with absorbing goal -/
+example [BI PROP] (P Q : PROP) : <absorb> P ∗ Q ⊢ <absorb> P := by
+  iintro ⟨HP, HQ⟩
+  iframe HP
+
+/- Tests `iframe` with pure hyp -/
+example [BI PROP] (Q : PROP) :
+  1 = 1 →
+  Q ⊢ ⌜1 = 1⌝ := by
+  iintro %heq HQ
+  iframe %heq
+
+/- Tests `iframe` error with pure hyp mismatch -/
+/-- error: iframe: cannot frame ⌜1 = 2⌝ -/
+#guard_msgs in
+example [BI PROP] (Q : PROP) :
+  1 = 2 →
+  Q ⊢ ⌜1 = 1⌝ := by
+  iintro %heq HQ
+  iframe %heq
+
+/- Tests `iframe` error with non-prop -/
+/-- error: iframe: Q is not a Prop -/
+#guard_msgs in
+example [BI PROP] (Q : PROP) :
+  Q ⊢ ⌜1 = 1⌝ := by
+  iintro HQ
+  iframe %Q
+
+/- Tests `iframe` under star -/
+example [BI PROP] (P Q : PROP) : P ∗ Q ⊢ P ∗ Q := by
+  iintro ⟨HP, HQ⟩
+  iframe HP HQ
+
+/- Tests `iframe` under nested star -/
+example [BI PROP] (P Q : PROP) : P ∗ Q ∗ Q ⊢ (P ∗ Q) ∗ Q := by
+  iintro ⟨HP, HQ1, HQ2⟩
+  iframe HP
+  iframe HQ1 HQ2
+
+/- Tests `iframe` without explicit patterns -/
+example [BI PROP] (P Q : PROP) : P ∗ Q ∗ Q ⊢ (P ∗ Q) ∗ Q := by
+  iintro ⟨HP, HQ1, HQ2⟩
+  iframe
+
+/- Tests `iframe` with persistent hyp cancelling multiple times -/
+example [BI PROP] (P Q : PROP) : P ∗ □ Q ⊢ (P ∗ Q) ∗ Q := by
+  iintro ⟨HP, #HQ1⟩
+  iframe HQ1
+  iframe
+
+/- Tests `iframe` under and -/
+example [BI PROP] (P : PROP) : P ⊢ (P ∧ P) := by
+  iintro HP
+  iframe HP
+
+/- Tests `iframe` under and -/
+example [BI PROP] (P Q : PROP) [BIAffine PROP] : P ∗ Q ⊢ (P ∧ Q) := by
+  iintro ⟨HP, HQ⟩
+  iframe HP
+  iframe HQ
+
+/- Tests `iframe` under and for non-affine P failing -/
+/-- error: iframe: cannot frame P -/
+#guard_msgs in
+example [BI PROP] (P Q : PROP) : P ∗ Q ⊢ (P ∧ Q) := by
+  iintro ⟨HP, HQ⟩
+  iframe HP
+
+/- Tests `iframe` under and for intuitionistic hyp -/
+example [BI PROP] (P Q : PROP) [Affine Q] : □ P ∗ Q ⊢ (P ∧ Q) := by
+  iintro ⟨#HP, HQ⟩
+  iframe HP
+  iframe HQ
+
+/- Tests `iframe` under or -/
+example [BI PROP] (P Q : PROP) : P ∗ Q ⊢ (P ∗ Q ∨ P ∗ Q) := by
+  iintro ⟨HP, HQ⟩
+  iframe HP
+  iframe HQ
+
+/- Tests `iframe` under or only left fails -/
+/-- error: iframe: cannot frame P -/
+#guard_msgs in
+example [BI PROP] (P Q : PROP) : P ∗ Q ⊢ (P ∗ Q ∨ Q) := by
+  iintro ⟨HP, HQ⟩
+  iframe HP
+
+/- Tests `iframe` under or only left works if persistent -/
+example [BI PROP] (P Q : PROP) : □ P ∗ Q ⊢ (P ∗ Q ∨ Q) := by
+  iintro ⟨#HP, HQ⟩
+  iframe HP
+  iframe HQ
+
+/- Tests `iframe` under or solve left -/
+example [BI PROP] (P Q : PROP) [BIAffine PROP] : P ∗ Q ⊢ (P ∨ Q) := by
+  iintro ⟨HP, HQ⟩
+  iframe HP
+
+/- Tests `iframe` under or solve right -/
+example [BI PROP] (P Q : PROP) [BIAffine PROP] : P ∗ Q ⊢ (Q ∨ P) := by
+  iintro ⟨HP, HQ⟩
+  iframe HP
+
+/- Tests `iframe` under modalities -/
+example [BI PROP] (P : PROP) : □ P ⊢ <pers> <affine> <absorb> □ P := by
+  iintro #HP
+  iframe HP
+
+/- Tests `iframe` under more modalities -/
+example [BI PROP] [BIUpdate PROP] [BIFUpdate PROP] (P : PROP) [BIAffine PROP] E :
+  P ⊢ ▷ |==> |={E}=> P := by
+  iintro HP
+  iframe HP
+
+/- Tests `iframe` under magic wand -/
+example [BI PROP] (P Q : PROP) : P ⊢ Q -∗ P ∗ Q := by
+  iintro HP
+  iframe HP
+  iintro HQ
+  iframe HQ
+
+/- Tests `iframe` under implication -/
+example [BI PROP] (P Q : PROP) [BIAffine PROP] : P ⊢ □ Q → P ∗ Q := by
+  iintro HP
+  iframe HP
+  iintro #HQ
+  iframe HQ
+
+/- Tests `iframe` under forall -/
+example [BI PROP] (P : PROP) : P ⊢ ∀ (x : Nat), P ∗ ⌜x = x⌝ := by
+  iintro HP
+  iframe HP
+  ipure_intro; simp
+
+/- Tests `iframe` with mvar -/
+example [BI PROP] (P Q : PROP) : (P ∗ Q ⊢ ∃ x, P ∗ x ∗ ⌜x = Q⌝) := by
+  iintro ⟨HP, HQ⟩
+  iexists _
+  iframe HP
+  iframe HQ
+  ipure_intro; trivial
+
+end iframe

--- a/Iris/Iris/Tests/Tactics.lean
+++ b/Iris/Iris/Tests/Tactics.lean
@@ -861,6 +861,13 @@ example [BI PROP] (Q : PROP) : (⌜φ1⌝ ∧ <affine> ⌜φ2⌝) ⊢ Q -∗ Q :
   ipure Hφ
   iexact HQ
 
+/-- Tests `ipure` with implication containing pure -/
+example [BI PROP] (Q : PROP) : <affine> (⌜φ1⌝ ∧ ⌜φ2⌝ → ⌜φ3⌝)  ⊢ Q -∗ Q := by
+  iintro Hφ
+  iintro HQ
+  ipure Hφ
+  iexact HQ
+
 /- Tests `ipure` failure -/
 /-- error: ipure: P is not pure -/
 #guard_msgs in
@@ -980,6 +987,16 @@ example [BI PROP] (H : A → B) (P Q : PROP) : <affine> P ⊢ <pers> Q → ⌜A�
   ipure_intro
   exact H
 
+/-- Tests `ipure_intro` with wand containing pure and affine lhs -/
+example [BI PROP] : ⊢@{PROP} (<affine> ⌜φ2⌝ -∗ emp) := by
+  ipure_intro
+  intro _; trivial
+
+/-- Tests `ipure_intro` with wand containing pure and absorbing rhs -/
+example [BI PROP] : ⊢@{PROP} (⌜φ2⌝ -∗ <absorb> emp) := by
+  ipure_intro
+  intro _; trivial
+
 /- Tests `ipure_intro` failure -/
 /-- error: ipure_intro: P is not pure -/
 #guard_msgs in
@@ -1027,26 +1044,10 @@ example [BI PROP] (Q : PROP) : P ⊢ P -∗ R -∗ (P ∗ P -∗ R -∗ Q) -∗ 
   . iexact HR
   iexact HPQ
 
-/-- Tests `ispecialize` with framing subgoal -/
+/-- Tests `ispecialize` with framing subgoal (different argument order) -/
 example [BI PROP] (Q : PROP) : P ⊢ P -∗ R -∗ (P ∗ P -∗ R -∗ Q) -∗ Q := by
   iintro HP1 HP2 HR HPQ
   ispecialize HPQ $$ [HP1 $HP2] [-]
-  . iexact HP1
-  . iexact HR
-  iexact HPQ
-
-/-- Tests `ispecialize` with framing subgoal -/
-example [BI PROP] (Q : PROP) : P ⊢ P -∗ R -∗ (P ∗ P -∗ R -∗ Q) -∗ Q := by
-  iintro HP1 HP2 HR HPQ
-  ispecialize HPQ $$ [- HR $HP2] [-]
-  . iexact HP1
-  . iexact HR
-  iexact HPQ
-
-/-- Tests `ispecialize` with framing subgoal -/
-example [BI PROP] (Q : PROP) : P ⊢ P -∗ R -∗ (P ∗ P -∗ R -∗ Q) -∗ Q := by
-  iintro HP1 HP2 HR HPQ
-  ispecialize HPQ $$ [- HR $HP2] [-]
   . iexact HP1
   . iexact HR
   iexact HPQ
@@ -1056,6 +1057,14 @@ example [BI PROP] (Q : PROP) : P ⊢ P -∗ R -∗ (P ∗ P -∗ R -∗ Q) -∗ 
   iintro HP1 HP2 HR HPQ
   ispecialize HPQ $$ [- $HP1 HR] [-]
   . iexact HP2
+  . iexact HR
+  iexact HPQ
+
+/-- Tests `ispecialize` with negated framing subgoal (different argument order) -/
+example [BI PROP] (Q : PROP) : P ⊢ P -∗ R -∗ (P ∗ P -∗ R -∗ Q) -∗ Q := by
+  iintro HP1 HP2 HR HPQ
+  ispecialize HPQ $$ [- HR $HP2] [-]
+  . iexact HP1
   . iexact HR
   iexact HPQ
 

--- a/Iris/Iris/Tests/Tactics.lean
+++ b/Iris/Iris/Tests/Tactics.lean
@@ -1027,6 +1027,30 @@ example [BI PROP] (Q : PROP) : P ⊢ P -∗ R -∗ (P ∗ P -∗ R -∗ Q) -∗ 
   . iexact HR
   iexact HPQ
 
+/-- Tests `ispecialize` with framing subgoal -/
+example [BI PROP] (Q : PROP) : P ⊢ P -∗ R -∗ (P ∗ P -∗ R -∗ Q) -∗ Q := by
+  iintro HP1 HP2 HR HPQ
+  ispecialize HPQ $$ [HP1 $HP2] [-]
+  . iexact HP1
+  . iexact HR
+  iexact HPQ
+
+/-- Tests `ispecialize` with framing subgoal -/
+example [BI PROP] (Q : PROP) : P ⊢ P -∗ R -∗ (P ∗ P -∗ R -∗ Q) -∗ Q := by
+  iintro HP1 HP2 HR HPQ
+  ispecialize HPQ $$ [- HR $HP2] [-]
+  . iexact HP1
+  . iexact HR
+  iexact HPQ
+
+/-- Tests `ispecialize` with framing subgoal -/
+example [BI PROP] (Q : PROP) : P ⊢ P -∗ R -∗ (P ∗ P -∗ R -∗ Q) -∗ Q := by
+  iintro HP1 HP2 HR HPQ
+  ispecialize HPQ $$ [- HR $HP2] [-]
+  . iexact HP1
+  . iexact HR
+  iexact HPQ
+
 /-- Tests `ispecialize` with negated framing subgoal -/
 example [BI PROP] (Q : PROP) : P ⊢ P -∗ R -∗ (P ∗ P -∗ R -∗ Q) -∗ Q := by
   iintro HP1 HP2 HR HPQ
@@ -1044,6 +1068,13 @@ example [BI PROP] (Q : PROP) : P ⊢ (P -∗ Q) -∗ Q := by
 /-- Tests `ispecialize` with more complex autoframe -/
 example [BI PROP] (Q : PROP) : P ⊢ P -∗ R -∗ (P ∗ P -∗ R -∗ Q) -∗ Q := by
   iintro HP1 HP2 HR HPQ
+  ispecialize HPQ $$ [$] [$]
+  iexact HPQ
+
+/-- Tests `ispecialize` with even more complex autoframe -/
+example [BI PROP] (P' : Nat → PROP) (Q : PROP)
+    : P' 1 ⊢ □ P' 1 -∗ P' 2 -∗ R -∗ (∀ n, ((□ P' n ∗ R ∗ P' n) -∗ P' 2 -∗ Q)) -∗ Q := by
+  iintro HP1 #HP1' HP2 HR HPQ
   ispecialize HPQ $$ [$] [$]
   iexact HPQ
 
@@ -1307,6 +1338,11 @@ example [BI PROP] (P Q : PROP) : ⊢ □ P -∗ (P -∗ Q) -∗ P ∗ Q := by
   icases HP with $
   iapply Hwand
   iframe #
+
+/-- Tests `icases` with complex pattern involving framing -/
+example [BI PROP] (P Q R : PROP) : ⊢ ((P ∗ □ Q ∗ (□ R ∨ R))) -∗ P ∗ Q ∗ R := by
+  iintro HP
+  icases HP with ⟨$, #HQ, ⟨#$ | $⟩⟩ <;> iframe #
 
 /-- Tests `icases` with nested conjunction -/
 example [BI PROP] (Q : PROP) : □ (P1 ∧ P2 ∧ Q) ⊢ Q := by
@@ -2107,11 +2143,17 @@ example [BI PROP] (P : PROP) : P ⊢ ∀ (x : Nat), P ∗ ⌜x = x⌝ := by
   ipure_intro; simp
 
 /- Tests `iframe` with mvar -/
-example [BI PROP] (P Q : PROP) : (P ∗ Q ⊢ ∃ x, P ∗ x ∗ ⌜x = Q⌝) := by
+example [BI PROP] (P Q : PROP) : (P ∗ Q ⊢ ∃ x, P ∗ ⌜x = Q⌝ ∗ x) := by
   iintro ⟨HP, HQ⟩
   iexists _
   iframe HP
   iframe HQ
   ipure_intro; trivial
+
+/- Tests `iframe` with mvar and or -/
+example [BI PROP] [BIAffine PROP] (Q : Nat → PROP) : (Q 0 ⊢ ∃ x, False ∨ Q x) := by
+  iintro HQ
+  iexists _
+  iframe
 
 end iframe

--- a/Iris/PORTING.md
+++ b/Iris/PORTING.md
@@ -296,18 +296,19 @@ Some porting tasks will require other tasks as dependencies, the GitHub issues p
   - [ ] AddModal
   - [x] IntoLater
 - [ ] `class_instances_make.v`
-  - [ ] QuickAffine
-  - [ ] QuickAbsorbing
-  - [ ] MakeEmbed
-  - [ ] MakeSep
-  - [ ] MakeAnd
-  - [ ] MakeOr
+  - [x] QuickAffine
+  - [x] QuickAbsorbing
+  - [x] MakeEmbed
+  - [x] MakeSep
+  - [x] MakeAnd
+  - [x] MakeOr
   - [x] MakeAffinely
   - [x] MakeIntuitionistically
   - [x] MakeAbsorbingly
   - [x] MakePersistenly
   - [x] MakeLaterN
-  - [ ] MakeExcept0
+  - [x] MakeExcept0
+  - [ ] MakeEmbed
 - [ ] `class_instances_plainly.v` (InstancesPlainly.lean)
   - [x] basic instances
   - [x] FromModal
@@ -352,7 +353,7 @@ Some porting tasks will require other tasks as dependencies, the GitHub issues p
   - [ ] CombineSepGives
   - [x] ElimModal
   - [ ] AddModal
-  - [ ] Frame
+  - [x] Frame
   - [x] IntoExcept0
   - [x] MaybeIntoLaterN / IntoLaterN
   - [ ] IntoEmbed
@@ -363,18 +364,19 @@ Some porting tasks will require other tasks as dependencies, the GitHub issues p
   - [ ] IntoAcc
   - [ ] ElimInv
 - [ ] `classes_make.v`
-  - [ ] QuickAffine
-  - [ ] QuickAbsorbing
-  - [ ] MakeEmbed
-  - [ ] MakeSep
-  - [ ] MakeAnd
-  - [ ] MakeOr
+  - [x] QuickAffine
+  - [x] QuickAbsorbing
+  - [x] MakeEmbed
+  - [x] MakeSep
+  - [x] MakeAnd
+  - [x] MakeOr
   - [x] MakeAffinely
   - [x] MakeIntuitionistically
   - [x] MakeAbsorbingly
   - [x] MakePersistenly
   - [x] MakeLaterN
-  - [ ] MakeExcept0
+  - [x] MakeExcept0
+  - [ ] MakeEmbed
 - [ ] `coq_tactics.v` / `ltac_tactics.v` (split into the files in Tactics/)
   - [x] iSolveSideCondition
   - [ ] iStartProof
@@ -399,6 +401,8 @@ Some porting tasks will require other tasks as dependencies, the GitHub issues p
   - [x] iEmpIntro
   - [x] iPureIntro
   - [ ] iFrame
+    - [x] basic
+    - [ ] existential quantifiers
   - [ ] iRevert
     - [x] basic
     - [ ] `intoIH` revert
@@ -438,7 +442,7 @@ Some porting tasks will require other tasks as dependencies, the GitHub issues p
   - [x] IIdent
   - [x] IFresh
   - [x] IDrop
-  - [ ] IFrame
+  - [x] IFrame
   - [x] IList
   - [x] IPure
   - [x] IIntuitionistic
@@ -463,14 +467,17 @@ Some porting tasks will require other tasks as dependencies, the GitHub issues p
 - [x] `sel_patterns.v`
 - [ ] `spec_patterns.v`
   - [x] SIdent
+  - [ ] Nested spec patterns
   - [x] SPureGoal
   - [ ] SGoal
-    - [ ] Kind
-    - [ ] Negate
-    - [ ] Frame
+    - [x] Kind: Spatial
+    - [ ] Kind: Intuitionistic
+    - [ ] Kind: Modal
+    - [x] Negate
+    - [x] Frame
     - [x] Hyps
     - [ ] Done
-  - [ ] SAutoFrame
+  - [x] SAutoFrame
 - [-] `string_ident.v` (not necessary in Lean)
 - [-] `tokens.v` (not necessary in Lean)
 


### PR DESCRIPTION
## Description

Implement the iframe tactic and make it available in specialization patterns and cases patterns.

Additional implement input / output handling to IPM synthesis roughly in the style of Hint Mode in Rocq. See the comment on `ParamKind` for a detailed description:
```
The parameters of a class declared with `ipm_class` are categorized into the following categories:

1. in: This is the default for a parameter when not annotated in another way.
2. out: These are parameters marked with `outParam`. These parameters must be mvars when starting typeclass search.
3. semiOut: These are parameters marked with `semiOutParam`. The preceding parameter must be of type `InOut`. The value of the `InOut` parameter decides whether the `semiOut` parameter is treated as an input or an output.
4. uncheckedIn: These are parameters marked with `uncheckedInParam`. These behave like `in` parameters, but allow mvars to match terms (see below).
5. inout: Parameters of type `InOut`, must appear before semiOut parameters (see above).

The following constraints apply to the parameters: (In the following, semiOut parameters are treated as inputs if the preceding `InOut` is `in` and as outputs if the `InOut` is `out`.)
1. semiOut parameters must have a preceding `InOut` parameter.
2. For each synthesis problem, all output parameters must be mvars.
3. When an input parameter is a mvar, it is not considered to match an instance which does not have an mvar at the top-level. This is to prevent accidentally instantiating mvars. Note that this only applies for mvars the top-level (matching the behavior of Hint Mode : ! in Rocq), since this is the simplest version to implement and catches most (all?) of the cases.
```

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have updated `PORTING.md` as appropriate
* [x] I have added my name to the `authors` section of any appropriate files
