### PR TITLE
feat: distinguish uniq from name in Hyps

### DIFF
--- a/Iris/Iris/ProofMode/Expr.lean
+++ b/Iris/Iris/ProofMode/Expr.lean
@@ -18,7 +18,7 @@ open Iris.BI Iris.Std
 open Lean Lean.Expr Lean.Meta Qq
 
 @[expose, match_pattern] def nameAnnotation := `name
-@[expose, match_pattern] def uniqAnnotation := `uniq
+@[expose, match_pattern] def ivarAnnotation := `ivar
 
 structure IVarId where
   name : Name
@@ -31,12 +31,12 @@ def mkFreshIVarId [Monad m] [MonadNameGenerator m] : m IVarId :=
   deriving Inhabited, EmptyCollection, Singleton
 
 def parseName? : Expr → Option (Name × IVarId × Expr)
-  | .mdata ⟨[(nameAnnotation, .ofName name), (uniqAnnotation, .ofName uniq)]⟩ e => do
-    some (name, ⟨uniq⟩, e)
+  | .mdata ⟨[(nameAnnotation, .ofName name), (ivarAnnotation, .ofName ivar)]⟩ e => do
+    some (name, ⟨ivar⟩, e)
   | _ => none
 
-def mkNameAnnotation (name : Name)(uniq : IVarId) (e : Expr) : Expr :=
-  .mdata ⟨[(nameAnnotation, .ofName name), (uniqAnnotation, .ofName uniq.name)]⟩ e
+def mkNameAnnotation (name : Name)(ivar : IVarId) (e : Expr) : Expr :=
+  .mdata ⟨[(nameAnnotation, .ofName name), (ivarAnnotation, .ofName ivar.name)]⟩ e
 
 def getFreshName : TSyntax ``binderIdent → CoreM (Name × Syntax)
   | `(binderIdent| $name:ident) => pure (name.getId, name)
@@ -53,7 +53,7 @@ inductive Hyps {prop : Q(Type u)} (bi : Q(BI $prop)) : (e : Q($prop)) → Type w
   | emp (_ : $e =Q emp) : Hyps bi e
   | sep (tm elhs erhs : Q($prop)) (_ : $e =Q iprop($elhs ∗ $erhs))
         (lhs : Hyps bi elhs) (rhs : Hyps bi erhs) : Hyps bi e
-  | hyp (tm : Q($prop)) (name : Name)(uniq : IVarId) (p : Q(Bool)) (ty : Q($prop))
+  | hyp (tm : Q($prop)) (name : Name) (ivar : IVarId) (p : Q(Bool)) (ty : Q($prop))
         (_ : $e =Q iprop(□?$p $ty)) : Hyps bi e
 deriving Repr
 
@@ -76,15 +76,15 @@ def mkIntuitionisticIf {prop : Q(Type u)} (_bi : Q(BI $prop))
   | .inr _ => ⟨e, ⟨⟩⟩
 
 def Hyps.mkHyp {prop : Q(Type u)} (bi : Q(BI $prop))
-    (name : Name) (uniq : IVarId) (p : Q(Bool)) (ty : Q($prop)) (e := q(iprop(□?$p $ty))) : Hyps bi e :=
-  .hyp (mkIntuitionisticIf bi p (mkNameAnnotation name uniq ty)) name uniq p ty ⟨⟩
+    (name : Name) (ivar : IVarId) (p : Q(Bool)) (ty : Q($prop)) (e := q(iprop(□?$p $ty))) : Hyps bi e :=
+  .hyp (mkIntuitionisticIf bi p (mkNameAnnotation name ivar ty)) name ivar p ty ⟨⟩
 
 -- TODO: should this ensure that adding a hypothesis to emp creates a
 -- hyp node instead of a sep node?
 def Hyps.add {prop : Q(Type u)} (bi : Q(BI $prop))
-    (name : Name) (uniq : IVarId) (p : Q(Bool)) (ty : Q($prop)) {e} (h : Hyps bi e)
+    (name : Name) (ivar : IVarId) (p : Q(Bool)) (ty : Q($prop)) {e} (h : Hyps bi e)
     : Hyps bi q(iprop($e ∗ □?$p $ty)) :=
-  Hyps.mkSep h (.mkHyp bi name uniq p ty)
+  Hyps.mkSep h (.mkHyp bi name ivar p ty)
 
 partial def parseHyps? {prop : Q(Type u)} (bi : Q(BI $prop)) (expr : Expr) :
     Option ((s : Q($prop)) × Hyps bi s) := do
@@ -95,31 +95,31 @@ partial def parseHyps? {prop : Q(Type u)} (bi : Q(BI $prop)) (expr : Expr) :
   else if expr.isAppOfArity ``emp 2 then
     some ⟨expr, .emp ⟨⟩⟩
   else if let some #[_, _, P] := appM? expr ``intuitionistically then
-    let (name, uniq, (ty : Q($prop))) ← parseName? P
-    some ⟨q(iprop(□ $ty)), .hyp expr name uniq q(true) ty ⟨⟩⟩
+    let (name, ivar, (ty : Q($prop))) ← parseName? P
+    some ⟨q(iprop(□ $ty)), .hyp expr name ivar q(true) ty ⟨⟩⟩
   else
-    let (name, uniq, ty) ← parseName? expr
-    some ⟨ty, .hyp expr name uniq q(false) ty ⟨⟩⟩
+    let (name, ivar, ty) ← parseName? expr
+    some ⟨ty, .hyp expr name ivar q(false) ty ⟨⟩⟩
 
 partial def Hyps.find? {u prop bi} (name : Name) :
     ∀ {s}, @Hyps u prop bi s → Option (IVarId × Q(Bool) × Q($prop))
   | _, .emp _ => none
-  | _, .hyp _ name' uniq p ty _ => if name == name' then (uniq, p, ty) else none
+  | _, .hyp _ name' ivar p ty _ => if name == name' then (ivar, p, ty) else none
   | _, .sep _ _ _ _ lhs rhs => rhs.find? name <|> lhs.find? name
 
-partial def Hyps.spatialUniqs {u prop bi} :
+partial def Hyps.spatialIVarIds {u prop bi} :
     ∀ {s}, @Hyps u prop bi s → List IVarId
   | _, .emp _ => []
-  | _, .hyp _ _ uniq p _ _ => if isTrue p then [] else [uniq]
-  | _, .sep _ _ _ _ lhs rhs => lhs.spatialUniqs ++ rhs.spatialUniqs
+  | _, .hyp _ _ ivar p _ _ => if isTrue p then [] else [ivar]
+  | _, .sep _ _ _ _ lhs rhs => lhs.spatialIVarIds ++ rhs.spatialIVarIds
 
