### PR TITLE
fix: Disable deploy for forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,8 @@ jobs:
           exit 1
 
   deploy:
-    if: github.ref == 'refs/heads/master'
+     # we disable deploy for forks to prevent spurious CI failures
+    if: github.ref == 'refs/heads/master' && github.repository == 'leanprover-community/iris-lean'
     needs: report
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Description
~~This fixes two problems with CI that I noticed when working on branches in forks. Also I think running CI on all branches is generally useful to spot problems earlier.~~

This fixes a problem with CI that I noticed when working in a fork: The deploy job fails since the fork does not have github pages configured. This PR disables the deploy job for forks.

EDIT: Previously, this PR als enabled CI for all branches, but this led to duplicate CI runs, so I removed it again.
