### PR TITLE
feat: add to_eq to simplify use of eq_of_eqv

### DIFF
--- a/Iris/Iris/Algebra/Auth.lean
+++ b/Iris/Iris/Algebra/Auth.lean
@@ -209,7 +209,7 @@ theorem auth_dfrac_op_inv {dq1 dq2 : DFrac F} {a b : A}
 @[rocq_alias auth_auth_dfrac_op_inv_L]
 theorem auth_dfrac_op_inv_L [Leibniz A] {dq1 dq2 : DFrac F} {a b : A}
     (h : ✓ ((●{dq1} a) • ●{dq2} b)) : a = b :=
-  Leibniz.eq_of_eqv (auth_dfrac_op_inv h)
+  (auth_dfrac_op_inv h).to_eq
 
 
 @[rocq_alias auth_auth_dfrac_validN]

--- a/Iris/Iris/Algebra/CMRA.lean
+++ b/Iris/Iris/Algebra/CMRA.lean
@@ -870,50 +870,50 @@ section Leibniz
 variable [Leibniz α]
 
 @[rocq_alias cmra_assoc_L]
-theorem assoc_L {x y z : α} : x • (y • z) = (x • y) • z := eq_of_eqv assoc
+theorem assoc_L {x y z : α} : x • (y • z) = (x • y) • z := assoc.to_eq
 
 @[rocq_alias cmra_comm_L]
-theorem comm_L {x y : α} : x • y = y • x := eq_of_eqv comm
+theorem comm_L {x y : α} : x • y = y • x := comm.to_eq
 
 @[rocq_alias cmra_pcore_l_L]
 theorem pcore_op_left_L {x cx : α} (h : pcore x = some cx) : cx • x = x :=
-  eq_of_eqv (pcore_op_left h)
+   (pcore_op_left h).to_eq
 
 @[rocq_alias cmra_pcore_idemp_L]
 theorem pcore_idem_L {x cx : α} (h : pcore x = some cx) : pcore cx = some cx :=
-  eq_of_eqv (pcore_idem h)
+  (pcore_idem h).to_eq
 
 @[rocq_alias cmra_op_opM_assoc_L]
 theorem op_opM_assoc_L {x y : α} {mz} : (x • y) •? mz = x • (y •? mz) :=
-  eq_of_eqv (op_opM_assoc ..)
+  (op_opM_assoc ..).to_eq
 
 @[rocq_alias cmra_pcore_r_L]
 theorem pcore_op_right_L {x cx : α} (h : pcore x = some cx) : x • cx = x :=
-  eq_of_eqv (pcore_op_right h)
+  (pcore_op_right h).to_eq
 
 @[rocq_alias cmra_pcore_dup_L]
 theorem pcore_op_self_L {x cx : α} (h : pcore x = some cx) : cx • cx = cx :=
-  eq_of_eqv (pcore_op_self h)
+  (pcore_op_self h).to_eq
 
 @[rocq_alias core_id_dup_L]
 theorem core_id_dup_L {x : α} [CoreId x] : x • x = x :=
-  eq_of_eqv (op_self x)
+  (op_self x).to_eq
 
 @[rocq_alias cmra_core_r_L]
 theorem op_core_L {x : α} [IsTotal α] : x • core x = x :=
-  eq_of_eqv (op_core x)
+  (op_core x).to_eq
 
 @[rocq_alias cmra_core_l_L]
 theorem core_op_L {x : α} [IsTotal α] : core x • x = x :=
-  eq_of_eqv (core_op x)
+  (core_op x).to_eq
 
 @[rocq_alias cmra_core_idemp_L]
 theorem core_idem_L {x : α} [IsTotal α] : core (core x) = core x :=
-  eq_of_eqv (core_idem x)
+  (core_idem x).to_eq
 
 @[rocq_alias cmra_core_dup_L]
 theorem core_op_core_L {x : α} [IsTotal α] : core x • core x = core x :=
-  eq_of_eqv core_op_core
+  core_op_core.to_eq
 
 @[rocq_alias core_id_total_L]
 theorem coreId_iff_core_eq_self {x : α} [IsTotal α] : CoreId x ↔ core x = x := calc