-partial def Hyps.intuitionisticUniqs {u prop bi} :
+partial def Hyps.intuitionisticIVarIds {u prop bi} :
     ∀ {s}, @Hyps u prop bi s → List IVarId
   | _, .emp _ => []
-  | _, .hyp _ _ uniq p _ _ => if isTrue p then [uniq] else []
-  | _, .sep _ _ _ _ lhs rhs => lhs.intuitionisticUniqs ++ rhs.intuitionisticUniqs
+  | _, .hyp _ _ ivar p _ _ => if isTrue p then [ivar] else []
+  | _, .sep _ _ _ _ lhs rhs => lhs.intuitionisticIVarIds ++ rhs.intuitionisticIVarIds
 
-variable (oldUniq : IVarId) (new : Name) {prop : Q(Type u)} {bi : Q(BI $prop)} in
+variable (oldIVar : IVarId) (new : Name) {prop : Q(Type u)} {bi : Q(BI $prop)} in
 def Hyps.rename : ∀ {e}, Hyps bi e → Option (Hyps bi e)
   | _, .emp _ => none
   | _, .sep _ _ _ _ lhs rhs =>
@@ -128,14 +128,14 @@ def Hyps.rename : ∀ {e}, Hyps bi e → Option (Hyps bi e)
     | none => match lhs.rename with
       | some lhs' => some (.mkSep lhs' rhs _)
       | none => none
-  | _, .hyp _ _ uniq p ty _ =>
-    if oldUniq == uniq then some (Hyps.mkHyp bi new uniq p ty _) else none
+  | _, .hyp _ _ ivar p ty _ =>
+    if oldIVar == ivar then some (Hyps.mkHyp bi new ivar p ty _) else none
 
 def Hyps.select (ty : Expr) : ∀ {s}, @Hyps u prop bi s → MetaM (IVarId × Q(Bool) × Q($prop))
   | _, .emp _ => failure
-  | _, .hyp _ _ uniq p ty' _ => do
+  | _, .hyp _ _ ivar p ty' _ => do
     let .true ← isDefEq ty ty' | failure
-    pure (uniq, p, ty')
+    pure (ivar, p, ty')
   | _, .sep _ _ _ _ lhs rhs => try Hyps.select ty rhs catch _ => Hyps.select ty lhs
 
 
@@ -174,12 +174,12 @@ inductive SplitResult {prop : Q(Type u)} (bi : Q(BI $prop)) (e : Q($prop)) where
 variable {prop : Q(Type u)} (bi : Q(BI $prop)) (toRight : Name → IVarId → Bool) in
 def Hyps.splitCore : ∀ {e}, Hyps bi e → SplitResult bi e
   | _, .emp _ => .emp ⟨⟩
-  | ehyp, h@(.hyp _ name uniq b ty _) =>
+  | ehyp, h@(.hyp _ name ivar b ty _) =>
     match matchBool b with
     | .inl _ =>
       have : $ehyp =Q iprop(□ $ty) := ⟨⟩
       .split h h q(intuitionistically_sep_dup)
-    | .inr _ => if toRight name uniq then .right else .left
+    | .inr _ => if toRight name ivar then .right else .left
   | _, .sep _ _ _ _ lhs rhs =>
     let resl := lhs.splitCore
     let resr := rhs.splitCore
@@ -233,8 +233,8 @@ variable [Monad m] {prop : Q(Type u)} (bi : Q(BI $prop)) (rp : Bool)
 /-- If `rp` is true, the hyp will be removed even if it is in the intuitionistic context. -/
 def Hyps.removeCore : ∀ {e}, Hyps bi e → m (RemoveHypCore bi e α)
   | _, .emp _ => pure .none
-  | e, h@(.hyp _ name uniq p ty _) => do
-    if let some a ← check name uniq p ty then
+  | e, h@(.hyp _ name ivar p ty _) => do
+    if let some a ← check name ivar p ty then
       match matchBool p, rp with
       | .inl _, false =>
         have : $e =Q iprop(□ $ty) := ⟨⟩
@@ -267,8 +267,8 @@ def Hyps.removeG [Monad m] {prop : Q(Type u)} {bi : Q(BI $prop)} {e : Q(Prop)}
   | .main a res => return some (a, res)
 
 def Hyps.remove {prop : Q(Type u)} {bi : Q(BI $prop)} {e}
-    (rp : Bool) (hyps : Hyps bi e) (uniq : IVarId) : RemoveHyp bi e :=
-  match Id.run (hyps.removeG rp fun _ uniq' _ _ => if uniq == uniq' then some () else none) with
+    (rp : Bool) (hyps : Hyps bi e) (ivar : IVarId) : RemoveHyp bi e :=
+  match Id.run (hyps.removeG rp fun _ ivar' _ _ => if ivar == ivar' then some () else none) with
   | some (_, r) => r
   | none => panic! "variable not found"
 
@@ -315,11 +315,11 @@ inductive ReplaceHyp {prop : Q(Type u)} (bi : Q(BI $prop)) (Q : Q($prop)) where
   | main (e e' : Q($prop)) (hyps' : Hyps bi e') (pf : Q(Replaces $Q $e $e'))
 
 variable [Monad m] [MonadLiftT MetaM m] {prop : Q(Type u)} (bi : Q(BI $prop)) (Q : Q($prop))
-  (uniq : IVarId) (repl : Name → Q(Bool) → Q($prop) → m (ReplaceHyp bi Q)) in
+  (ivar : IVarId) (repl : Name → Q(Bool) → Q($prop) → m (ReplaceHyp bi Q)) in
 def Hyps.replace : ∀ {e}, Hyps bi e → m (ReplaceHyp bi Q)
   | _, .emp _ => pure .none
-  | _, .hyp _ name uniq' p ty _ => do
-    if uniq == uniq' then
+  | _, .hyp _ name ivar' p ty _ => do
+    if ivar == ivar' then
       let res ← repl name p ty
       if let .main e e' hyps' _ := res then
         let e' ← instantiateMVarsQ e'
@@ -349,8 +349,8 @@ partial def Hyps.findDependencyOnFVar {prop : Q(Type u)} {bi : Q(BI $prop)}
   | _, .emp _ => none
   | _, .sep _ _ _ _ lhs rhs =>
       lhs.findDependencyOnFVar fvarId <|> rhs.findDependencyOnFVar fvarId
-  | _, .hyp _ name uniq p ty _ =>
-      if (ty : Expr).containsFVar fvarId then some (name, uniq, p, ty)
+  | _, .hyp _ name ivar p ty _ =>
+      if (ty : Expr).containsFVar fvarId then some (name, ivar, p, ty)
       else none
 
 /-- Check that removing the Lean local `fvarId` leaves no dangling dependencies in the
@@ -423,24 +423,24 @@ def addLocalVarInfo (stx : Syntax) (lctx : LocalContext)
         { elaborator := .anonymous, lctx, expr, stx, expectedType?, isBinder })
     (return .ofPartialTermInfo { elaborator := .anonymous, lctx, stx, expectedType? })
 
