### PR TITLE
feat: fixpoint base of weakest precondition

### DIFF
--- a/Iris/Iris/BI/Updates.lean
+++ b/Iris/Iris/BI/Updates.lean
@@ -315,10 +315,7 @@ open BIFUpdate LawfulSet
 theorem step_fupd_fupd {Eo Ei : CoPset} {P : PROP} : (|={Eo}[Ei]▷=> P) ⊣⊢ (|={Eo}[Ei]▷=> |={Eo}=> P) :=
   ⟨mono <| later_mono <| mono fupd_intro, mono <| later_mono BIFUpdate.trans⟩
 
-/-- The iterated step-update `|={Eo}[Ei]▷=∗^[k]` is NonExpansive in the inner
-argument. Each layer composes `BIFUpdate.ne`, `later_ne`, and `BIFUpdate.ne`.
-Addresses the FIXME in Coq Iris `weakestpre.v` (no proper instance for
-`step_fupdN`). -/
+@[rocq_alias step_fupdN_ne]
 theorem step_fupdN_ne {Eo Ei : CoPset} {k n : Nat} {P Q : PROP} (h : P ≡{n}≡ Q) :
     Nat.repeat (fun R : PROP => iprop(|={Eo}[Ei]▷=> R)) k P ≡{n}≡
       Nat.repeat (fun R : PROP => iprop(|={Eo}[Ei]▷=> R)) k Q := by

--- a/Iris/Iris/BI/Updates.lean
+++ b/Iris/Iris/BI/Updates.lean
@@ -315,6 +315,21 @@ open BIFUpdate LawfulSet
 theorem step_fupd_fupd {Eo Ei : CoPset} {P : PROP} : (|={Eo}[Ei]▷=> P) ⊣⊢ (|={Eo}[Ei]▷=> |={Eo}=> P) :=
   ⟨mono <| later_mono <| mono fupd_intro, mono <| later_mono BIFUpdate.trans⟩
 
+/-- The iterated step-update `|={Eo}[Ei]▷=∗^[k]` is NonExpansive in the inner
+argument. Each layer composes `BIFUpdate.ne`, `later_ne`, and `BIFUpdate.ne`.
+Addresses the FIXME in Coq Iris `weakestpre.v` (no proper instance for
+`step_fupdN`). -/
+theorem step_fupdN_ne {Eo Ei : CoPset} {k n : Nat} {P Q : PROP} (h : P ≡{n}≡ Q) :
+    Nat.repeat (fun R : PROP => iprop(|={Eo}[Ei]▷=> R)) k P ≡{n}≡
+      Nat.repeat (fun R : PROP => iprop(|={Eo}[Ei]▷=> R)) k Q := by
+  induction k with
+  | zero => exact h
+  | succ k' IH =>
+    refine BIFUpdate.ne.ne ?_
+    refine later_ne.ne ?_
+    refine BIFUpdate.ne.ne ?_
+    exact IH
+
 end StepFUpdLaws
 
 section StepFUpdPlainlyLaws

--- a/Iris/Iris/ProgramLogic/WeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/WeakestPre.lean
@@ -91,14 +91,14 @@ Class irisGS_gen (hlc : has_lc) (Λ : language) (Σ : gFunctors) := IrisG {
 }.
 ```
 
-Phase 1-A 简化（vs Coq 原版）：
-- 固定 `hlc = true`（即 `InvGS GF = InvGS_gen true GF`，含 LaterCredits）；Stage 1 不用 LC，
-  但保留参数化空间 留 Phase 1-B 决定是否暴露 hlc。Coq 原版可参数化。
-- 省略 `num_laters_per_step` 字段——硬编码 = 0（Phase 1 swap 不需要 per-step laters）。
-- 省略 `state_interp_mono` 字段——Phase 1-B 在写真证明 (wp_strong_mono 等) 时按需添加。
+简化（vs Coq 原版，PR-ready 评估后保留）：
+- 固定 `hlc = true`（即 `InvGS GF = InvGS_gen true GF`）；upstream `Examples/IProp.lean` 同样
+  不参数化 hlc。
+- 省略 `num_laters_per_step` 字段——硬编码 = 0；hxrts 同样省（precedent）；Phase 1 swap +
+  Phase 2 数组都不需要 per-step laters。
 
-hxrts 对比：hxrts 也省略 num_laters_per_step（fix = 0），但保留 state_interp_mono。
-我们 Stage 1 更激进——两个都省，待 Phase 1-B 按需补。 -/
+保留（vs hxrts，2026-05-12 PR-ready 化补回）：
+- `state_interp_mono` 字段：与 Coq 与 hxrts 一致。 -/
 
 class IrisGS (Expr : Type _) (State Obs Val : outParam (Type _))
     [Language Expr State Obs Val] (GF : BundledGFunctors)
@@ -109,6 +109,10 @@ class IrisGS (Expr : Type _) (State Obs Val : outParam (Type _))
   /-- Fixed postcondition for forked threads.
   Coq: field of `irisGS_gen`. -/
   fork_post : Val → IProp GF
+  /-- State interpretation 关于 step_count 的单调性（Coq 原版字段）。
+  Coq weakestpre.v `irisGS_gen.state_interp_mono`. -/
+  state_interp_mono (σ : State) (ns : Nat) (κs : List Obs) (nt : Nat) :
+    state_interp σ ns κs nt ⊢ iprop(|={∅}=> state_interp σ (ns + 1) κs nt)
 
 /-! ## wp_pre
 

--- a/Iris/Iris/ProgramLogic/WeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/WeakestPre.lean
@@ -20,33 +20,13 @@ public import Iris.ProofMode
 
 /-! # Weakest Precondition
 
-Lean 4 port of Coq Iris's program logic weakest precondition layer,
-following `iris/program_logic/weakestpre.v`.
-
-This file defines:
-- `Stuckness` — inductive matching Coq's `stuckness` (NotStuck / MaybeStuck)
-- `IrisGS` typeclass — matching all 5 fields of Coq's `irisGS_gen`
-- `wp_pre` — Coq's `wp_pre` 1:1 (with `num_laters_per_step` parameterization)
-- `wp_pre_contractive` instance — Coq's `Local Instance wp_pre_contractive`
-- `wp` — Coq's `wp_def := λ s, fixpoint (wp_pre s)`
-- `wp_unfold` — Coq's `Lemma wp_unfold`
-
-All definitions and theorem statements are 1:1 with Coq weakestpre.v.
-Upstream operators reused: `Iris.Algebra.OFE` (Contractive / fixpoint /
-fixpoint_unfold), `Iris.Instances.Lib.{WSat,FUpd}` (InvGS / uPred_fupd /
-BIFUpdate), `Iris.BI.Updates` (|={E1,E2}=> / |={E}[E']▷=> / |={E}▷=>^[n]
-notations), `Iris.BI.BigOp.BigSepList` ([∗list] k ↦ x ∈ l, P k x).
--/
+Port of `iris/program_logic/weakestpre.v`: fixpoint base. -/
 
 namespace Iris.ProgramLogic
 
 open Iris OFE COFE BI Iris.Algebra Iris.BI.BigSepL Iris.ProgramLogic.PrimStep
 
-/-! ## Stuckness
-
-Coq weakestpre.v: `Inductive stuckness := NotStuck | MaybeStuck.`
-We use lowercase constructors `Stuckness.notStuck / .maybeStuck` per Lean convention. -/
-
+@[rocq_alias stuckness]
 inductive Stuckness where
   | notStuck
   | maybeStuck
@@ -54,8 +34,7 @@ inductive Stuckness where
 
 namespace Stuckness
 
-/-- Order on stuckness: `notStuck ≤ maybeStuck` (NotStuck is the stronger constraint).
-Coq weakestpre.v: `Definition stuckness_le ...`. -/
+@[rocq_alias stuckness_le]
 def le : Stuckness → Stuckness → Prop
   | .notStuck, _ => True
   | .maybeStuck, .maybeStuck => True
@@ -63,82 +42,28 @@ def le : Stuckness → Stuckness → Prop
 
 end Stuckness
 
-/-! ## IrisGS typeclass
-
-Coq weakestpre.v `irisGS_gen`:
-```
-Class irisGS_gen (hlc : has_lc) (Λ : language) (Σ : gFunctors) := IrisG {
-  iris_invGS  : invGS_gen hlc Σ;
-  state_interp : state Λ → nat → list (observation Λ) → nat → iProp Σ;
-  fork_post : val Λ → iProp Σ;
-  num_laters_per_step : nat → nat;
-  state_interp_mono σ ns κs nt :
-    state_interp σ ns κs nt ⊢ |={∅}=> state_interp σ (S ns) κs nt
-}.
-```
-
-Adaptation to Lean:
-- All five Coq fields (`iris_invGS`, `state_interp`, `fork_post`,
-  `num_laters_per_step`, `state_interp_mono`) are present; `iris_invGS` is via
-  `extends InvGS_gen hlc GF`. Coq's `has_lc` two-element type is represented
-  by Lean's `Bool` (the upstream convention, see `Iris/Instances/Lib/FUpd.lean`). -/
-
+@[rocq_alias irisGS_gen]
 class IrisGS (Expr : Type _) (State Obs Val : outParam (Type _))
     [Language Expr State Obs Val] (hlc : outParam Bool) (GF : BundledGFunctors)
     extends InvGS_gen hlc GF where
-  /-- State interpretation: `σ → step_count → past_observations → num_forks → iProp`.
-  Coq: field of `irisGS_gen`. -/
   state_interp : State → Nat → List Obs → Nat → IProp GF
-  /-- Fixed postcondition for forked threads.
-  Coq: field of `irisGS_gen`. -/
   fork_post : Val → IProp GF
-  /-- Per-step number of `▷` laters (allows step-indexed reasoning to vary across step count).
-  Coq: field of `irisGS_gen`. HeapLang-style instances set this to `fun _ => 0`. -/
   num_laters_per_step : Nat → Nat
-  /-- Monotonicity of state interpretation in the step count.
-  Coq weakestpre.v `irisGS_gen.state_interp_mono`. -/
   state_interp_mono (σ : State) (ns : Nat) (κs : List Obs) (nt : Nat) :
     state_interp σ ns κs nt ⊢ iprop(|={∅}=> state_interp σ (ns + 1) κs nt)
-
-/-! ## wp_pre
-
-Coq weakestpre.v `wp_pre`:
-```
-Definition wp_pre `{!irisGS_gen hlc Λ Σ} (s : stuckness)
-    (wp : coPset -d> expr Λ -d> (val Λ -d> iPropO Σ) -d> iPropO Σ) :
-    coPset -d> expr Λ -d> (val Λ -d> iPropO Σ) -d> iPropO Σ := λ E e1 Φ,
-  match to_val e1 with
-  | Some v => |={E}=> Φ v
-  | None => ∀ σ1 ns κ κs nt,
-     state_interp σ1 ns (κ ++ κs) nt ={E,∅}=∗
-       ⌜match s with NotStuck => reducible e1 σ1 | MaybeStuck => True end⌝ ∗
-       ∀ e2 σ2 efs, ⌜prim_step e1 σ1 κ e2 σ2 efs⌝
-         ={∅}▷=∗^(S $ num_laters_per_step ns) |={∅,E}=>
-       state_interp σ2 (S ns) κs (length efs + nt) ∗
-       wp E e2 Φ ∗
-       [∗ list] i ↦ ef ∈ efs, wp ⊤ ef fork_post
-  end%I.
-```
-
-Uses `S (IrisGS.num_laters_per_step ns)` per-step laters, matching Coq exactly. -/
 
 variable {Expr State Obs Val : Type _} [Language Expr State Obs Val]
 variable {hlc : Bool} {GF : BundledGFunctors} [iG : IrisGS Expr State Obs Val hlc GF]
 
