### PR TITLE
feat: paren-less iprop notation scope

### DIFF
--- a/Iris/Iris/BI/Notation.lean
+++ b/Iris/Iris/BI/Notation.lean
@@ -31,9 +31,9 @@ macro_rules
 macro:max "iprop(" P:term " : " t:term ")" : term => `((iprop($P) : $t))
 
 -- paren-less form: eats the rest of the term at minimum precedence
-syntax:min "iprop$ " term:min : term
+syntax:min "iprop% " term:min : term
 macro_rules
-  | `(iprop$ $t) => `(iprop($t))
+  | `(iprop% $t) => `(iprop($t))
 
 /-- Remove an `iprop` quotation from a `term` syntax object. -/
 partial def unpackIprop [Monad m] [MonadRef m] [MonadQuotation m] : Term → m Term

--- a/Iris/Iris/BI/Notation.lean
+++ b/Iris/Iris/BI/Notation.lean
@@ -26,8 +26,14 @@ macro_rules
   | `(iprop(($P)))                  => ``((iprop($P)))
   | `(iprop(if $c then $t else $e)) => ``(if $c then iprop($t) else iprop($e))
   | `(iprop(($P : $t)))             => ``((iprop($P) : $t))
+  | `(iprop(fun $xs* => $P))        => ``(fun $xs* => iprop($P))
 
 macro:max "iprop(" P:term " : " t:term ")" : term => `((iprop($P) : $t))
+
+-- paren-less form: eats the rest of the term at minimum precedence
+syntax:min "iprop$ " term:min : term
+macro_rules
+  | `(iprop$ $t) => `(iprop($t))
 
 /-- Remove an `iprop` quotation from a `term` syntax object. -/
 partial def unpackIprop [Monad m] [MonadRef m] [MonadQuotation m] : Term → m Term

--- a/Iris/Iris/Tests/Notation.lean
+++ b/Iris/Iris/Tests/Notation.lean
@@ -182,11 +182,11 @@ variable [BIBase PROP] (P Q R : PROP) (Ψ : Nat → PROP) (Φ : Nat → Nat → 
 /-! ## Paren-less form -/
 
 /-- info: iprop(P ∧ Q) : PROP -/
-#guard_msgs in #check iprop$ P ∧ Q
+#guard_msgs in #check iprop% P ∧ Q
 /-- info: iprop(P ∗ Q) : PROP -/
-#guard_msgs in #check iprop$ P ∗ Q
+#guard_msgs in #check iprop% P ∗ Q
 /-- info: iprop(∀ x, Ψ x) : PROP -/
-#guard_msgs in #check iprop$ ∀ x, Ψ x
+#guard_msgs in #check iprop% ∀ x, Ψ x
 
 /-! ### Paren-less MWE
 
@@ -205,11 +205,11 @@ inductive A (R : Type) where
 variable {R : Type} (E1 E2 : CoPset)
 
 def f (g : A R → (R → PROP) → PROP) :
-    A R → (R → PROP) → PROP := iprop$
+    A R → (R → PROP) → PROP := iprop%
   fun x Φ => |={E1}=>
     match x with
     | A.a r  => Φ r
-    | A.b x' => iprop$ |={E1,E2}=> g x' Φ
+    | A.b x' => iprop% |={E1,E2}=> g x' Φ
 
 end MWE
 

--- a/Iris/Iris/Tests/Notation.lean
+++ b/Iris/Iris/Tests/Notation.lean
@@ -6,6 +6,7 @@ Authors: Lars König
 module
 
 public import Iris.BI.BIBase
+public import Iris.BI.Updates
 
 @[expose] public section
 
@@ -177,5 +178,39 @@ variable [BIBase PROP] (P Q R : PROP) (Ψ : Nat → PROP) (Φ : Nat → Nat → 
 #guard_msgs in #check iprop((□?p P) ∧ Q)
 /-- info: iprop(P ∗ □?p Q) : PROP -/
 #guard_msgs in #check iprop(P ∗ (□?p Q))
+
+/-! ## Paren-less form -/
+
+/-- info: iprop(P ∧ Q) : PROP -/
+#guard_msgs in #check iprop$ P ∧ Q
+/-- info: iprop(P ∗ Q) : PROP -/
+#guard_msgs in #check iprop$ P ∗ Q
+/-- info: iprop(∀ x, Ψ x) : PROP -/
+#guard_msgs in #check iprop$ ∀ x, Ψ x
+
+/-! ### Paren-less MWE
+
+A fancy update over a `match` on a small inductive: one branch returns
+`Φ r` directly, the other shifts masks before a recursive call. The body
+is written with the paren-less `iprop`, which eats the entire RHS. -/
+
+section MWE
+
+variable [FUpd PROP]
+
+inductive A (R : Type) where
+  | a : R → A R
+  | b : A R → A R
+
+variable {R : Type} (E1 E2 : CoPset)
+
+def f (g : A R → (R → PROP) → PROP) :
+    A R → (R → PROP) → PROP := iprop$
+  fun x Φ => |={E1}=>
+    match x with
+    | A.a r  => Φ r
+    | A.b x' => iprop$ |={E1,E2}=> g x' Φ
+
+end MWE
 
 end Iris.Tests


### PR DESCRIPTION
## Description
Briefly describe your changes, and link any issues if appropriate.

Fixes # (issue number)

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have updated `PORTING.md` as appropriate
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