-def addHypInfo (stx : Syntax) (name : Name) (uniq : IVarId) (prop : Q(Type u)) (ty : Q($prop))
+def addHypInfo (stx : Syntax) (name : Name) (ivar : IVarId) (prop : Q(Type u)) (ty : Q($prop))
     (isBinder := false) : MetaM Unit := do
   let lctx ← getLCtx
   let ty := q(HypMarker $ty)
-  addLocalVarInfo stx (lctx.mkLocalDecl ⟨uniq.name⟩ name ty) (.fvar ⟨uniq.name⟩) ty isBinder
+  addLocalVarInfo stx (lctx.mkLocalDecl ⟨ivar.name⟩ name ty) (.fvar ⟨ivar.name⟩) ty isBinder
 
 /-- Hyps.findWithInfo should be used on names obtained from the syntax of a tactic to highlight them correctly. -/
 def Hyps.findWithInfo {u prop bi} (hyps : @Hyps u prop bi s) (name : Ident) : MetaM IVarId := do
-  let some (uniq, _, ty) := hyps.find? name.getId | throwError "unknown hypothesis {name}"
-  addHypInfo name name.getId uniq prop ty
-  pure uniq
+  let some (ivar, _, ty) := hyps.find? name.getId | throwError "unknown hypothesis {name}"
+  addHypInfo name name.getId ivar prop ty
+  pure ivar
 
 /-- Hyps.addWithInfo should be used by tactics that introduce a hypothesis based on the name given by the user. -/
 def Hyps.addWithInfo {prop : Q(Type u)} (bi : Q(BI $prop))
     (name : TSyntax ``binderIdent) (p : Q(Bool)) (ty : Q($prop)) {e} (h : Hyps bi e)
     : MetaM (IVarId × Hyps bi q(iprop($e ∗ □?$p $ty))) := do
-  let uniq' ← mkFreshIVarId
+  let ivar' ← mkFreshIVarId
   let (nameTo, nameRef) ← getFreshName name
-  addHypInfo nameRef nameTo uniq' prop ty (isBinder := true)
-  let hyps := Hyps.add bi nameTo uniq' p ty h
-  return ⟨uniq', hyps⟩
+  addHypInfo nameRef nameTo ivar' prop ty (isBinder := true)
+  let hyps := Hyps.add bi nameTo ivar' p ty h
+  return ⟨ivar', hyps⟩

--- a/Iris/Iris/ProofMode/Expr.lean
+++ b/Iris/Iris/ProofMode/Expr.lean
@@ -20,13 +20,23 @@ open Lean Lean.Expr Lean.Meta Qq
 @[expose, match_pattern] def nameAnnotation := `name
 @[expose, match_pattern] def uniqAnnotation := `uniq
 
-def parseName? : Expr → Option (Name × Name × Expr)
+structure IVarId where
+  name : Name
+  deriving Inhabited, BEq, Hashable, Repr
+
+def mkFreshIVarId [Monad m] [MonadNameGenerator m] : m IVarId :=
+  return { name := (← mkFreshId) }
+
+@[expose] def IVarIdSet := Std.TreeSet IVarId (Name.quickCmp ·.name ·.name)
+  deriving Inhabited, EmptyCollection, Singleton
+
+def parseName? : Expr → Option (Name × IVarId × Expr)
   | .mdata ⟨[(nameAnnotation, .ofName name), (uniqAnnotation, .ofName uniq)]⟩ e => do
-    some (name, uniq, e)
+    some (name, ⟨uniq⟩, e)
   | _ => none
 