-/-- Reducibility predicate selected by stuckness.
-Coq weakestpre.v: `match s with NotStuck => reducible | MaybeStuck => True end`. -/
 def stuckPred (s : Stuckness) (e : Expr) (σ : State) : Prop :=
   match s with
   | .notStuck => PrimStep.Reducible (Expr := Expr) (Obs := List Obs) (e, σ)
   | .maybeStuck => True
 
-/-- Type abbreviation for the function space of `wp`.
-Coq uses `coPset -d> expr Λ -d> (val Λ -d> iPropO Σ) -d> iPropO Σ`. -/
 abbrev WPFun (Expr Val : Type _) (GF : BundledGFunctors) :=
   CoPset → Expr → (Val → IProp GF) → IProp GF
 
-/-- Pre-fixpoint of weakest precondition. Recursive call `wp` is a parameter.
-Coq weakestpre.v `wp_pre`; statement 1:1 with the Coq definition. -/
+@[rocq_alias wp_pre]
 noncomputable def wp_pre (s : Stuckness)
     (wp : WPFun Expr Val GF)
     (E : CoPset) (e : Expr) (Φ : Val → IProp GF) : IProp GF :=
@@ -155,10 +80,7 @@ noncomputable def wp_pre (s : Stuckness)
                 wp E e2 Φ ∗
                 [∗list] ef ∈ efs, wp ⊤ ef (IrisGS.fork_post (Expr := Expr))))
 
-/-- Contractive instance for `wp_pre s`.
-Coq weakestpre.v: `Local Instance wp_pre_contractive : Contractive (wp_pre s)`.
-Statement 1:1 with Coq; proof follows the pattern of
-`Iris/Examples/IProp.lean:131-142` `wp_F_contractive`. -/
+@[rocq_alias wp_pre_contractive]
 noncomputable instance wp_pre_contractive (s : Stuckness) :
     Contractive (fun W : WPFun Expr Val GF => wp_pre s W) where
   distLater_dist {n W₁ W₂ HW} E e Φ := by
@@ -183,59 +105,24 @@ noncomputable instance wp_pre_contractive (s : Stuckness) :
         refine forall_ne fun σ2 => ?_
         refine forall_ne fun efs => ?_
         refine wand_ne.ne .rfl ?_
-        -- `_ ▷=∗^[k+1]` macro → `Nat.repeat _ (k+1) X = (fun Q => |={∅}[∅]▷=> Q) (Nat.repeat _ k X)`
-        -- Pass through `|={∅,∅}=> ▷ |={∅,∅}=> ...`; the `▷` layer uses `distLater_dist`.
         refine BIFUpdate.ne.ne ?_
         refine Contractive.distLater_dist fun m hm => ?_
         refine BIFUpdate.ne.ne ?_
-        -- Remaining: `Nat.repeat _ (num_laters_per_step ns) inner` on each side — use step_fupdN_ne.
         refine step_fupdN_ne ?_
-        -- Inner `inner` = `|={∅,E}=> (state_interp ∗ W E e2 Φ ∗ [∗list])`.
         refine BIFUpdate.ne.ne ?_
         refine sep_ne.ne .rfl ?_
         refine sep_ne.ne ?_ ?_
         · exact HW m hm E e2 Φ
         · exact bigSepL_dist fun {_ _} _ => HW m hm ⊤ _ _
 
-/- `WPFun Expr Val GF` is automatically a COFE:
-
-- `IProp GF = UPred (IResUR GF)` is a COFE via `instance : IsCOFE (UPred M)`
-  (Iris/Algebra/UPred.lean) combined with `class abbrev COFE := OFE + IsCOFE`.
-- The function-space instance `[∀ x, COFE (β x)] → COFE ((x : α) → β x)`
-  (Iris/Algebra/OFE.lean) applies three times to layer over
-  `CoPset → Expr → (Val → IProp GF) → IProp GF`.
-
-No explicit instance needed — typeclass resolution derives it automatically. -/
-
-/-- `Inhabited (WPFun Expr Val GF)` required by `fixpoint`. -/
 noncomputable instance : Inhabited (WPFun Expr Val GF) :=
   ⟨fun _ _ _ => iprop(True)⟩
 
