### PR TITLE
feat: Port `big_op_instances` section of `lib/own.v`

### DIFF
--- a/Iris/Iris/Algebra/CMRA.lean
+++ b/Iris/Iris/Algebra/CMRA.lean
@@ -858,7 +858,7 @@ theorem _root_.Iris.OFE.Dist.to_incN {n} {x y : α} (H : x ≡{n}≡ y) : x ≼{
   ⟨unit, ((equiv_dist.mp unit_right_id n).trans H).symm⟩
 
 instance ucmraMonoidOps {α : Type _} [UCMRA α] : Algebra.MonoidOps (CMRA.op (α := α)) UCMRA.unit where
-  op_ne := { ne := fun _ _ _ hx _ _ hy => hx.op hy }
+  op_ne := ⟨fun _ _ _ hx _ _ hy => hx.op hy⟩
   op_assoc := CMRA.assoc.symm
   op_comm := CMRA.comm
   op_left_id := UCMRA.unit_left_id

--- a/Iris/Iris/Algebra/CMRA.lean
+++ b/Iris/Iris/Algebra/CMRA.lean
@@ -6,6 +6,7 @@ Authors: Mario Carneiro, Сухарик (@suhr), Markus de Medeiros, Puming Liu
 module
 
 public import Iris.Algebra.OFE
+public import Iris.Algebra.Monoid
 meta import Iris.Std.RocqPorting
 
 @[expose] public section
@@ -855,6 +856,12 @@ instance empty_cancelable : Cancelable (unit : α) where
 
 theorem _root_.Iris.OFE.Dist.to_incN {n} {x y : α} (H : x ≡{n}≡ y) : x ≼{n} y :=
   ⟨unit, ((equiv_dist.mp unit_right_id n).trans H).symm⟩
+
+instance ucmraMonoidOps {α : Type _} [UCMRA α] : Algebra.MonoidOps (CMRA.op (α := α)) UCMRA.unit where
+  op_ne := { ne := fun _ _ _ hx _ _ hy => hx.op hy }
+  op_assoc := CMRA.assoc.symm
+  op_comm := CMRA.comm
+  op_left_id := UCMRA.unit_left_id
 
 end ucmra
 

--- a/Iris/Iris/Instances/IProp/Instance.lean
+++ b/Iris/Iris/Instances/IProp/Instance.lean
@@ -7,6 +7,7 @@ module
 
 
 public import Iris.BI
+public import Iris.BI.BigOp
 public import Iris.Algebra
 public import Iris.Instances.UPred
 public meta import Iris.Std.RocqPorting
@@ -767,4 +768,76 @@ instance combineSepGives_iOwn {γ} {a1 a2 : F.ap (IProp GF)} :
   combine_sep_gives := iOwn_cmraValid_op
 
 end iOwn
+
+section big_op_instances
+
+open IProp OFE UPred BI GenMap ProofMode Algebra Std
+open scoped Iris.Std.PartialMap
+
+variable {GF F} [URFunctorContractive F] [E : ElemG GF F]
+
+@[rocq_alias own_cmra_sep_homomorphism]
+instance iOwn_cmra_sep_homomorphism (γ : GName) :
+    WeakMonoidHomomorphism (CMRA.op (α := F.ap (IProp GF))) sep
+      UCMRA.unit iprop(emp) BiEntails (iOwn γ) where
+  rel_refl := .rfl
+  rel_trans := .trans
+  rel_proper := BIBase.BiEntails.proper
+  op_proper aa' bb' := equiv_iff.1 (sep_ne.eqv (equiv_iff.2 aa') (equiv_iff.2 bb'))
+  map_ne := iOwn_ne
+  map_op := iOwn_op
+
+@[rocq_alias big_opL_own]
+theorem bigOpL_iOwn {B : Type _} (γ : GName) (f : Nat → B → F.ap (IProp GF)) (l : List B) :
+    l ≠ [] →
+    iOwn γ ([^ CMRA.op list] k ↦ x ∈ l, f k x) ⊣⊢ [∗list] k ↦ x ∈ l, iOwn γ (f k x) :=
+  BigOpL.bigOpL_hom_weak f
+
+@[rocq_alias big_opM_own]
+theorem bigOpM_iOwn {K : Type _} {M : Type _ → Type _} {B : Type _} [LawfulFiniteMap M K]
+    [DecidableEq K] (γ : GName) (g : K → B → F.ap (IProp GF)) (m : M B) :
+    ¬ m ≡ₘ (∅ : M B) →
+    iOwn γ ([^ CMRA.op map] k ↦ x ∈ m, g k x) ⊣⊢ [∗map] k ↦ x ∈ m, iOwn γ (g k x) :=
+  BigOpM.bigOpM_weak_hom g m
+
+@[rocq_alias big_opS_own]
+theorem bigOpS_iOwn {B : Type _} {S : Type _} [LawfulFiniteSet S B] (γ : GName)
+    (g : B → F.ap (IProp GF)) (X : S) :
+    X ≠ ∅ →
+    iOwn γ ([^ CMRA.op set] x ∈ X, g x) ⊣⊢ [∗set] x ∈ X, iOwn γ (g x) :=
+  BigOpS.hom_weak (iOwn_cmra_sep_homomorphism γ) g X
+
+@[rocq_alias own_cmra_sep_entails_homomorphism]
+instance iOwn_cmra_sep_entails_homomorphism (γ : GName) :
+    MonoidHomomorphism (CMRA.op (α := F.ap (IProp GF))) BIBase.sep
+      UCMRA.unit iprop(emp) BIBase.Entails (iOwn γ) where
+  rel_refl := .rfl
+  rel_trans := .trans
+  rel_proper ha hb :=
+    ⟨fun h => (equiv_iff.1 ha).mpr.trans <| h.trans (equiv_iff.1 hb).mp,
+     fun h => (equiv_iff.1 ha).mp.trans <| h.trans (equiv_iff.1 hb).mpr⟩
+  op_proper := sep_mono
+  map_ne := iOwn_ne
+  map_op := iOwn_op.mp
+  map_unit := affine
+
+@[rocq_alias big_opL_own_1]
+theorem bigOpL_iOwn_entail {B : Type _} (γ : GName) (f : Nat → B → F.ap (IProp GF)) (l : List B) :
+    iOwn γ ([^ CMRA.op list] k ↦ x ∈ l, f k x) ⊢ [∗list] k ↦ x ∈ l, iOwn γ (f k x) :=
+  BigOpL.bigOpL_hom f l
+
+@[rocq_alias big_opM_own_1]
+theorem bigOpM_iOwn_entail {K : Type _} {M : Type _ → Type _} {B : Type _} [LawfulFiniteMap M K]
+    (γ : GName) (g : K → B → F.ap (IProp GF)) (m : M B) :
+    iOwn γ ([^ CMRA.op map] k ↦ x ∈ m, g k x) ⊢ [∗map] k ↦ x ∈ m, iOwn γ (g k x) :=
+  BigOpM.bigOpM_hom g m
+
+@[rocq_alias big_opS_own_1]
+theorem bigOpS_iOwn_entail {B : Type _} {S : Type _} [LawfulFiniteSet S B] (γ : GName)
+    (g : B → F.ap (IProp GF)) (X : S) :
+    iOwn γ ([^ CMRA.op set] x ∈ X, g x) ⊢ [∗set] x ∈ X, iOwn γ (g x) :=
+  BigOpS.hom (iOwn_cmra_sep_entails_homomorphism γ) g X
+
+end big_op_instances
+
 end Iris

--- a/Iris/Iris/Instances/IProp/Instance.lean
+++ b/Iris/Iris/Instances/IProp/Instance.lean
@@ -809,8 +809,8 @@ theorem bigOpS_iOwn {B : Type _} {S : Type _} [LawfulFiniteSet S B] (γ : GName)
 
 @[rocq_alias own_cmra_sep_entails_homomorphism]
 instance iOwn_cmra_sep_entails_homomorphism (γ : GName) :
-    MonoidHomomorphism (CMRA.op (α := F.ap (IProp GF))) BIBase.sep
-      UCMRA.unit iprop(emp) BIBase.Entails (iOwn γ) where
+    MonoidHomomorphism (CMRA.op (α := F.ap (IProp GF))) sep
+      UCMRA.unit iprop(emp) Entails (iOwn γ) where
   rel_refl := .rfl
   rel_trans := .trans
   rel_proper ha hb :=


### PR DESCRIPTION
## Description

Useful for #407.

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