-def mkNameAnnotation (name uniq : Name) (e : Expr) : Expr :=
-  .mdata ⟨[(nameAnnotation, .ofName name), (uniqAnnotation, .ofName uniq)]⟩ e
+def mkNameAnnotation (name : Name)(uniq : IVarId) (e : Expr) : Expr :=
+  .mdata ⟨[(nameAnnotation, .ofName name), (uniqAnnotation, .ofName uniq.name)]⟩ e
 
 def getFreshName : TSyntax ``binderIdent → CoreM (Name × Syntax)
   | `(binderIdent| $name:ident) => pure (name.getId, name)
@@ -43,7 +53,7 @@ inductive Hyps {prop : Q(Type u)} (bi : Q(BI $prop)) : (e : Q($prop)) → Type w
   | emp (_ : $e =Q emp) : Hyps bi e
   | sep (tm elhs erhs : Q($prop)) (_ : $e =Q iprop($elhs ∗ $erhs))
         (lhs : Hyps bi elhs) (rhs : Hyps bi erhs) : Hyps bi e
-  | hyp (tm : Q($prop)) (name uniq : Name) (p : Q(Bool)) (ty : Q($prop))
+  | hyp (tm : Q($prop)) (name : Name)(uniq : IVarId) (p : Q(Bool)) (ty : Q($prop))
         (_ : $e =Q iprop(□?$p $ty)) : Hyps bi e
 deriving Repr
 
@@ -66,13 +76,13 @@ def mkIntuitionisticIf {prop : Q(Type u)} (_bi : Q(BI $prop))
   | .inr _ => ⟨e, ⟨⟩⟩
 
 def Hyps.mkHyp {prop : Q(Type u)} (bi : Q(BI $prop))
-    (name uniq : Name) (p : Q(Bool)) (ty : Q($prop)) (e := q(iprop(□?$p $ty))) : Hyps bi e :=
+    (name : Name) (uniq : IVarId) (p : Q(Bool)) (ty : Q($prop)) (e := q(iprop(□?$p $ty))) : Hyps bi e :=
   .hyp (mkIntuitionisticIf bi p (mkNameAnnotation name uniq ty)) name uniq p ty ⟨⟩
 
 -- TODO: should this ensure that adding a hypothesis to emp creates a
 -- hyp node instead of a sep node?
 def Hyps.add {prop : Q(Type u)} (bi : Q(BI $prop))
-    (name uniq : Name) (p : Q(Bool)) (ty : Q($prop)) {e} (h : Hyps bi e)
+    (name : Name) (uniq : IVarId) (p : Q(Bool)) (ty : Q($prop)) {e} (h : Hyps bi e)
     : Hyps bi q(iprop($e ∗ □?$p $ty)) :=
   Hyps.mkSep h (.mkHyp bi name uniq p ty)
 
@@ -92,24 +102,24 @@ partial def parseHyps? {prop : Q(Type u)} (bi : Q(BI $prop)) (expr : Expr) :
     some ⟨ty, .hyp expr name uniq q(false) ty ⟨⟩⟩
 
 partial def Hyps.find? {u prop bi} (name : Name) :
-    ∀ {s}, @Hyps u prop bi s → Option (Name × Q(Bool) × Q($prop))
+    ∀ {s}, @Hyps u prop bi s → Option (IVarId × Q(Bool) × Q($prop))
   | _, .emp _ => none
   | _, .hyp _ name' uniq p ty _ => if name == name' then (uniq, p, ty) else none
   | _, .sep _ _ _ _ lhs rhs => rhs.find? name <|> lhs.find? name
 
 partial def Hyps.spatialUniqs {u prop bi} :
-    ∀ {s}, @Hyps u prop bi s → List Name
+    ∀ {s}, @Hyps u prop bi s → List IVarId
   | _, .emp _ => []
   | _, .hyp _ _ uniq p _ _ => if isTrue p then [] else [uniq]
   | _, .sep _ _ _ _ lhs rhs => lhs.spatialUniqs ++ rhs.spatialUniqs
 
 partial def Hyps.intuitionisticUniqs {u prop bi} :
-    ∀ {s}, @Hyps u prop bi s → List Name
+    ∀ {s}, @Hyps u prop bi s → List IVarId
   | _, .emp _ => []
   | _, .hyp _ _ uniq p _ _ => if isTrue p then [uniq] else []
   | _, .sep _ _ _ _ lhs rhs => lhs.intuitionisticUniqs ++ rhs.intuitionisticUniqs
 
-variable (oldUniq new : Name) {prop : Q(Type u)} {bi : Q(BI $prop)} in
+variable (oldUniq : IVarId) (new : Name) {prop : Q(Type u)} {bi : Q(BI $prop)} in
 def Hyps.rename : ∀ {e}, Hyps bi e → Option (Hyps bi e)
   | _, .emp _ => none
   | _, .sep _ _ _ _ lhs rhs =>
@@ -121,7 +131,7 @@ def Hyps.rename : ∀ {e}, Hyps bi e → Option (Hyps bi e)
   | _, .hyp _ _ uniq p ty _ =>
     if oldUniq == uniq then some (Hyps.mkHyp bi new uniq p ty _) else none
 
-def Hyps.select (ty : Expr) : ∀ {s}, @Hyps u prop bi s → MetaM (Name × Q(Bool) × Q($prop))
+def Hyps.select (ty : Expr) : ∀ {s}, @Hyps u prop bi s → MetaM (IVarId × Q(Bool) × Q($prop))
   | _, .emp _ => failure
   | _, .hyp _ _ uniq p ty' _ => do
     let .true ← isDefEq ty ty' | failure
@@ -161,7 +171,7 @@ inductive SplitResult {prop : Q(Type u)} (bi : Q(BI $prop)) (e : Q($prop)) where
   | split {elhs erhs : Q($prop)} (lhs : Hyps bi elhs) (rhs : Hyps bi erhs)
           (pf : Q($e ⊣⊢ $elhs ∗ $erhs))
 
-variable {prop : Q(Type u)} (bi : Q(BI $prop)) (toRight : Name → Name → Bool) in
+variable {prop : Q(Type u)} (bi : Q(BI $prop)) (toRight : Name → IVarId → Bool) in
 def Hyps.splitCore : ∀ {e}, Hyps bi e → SplitResult bi e
   | _, .emp _ => .emp ⟨⟩
   | ehyp, h@(.hyp _ name uniq b ty _) =>
@@ -186,7 +196,7 @@ def Hyps.splitCore : ∀ {e}, Hyps bi e → SplitResult bi e
     | .split l1 l2 lpf, .right => .split l1 (l2.mkSep rhs) q(split_sr $lpf)
     | .split l1 l2 lpf, .split r1 r2 rpf => .split (l1.mkSep r1) (l2.mkSep r2) q(split_ss $lpf $rpf)
 
-def Hyps.split {prop : Q(Type u)} (bi : Q(BI $prop)) (toRight : Name → Name → Bool)
+def Hyps.split {prop : Q(Type u)} (bi : Q(BI $prop)) (toRight : Name → IVarId → Bool)
     {e} (hyps : Hyps bi e) :
     (elhs erhs : Q($prop)) × Hyps bi elhs × Hyps bi erhs × Q($e ⊣⊢ $elhs ∗ $erhs) :=
   match hyps.splitCore bi toRight with
@@ -219,7 +229,7 @@ theorem remove_r [BI PROP] {P Q Q' R : PROP} (h : Q ⊣⊢ Q' ∗ R) :
   (sep_congr_r h).trans sep_assoc.symm
 
 variable [Monad m] {prop : Q(Type u)} (bi : Q(BI $prop)) (rp : Bool)
-  (check : Name → Name → Q(Bool) → Q($prop) → m (Option α)) in
+  (check : Name → IVarId → Q(Bool) → Q($prop) → m (Option α)) in
 /-- If `rp` is true, the hyp will be removed even if it is in the intuitionistic context. -/
 def Hyps.removeCore : ∀ {e}, Hyps bi e → m (RemoveHypCore bi e α)
   | _, .emp _ => pure .none
@@ -249,7 +259,7 @@ def Hyps.removeCore : ∀ {e}, Hyps bi e → m (RemoveHypCore bi e α)
 
 def Hyps.removeG [Monad m] {prop : Q(Type u)} {bi : Q(BI $prop)} {e : Q(Prop)}
     (rp : Bool) (hyps : Hyps bi e)
-    (check : Name → Name → Q(Bool) → Q($prop) → m (Option α)) :
+    (check : Name → IVarId → Q(Bool) → Q($prop) → m (Option α)) :
     m (Option (α × RemoveHyp bi e)) := do
   match ← hyps.removeCore bi rp check with
   | .none => return none
@@ -257,7 +267,7 @@ def Hyps.removeG [Monad m] {prop : Q(Type u)} {bi : Q(BI $prop)} {e : Q(Prop)}
   | .main a res => return some (a, res)
 
 def Hyps.remove {prop : Q(Type u)} {bi : Q(BI $prop)} {e}
-    (rp : Bool) (hyps : Hyps bi e) (uniq : Name) : RemoveHyp bi e :=
+    (rp : Bool) (hyps : Hyps bi e) (uniq : IVarId) : RemoveHyp bi e :=
   match Id.run (hyps.removeG rp fun _ uniq' _ _ => if uniq == uniq' then some () else none) with
   | some (_, r) => r
   | none => panic! "variable not found"
@@ -305,7 +315,7 @@ inductive ReplaceHyp {prop : Q(Type u)} (bi : Q(BI $prop)) (Q : Q($prop)) where
   | main (e e' : Q($prop)) (hyps' : Hyps bi e') (pf : Q(Replaces $Q $e $e'))
 
 variable [Monad m] [MonadLiftT MetaM m] {prop : Q(Type u)} (bi : Q(BI $prop)) (Q : Q($prop))
-  (uniq : Name) (repl : Name → Q(Bool) → Q($prop) → m (ReplaceHyp bi Q)) in
+  (uniq : IVarId) (repl : Name → Q(Bool) → Q($prop) → m (ReplaceHyp bi Q)) in
 def Hyps.replace : ∀ {e}, Hyps bi e → m (ReplaceHyp bi Q)
   | _, .emp _ => pure .none
   | _, .hyp _ name uniq' p ty _ => do
@@ -335,7 +345,7 @@ end replace
 section dependency
 
 partial def Hyps.findDependencyOnFVar {prop : Q(Type u)} {bi : Q(BI $prop)}
-    (fvarId : FVarId) : ∀ {e}, Hyps bi e → Option (Name × Name × Q(Bool) × Q($prop))
+    (fvarId : FVarId) : ∀ {e}, Hyps bi e → Option (Name × IVarId × Q(Bool) × Q($prop))
   | _, .emp _ => none
   | _, .sep _ _ _ _ lhs rhs =>
       lhs.findDependencyOnFVar fvarId <|> rhs.findDependencyOnFVar fvarId
@@ -413,14 +423,14 @@ def addLocalVarInfo (stx : Syntax) (lctx : LocalContext)
         { elaborator := .anonymous, lctx, expr, stx, expectedType?, isBinder })
     (return .ofPartialTermInfo { elaborator := .anonymous, lctx, stx, expectedType? })
 
-def addHypInfo (stx : Syntax) (name uniq : Name) (prop : Q(Type u)) (ty : Q($prop))
+def addHypInfo (stx : Syntax) (name : Name) (uniq : IVarId) (prop : Q(Type u)) (ty : Q($prop))
     (isBinder := false) : MetaM Unit := do
   let lctx ← getLCtx
   let ty := q(HypMarker $ty)
-  addLocalVarInfo stx (lctx.mkLocalDecl ⟨uniq⟩ name ty) (.fvar ⟨uniq⟩) ty isBinder
+  addLocalVarInfo stx (lctx.mkLocalDecl ⟨uniq.name⟩ name ty) (.fvar ⟨uniq.name⟩) ty isBinder
 
 /-- Hyps.findWithInfo should be used on names obtained from the syntax of a tactic to highlight them correctly. -/
-def Hyps.findWithInfo {u prop bi} (hyps : @Hyps u prop bi s) (name : Ident) : MetaM Name := do
+def Hyps.findWithInfo {u prop bi} (hyps : @Hyps u prop bi s) (name : Ident) : MetaM IVarId := do
   let some (uniq, _, ty) := hyps.find? name.getId | throwError "unknown hypothesis {name}"
   addHypInfo name name.getId uniq prop ty
   pure uniq
@@ -428,8 +438,8 @@ def Hyps.findWithInfo {u prop bi} (hyps : @Hyps u prop bi s) (name : Ident) : Me
 /-- Hyps.addWithInfo should be used by tactics that introduce a hypothesis based on the name given by the user. -/
 def Hyps.addWithInfo {prop : Q(Type u)} (bi : Q(BI $prop))
     (name : TSyntax ``binderIdent) (p : Q(Bool)) (ty : Q($prop)) {e} (h : Hyps bi e)
-    : MetaM (Name × Hyps bi q(iprop($e ∗ □?$p $ty))) := do
-  let uniq' ← mkFreshId
+    : MetaM (IVarId × Hyps bi q(iprop($e ∗ □?$p $ty))) := do
+  let uniq' ← mkFreshIVarId
   let (nameTo, nameRef) ← getFreshName name
   addHypInfo nameRef nameTo uniq' prop ty (isBinder := true)
   let hyps := Hyps.add bi nameTo uniq' p ty h

--- a/Iris/Iris/ProofMode/Patterns/SelPattern.lean
+++ b/Iris/Iris/ProofMode/Patterns/SelPattern.lean
@@ -56,9 +56,9 @@ def SelPat.resolveOne (hyps : Hyps bi e) : SelPat → ProofModeM (List SelTarget
       let ldecl ← getLocalDeclFromUserName name.getId
       return [.inr ldecl.fvarId]
   | .intuitionistic =>
-      return hyps.intuitionisticUniqs.map .inl
+      return hyps.intuitionisticIVarIds.map .inl
   | .spatial =>
-      return hyps.spatialUniqs.map .inl
+      return hyps.spatialIVarIds.map .inl
   | .pure => do
       -- `%` selects user-facing Lean pure assumptions, so we keep only `Prop` hypotheses.
       let mut hyps := #[]

--- a/Iris/Iris/ProofMode/Patterns/SelPattern.lean
+++ b/Iris/Iris/ProofMode/Patterns/SelPattern.lean
@@ -46,7 +46,7 @@ partial def SelPat.parse (pats : TSyntaxArray `selPat) : MacroM (List SelPat) :=
 
 public meta section
 