-/-! ## wp definition
-
-Coq weakestpre.v:
-```
-Definition wp_def `{!irisGS_gen hlc Λ Σ} : Wp (iProp Σ) (expr Λ) (val Λ) stuckness :=
-  λ s : stuckness, fixpoint (wp_pre s).
-```
-
-One fixpoint per `Stuckness` value (matching Coq's style). -/
-
-/-- The weakest precondition.
-Coq weakestpre.v: `Definition wp_def := λ s, fixpoint (wp_pre s)`. -/
+@[rocq_alias wp_def]
 noncomputable def wp (s : Stuckness) : WPFun Expr Val GF :=
   fixpoint (fun W : WPFun Expr Val GF => wp_pre s W)
 
-/-! ## wp_unfold
-
-Coq weakestpre.v `wp_unfold`:
-```
-Lemma wp_unfold s E e Φ :
-  WP e @ s; E {{ Φ }} ⊣⊢ wp_pre s (wp s) E e Φ.
-```
-
-Proof uses upstream `fixpoint_unfold` to obtain `≡`, then converts to `⊣⊢` via
-function-space pointwise evaluation and `BI.equiv_iff`. -/
+@[rocq_alias wp_unfold]
 theorem wp_unfold (s : Stuckness) (E : CoPset) (e : Expr) (Φ : Val → IProp GF) :
     wp (Expr := Expr) (Val := Val) (GF := GF) s E e Φ ⊣⊢
       wp_pre s (wp (Expr := Expr) (Val := Val) (GF := GF) s) E e Φ := by

--- a/Iris/Iris/ProgramLogic/WeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/WeakestPre.lean
@@ -173,10 +173,16 @@ distLater_dist). -/
 noncomputable instance wp_pre_contractive (s : Stuckness) :
     Contractive (fun W : WPFun Expr Val GF => wp_pre s W) := sorry
 
-/-- 强制 `WPFun Expr Val GF` 为 COFE（用于 `fixpoint`）。
-Coq 端通过 `iPropO Σ` discrete OFE / function space 自动得到。
-Lean 端 `IProp GF` 是 OFE，函数空间 OFE 通过 `OFE.discrete_funO` 提供——sorry 占位。 -/
-noncomputable instance : COFE (WPFun Expr Val GF) := sorry
+/- `WPFun Expr Val GF` 自动是 COFE：
+
+- `IProp GF = UPred (IResUR GF)` 是 COFE，通过 `instance : IsCOFE (UPred M)`
+  (Iris/Algebra/UPred.lean:93) 与 `class abbrev COFE := OFE + IsCOFE` (OFE.lean:796) 合成
+- 函数空间封闭性 `instance [∀ x, COFE (β x)] : COFE ((x : α) → β x)`
+  (Iris/Algebra/OFE.lean:854) 套用 3 层：`Val → IProp GF`, `Expr → ...`, `CoPset → ...`
+
+不需要显式 instance —— typeclass resolution 自动 derive。
+
+旧 sorry 实例（Stage 1 接口骨架阶段占位）已移除（2026-05-12 Phase 1-B 消 sorry）. -/
 
 /-- 强制 `WPFun Expr Val GF` 有默认值（fixpoint 需要 Inhabited）。 -/
 noncomputable instance : Inhabited (WPFun Expr Val GF) :=

--- a/Iris/Iris/ProgramLogic/WeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/WeakestPre.lean
@@ -77,17 +77,15 @@ Class irisGS_gen (hlc : has_lc) (Λ : language) (Σ : gFunctors) := IrisG {
 }.
 ```
 
-Adaptation to Lean / upstream iris-lean:
-- `hlc = true` fixed (i.e. `InvGS GF = InvGS_gen true GF`), matching the style of
-  `Iris/Examples/IProp.lean`. Coq parameterizes over `has_lc`; we may revisit if
-  later-credits-free use cases arise.
+Adaptation to Lean:
 - All five Coq fields (`iris_invGS`, `state_interp`, `fork_post`,
   `num_laters_per_step`, `state_interp_mono`) are present; `iris_invGS` is via
-  `extends InvGS GF`. -/
+  `extends InvGS_gen hlc GF`. Coq's `has_lc` two-element type is represented
+  by Lean's `Bool` (the upstream convention, see `Iris/Instances/Lib/FUpd.lean`). -/
 
 class IrisGS (Expr : Type _) (State Obs Val : outParam (Type _))
-    [Language Expr State Obs Val] (GF : BundledGFunctors)
-    extends InvGS GF where
+    [Language Expr State Obs Val] (hlc : outParam Bool) (GF : BundledGFunctors)
+    extends InvGS_gen hlc GF where
   /-- State interpretation: `σ → step_count → past_observations → num_forks → iProp`.
   Coq: field of `irisGS_gen`. -/
   state_interp : State → Nat → List Obs → Nat → IProp GF
@@ -125,7 +123,7 @@ Definition wp_pre `{!irisGS_gen hlc Λ Σ} (s : stuckness)
 Uses `S (IrisGS.num_laters_per_step ns)` per-step laters, matching Coq exactly. -/
 
 variable {Expr State Obs Val : Type _} [Language Expr State Obs Val]
-variable {GF : BundledGFunctors} [iG : IrisGS Expr State Obs Val GF]
+variable {hlc : Bool} {GF : BundledGFunctors} [iG : IrisGS Expr State Obs Val hlc GF]
 
 /-- Reducibility predicate selected by stuckness.
 Coq weakestpre.v: `match s with NotStuck => reducible | MaybeStuck => True end`. -/
@@ -155,7 +153,7 @@ noncomputable def wp_pre (s : Stuckness)
               ={ ∅ }▷=∗^[ iG.num_laters_per_step ns + 1 ] (|={∅,E}=>
                 IrisGS.state_interp (Expr := Expr) σ2 (ns + 1) κs (efs.length + nt) ∗
                 wp E e2 Φ ∗
-                [∗list] _i ↦ ef ∈ efs, wp ⊤ ef (IrisGS.fork_post (Expr := Expr))))
+                [∗list] ef ∈ efs, wp ⊤ ef (IrisGS.fork_post (Expr := Expr))))
 
 /-- Helper: `|={E1}[E2]▷=∗^[k]` is NonExpansive in the inner argument `Q`.
 Proof: induction on `k`, with each layer using `BIFUpdate.ne + later_ne + BIFUpdate.ne`. -/

--- a/Iris/Iris/ProgramLogic/WeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/WeakestPre.lean
@@ -94,10 +94,10 @@ Class irisGS_gen (hlc : has_lc) (Λ : language) (Σ : gFunctors) := IrisG {
 简化（vs Coq 原版，PR-ready 评估后保留）：
 - 固定 `hlc = true`（即 `InvGS GF = InvGS_gen true GF`）；upstream `Examples/IProp.lean` 同样
   不参数化 hlc。
-- 省略 `num_laters_per_step` 字段——硬编码 = 0；hxrts 同样省（precedent）；Phase 1 swap +
-  Phase 2 数组都不需要 per-step laters。
 
-保留（vs hxrts，2026-05-12 PR-ready 化补回）：
+补全（vs hxrts，2026-05-12 PR-ready 化）：
+- `num_laters_per_step` 字段：与 Coq 严格 1:1（per-step laters 参数化，HeapLang 风格 instance
+  可填 `fun _ => 0`）。
 - `state_interp_mono` 字段：与 Coq 与 hxrts 一致。 -/
 
 class IrisGS (Expr : Type _) (State Obs Val : outParam (Type _))
@@ -109,6 +109,9 @@ class IrisGS (Expr : Type _) (State Obs Val : outParam (Type _))
   /-- Fixed postcondition for forked threads.
   Coq: field of `irisGS_gen`. -/
   fork_post : Val → IProp GF
+  /-- Per-step number of `▷` laters (allows step-indexed reasoning to vary across step count).
+  Coq: field of `irisGS_gen`. HeapLang-style instance 填 `fun _ => 0`. -/
+  num_laters_per_step : Nat → Nat
   /-- State interpretation 关于 step_count 的单调性（Coq 原版字段）。
   Coq weakestpre.v `irisGS_gen.state_interp_mono`. -/
   state_interp_mono (σ : State) (ns : Nat) (κs : List Obs) (nt : Nat) :
@@ -134,7 +137,7 @@ Definition wp_pre `{!irisGS_gen hlc Λ Σ} (s : stuckness)
   end%I.
 ```
 
-Phase 1-A 简化：硬编码 `num_laters_per_step = 0`，即 `S (..) = 1`，`|={∅}▷=>^[1] _`。 -/
+2026-05-12 PR-ready 化：用 `S (IrisGS.num_laters_per_step ns)` 替代硬编码 1，严格 1:1 自 Coq。 -/
 
 variable {Expr State Obs Val : Type _} [Language Expr State Obs Val]
 variable {GF : BundledGFunctors} [iG : IrisGS Expr State Obs Val GF]
@@ -163,15 +166,30 @@ noncomputable def wp_pre (s : Stuckness)
           ⌜stuckPred s e σ1⌝ ∗
           ∀ (e2 : Expr) (σ2 : State) (efs : List Expr),
             ⌜PrimStep.primStep (e, σ1) κ (e2, σ2, efs)⌝
-              ={ ∅ }▷=∗^[ 1 ] (|={∅,E}=>
+              ={ ∅ }▷=∗^[ iG.num_laters_per_step ns + 1 ] (|={∅,E}=>
                 IrisGS.state_interp (Expr := Expr) σ2 (ns + 1) κs (efs.length + nt) ∗
                 wp E e2 Φ ∗
                 [∗list] _i ↦ ef ∈ efs, wp ⊤ ef (IrisGS.fork_post (Expr := Expr))))
 
+/-- Helper: `step_fupdN_ne` —— `|={E1}[E2]▷=∗^[k]` 是 NonExpansive in 内层 Q.
+
+证明：induction over k；每层用 `BIFUpdate.ne + later_ne + BIFUpdate.ne`. -/
+private theorem step_fupdN_ne {E1 E2 : CoPset} {k : Nat} {n : Nat}
+    {X Y : IProp GF} (h : X ≡{n}≡ Y) :
+    Nat.repeat (fun Q : IProp GF => iprop(|={E1}[E2]▷=> Q)) k X ≡{n}≡
+      Nat.repeat (fun Q : IProp GF => iprop(|={E1}[E2]▷=> Q)) k Y := by
+  induction k with
+  | zero => exact h
+  | succ k' IH =>
+    refine BIFUpdate.ne.ne ?_
+    refine later_ne.ne ?_
+    refine BIFUpdate.ne.ne ?_
+    exact IH
+
 /-- Contractive instance for `wp_pre s`.
 Coq weakestpre.v: `Local Instance wp_pre_contractive : Contractive (wp_pre s)`.
 hxrts WeakestPre.lean:315 `wp_pre_contractive`（思路参考）。
-模板：`Iris/Examples/IProp.lean:131-142` `wp_F_contractive`（11 行同模式）。 -/
+模板：`Iris/Examples/IProp.lean:131-142` `wp_F_contractive`. -/
 noncomputable instance wp_pre_contractive (s : Stuckness) :
     Contractive (fun W : WPFun Expr Val GF => wp_pre s W) where
   distLater_dist {n W₁ W₂ HW} E e Φ := by
@@ -196,9 +214,14 @@ noncomputable instance wp_pre_contractive (s : Stuckness) :
         refine forall_ne fun σ2 => ?_
         refine forall_ne fun efs => ?_
         refine wand_ne.ne .rfl ?_
+        -- `_ ▷=∗^[k+1]` macro → `Nat.repeat _ (k+1) X = (fun Q => |={∅}[∅]▷=> Q) (Nat.repeat _ k X)`
+        -- 透过外层 |={∅,∅}=> ▷ |={∅,∅}=> ...，▷ 那一层用 distLater_dist
         refine BIFUpdate.ne.ne ?_
         refine Contractive.distLater_dist fun m hm => ?_
         refine BIFUpdate.ne.ne ?_
+        -- 现在余 `Nat.repeat _ (num_laters_per_step ns) inner` 两边对比——用 step_fupdN_ne helper
+        refine step_fupdN_ne ?_
+        -- 内 inner = |={∅,E}=> (state_interp ∗ W E e2 Φ ∗ [∗list])
         refine BIFUpdate.ne.ne ?_
         refine sep_ne.ne .rfl ?_
         refine sep_ne.ne ?_ ?_

--- a/Iris/Iris/ProgramLogic/WeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/WeakestPre.lean
@@ -228,11 +228,12 @@ hxrts WeakestPre.lean:416 `wp` 把 stuckness 一起带进 fixpoint（`wp_pre_all
 我们沿 Coq 原版风格：每个 stuckness 一个 fixpoint。 -/
 
 /-- The weakest precondition.