--- a/Iris/Iris/Algebra/Lib/ExclAuth.lean
+++ b/Iris/Iris/Algebra/Lib/ExclAuth.lean
@@ -74,7 +74,7 @@ theorem agree {a b : A} (h : ✓ (●E a) • ◯E b) : a ≡ b :=
 
 @[rocq_alias excl_auth_agree_L]
 theorem agree_L [Leibniz A] {a b : A} (h : ✓ (●E a) • ◯E b) : a = b :=
-  eq_of_eqv (agree h)
+  (agree h).to_eq
 
 @[rocq_alias excl_auth_auth_op_validN]
 theorem auth_op_validN {a b : A} : (✓{n} (●E a) • ●E b) ↔ False :=

--- a/Iris/Iris/Algebra/Lib/FracAuth.lean
+++ b/Iris/Iris/Algebra/Lib/FracAuth.lean
@@ -101,7 +101,7 @@ theorem agree {dq : DFrac F} {a b : A} (h : ✓ (●F{dq} a) • ◯F b) : a ≡
 
 @[rocq_alias frac_auth_agree_L]
 theorem agree_L [OFE.Leibniz A] {dq : DFrac F} {a b : A} (h : ✓ (●F{dq} a) • ◯F b) : a = b :=
-  eq_of_eqv (agree h)
+  (agree h).to_eq
 
 /-! ## Inclusion -/
 

--- a/Iris/Iris/Algebra/Numbers.lean
+++ b/Iris/Iris/Algebra/Numbers.lean
@@ -49,7 +49,7 @@ scoped instance : CMRA α where
   op := add
   ValidN _ _ := True
   Valid _ := True
-  op_ne.ne _ _ _ h := by rw [eq_of_eqv (discrete h)]
+  op_ne.ne _ _ _ h := by rw [(discrete h).to_eq]
   pcore_ne _ := dist_some ∘ Dist.of_eq
   validN_ne _ _ := .intro
   valid_iff_validN := .symm <| forall_const Nat
@@ -112,7 +112,7 @@ scoped instance : CMRA α where
   op := add
   ValidN _ _ := True
   Valid _ := True
-  op_ne.ne _ _ _ h := by rw [eq_of_eqv (discrete h)]
+  op_ne.ne _ _ _ h := by rw [(discrete h).to_eq]
   pcore_ne {_ y _ _} h := by
     rintro ⟨rfl⟩
     exact ⟨y, congrArg _ <| leibniz.mp (discrete h.symm), .rfl⟩
@@ -164,7 +164,7 @@ scoped instance : CMRA α where
   op := add
   ValidN _ _ := True
   Valid _ := True
-  op_ne.ne _ _ _ h := by rw [eq_of_eqv (discrete h)]
+  op_ne.ne _ _ _ h := by rw [(discrete h).to_eq]
   pcore_ne _ := by rintro ⟨rfl⟩
   validN_ne _ _ := .intro
   valid_iff_validN := .symm <| forall_const Nat

--- a/Iris/Iris/Algebra/OFE.lean
+++ b/Iris/Iris/Algebra/OFE.lean
@@ -213,6 +213,9 @@ class Leibniz (α : Type _) [OFE α] where
   eq_of_eqv {x y : α} : x ≡ y → x = y
 export OFE.Leibniz (eq_of_eqv)
 
+theorem Equiv.to_eq {α} [OFE α] [Leibniz α] {x y : α} (h : x ≡ y) : x = y :=
+  eq_of_eqv h
+
 #rocq_ignore boolO "Canonical Leibniz OFE on `bool`; Lean uses `LeibnizO Bool`."
 #rocq_ignore natO "Canonical Leibniz OFE on `nat`; Lean uses `LeibnizO Nat`."
 #rocq_ignore positiveO "Canonical Leibniz OFE on `positive`; not applicable in Lean."

--- a/Iris/Iris/BI/BI.lean
+++ b/Iris/Iris/BI/BI.lean
@@ -97,6 +97,8 @@ theorem BIBase.Entails.of_eq [BI PROP] {P Q : PROP} (h : P = Q) : P ⊢ Q := h �
 
 theorem BIBase.BiEntails.of_eq [BI PROP] {P Q : PROP} (h : P = Q) : P ⊣⊢ Q := h ▸ .rfl
 