-abbrev SelTarget := Name ⊕ FVarId
+abbrev SelTarget := IVarId ⊕ FVarId
 
 /-- Resolve selection patterns to concrete proofmode hypotheses (`.inl`) and Lean locals (`.inr`). -/
 def SelPat.resolveOne (hyps : Hyps bi e) : SelPat → ProofModeM (List SelTarget)

--- a/Iris/Iris/ProofMode/Tactics/Cases.lean
+++ b/Iris/Iris/ProofMode/Tactics/Cases.lean
@@ -196,9 +196,9 @@ partial def iCasesCore {P} (hyps : Hyps bi P) (goal : Q($prop)) (pat : iCasesPat
   | .one name => do
     -- TODO: use Hyps.addWithInfo here?
     let (name, ref) ← getFreshName name
-    let uniq ← mkFreshIVarId
-    addHypInfo ref name uniq prop A (isBinder := true)
-    let hyp := .mkHyp bi name uniq p A
+    let ivar ← mkFreshIVarId
+    addHypInfo ref name ivar prop A (isBinder := true)
+    let hyp := .mkHyp bi name ivar p A
     if let .emp _ := hyps then pure q(of_emp_sep $(← k hyp goal))
     else k (.mkSep hyps hyp) goal
 

--- a/Iris/Iris/ProofMode/Tactics/Cases.lean
+++ b/Iris/Iris/ProofMode/Tactics/Cases.lean
@@ -196,7 +196,7 @@ partial def iCasesCore {P} (hyps : Hyps bi P) (goal : Q($prop)) (pat : iCasesPat
   | .one name => do
     -- TODO: use Hyps.addWithInfo here?
     let (name, ref) ← getFreshName name
-    let uniq ← mkFreshId
+    let uniq ← mkFreshIVarId
     addHypInfo ref name uniq prop A (isBinder := true)
     let hyp := .mkHyp bi name uniq p A
     if let .emp _ := hyps then pure q(of_emp_sep $(← k hyp goal))

--- a/Iris/Iris/ProofMode/Tactics/Clear.lean
+++ b/Iris/Iris/ProofMode/Tactics/Clear.lean
@@ -40,7 +40,7 @@ private structure ClearState {u} {prop : Q(Type u)} {bi : Q(BI $prop)} (origE go
   pf : Q(($e ⊢ $goal) → ($origE ⊢ $goal))
 
 private def ClearState.clearProofModeHyp {u prop bi origE goal} :
-    @ClearState u prop bi origE goal → Name →
+    @ClearState u prop bi origE goal → IVarId →
     ProofModeM (@ClearState u prop bi origE goal)
   | { e, hyps, pf }, uniq => do
       let ⟨e', hyps', _, out', p, _, hrem⟩ := hyps.remove true uniq

--- a/Iris/Iris/ProofMode/Tactics/Clear.lean
+++ b/Iris/Iris/ProofMode/Tactics/Clear.lean
@@ -42,8 +42,8 @@ private structure ClearState {u} {prop : Q(Type u)} {bi : Q(BI $prop)} (origE go
 private def ClearState.clearProofModeHyp {u prop bi origE goal} :
     @ClearState u prop bi origE goal → IVarId →
     ProofModeM (@ClearState u prop bi origE goal)
-  | { e, hyps, pf }, uniq => do
-      let ⟨e', hyps', _, out', p, _, hrem⟩ := hyps.remove true uniq
+  | { e, hyps, pf }, ivar => do
+      let ⟨e', hyps', _, out', p, _, hrem⟩ := hyps.remove true ivar
       let step ← iClearCore bi e e' p out' goal hrem
       let pf' : Q(($e' ⊢ $goal) → ($origE ⊢ $goal)) := q(λ h => $pf ($step h))
       return {  e := e', hyps := hyps', pf := pf' }
@@ -52,11 +52,11 @@ elab "iclear" pats:(colGt selPat)+ : tactic => do
   let pats ← liftMacroM <| SelPat.parse pats
 
   ProofModeM.runTactic λ mvar { e, hyps, goal, .. } => do
-  let (uniqs, fvars) := (← SelPat.resolve hyps pats).partitionMap id
+  let (ivars, fvars) := (← SelPat.resolve hyps pats).partitionMap id
 
   -- Clear the selected Iris hypotheses first, updating the proof-mode context and proof term.
   let mut st : ClearState e goal := { e, hyps, pf := q(fun h => h) }
-  for uniq in uniqs do st ← st.clearProofModeHyp uniq
+  for ivar in ivars do st ← st.clearProofModeHyp ivar
 
   -- Lean locals are cleared afterwards; first ensure no remaining hypothesis or goal depends on them.
   for fvar in fvars do

--- a/Iris/Iris/ProofMode/Tactics/Exact.lean
+++ b/Iris/Iris/ProofMode/Tactics/Exact.lean
@@ -14,8 +14,8 @@ open Lean Elab Tactic Meta Qq BI Std
 
 elab "iexact" colGt hyp:ident : tactic => do
   ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
-  let uniq ← hyps.findWithInfo hyp
-  let ⟨e', _, _, out, p, _, pf⟩ := hyps.remove true uniq
+  let ivar ← hyps.findWithInfo hyp
+  let ⟨e', _, _, out, p, _, pf⟩ := hyps.remove true ivar
 
   let some _ ← ProofModeM.trySynthInstanceQ q(FromAssumption $p .in $out $goal)
     | throwError "iexact: cannot unify {out} and {goal}"

--- a/Iris/Iris/ProofMode/Tactics/HaveCore.lean
+++ b/Iris/Iris/ProofMode/Tactics/HaveCore.lean
@@ -49,9 +49,9 @@ A tuple containing:
 private def iHaveCore {e} (hyps : @Hyps u prop bi e)
   (tm : Term) (keep : Bool) :
   ProofModeM ((e' : _) × Hyps bi e' × (p : Q(Bool)) × (out : Q($prop)) × Q($e ⊢ $e' ∗ □?$p $out)) := do
-  if let some uniq ← try? <| hyps.findWithInfo ⟨tm⟩ then
+  if let some ivar ← try? <| hyps.findWithInfo ⟨tm⟩ then
     -- assertion from the Iris context
-    let ⟨_, hyps, _, out', p, _, pf⟩ := hyps.remove (!keep) uniq
+    let ⟨_, hyps, _, out', p, _, pf⟩ := hyps.remove (!keep) ivar
     return ⟨_, hyps, p, out', q($pf.1)⟩
   else
     -- lean hypothesis

--- a/Iris/Iris/ProofMode/Tactics/ModIntro.lean
+++ b/Iris/Iris/ProofMode/Tactics/ModIntro.lean
@@ -94,7 +94,7 @@ private def iModAction {prop1 : Q(Type u)} {bi1 : Q(BI $prop1)} {bi2} {e}
   ProofModeM ((e' : _) × Hyps bi1 e' × Q($e ⊢ $(M).M $e')) :=
   match hyps with
   | .emp _ => return ⟨_, .mkEmp bi1, q($(M).emp)⟩
-  | .hyp _ name uniq p ty _ =>
+  | .hyp _ name ivar p ty _ =>
     let p' := isTrue p
     match act p' with
     | .isEmpty => throwError "imodintro: {if p' then "intuitionistic" else "spatial"} context is not empty"
@@ -106,14 +106,14 @@ private def iModAction {prop1 : Q(Type u)} {bi1 : Q(BI $prop1)} {bi2} {e}
       -- bridge through defeq since `M.action` cannot unify directly with the pattern (same in other cases)
       have heq : Q(@ModalityAction.forall $prop1 $C = .forall $C) := q(Eq.refl (ModalityAction.forall $C))
       have heq : Q($(M).action $p = .forall $C) := heq
-      return ⟨_, .mkHyp bi1 name uniq p ty, q(modaction_forall $M $heq $hC)⟩
+      return ⟨_, .mkHyp bi1 name ivar p ty, q(modaction_forall $M $heq $hC)⟩
     | .transform C => do
       let ty' ← mkFreshExprMVarQ q($prop1)
       let .some hC ← trySynthInstanceQ q($C $ty $ty')
         | throwError "imodintro: cannot transform hypothesis {name} : {ty} with {C}"
       have heq : Q(@ModalityAction.transform $prop1 $prop2 $C = .transform $C) := q(Eq.refl (ModalityAction.transform $C))
       have heq : Q($(M).action $p = .transform $C) := heq
-      return ⟨_, .mkHyp bi1 name uniq p ty', q(modaction_transform $M $heq $hC)⟩
+      return ⟨_, .mkHyp bi1 name ivar p ty', q(modaction_transform $M $heq $hC)⟩
     | .clear =>
        have heq : Q(@ModalityAction.clear $prop1 $prop2 = .clear) := q(Eq.refl (ModalityAction.clear))
        have heq : Q($(M).action $p = @ModalityAction.clear $prop1 $prop2) := heq
@@ -123,7 +123,7 @@ private def iModAction {prop1 : Q(Type u)} {bi1 : Q(BI $prop1)} {bi2} {e}
       have : $bi1 =Q $bi2 := ⟨⟩
       have heq : Q(@ModalityAction.id $prop1 = .id) := q(Eq.refl (ModalityAction.id))
       have heq : Q($(M).action $p = .id) := heq
-      return ⟨_, .mkHyp bi1 name uniq p ty, q(modaction_id $M $heq)⟩
+      return ⟨_, .mkHyp bi1 name ivar p ty, q(modaction_id $M $heq)⟩
   | .sep _ _ _ _ lhs rhs => do
     let ⟨_, lhs', pflhs⟩ ← iModAction lhs M act
     let ⟨_, rhs', pfrhs⟩ ← iModAction rhs M act

--- a/Iris/Iris/ProofMode/Tactics/Pure.lean
+++ b/Iris/Iris/ProofMode/Tactics/Pure.lean
@@ -56,8 +56,8 @@ def iPureCore {prop : Q(Type u)} (_bi : Q(BI $prop))
 elab "ipure" colGt hyp:ident : tactic => do
   ProofModeM.runTactic λ mvar { bi, e, hyps, goal, .. } => do
 
-  let uniq ← hyps.findWithInfo hyp
-  let ⟨e', hyps', _, out', p, _, pf⟩ := hyps.remove true uniq
+  let ivar ← hyps.findWithInfo hyp
+  let ⟨e', hyps', _, out', p, _, pf⟩ := hyps.remove true ivar
 
   let pf ← iPureCore bi e e' p out' goal (← `(binderIdent| $hyp:ident)) pf fun _ _ => addBIGoal hyps' goal
 

--- a/Iris/Iris/ProofMode/Tactics/Rename.lean
+++ b/Iris/Iris/ProofMode/Tactics/Rename.lean
@@ -16,10 +16,10 @@ elab "irename" colGt nameFrom:ident " => " colGt nameTo:ident : tactic => do
   ProofModeM.runTactic λ mvar { prop, bi, hyps, goal, .. } => do
 
   -- find hypothesis index
-  let some (uniq, _, ty) := hyps.find? nameFrom.getId | throwError "irename: unknown hypothesis"
-  addHypInfo nameFrom nameFrom.getId uniq prop ty
-  let some hyps' := hyps.rename uniq nameTo.getId | unreachable!
-  addHypInfo nameTo nameTo.getId uniq prop ty (isBinder := true)
+  let some (ivar, _, ty) := hyps.find? nameFrom.getId | throwError "irename: unknown hypothesis"
+  addHypInfo nameFrom nameFrom.getId ivar prop ty
+  let some hyps' := hyps.rename ivar nameTo.getId | unreachable!
+  addHypInfo nameTo nameTo.getId ivar prop ty (isBinder := true)
 
   mvar.setType (IrisGoal.toExpr { prop, bi, hyps := hyps', goal, .. })
   addMVarGoal mvar
@@ -33,9 +33,9 @@ elab "irename" ":" colGt ty:term " => " colGt nameTo:ident : tactic => do
   ProofModeM.runTactic λ mvar { prop, bi, hyps, goal, .. } => do
 
   let ty ← elabTerm ty prop
-  let (uniq, _, ty) ← try Hyps.select ty hyps catch _ => throwError "irename: unknown hypothesis"
-  let some hyps' := hyps.rename uniq nameTo.getId | unreachable!
-  addHypInfo nameTo nameTo.getId uniq prop ty (isBinder := true)
+  let (ivar, _, ty) ← try Hyps.select ty hyps catch _ => throwError "irename: unknown hypothesis"
+  let some hyps' := hyps.rename ivar nameTo.getId | unreachable!
+  addHypInfo nameTo nameTo.getId ivar prop ty (isBinder := true)
 
   mvar.setType (IrisGoal.toExpr { prop, bi, hyps := hyps', goal, .. })
   addMVarGoal mvar

--- a/Iris/Iris/ProofMode/Tactics/Revert.lean
+++ b/Iris/Iris/ProofMode/Tactics/Revert.lean
@@ -44,7 +44,7 @@ private structure RevertState {prop : Q(Type u)} {bi : Q(BI $prop)} (origE origG
 
 /-- Revert a proofmode hypothesis by turning it into a wand premise. -/
 private def RevertState.revertProofModeHyp
-    : @RevertState u prop bi origE origGoal → Name →
+    : @RevertState u prop bi origE origGoal → IVarId →
       ProofModeM (@RevertState u prop bi origE origGoal)
   | { hyps, goal, reverted, pf, .. }, uniq => do
     let ⟨e', hyps', out, _, _, _, hΔ⟩ := hyps.remove true uniq

--- a/Iris/Iris/ProofMode/Tactics/Revert.lean
+++ b/Iris/Iris/ProofMode/Tactics/Revert.lean
@@ -46,8 +46,8 @@ private structure RevertState {prop : Q(Type u)} {bi : Q(BI $prop)} (origE origG
 private def RevertState.revertProofModeHyp
     : @RevertState u prop bi origE origGoal → IVarId →
       ProofModeM (@RevertState u prop bi origE origGoal)
-  | { hyps, goal, reverted, pf, .. }, uniq => do
-    let ⟨e', hyps', out, _, _, _, hΔ⟩ := hyps.remove true uniq
+  | { hyps, goal, reverted, pf, .. }, ivar => do
+    let ⟨e', hyps', out, _, _, _, hΔ⟩ := hyps.remove true ivar
     return { e := e', hyps := hyps', goal := q(wand $out $goal), reverted,
              pf := q(fun h => $pf (wand_revert $hΔ h)) }
 
@@ -97,7 +97,7 @@ elab "irevert" pats:(colGt selPat)+ : tactic => do
     let init : RevertState e goal := { e, hyps, goal, pf := q(id) }
     let st ← targets.reverse.foldlM (init := init) fun st target => do
       match target with
-      | .inl uniq => st.revertProofModeHyp uniq
+      | .inl ivar => st.revertProofModeHyp ivar
       | .inr fvar => st.revertLeanHyp fvar
 
     let pf' ← addBIGoalWithoutFVars st.hyps st.goal st.reverted.reverse

--- a/Iris/Iris/ProofMode/Tactics/Specialize.lean
+++ b/Iris/Iris/ProofMode/Tactics/Specialize.lean
@@ -81,7 +81,7 @@ private def processWand :
     for mvar in newMVarIds do addMVarGoal mvar
     return { e, hyps, p, out := out', pf := q(specialize_forall $pf $x) }
   | { hyps, p, out, pf, .. }, .goal ns g => do
-    let mut uniqs : NameSet := {}
+    let mut uniqs : IVarIdSet := {}
     for name in ns do
       uniqs := uniqs.insert (← hyps.findWithInfo name)
     let ⟨el', _, hypsl', hypsr', h'⟩ := Hyps.split bi (λ _ uniq => uniqs.contains uniq) hyps

--- a/Iris/Iris/ProofMode/Tactics/Specialize.lean
+++ b/Iris/Iris/ProofMode/Tactics/Specialize.lean
@@ -57,8 +57,8 @@ structure SpecializeState {prop : Q(Type u)} (bi : Q(BI $prop)) (orig : Q($prop)
 private def processWand :
     @SpecializeState u prop bi orig → SpecPat → ProofModeM (SpecializeState bi orig)
   | { hyps, p, out, pf, .. }, .ident i => do
-    let uniq ← hyps.findWithInfo i
-    let ⟨e', hyps', out₁, out₁', p1, _, pf'⟩ := hyps.remove false uniq
+    let ivar ← hyps.findWithInfo i
+    let ⟨e', hyps', out₁, out₁', p1, _, pf'⟩ := hyps.remove false ivar
     let p2 := if p1.constName! == ``true then p else q(false)
     have : $out₁ =Q iprop(□?$p1 $out₁') := ⟨⟩
     have : $p2 =Q ($p1 && $p) := ⟨⟩
@@ -81,10 +81,10 @@ private def processWand :
     for mvar in newMVarIds do addMVarGoal mvar
     return { e, hyps, p, out := out', pf := q(specialize_forall $pf $x) }
   | { hyps, p, out, pf, .. }, .goal ns g => do
-    let mut uniqs : IVarIdSet := {}
+    let mut ivars : IVarIdSet := {}
     for name in ns do
-      uniqs := uniqs.insert (← hyps.findWithInfo name)
-    let ⟨el', _, hypsl', hypsr', h'⟩ := Hyps.split bi (λ _ uniq => uniqs.contains uniq) hyps
+      ivars := ivars.insert (← hyps.findWithInfo name)
+    let ⟨el', _, hypsl', hypsr', h'⟩ := Hyps.split bi (λ _ ivar => ivars.contains ivar) hyps
     let out₁ ← mkFreshExprMVarQ prop
     let out₂ ← mkFreshExprMVarQ prop
     let some _ ← ProofModeM.trySynthInstanceQ q(IntoWand $p false $out .out $out₁ .out $out₂)
@@ -144,13 +144,13 @@ elab "ispecialize" colGt pmt:pmTerm : tactic => do
   ProofModeM.runTactic λ mvar { bi, hyps, goal, .. } => do
   -- hypothesis must be in the context, otherwise use ihave
   let name := ⟨pmt.term⟩
-  let some uniq ← try? <| hyps.findWithInfo name
+  let some ivar ← try? <| hyps.findWithInfo name
     | throwError "{name} should be a hypothesis, use ihave instead"
   let some ⟨name, _, hyps', _, out, p, _, pf⟩ := Id.run <|
-    hyps.removeG true λ name uniq' _ _ => if uniq == uniq' then some name else none
+    hyps.removeG true λ name ivar' _ _ => if ivar == ivar' then some name else none
     | throwError "ispecialize: cannot find argument"
 
   let ⟨_, hyps'', pb, B, pf'⟩ ← iSpecializeCore hyps' p out pmt.spats
-  let hyps''' := Hyps.add bi name uniq pb B hyps''
+  let hyps''' := Hyps.add bi name ivar pb B hyps''
   let pf'' ← addBIGoal hyps''' goal
   mvar.assign q(($pf).1.trans <| $(pf').trans <| $pf'')

--- a/Iris/Iris/ProofMode/Tactics/Split.lean
+++ b/Iris/Iris/ProofMode/Tactics/Split.lean
@@ -46,9 +46,9 @@ private def isplitCore (side : splitSide) (names : Array (TSyntax `ident)) : Tac
   -- extract environment
   ProofModeM.runTactic λ mvar { prop, bi, hyps, goal, .. } => do
 
-  let mut uniqs : IVarIdSet := {}
+  let mut ivars : IVarIdSet := {}
   for name in names do
-    uniqs := uniqs.insert (← hyps.findWithInfo name)
+    ivars := ivars.insert (← hyps.findWithInfo name)
 
   let Q1 ← mkFreshExprMVarQ prop
   let Q2 ← mkFreshExprMVarQ prop
@@ -56,7 +56,7 @@ private def isplitCore (side : splitSide) (names : Array (TSyntax `ident)) : Tac
     throwError "isplit: {goal} is not a separating conjunction"
 
   -- split conjunction
-  let ⟨_, _, lhs, rhs, pf⟩ := hyps.split bi (fun _ uniq => uniqs.contains uniq == splitRight)
+  let ⟨_, _, lhs, rhs, pf⟩ := hyps.split bi (fun _ ivar => ivars.contains ivar == splitRight)
 
   let m1 ← addBIGoal lhs Q1
   let m2 ← addBIGoal rhs Q2

--- a/Iris/Iris/ProofMode/Tactics/Split.lean
+++ b/Iris/Iris/ProofMode/Tactics/Split.lean
@@ -46,7 +46,7 @@ private def isplitCore (side : splitSide) (names : Array (TSyntax `ident)) : Tac
   -- extract environment
   ProofModeM.runTactic λ mvar { prop, bi, hyps, goal, .. } => do
 
-  let mut uniqs : NameSet := {}
+  let mut uniqs : IVarIdSet := {}
   for name in names do
     uniqs := uniqs.insert (← hyps.findWithInfo name)
 


### PR DESCRIPTION
## Description
Differentiate the types of `uniq` and `name` fields in `Hyps.hyp`. Mimics how `FVarId` is implemented.

## Checklist
* [X] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [X] I have updated `PORTING.md` as appropriate
* [ ] I have added my name to the `authors` section of any appropriate files