+Coq weakestpre.v: `Definition wp_def := λ s, fixpoint (wp_pre s)`.
 
-Stage 1 占位：实际 Phase 1-B 用 `fixpoint (wp_pre s)`（依赖 COFE/Contractive/Inhabited
-instance 全 sorry 才能开 fixpoint）。本 stage 直接 sorry — wp_unfold lemma 会成为后续
-stage 与该 fixpoint 之间的唯一接口。 -/
-noncomputable def wp (s : Stuckness) : WPFun Expr Val GF := sorry
+Phase 1-B（2026-05-12）：COFE / Inhabited / wp_pre_contractive 都已就位，
+fixpoint 可直接 elaborate。 -/
+noncomputable def wp (s : Stuckness) : WPFun Expr Val GF :=
+  fixpoint (fun W : WPFun Expr Val GF => wp_pre s W)
 
 /-! ## wp_unfold
 
@@ -242,10 +243,13 @@ Lemma wp_unfold s E e Φ :
   WP e @ s; E {{ Φ }} ⊣⊢ wp_pre s (wp s) E e Φ.
 ```
 
-Stage 1: sorry. Phase 1-B 用 upstream `fixpoint_unfold` 翻 `≡` 为 `⊣⊢`. -/
+Phase 1-B（2026-05-12）：用 upstream `fixpoint_unfold` 翻 `≡` 为 `⊣⊢`。 -/
 theorem wp_unfold (s : Stuckness) (E : CoPset) (e : Expr) (Φ : Val → IProp GF) :
     wp (Expr := Expr) (Val := Val) (GF := GF) s E e Φ ⊣⊢
       wp_pre s (wp (Expr := Expr) (Val := Val) (GF := GF) s) E e Φ := by
-  sorry
+  let F : ContractiveHom (WPFun Expr Val GF) (WPFun Expr Val GF) :=
+    { f := fun W => wp_pre s W, contractive := inferInstance }
+  have h := fixpoint_unfold F
+  exact BI.equiv_iff.mp (h E e Φ)
 
 end Iris.ProgramLogic

--- a/Iris/Iris/ProgramLogic/WeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/WeakestPre.lean
@@ -40,7 +40,7 @@ notations), `Iris.BI.BigOp.BigSepList` ([∗list] k ↦ x ∈ l, P k x).
 
 namespace Iris.ProgramLogic
 
-open Iris OFE COFE BI Iris.BI Iris.Algebra Iris.ProgramLogic.PrimStep
+open Iris OFE COFE BI Iris.Algebra Iris.BI.BigSepL Iris.ProgramLogic.PrimStep
 
 /-! ## Stuckness
 
@@ -155,20 +155,6 @@ noncomputable def wp_pre (s : Stuckness)
                 wp E e2 Φ ∗
                 [∗list] ef ∈ efs, wp ⊤ ef (IrisGS.fork_post (Expr := Expr))))
 
-/-- Helper: `|={E1}[E2]▷=∗^[k]` is NonExpansive in the inner argument `Q`.
-Proof: induction on `k`, with each layer using `BIFUpdate.ne + later_ne + BIFUpdate.ne`. -/
-private theorem step_fupdN_ne {E1 E2 : CoPset} {k : Nat} {n : Nat}
-    {X Y : IProp GF} (h : X ≡{n}≡ Y) :
-    Nat.repeat (fun Q : IProp GF => iprop(|={E1}[E2]▷=> Q)) k X ≡{n}≡
-      Nat.repeat (fun Q : IProp GF => iprop(|={E1}[E2]▷=> Q)) k Y := by
-  induction k with
-  | zero => exact h
-  | succ k' IH =>
-    refine BIFUpdate.ne.ne ?_
-    refine later_ne.ne ?_
-    refine BIFUpdate.ne.ne ?_
-    exact IH
-
 /-- Contractive instance for `wp_pre s`.
 Coq weakestpre.v: `Local Instance wp_pre_contractive : Contractive (wp_pre s)`.
 Statement 1:1 with Coq; proof follows the pattern of
@@ -209,7 +195,7 @@ noncomputable instance wp_pre_contractive (s : Stuckness) :
         refine sep_ne.ne .rfl ?_
         refine sep_ne.ne ?_ ?_
         · exact HW m hm E e2 Φ
-        · exact Iris.BI.BigSepL.bigSepL_dist fun {_ _} _ => HW m hm ⊤ _ _
+        · exact bigSepL_dist fun {_ _} _ => HW m hm ⊤ _ _
 
 /- `WPFun Expr Val GF` is automatically a COFE:
 

--- a/Iris/Iris/ProgramLogic/WeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/WeakestPre.lean
@@ -166,12 +166,40 @@ noncomputable def wp_pre (s : Stuckness)
 
 /-- Contractive instance for `wp_pre s`.
 Coq weakestpre.v: `Local Instance wp_pre_contractive : Contractive (wp_pre s)`.
-hxrts WeakestPre.lean:315 `wp_pre_contractive`.
-
-Stage 1: sorry (Phase 1-B 补；hxrts proof 思路：拆 to_val match → 在 step 分支推 `▷` 守护下的
-distLater_dist). -/
+hxrts WeakestPre.lean:315 `wp_pre_contractive`（思路参考）。
+模板：`Iris/Examples/IProp.lean:131-142` `wp_F_contractive`（11 行同模式）。 -/
 noncomputable instance wp_pre_contractive (s : Stuckness) :
-    Contractive (fun W : WPFun Expr Val GF => wp_pre s W) := sorry
+    Contractive (fun W : WPFun Expr Val GF => wp_pre s W) where
+  distLater_dist {n W₁ W₂ HW} E e Φ := by
+    show wp_pre s W₁ E e Φ ≡{n}≡ wp_pre s W₂ E e Φ
+    cases hto : toVal (Val := Val) e with
+    | some v =>
+        unfold wp_pre
+        simp only [hto]
+        exact .rfl
+    | none =>
+        unfold wp_pre
+        simp only [hto]
+        refine forall_ne fun σ => ?_
+        refine forall_ne fun ns => ?_
+        refine forall_ne fun κ => ?_
+        refine forall_ne fun κs => ?_
+        refine forall_ne fun nt => ?_
+        refine wand_ne.ne .rfl ?_
+        refine BIFUpdate.ne.ne ?_
+        refine sep_ne.ne .rfl ?_
+        refine forall_ne fun e2 => ?_
+        refine forall_ne fun σ2 => ?_
+        refine forall_ne fun efs => ?_
+        refine wand_ne.ne .rfl ?_
+        refine BIFUpdate.ne.ne ?_
+        refine Contractive.distLater_dist fun m hm => ?_
+        refine BIFUpdate.ne.ne ?_
+        refine BIFUpdate.ne.ne ?_
+        refine sep_ne.ne .rfl ?_
+        refine sep_ne.ne ?_ ?_
+        · exact HW m hm E e2 Φ
+        · exact Iris.BI.BigSepL.bigSepL_dist fun {_ _} _ => HW m hm ⊤ _ _
 
 /- `WPFun Expr Val GF` 自动是 COFE：
 

--- a/Iris/Iris/ProgramLogic/WeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/WeakestPre.lean
@@ -1,0 +1,217 @@
+/-
+Copyright (c) 2026 Haokun Li. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Haokun Li
+-/
+module
+
+public import Iris.ProgramLogic.Language
+public import Iris.Algebra.OFE
+public import Iris.Algebra.IProp
+public import Iris.Instances.IProp
+public import Iris.Instances.Lib.WSat
+public import Iris.Instances.Lib.FUpd
+public import Iris.BI
+public import Iris.BI.BigOp
+public import Iris.BI.Updates
+public import Iris.ProofMode
+
+@[expose] public section
+
+/-! # Weakest Precondition (Stage 1: fixpoint skeleton)
+
+References (Stage 1 接口审视，三参考交叉对比)：
+
+- **Canonical**: Coq Iris `iris/program_logic/weakestpre.v` (commit d663f775)
+  Defines `Inductive stuckness`, `Class irisGS_gen`, `Definition wp_pre`,
+  `Local Instance wp_pre_contractive`, `Definition wp_def := λ s, fixpoint (wp_pre s)`,
+  `Lemma wp_unfold`. 本文件 def/命题严格 1:1 自此处。
+- **Proof-side reference**: `hxrts/iris-lean@fork/iris/vendor:src/Iris/ProgramLogic/WeakestPre.lean`
+  (lines 60-470). 命题形态参考、tactic 思路参考——不复制代码。
+- **Upstream operator source**: `Iris/Algebra/OFE.lean` (Contractive, fixpoint, fixpoint_unfold)；
+  `Iris/Instances/Lib/{WSat,FUpd}.lean` (`InvGS_gen`, `uPred_fupd`, `BIFUpdate (IProp GF)`)；
+  `Iris/BI/Updates.lean` (notation `|={E1,E2}=>`, `|={E}[E']▷=>`, `|={E}▷=>^[n]`)；
+  `Iris/BI/BigOp/BigSepList.lean` (`[∗list] k ↦ x ∈ l, P k x`).
+  本 stage 算子全部走 upstream，**不**复制 hxrts vendor 算子。
+
+Phase 1-A 简化（CLAUDE.md §7 规定阶段 1 节奏 = 接口签名 + 命题真实 + proof sorry）：
+
+- `num_laters_per_step = 0` （即每步用 1 个 ▷；matches hxrts；Coq 原版是 `S (num_laters_per_step ns)`）。
+- `IrisGS` typeclass 暂不含 `state_interp_mono` 字段——Phase 1-B 在补真证明时回填。
+- 所有 lemma proof = `sorry`。Stage 1 只需保证 lake build 通过 + 命题与 Coq weakestpre.v 1:1。
+
+Stage 1 出口：Stuckness + IrisGS + wp_pre + wp_pre_contractive + wp + wp_unfold。
+后续 stages（参见 CLAUDE.md §7 stage 分支组织）：
+
+- stage/2-wp-basic: wp_value_fupd / wp_strong_mono / fupd_wp 等 ~10 lemma
+- stage/3-wp-frame-bind: wp_frame_l/r / wp_wand / wp_bind / wp_pure_step
+- stage/4-lifting: 见 Lifting.lean
+- stage/5-7: Adequacy 系列
+- stage/8-9: GhostMap / GenHeap
+-/
+
+namespace Iris.ProgramLogic
+
+open Iris OFE COFE BI Iris.BI Iris.Algebra Iris.ProgramLogic.PrimStep
+
+/-! ## Stuckness
+
+Coq weakestpre.v: `Inductive stuckness := NotStuck | MaybeStuck.`
+hxrts WeakestPre.lean line ~50: 用 `Stuckness.notStuck / .maybeStuck`（小写）。
+本文件采用 hxrts 命名（Lean 习惯）。 -/
+
+inductive Stuckness where
+  | notStuck
+  | maybeStuck
+  deriving DecidableEq
+
+namespace Stuckness
+
+/-- 偏序：`notStuck ≤ maybeStuck`（即 NotStuck 是更强的要求）。
+Coq weakestpre.v: `Definition stuckness_le ...`
+hxrts WeakestPre.lean line ~260。 -/
+def le : Stuckness → Stuckness → Prop
+  | .notStuck, _ => True
+  | .maybeStuck, .maybeStuck => True
+  | .maybeStuck, .notStuck => False
+
+end Stuckness
+
+/-! ## IrisGS typeclass
+
+Coq weakestpre.v `irisGS_gen`:
+```
+Class irisGS_gen (hlc : has_lc) (Λ : language) (Σ : gFunctors) := IrisG {
+  iris_invGS  : invGS_gen hlc Σ;
+  state_interp : state Λ → nat → list (observation Λ) → nat → iProp Σ;
+  fork_post : val Λ → iProp Σ;
+  num_laters_per_step : nat → nat;
+  state_interp_mono σ ns κs nt :
+    state_interp σ ns κs nt ⊢ |={∅}=> state_interp σ (S ns) κs nt
+}.
+```
+
+Phase 1-A 简化（vs Coq 原版）：
+- 固定 `hlc = true`（即 `InvGS GF = InvGS_gen true GF`，含 LaterCredits）；Stage 1 不用 LC，
+  但保留参数化空间 留 Phase 1-B 决定是否暴露 hlc。Coq 原版可参数化。
+- 省略 `num_laters_per_step` 字段——硬编码 = 0（Phase 1 swap 不需要 per-step laters）。
+- 省略 `state_interp_mono` 字段——Phase 1-B 在写真证明 (wp_strong_mono 等) 时按需添加。
+
+hxrts 对比：hxrts 也省略 num_laters_per_step（fix = 0），但保留 state_interp_mono。
+我们 Stage 1 更激进——两个都省，待 Phase 1-B 按需补。 -/
+
+class IrisGS (Expr : Type _) (State Obs Val : outParam (Type _))
+    [Language Expr State Obs Val] (GF : BundledGFunctors)
+    extends InvGS GF where
+  /-- State interpretation: `σ → step_count → past_observations → num_forks → iProp`.
+  Coq: field of `irisGS_gen`. -/
+  state_interp : State → Nat → List Obs → Nat → IProp GF
+  /-- Fixed postcondition for forked threads.
+  Coq: field of `irisGS_gen`. -/
+  fork_post : Val → IProp GF
+
+/-! ## wp_pre
+
+Coq weakestpre.v `wp_pre`:
+```
+Definition wp_pre `{!irisGS_gen hlc Λ Σ} (s : stuckness)
+    (wp : coPset -d> expr Λ -d> (val Λ -d> iPropO Σ) -d> iPropO Σ) :
+    coPset -d> expr Λ -d> (val Λ -d> iPropO Σ) -d> iPropO Σ := λ E e1 Φ,
+  match to_val e1 with
+  | Some v => |={E}=> Φ v
+  | None => ∀ σ1 ns κ κs nt,
+     state_interp σ1 ns (κ ++ κs) nt ={E,∅}=∗
+       ⌜match s with NotStuck => reducible e1 σ1 | MaybeStuck => True end⌝ ∗
+       ∀ e2 σ2 efs, ⌜prim_step e1 σ1 κ e2 σ2 efs⌝
+         ={∅}▷=∗^(S $ num_laters_per_step ns) |={∅,E}=>
+       state_interp σ2 (S ns) κs (length efs + nt) ∗
+       wp E e2 Φ ∗
+       [∗ list] i ↦ ef ∈ efs, wp ⊤ ef fork_post
+  end%I.
+```
+
+Phase 1-A 简化：硬编码 `num_laters_per_step = 0`，即 `S (..) = 1`，`|={∅}▷=>^[1] _`。 -/
+
+variable {Expr State Obs Val : Type _} [Language Expr State Obs Val]
+variable {GF : BundledGFunctors} [iG : IrisGS Expr State Obs Val GF]
+
+/-- 是否可还原（按 stuckness 选择）。Coq weakestpre.v 用 `match s with NotStuck => reducible | _ => True`。 -/
+def stuckPred (s : Stuckness) (e : Expr) (σ : State) : Prop :=
+  match s with
+  | .notStuck => PrimStep.Reducible (Expr := Expr) (Obs := List Obs) (e, σ)
+  | .maybeStuck => True
+
+/-- 类型简写：wp 的函数类型 = `CoPset → Expr → (Val → IProp GF) → IProp GF`。
+Coq 用 `coPset -d> expr Λ -d> (val Λ -d> iPropO Σ) -d> iPropO Σ`. -/
+abbrev WPFun (Expr Val : Type _) (GF : BundledGFunctors) :=
+  CoPset → Expr → (Val → IProp GF) → IProp GF
+
+/-- Pre-fixpoint of weakest precondition. Recursive call `wp` is a parameter.
+Coq weakestpre.v `wp_pre`. hxrts WeakestPre.lean:301. -/
+noncomputable def wp_pre (s : Stuckness)
+    (wp : WPFun Expr Val GF)
+    (E : CoPset) (e : Expr) (Φ : Val → IProp GF) : IProp GF :=
+  match toVal (Val := Val) e with
+  | some v => iprop(|={E}=> Φ v)
+  | none => iprop(
+      ∀ (σ1 : State) (ns : Nat) (κ κs : List Obs) (nt : Nat),
+        IrisGS.state_interp (Expr := Expr) σ1 ns (κ ++ κs) nt ={E,∅}=∗
+          ⌜stuckPred s e σ1⌝ ∗
+          ∀ (e2 : Expr) (σ2 : State) (efs : List Expr),
+            ⌜PrimStep.primStep (e, σ1) κ (e2, σ2, efs)⌝
+              ={ ∅ }▷=∗^[ 1 ] (|={∅,E}=>
+                IrisGS.state_interp (Expr := Expr) σ2 (ns + 1) κs (efs.length + nt) ∗
+                wp E e2 Φ ∗
+                [∗list] _i ↦ ef ∈ efs, wp ⊤ ef (IrisGS.fork_post (Expr := Expr))))
+
+/-- Contractive instance for `wp_pre s`.
+Coq weakestpre.v: `Local Instance wp_pre_contractive : Contractive (wp_pre s)`.
+hxrts WeakestPre.lean:315 `wp_pre_contractive`.
+
+Stage 1: sorry (Phase 1-B 补；hxrts proof 思路：拆 to_val match → 在 step 分支推 `▷` 守护下的
+distLater_dist). -/
+noncomputable instance wp_pre_contractive (s : Stuckness) :
+    Contractive (fun W : WPFun Expr Val GF => wp_pre s W) := sorry
+
+/-- 强制 `WPFun Expr Val GF` 为 COFE（用于 `fixpoint`）。
+Coq 端通过 `iPropO Σ` discrete OFE / function space 自动得到。
+Lean 端 `IProp GF` 是 OFE，函数空间 OFE 通过 `OFE.discrete_funO` 提供——sorry 占位。 -/
+noncomputable instance : COFE (WPFun Expr Val GF) := sorry
+
+/-- 强制 `WPFun Expr Val GF` 有默认值（fixpoint 需要 Inhabited）。 -/
+noncomputable instance : Inhabited (WPFun Expr Val GF) :=
+  ⟨fun _ _ _ => iprop(True)⟩
+
+/-! ## wp 定义
+
+Coq weakestpre.v:
+```
+Definition wp_def `{!irisGS_gen hlc Λ Σ} : Wp (iProp Σ) (expr Λ) (val Λ) stuckness :=
+  λ s : stuckness, fixpoint (wp_pre s).
+```
+
+hxrts WeakestPre.lean:416 `wp` 把 stuckness 一起带进 fixpoint（`wp_pre_all`）。
+我们沿 Coq 原版风格：每个 stuckness 一个 fixpoint。 -/
+
+/-- The weakest precondition.
+
+Stage 1 占位：实际 Phase 1-B 用 `fixpoint (wp_pre s)`（依赖 COFE/Contractive/Inhabited
+instance 全 sorry 才能开 fixpoint）。本 stage 直接 sorry — wp_unfold lemma 会成为后续
+stage 与该 fixpoint 之间的唯一接口。 -/
+noncomputable def wp (s : Stuckness) : WPFun Expr Val GF := sorry
+
+/-! ## wp_unfold
+
+Coq weakestpre.v `wp_unfold`:
+```
+Lemma wp_unfold s E e Φ :
+  WP e @ s; E {{ Φ }} ⊣⊢ wp_pre s (wp s) E e Φ.
+```
+
+Stage 1: sorry. Phase 1-B 用 upstream `fixpoint_unfold` 翻 `≡` 为 `⊣⊢`. -/
+theorem wp_unfold (s : Stuckness) (E : CoPset) (e : Expr) (Φ : Val → IProp GF) :
+    wp (Expr := Expr) (Val := Val) (GF := GF) s E e Φ ⊣⊢
+      wp_pre s (wp (Expr := Expr) (Val := Val) (GF := GF) s) E e Φ := by
+  sorry
+
+end Iris.ProgramLogic

--- a/Iris/Iris/ProgramLogic/WeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/WeakestPre.lean
@@ -18,36 +18,24 @@ public import Iris.ProofMode
 
 @[expose] public section
 
-/-! # Weakest Precondition (Stage 1: fixpoint skeleton)
+/-! # Weakest Precondition
 
-References (Stage 1 接口审视，三参考交叉对比)：
+Lean 4 port of Coq Iris's program logic weakest precondition layer,
+following `iris/program_logic/weakestpre.v`.
 
-- **Canonical**: Coq Iris `iris/program_logic/weakestpre.v` (commit d663f775)
-  Defines `Inductive stuckness`, `Class irisGS_gen`, `Definition wp_pre`,
-  `Local Instance wp_pre_contractive`, `Definition wp_def := λ s, fixpoint (wp_pre s)`,
-  `Lemma wp_unfold`. 本文件 def/命题严格 1:1 自此处。
-- **Proof-side reference**: `hxrts/iris-lean@fork/iris/vendor:src/Iris/ProgramLogic/WeakestPre.lean`
-  (lines 60-470). 命题形态参考、tactic 思路参考——不复制代码。
-- **Upstream operator source**: `Iris/Algebra/OFE.lean` (Contractive, fixpoint, fixpoint_unfold)；
-  `Iris/Instances/Lib/{WSat,FUpd}.lean` (`InvGS_gen`, `uPred_fupd`, `BIFUpdate (IProp GF)`)；
-  `Iris/BI/Updates.lean` (notation `|={E1,E2}=>`, `|={E}[E']▷=>`, `|={E}▷=>^[n]`)；
-  `Iris/BI/BigOp/BigSepList.lean` (`[∗list] k ↦ x ∈ l, P k x`).
-  本 stage 算子全部走 upstream，**不**复制 hxrts vendor 算子。
+This file defines:
+- `Stuckness` — inductive matching Coq's `stuckness` (NotStuck / MaybeStuck)
+- `IrisGS` typeclass — matching all 5 fields of Coq's `irisGS_gen`
+- `wp_pre` — Coq's `wp_pre` 1:1 (with `num_laters_per_step` parameterization)
+- `wp_pre_contractive` instance — Coq's `Local Instance wp_pre_contractive`
+- `wp` — Coq's `wp_def := λ s, fixpoint (wp_pre s)`
+- `wp_unfold` — Coq's `Lemma wp_unfold`
 
-Phase 1-A 简化（CLAUDE.md §7 规定阶段 1 节奏 = 接口签名 + 命题真实 + proof sorry）：
-
-- `num_laters_per_step = 0` （即每步用 1 个 ▷；matches hxrts；Coq 原版是 `S (num_laters_per_step ns)`）。
-- `IrisGS` typeclass 暂不含 `state_interp_mono` 字段——Phase 1-B 在补真证明时回填。
-- 所有 lemma proof = `sorry`。Stage 1 只需保证 lake build 通过 + 命题与 Coq weakestpre.v 1:1。
-
-Stage 1 出口：Stuckness + IrisGS + wp_pre + wp_pre_contractive + wp + wp_unfold。
-后续 stages（参见 CLAUDE.md §7 stage 分支组织）：
-
-- stage/2-wp-basic: wp_value_fupd / wp_strong_mono / fupd_wp 等 ~10 lemma
-- stage/3-wp-frame-bind: wp_frame_l/r / wp_wand / wp_bind / wp_pure_step
-- stage/4-lifting: 见 Lifting.lean
-- stage/5-7: Adequacy 系列
-- stage/8-9: GhostMap / GenHeap
+All definitions and theorem statements are 1:1 with Coq weakestpre.v.
+Upstream operators reused: `Iris.Algebra.OFE` (Contractive / fixpoint /
+fixpoint_unfold), `Iris.Instances.Lib.{WSat,FUpd}` (InvGS / uPred_fupd /
+BIFUpdate), `Iris.BI.Updates` (|={E1,E2}=> / |={E}[E']▷=> / |={E}▷=>^[n]
+notations), `Iris.BI.BigOp.BigSepList` ([∗list] k ↦ x ∈ l, P k x).
 -/
 
 namespace Iris.ProgramLogic
@@ -57,8 +45,7 @@ open Iris OFE COFE BI Iris.BI Iris.Algebra Iris.ProgramLogic.PrimStep
 /-! ## Stuckness
 
 Coq weakestpre.v: `Inductive stuckness := NotStuck | MaybeStuck.`
-hxrts WeakestPre.lean line ~50: 用 `Stuckness.notStuck / .maybeStuck`（小写）。
-本文件采用 hxrts 命名（Lean 习惯）。 -/
+We use lowercase constructors `Stuckness.notStuck / .maybeStuck` per Lean convention. -/
 
 inductive Stuckness where
   | notStuck
@@ -67,9 +54,8 @@ inductive Stuckness where
 
 namespace Stuckness
 
-/-- 偏序：`notStuck ≤ maybeStuck`（即 NotStuck 是更强的要求）。
-Coq weakestpre.v: `Definition stuckness_le ...`
-hxrts WeakestPre.lean line ~260。 -/
+/-- Order on stuckness: `notStuck ≤ maybeStuck` (NotStuck is the stronger constraint).
+Coq weakestpre.v: `Definition stuckness_le ...`. -/
 def le : Stuckness → Stuckness → Prop
   | .notStuck, _ => True
   | .maybeStuck, .maybeStuck => True
@@ -91,14 +77,13 @@ Class irisGS_gen (hlc : has_lc) (Λ : language) (Σ : gFunctors) := IrisG {
 }.
 ```
 
-简化（vs Coq 原版，PR-ready 评估后保留）：
-- 固定 `hlc = true`（即 `InvGS GF = InvGS_gen true GF`）；upstream `Examples/IProp.lean` 同样
-  不参数化 hlc。
-
-补全（vs hxrts，2026-05-12 PR-ready 化）：
-- `num_laters_per_step` 字段：与 Coq 严格 1:1（per-step laters 参数化，HeapLang 风格 instance
-  可填 `fun _ => 0`）。
-- `state_interp_mono` 字段：与 Coq 与 hxrts 一致。 -/
+Adaptation to Lean / upstream iris-lean:
+- `hlc = true` fixed (i.e. `InvGS GF = InvGS_gen true GF`), matching the style of
+  `Iris/Examples/IProp.lean`. Coq parameterizes over `has_lc`; we may revisit if
+  later-credits-free use cases arise.
+- All five Coq fields (`iris_invGS`, `state_interp`, `fork_post`,
+  `num_laters_per_step`, `state_interp_mono`) are present; `iris_invGS` is via
+  `extends InvGS GF`. -/
 
 class IrisGS (Expr : Type _) (State Obs Val : outParam (Type _))
     [Language Expr State Obs Val] (GF : BundledGFunctors)
@@ -110,9 +95,9 @@ class IrisGS (Expr : Type _) (State Obs Val : outParam (Type _))
   Coq: field of `irisGS_gen`. -/
   fork_post : Val → IProp GF
   /-- Per-step number of `▷` laters (allows step-indexed reasoning to vary across step count).
-  Coq: field of `irisGS_gen`. HeapLang-style instance 填 `fun _ => 0`. -/
+  Coq: field of `irisGS_gen`. HeapLang-style instances set this to `fun _ => 0`. -/
   num_laters_per_step : Nat → Nat
-  /-- State interpretation 关于 step_count 的单调性（Coq 原版字段）。
+  /-- Monotonicity of state interpretation in the step count.
   Coq weakestpre.v `irisGS_gen.state_interp_mono`. -/
   state_interp_mono (σ : State) (ns : Nat) (κs : List Obs) (nt : Nat) :
     state_interp σ ns κs nt ⊢ iprop(|={∅}=> state_interp σ (ns + 1) κs nt)
@@ -137,24 +122,25 @@ Definition wp_pre `{!irisGS_gen hlc Λ Σ} (s : stuckness)
   end%I.
 ```
 
-2026-05-12 PR-ready 化：用 `S (IrisGS.num_laters_per_step ns)` 替代硬编码 1，严格 1:1 自 Coq。 -/
+Uses `S (IrisGS.num_laters_per_step ns)` per-step laters, matching Coq exactly. -/
 
 variable {Expr State Obs Val : Type _} [Language Expr State Obs Val]
 variable {GF : BundledGFunctors} [iG : IrisGS Expr State Obs Val GF]
 
-/-- 是否可还原（按 stuckness 选择）。Coq weakestpre.v 用 `match s with NotStuck => reducible | _ => True`。 -/
+/-- Reducibility predicate selected by stuckness.
+Coq weakestpre.v: `match s with NotStuck => reducible | MaybeStuck => True end`. -/
 def stuckPred (s : Stuckness) (e : Expr) (σ : State) : Prop :=
   match s with
   | .notStuck => PrimStep.Reducible (Expr := Expr) (Obs := List Obs) (e, σ)
   | .maybeStuck => True
 
-/-- 类型简写：wp 的函数类型 = `CoPset → Expr → (Val → IProp GF) → IProp GF`。
-Coq 用 `coPset -d> expr Λ -d> (val Λ -d> iPropO Σ) -d> iPropO Σ`. -/
+/-- Type abbreviation for the function space of `wp`.
+Coq uses `coPset -d> expr Λ -d> (val Λ -d> iPropO Σ) -d> iPropO Σ`. -/
 abbrev WPFun (Expr Val : Type _) (GF : BundledGFunctors) :=
   CoPset → Expr → (Val → IProp GF) → IProp GF
 
 /-- Pre-fixpoint of weakest precondition. Recursive call `wp` is a parameter.
-Coq weakestpre.v `wp_pre`. hxrts WeakestPre.lean:301. -/
+Coq weakestpre.v `wp_pre`; statement 1:1 with the Coq definition. -/
 noncomputable def wp_pre (s : Stuckness)
     (wp : WPFun Expr Val GF)
     (E : CoPset) (e : Expr) (Φ : Val → IProp GF) : IProp GF :=
@@ -171,9 +157,8 @@ noncomputable def wp_pre (s : Stuckness)
                 wp E e2 Φ ∗
                 [∗list] _i ↦ ef ∈ efs, wp ⊤ ef (IrisGS.fork_post (Expr := Expr))))
 
-/-- Helper: `step_fupdN_ne` —— `|={E1}[E2]▷=∗^[k]` 是 NonExpansive in 内层 Q.
-
-证明：induction over k；每层用 `BIFUpdate.ne + later_ne + BIFUpdate.ne`. -/
+/-- Helper: `|={E1}[E2]▷=∗^[k]` is NonExpansive in the inner argument `Q`.
+Proof: induction on `k`, with each layer using `BIFUpdate.ne + later_ne + BIFUpdate.ne`. -/
 private theorem step_fupdN_ne {E1 E2 : CoPset} {k : Nat} {n : Nat}
     {X Y : IProp GF} (h : X ≡{n}≡ Y) :
     Nat.repeat (fun Q : IProp GF => iprop(|={E1}[E2]▷=> Q)) k X ≡{n}≡
@@ -188,8 +173,8 @@ private theorem step_fupdN_ne {E1 E2 : CoPset} {k : Nat} {n : Nat}
 
 /-- Contractive instance for `wp_pre s`.
 Coq weakestpre.v: `Local Instance wp_pre_contractive : Contractive (wp_pre s)`.
-hxrts WeakestPre.lean:315 `wp_pre_contractive`（思路参考）。
-模板：`Iris/Examples/IProp.lean:131-142` `wp_F_contractive`. -/
+Statement 1:1 with Coq; proof follows the pattern of
+`Iris/Examples/IProp.lean:131-142` `wp_F_contractive`. -/
 noncomputable instance wp_pre_contractive (s : Stuckness) :
     Contractive (fun W : WPFun Expr Val GF => wp_pre s W) where
   distLater_dist {n W₁ W₂ HW} E e Φ := by
@@ -215,35 +200,34 @@ noncomputable instance wp_pre_contractive (s : Stuckness) :
         refine forall_ne fun efs => ?_
         refine wand_ne.ne .rfl ?_
         -- `_ ▷=∗^[k+1]` macro → `Nat.repeat _ (k+1) X = (fun Q => |={∅}[∅]▷=> Q) (Nat.repeat _ k X)`
-        -- 透过外层 |={∅,∅}=> ▷ |={∅,∅}=> ...，▷ 那一层用 distLater_dist
+        -- Pass through `|={∅,∅}=> ▷ |={∅,∅}=> ...`; the `▷` layer uses `distLater_dist`.
         refine BIFUpdate.ne.ne ?_
         refine Contractive.distLater_dist fun m hm => ?_
         refine BIFUpdate.ne.ne ?_
-        -- 现在余 `Nat.repeat _ (num_laters_per_step ns) inner` 两边对比——用 step_fupdN_ne helper
+        -- Remaining: `Nat.repeat _ (num_laters_per_step ns) inner` on each side — use step_fupdN_ne.
         refine step_fupdN_ne ?_
-        -- 内 inner = |={∅,E}=> (state_interp ∗ W E e2 Φ ∗ [∗list])
+        -- Inner `inner` = `|={∅,E}=> (state_interp ∗ W E e2 Φ ∗ [∗list])`.
         refine BIFUpdate.ne.ne ?_
         refine sep_ne.ne .rfl ?_
         refine sep_ne.ne ?_ ?_
         · exact HW m hm E e2 Φ
         · exact Iris.BI.BigSepL.bigSepL_dist fun {_ _} _ => HW m hm ⊤ _ _
 
-/- `WPFun Expr Val GF` 自动是 COFE：
+/- `WPFun Expr Val GF` is automatically a COFE:
 
-- `IProp GF = UPred (IResUR GF)` 是 COFE，通过 `instance : IsCOFE (UPred M)`
-  (Iris/Algebra/UPred.lean:93) 与 `class abbrev COFE := OFE + IsCOFE` (OFE.lean:796) 合成
-- 函数空间封闭性 `instance [∀ x, COFE (β x)] : COFE ((x : α) → β x)`
-  (Iris/Algebra/OFE.lean:854) 套用 3 层：`Val → IProp GF`, `Expr → ...`, `CoPset → ...`
+- `IProp GF = UPred (IResUR GF)` is a COFE via `instance : IsCOFE (UPred M)`
+  (Iris/Algebra/UPred.lean) combined with `class abbrev COFE := OFE + IsCOFE`.
+- The function-space instance `[∀ x, COFE (β x)] → COFE ((x : α) → β x)`
+  (Iris/Algebra/OFE.lean) applies three times to layer over
+  `CoPset → Expr → (Val → IProp GF) → IProp GF`.
 
-不需要显式 instance —— typeclass resolution 自动 derive。
+No explicit instance needed — typeclass resolution derives it automatically. -/
 
-旧 sorry 实例（Stage 1 接口骨架阶段占位）已移除（2026-05-12 Phase 1-B 消 sorry）. -/
-
-/-- 强制 `WPFun Expr Val GF` 有默认值（fixpoint 需要 Inhabited）。 -/
+/-- `Inhabited (WPFun Expr Val GF)` required by `fixpoint`. -/
 noncomputable instance : Inhabited (WPFun Expr Val GF) :=
   ⟨fun _ _ _ => iprop(True)⟩
 
-/-! ## wp 定义
+/-! ## wp definition
 
 Coq weakestpre.v:
 ```
@@ -251,14 +235,10 @@ Definition wp_def `{!irisGS_gen hlc Λ Σ} : Wp (iProp Σ) (expr Λ) (val Λ) st
   λ s : stuckness, fixpoint (wp_pre s).
 ```
 
-hxrts WeakestPre.lean:416 `wp` 把 stuckness 一起带进 fixpoint（`wp_pre_all`）。
-我们沿 Coq 原版风格：每个 stuckness 一个 fixpoint。 -/
+One fixpoint per `Stuckness` value (matching Coq's style). -/
 
 /-- The weakest precondition.
-Coq weakestpre.v: `Definition wp_def := λ s, fixpoint (wp_pre s)`.
-
-Phase 1-B（2026-05-12）：COFE / Inhabited / wp_pre_contractive 都已就位，
-fixpoint 可直接 elaborate。 -/
+Coq weakestpre.v: `Definition wp_def := λ s, fixpoint (wp_pre s)`. -/
 noncomputable def wp (s : Stuckness) : WPFun Expr Val GF :=
   fixpoint (fun W : WPFun Expr Val GF => wp_pre s W)
 
@@ -270,7 +250,8 @@ Lemma wp_unfold s E e Φ :
   WP e @ s; E {{ Φ }} ⊣⊢ wp_pre s (wp s) E e Φ.
 ```
 
-Phase 1-B（2026-05-12）：用 upstream `fixpoint_unfold` 翻 `≡` 为 `⊣⊢`。 -/
+Proof uses upstream `fixpoint_unfold` to obtain `≡`, then converts to `⊣⊢` via
+function-space pointwise evaluation and `BI.equiv_iff`. -/
 theorem wp_unfold (s : Stuckness) (E : CoPset) (e : Expr) (Φ : Val → IProp GF) :
     wp (Expr := Expr) (Val := Val) (GF := GF) s E e Φ ⊣⊢
       wp_pre s (wp (Expr := Expr) (Val := Val) (GF := GF) s) E e Φ := by

--- a/Iris/PORTING.md
+++ b/Iris/PORTING.md
@@ -259,7 +259,12 @@ Some porting tasks will require other tasks as dependencies, the GitHub issues p
   - [ ] Fupd mask change laws
   - [ ] Fupd step derived rules 
   - [ ] Fupd plainly general laws
-- [ ] `weakestpre.v`
+- [-] `weakestpre.v`
+  - [x] `Stuckness` inductive + `IrisGS` typeclass (all 5 fields)
+  - [x] `wp_pre` + `wp_pre_contractive`
+  - [x] `wp := fixpoint (wp_pre s)` + `wp_unfold`
+  - [ ] `wp_value_fupd` / `wp_strong_mono` / `wp_mono` / `fupd_wp` / `wp_fupd` / `wp_wand` / `wp_atomic`
+  - [ ] `wp_frame_l` / `wp_frame_r` / `wp_bind` / `wp_bind_inv`
 - [ ] `lib/atomic.v`
 - [ ] `lib/core.v`
 - [ ] `lib/counterexamples.v`


### PR DESCRIPTION
## Description

Lean 4 port of the fixpoint base of Coq Iris's program logic weakest
precondition (`iris/program_logic/weakestpre.v`). Adds `Stuckness`, the
`IrisGS` typeclass, `wp_pre` (with `num_laters_per_step` parameterization),
its `Contractive` instance, and `wp` / `wp_unfold` via the upstream
`fixpoint` / `fixpoint_unfold` machinery.

Builds on #370 (`Language` interface).

Contributes to porting `weakestpre.v` in `PORTING.md`.

### `Iris/Iris/ProgramLogic/WeakestPre.lean`

- `Stuckness` inductive — 1:1 with Coq `stuckness`
- `IrisGS` typeclass — all 5 fields of Coq `irisGS_gen`:
  - `iris_invGS` via `extends InvGS_gen hlc GF`
  - `state_interp` / `fork_post`
  - `num_laters_per_step` / `state_interp_mono`
- `wp_pre` (body 1:1 with Coq, using `={∅}▷=∗^[num_laters_per_step ns + 1]`)
- `wp_pre_contractive` Contractive instance
- `wp := fixpoint (wp_pre s)`
- `wp_unfold` via upstream `fixpoint_unfold`

Adds one private helper `step_fupdN_ne` to factor out the
`BIFUpdate.ne + later_ne + BIFUpdate.ne` induction over
`num_laters_per_step ns` needed by the Contractive proof.

### Adaptations vs Coq

- **`Stuckness` constructors lowercase**: `notStuck` / `maybeStuck` per Lean
  convention.
- **Plain function-space arrows**: `CoPset → Expr → (Val → IProp GF) → IProp GF`
  rather than Coq's explicit discrete-OFE arrows `-d>`. The upstream
  function-space COFE instance derives the equivalent OFE structure
  automatically (and the source types here have no non-trivial OFE structure).
- **`wp_pre_contractive` proof is manual**: ~25 lines plus the small private
  `step_fupdN_ne` helper, since iris-lean doesn't yet have the equivalent of
  Coq's `f_contractive` tactic. Structure follows
  `Iris/Examples/IProp.lean:wp_F_contractive`. Once tactic automation lands
  (cf. #387 for `iLöb`), this can likely be shortened.
- **`wp_unfold` proof**: wraps `wp_pre s` into a `ContractiveHom`, then
  combines `fixpoint_unfold` with pointwise evaluation on the function-space
  OFE and `BI.equiv_iff` to convert `≡` to `⊣⊢`. Same pattern as
  `Iris/Examples/IProp.lean:wp_unfold`.
- **Auxiliary instance**: `Inhabited (WPFun)` (required by `fixpoint`); set to
  the constant `True` proposition.

## Checklist
* [x] My code follows the mathlib naming and code style conventions
* [x] I have updated `PORTING.md` as appropriate
* [x] I have added my name to the `authors` section of any appropriate files