+theorem BIBase.BiEntails.to_eq [BI PROP] [Leibniz PROP] {P Q : PROP} (h : P ⊣⊢ Q) : P = Q := (equiv_iff.mpr h).to_eq
+
 theorem BIBase.BiEntails.symm [BI PROP] {P Q : PROP} (h : P ⊣⊢ Q) : Q ⊣⊢ P := ⟨h.2, h.1⟩
 
 theorem BIBase.BiEntails.trans [BI PROP] {P Q R : PROP} (h1 : P ⊣⊢ Q) (h2 : Q ⊣⊢ R) : P ⊣⊢ R :=

--- a/Iris/Iris/Examples/Fix.lean
+++ b/Iris/Iris/Examples/Fix.lean
@@ -54,9 +54,9 @@ def unfold : Dom V E -n> V ⊕ E ⊕ Later (Dom V E) ⊕ Later (Dom V E -n> Dom 
 
 theorem unfold_fold {x : V ⊕ E ⊕ Later (Dom V E) ⊕ Later (Dom V E -n> Dom V E)} :
     unfold (fold x) = x :=
-  eq_of_eqv (OFunctor.Fix.unfold_fold (F := DomF (Val := V) (Err := E)) x)
+  (OFunctor.Fix.unfold_fold (F := DomF (Val := V) (Err := E)) x).to_eq
 
 theorem fold_unfold {x : Dom V E} : fold (unfold x) = x :=
-  eq_of_eqv (OFunctor.Fix.fold_unfold (F := DomF (Val := V) (Err := E)) x)
+  (OFunctor.Fix.fold_unfold (F := DomF (Val := V) (Err := E)) x).to_eq
 
 end Dom

--- a/Iris/Iris/Instances/Lib/FUpd.lean
+++ b/Iris/Iris/Instances/Lib/FUpd.lean
@@ -173,7 +173,7 @@ section LaterCreditLemmas
 theorem fupd_unfold_no_lc [Hi:InvGS_gen .hasNoLC GF] E1 E2 (P : IProp GF) :
   (|={E1,E2}=> P) ⊣⊢ (wsat ∗ ownE E1 ==∗ ◇ (wsat ∗ ownE E2 ∗ P)) := by
   simp only [fupd, uPred_fupd]
-  rw [eq_of_eqv <| equiv_iff.mpr (le_upd_unfold_no_le (GF := GF))]
+  rw [(le_upd_unfold_no_le (GF := GF)).to_eq]
   exact .rfl
 
 variable {GF : BundledGFunctors} [InvGS GF]
@@ -530,7 +530,7 @@ theorem step_fupdN_soundness [InvGpreS GF] (n m : Nat) {P : IProp GF} [Plain P] 
   apply fupd_finally_soundness hlc (n := m) (E := ⊤)
   iintro %Hinv Hc
   imod HP $$ Hc with HP
-  rw [eq_of_eqv <| equiv_iff.mpr (laterN_later n)]
+  rw [(laterN_later n).to_eq]
   iapply fupd_finally_mono (laterN_mono _ except0_into_later)
   iapply step_fupdN_fupd_finally
   iapply step_fupdN_wand $$ HP
@@ -545,7 +545,7 @@ theorem step_fupdN_soundness_close [InvGpreS GF] (n m : Nat) {P : IProp GF} [Pla
   apply fupd_finally_soundness hlc (n := m) (E := ⊤)
   iintro %Hinv Hc
   ihave HP := HP $$ Hc
-  rw [eq_of_eqv <| equiv_iff.mpr (laterN_later n)]
+  rw [(laterN_later n).to_eq]
   iapply fupd_finally_mono (laterN_mono _ except0_into_later)
   iapply step_fupdN_fupd_finally
   iapply step_fupdN_wand $$ HP
@@ -568,7 +568,7 @@ theorem fupd_soundness_no_lc_unfold [InvGpreS GF] m E :
   iintro !>!>  %E1 %E2 %P HP HwE
   simp only [fupd, uPred_fupd]
   iapply le_upd_unfold_no_le
-  rw [eq_of_eqv <| equiv_iff.mpr <| sep_assoc (R := P)]
+  rw [(sep_assoc (R := P)).to_eq]
   iapply HP $$ HwE
 
 end StepIndexed

--- a/Iris/Iris/Instances/Lib/GhostMap.lean
+++ b/Iris/Iris/Instances/Lib/GhostMap.lean
@@ -411,7 +411,7 @@ theorem ghost_map_insert_big [DecidableEq K] {γ m} (m' : H V) (Hdisj : m' ##ₘ
     · iapply iOwn_mono $$ H
       exact auth_inc_of_pmap_equiv _ (map_equiv ((union_equiv h .refl).trans union_empty_left))
     · iapply (BigSepM.bigSepM_equiv_empty h).mpr; itrivial
-  · rw [←IProp.ext (bigOpM_iOwn γ _ _ h), ←IProp.ext iOwn_op]
+  · rw [←(bigOpM_iOwn γ _ _ h).to_eq, ←iOwn_op.to_eq]
     imod iOwn_update (E := GhostMapG.elem) (update_big_alloc _
         (Std.PartialMap.map (fun x ↦ toAgree ⟨x⟩) m') (DFrac.own 1)
         (disjoint_map Hdisj) DFrac.valid_own_one
@@ -461,7 +461,7 @@ theorem ghost_map_update_big [DecidableEq K] {γ m} (m0 m1 : H V) (Heq : dom m0 
     · iapply (BigSepM.bigSepM_equiv_empty h).mpr; itrivial
   · unfold ghost_map_elem ghost_map_auth
     icombine H1 H2 as H
-    rw [←IProp.ext (bigOpM_iOwn γ _ _ h), ←IProp.ext iOwn_op]
+    rw [←(bigOpM_iOwn γ _ _ h).to_eq, ←iOwn_op.to_eq]
     iapply iOwn_update $$ H
     refine Update.equiv_left (CMRA.op_right_eqv _ (BigOpM.bigOpM_map_equiv _ _ m0)) ?_
     have Heq' : dom (Std.PartialMap.map (fun x : V => toAgree (LeibnizO.mk x)) m0) =

--- a/Iris/Iris/Instances/Lib/LaterCredits.lean
+++ b/Iris/Iris/Instances/Lib/LaterCredits.lean
@@ -602,9 +602,7 @@ theorem le_upd_keep (P Q : IProp GF) [TCOr (TCEq hlc .hasNoLC) (Timeless P)] :
       subst n
       ispecialize H $$ Hc
       icases laterN_0.mp $$ H with H
-      rw [← Nat.add_one]
-      rw [eq_of_eqv <| equiv_iff.mpr <| laterN_later (n := 0)]
-      rw [eq_of_eqv <| equiv_iff.mpr <| laterN_0]
+      rw [← Nat.add_one, (laterN_later (n := 0)).to_eq, (laterN_0).to_eq]
       unfold BIBase.except0
       iapply H
   icases H with ⟨-, H⟩

--- a/Iris/Iris/ProgramLogic/Adequacy.lean
+++ b/Iris/Iris/ProgramLogic/Adequacy.lean
@@ -44,7 +44,7 @@ theorem wp_step (s : Stuckness) (e1 : Expr) (σ1 : State)
         stateInterp σ2 (ns + 1) κs (nt + efs.length) ∗
         WP e2 @ s ; ⊤ {{ Φ }} ∗
         wptp s efs (List.replicate efs.length iG.forkPost) := by
-  rw [IProp.ext wp_unfold]
+  rw [wp_unfold.to_eq]
   simp only [wp.pre, Language.val_stuck Hstep]
   iintro Hσ Hcred Hwp
   imod Hwp $$ %σ1 %ns %κ %κs %nt Hσ with ⟨%_, Hcont⟩
@@ -91,7 +91,7 @@ theorem wp_not_stuck (κs : List Obs) (nt : Nat) (e : Expr) (σ : State)
     (ns : Nat) (Φ : Val → IProp GF) :
     ⊢ stateInterp σ ns κs nt -∗
       WP e @ Stuckness.NotStuck ; ⊤ {{ Φ }} ={⊤,∅}=∗ ⌜NotStuck (e, σ)⌝ := by
-  rw [IProp.ext wp_unfold]
+  rw [wp_unfold.to_eq]
   unfold wp.pre
   match h : toVal e with
   | some v =>

--- a/Iris/Iris/ProgramLogic/Adequacy.lean
+++ b/Iris/Iris/ProgramLogic/Adequacy.lean
@@ -192,7 +192,7 @@ theorem wp_strong_adequacy_gen [InvGpreS GF] (s : Stuckness) (es : List Expr) (�
     φ := by
   apply pure_soundness (PROP := IProp GF)
   apply laterN_soundness (n := steps_sum numLaters 0 n + 1)
-  rw [eq_of_eqv <| equiv_iff.mpr <| laterN_later _]
+  rw [(laterN_later _).to_eq]
   refine Entails.trans ?_ (laterN_mono _ except0_into_later)
   apply fupd_finally_soundness hlc (steps_sum numLaters 0 n) ⊤
   iintro %Hinv Hf

--- a/Iris/Iris/ProgramLogic/Lifting.lean
+++ b/Iris/Iris/ProgramLogic/Lifting.lean
@@ -30,7 +30,7 @@ theorem wp_lift_step_fupdN (h : toVal e₁ = none) :
         stateInterp σ₂ (ns + 1) obs' (nt + eₜ.length) ∗
         WP e₂ @ s; E {{ Φ }} ∗
         [∗list] ef ∈ eₜ, WP ef @ s; ⊤ {{ ι.forkPost }})
-    ⊢ WP e₁ @ s; E {{ Φ }} := by simp [IProp.ext (wp_unfold (e := e₁)), wp.pre, h]
+    ⊢ WP e₁ @ s; E {{ Φ }} := by simp [(wp_unfold (e := e₁)).to_eq, wp.pre, h]
 
 @[rocq_alias wp_lift_step_fupd]
 theorem wp_lift_step_fupd (h : toVal e₁ = none) :
@@ -60,7 +60,7 @@ theorem wp_lift_stuck (h : toVal e = none) :
     (∀ σ ns obs nt, stateInterp σ ns obs nt ={E,∅}=∗ ⌜PrimStep.Stuck (e,σ)⌝)
     ⊢ WP e @ E ? {{ Φ }} := by
   iintro H
-  rw [IProp.ext wp_unfold]
+  rw [wp_unfold.to_eq]
   simp only [wp.pre, h]
   iintro %σ₁ %ns %obs %obs' %nt Hσ
   imod H $$ Hσ with %Hirr
@@ -191,7 +191,7 @@ theorem wp_pure_step_fupd [Inhabited State] (E₂ : CoPset)
   induction Hexec using Relation.Iterate.head_induction_on with
   | rfl =>
     simp only [Nat.repeat]
-    rw (occs := [2]) [IProp.ext fupd_wp_iff]
+    rw (occs := [2]) [fupd_wp_iff.to_eq]
     icases lc_zero with >Hz
     iapply Hwp $$ Hz
   | @head n e₁ e₃ _ _ IH =>
@@ -222,6 +222,6 @@ theorem wp_pure_step_later [Inhabited State] (Hexec : PureExec φ n e₁ e₂) (
   | zero => exact .rfl
   | succ n IH =>
     simp only [Nat.repeat]
-    rw [IProp.ext <| later_laterN n]
+    rw [(later_laterN n).to_eq]
     refine (later_mono IH).trans ?_
     exact step_fupd_intro Std.LawfulSet.subset_refl

--- a/Iris/Iris/ProgramLogic/WeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/WeakestPre.lean
@@ -328,7 +328,7 @@ theorem wp_credit_access {s : Stuckness} {E : CoPset} {e : Expr} {Φ} {P: IProp 
   dsimp only [Nat.repeat]
   ihave Hwp := Hwp $$ [] [Hm]
   · ipure_intro; assumption
-  · simp [OFE.eq_of_eqv (BI.equiv_iff.mpr lc_split)]
+  · simp [lc_split.to_eq]
   iapply step_fupd_wand $$ Hwp; iintro Hwp
   iapply step_fupdN_le (n := ι.numLatersPerStep m) (by grind only) LawfulSet.subset_refl
   iapply step_fupdN_wand $$ Hwp; iintro >⟨SI, Hwp, $⟩

--- a/Iris/Iris/ProgramLogic/WeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/WeakestPre.lean
@@ -130,7 +130,7 @@ instance wp_ne {s : Stuckness} {E} {e : Expr} :
     OFE.NonExpansive (Wp.wp (PROP := IProp GF) s E e) where
   ne {n Φ₁ Φ₂} HΦ := by
     induction n using Nat.strongRecOn generalizing e E Φ₁ Φ₂ with | ind n IH =>
-    simp only [IProp.ext wp_unfold]
+    simp only [wp_unfold.to_eq]
     dsimp only [wp.pre]
     cases toVal e
     case some v =>
@@ -161,7 +161,7 @@ instance wp_ne {s : Stuckness} {E} {e : Expr} :
 instance wp_contractive (s : Stuckness) E (e : Expr) (h : toVal e = none) :
     OFE.Contractive (Wp.wp (PROP := IProp GF) s E e) where
   distLater_dist {n Φ₁ Φ₂} HΦ := by
-    simp only [IProp.ext wp_unfold]
+    simp only [wp_unfold.to_eq]
     simp only [wp.pre, h]
     refine BI.forall_ne fun σ₁ => ?_
     refine BI.forall_ne fun ns => ?_
@@ -186,14 +186,14 @@ instance wp_contractive (s : Stuckness) E (e : Expr) (h : toVal e = none) :
 @[rocq_alias wp_value_fupd']
 theorem wp_value_fupd' {s : Stuckness} {E} {Φ : Val → IProp GF} {v : Val} :
     WP (v : Expr) @ s ; E {{ Φ }} ⊣⊢ |={E}=> Φ v := by
-  simp [IProp.ext wp_unfold, toVal_coe, BI.BIBase.BiEntails.rfl, wp.pre]
+  simp [wp_unfold.to_eq, toVal_coe, BI.BIBase.BiEntails.rfl, wp.pre]
 
 @[rocq_alias wp_strong_mono]
 theorem wp_strong_mono {s₁ s₂ : Stuckness} {E₁ E₂} {e : Expr} {Φ Ψ : Val → IProp GF}
     (hs : s₁ ≤ s₂) (hE : E₁ ⊆ E₂) :
     ⊢ WP e @ s₁ ; E₁ {{ Φ }} -∗ (∀ v, Φ v ={E₂}=∗ Ψ v) -∗ WP e @ s₂ ; E₂ {{ Ψ }} := by
   iloeb as IH generalizing %e %Φ %Ψ %E₁ %E₂ %hE
-  rw [IProp.ext wp_unfold, IProp.ext wp_unfold]
+  rw [wp_unfold.to_eq, wp_unfold.to_eq]
   iintro H HΦ
   dsimp only [wp.pre]
   match toVal e with
@@ -232,7 +232,7 @@ theorem wp_strong_mono {s₁ s₂ : Stuckness} {E₁ E₂} {e : Expr} {Φ Ψ : V
 @[rocq_alias fupd_wp]
 theorem fupd_wp {s : Stuckness}{E}{e : Expr} {Φ : Val → IProp GF} :
     (|={E}=> WP e @ s ; E {{ Φ }}) ⊢ WP e @ s ; E {{ Φ }} := by
-  simp only [IProp.ext wp_unfold]
+  simp only [wp_unfold.to_eq]
   iintro H
   match h: toVal e with
   | some v =>
@@ -261,7 +261,7 @@ theorem wp_fupd (s : Stuckness) E (e : Expr) (Φ : Val → IProp GF) :
 theorem wp_atomic {s : Stuckness} {E1 E2 : CoPset} {e : Expr} {Φ : Val → IProp GF}
   [ι : Language.Atomic ↑s e] :
     (|={E1,E2}=> WP e @ s ;  E2 {{v, |={E2,E1}=> Φ v }}) ⊢ (WP e @ s ; E1 {{ Φ }}) := by
-  simp only [IProp.ext wp_unfold]
+  simp only [wp_unfold.to_eq]
   iintro H
   match He : toVal e with
   | some v =>
@@ -282,7 +282,7 @@ theorem wp_atomic {s : Stuckness} {E1 E2 : CoPset} {e : Expr} {Φ : Val → IPro
     irevert %ι
     match s with
     | .NotStuck =>
-      simp only [IProp.ext wp_unfold]
+      simp only [wp_unfold.to_eq]
       dsimp only [wp.pre]
       match h₂ : toVal e2 with
       | some v2 =>
@@ -298,7 +298,7 @@ theorem wp_atomic {s : Stuckness} {E1 E2 : CoPset} {e : Expr} {Φ : Val → IPro
       iintro %ι
       have ⟨v, h⟩ := Option.isSome_iff_exists.mp (ι.atomic Hstep)
       obtain ⟨rfl⟩ := (ToVal.coe_of_toVal_eq_some h)
-      simp only [IProp.ext wp_value_fupd']
+      simp only [wp_value_fupd'.to_eq]
       imod H with > H
       iframe
 
@@ -312,7 +312,7 @@ theorem wp_credit_access {s : Stuckness} {E : CoPset} {e : Expr} {Φ} {P: IProp 
           stateInterp σ₂ (ns+1) obs nt ∗ P)) ⊢
     WP e @ s ; E {{ v, P ={E}=∗ Φ v }} -∗
     WP e @ s ; E {{ Φ }} := by
-  simp only [IProp.ext wp_unfold]
+  simp only [wp_unfold.to_eq]
   iintro Hupd Hwp
   simp only [wp.pre, h]
   iintro %σ₁ %ns %obs %obs' %nt Hσ₁
@@ -320,7 +320,7 @@ theorem wp_credit_access {s : Stuckness} {E : CoPset} {e : Expr} {Φ} {P: IProp 
   imod Hwp $$ Hσ₁ with ⟨$,Hwp⟩
   imodintro
   iintro %e₂ %σ₂ %efs %Hstep Hc
-  simp only [IProp.ext lc_split]
+  simp only [lc_split.to_eq]
   icases Hc with ⟨Hc,Hone⟩
   ihave Hc := lc_weaken _ (Htri m k) $$ Hc
   icases lc_split $$ Hc with ⟨Hm, Hk⟩
@@ -355,7 +355,7 @@ theorem wp_step_fupdN_strong {s : Stuckness} {E1 E2 : CoPset} {e : Expr} {P : IP
     imod Hp
     iapply H $$ Hp
   | n+1 =>
-    simp only [IProp.ext wp_unfold]
+    simp only [wp_unfold.to_eq]
     simp only [wp.pre, toVal_e]
     iintro H %σ₁ %ns %obs %obs' %nt Hσ₁
     by_cases Hn : n ≤ ι.numLatersPerStep ns
@@ -397,14 +397,14 @@ theorem wp_bind (K : Expr → Expr) [κ : Language.Context K] {s : Stuckness} {E
     WP e @ s ; E {{v, WP (K (↑v : Val)) @ s ; E {{ Φ }} }} ⊢ WP (K e) @ s ; E {{ Φ }} := by
   iintro H
   iloeb as IH generalizing %E %e %Φ
-  rewrite (occs := [2]) [IProp.ext wp_unfold]
+  rewrite (occs := [2]) [wp_unfold.to_eq]
   simp only [wp.pre]
   match h : toVal e with
   | some v =>
     simp only [ToVal.coe_of_toVal_eq_some h]
     iapply fupd_wp $$ H
   | none =>
-    rw [IProp.ext wp_unfold]
+    rw [wp_unfold.to_eq]
     simp only [wp.pre, κ.toVal_eq_none_fill h, Nat.repeat]
     iintro %σ₁ %step %obs %obs' %n Hσ
     imod H $$ [$] with ⟨%_, H⟩
@@ -423,14 +423,14 @@ theorem wp_bind_inv (K : Expr → Expr) [κ : Language.Context K] {s : Stuckness
     WP (K e) @ s ; E {{ Φ }} ⊢ WP e @ s ; E {{v, WP (K (↑v : Val)) @ s ; E {{ Φ }} }} := by
   iintro H
   iloeb as IH generalizing %E %e %Φ
-  rewrite (occs := [3]) [IProp.ext wp_unfold]
+  rewrite (occs := [3]) [wp_unfold.to_eq]
   simp only [wp.pre]
   match h : toVal e with
   | some v =>
     simp only [ToVal.coe_of_toVal_eq_some h]
     iapply fupd_wp $$ H
   | none =>
-    rewrite (occs := [2]) [IProp.ext wp_unfold]
+    rewrite (occs := [2]) [wp_unfold.to_eq]
     simp only [wp.pre, κ.toVal_eq_none_fill h, Nat.repeat]
     iintro %σ₁ %step %obs %obs' %n Hσ
     imod H $$ [$] with ⟨%_, H⟩


### PR DESCRIPTION
This PR allows to use `x.to_eq` instead of `eq_of_eqv x` and `eq_of_eqv <| equiv_iff.mpr x`, cleaning up some code and in general making it nicer to use Leibniz equality.