### PR TITLE
feat: finish GenHeap

### DIFF
--- a/Iris/Iris/BI/Lib/GenHeap.lean
+++ b/Iris/Iris/BI/Lib/GenHeap.lean
@@ -70,7 +70,7 @@ section definitions
 variable {GF : BundledGFunctors} {L V : Type _}
 variable {H : outParam <| Type _ → Type _} [Std.LawfulFiniteMap H L]
 variable {F : outParam (Type _)} [UFraction F]
-variable [genHeapGS F L V GF H]
+variable [G : genHeapGS F L V GF H]
 
 open Std.FiniteMap Std.PartialMap genHeapGS
 
@@ -155,13 +155,34 @@ theorem pointsTo_combine :
   iintro ⟨H₁, H₂⟩
   iapply ghost_map_elem_combine $$ H₁ H₂
 
--- TODO: pointsto_frac_ne
--- TODO: pointsto_ne
--- TODO: pointsto_persist
--- TODO: pointsto_unpersist
+@[rocq_alias pointsto_frac_ne]
+theorem pointsTo_frac_ne {l₁ l₂ : L} {dq₁ dq₂ : DFrac F} {v₁ v₂ : V}
+    (Hk : ¬ ✓ (dq₁ • dq₂)) :
+    ⊢@{IProp GF} (l₁ ↦{dq₁} v₁) -∗ (l₂ ↦{dq₂} v₂) -∗ ⌜l₁ ≠ l₂⌝ := by
+  unfold pointsTo
+  iapply ghost_map_elem_frac_ne (Hk := Hk)
+
+@[rocq_alias pointsto_ne]
+theorem pointsTo_ne {l₁ l₂ : L} {dq₂ : DFrac F} {v₁ v₂ : V} :
+    ⊢@{IProp GF} (l₁ ↦ v₁) -∗ (l₂ ↦{dq₂} v₂) -∗ ⌜l₁ ≠ l₂⌝ := by
+  unfold pointsTo
+  iapply ghost_map_elem_ne
+
+/-- Permanently turn any points-to predicate into a persistent points-to. -/
+@[rocq_alias pointsto_persist]
+theorem pointsTo_persist {l : L} {dq : DFrac F} {v : V} :
+    ⊢@{IProp GF} (l ↦{dq} v) ==∗ (l ↦{.discard} v) := by
+  unfold pointsTo
+  iapply ghost_map_elem_persist
+
+/-- Recover fractional ownership of a read-only element. -/
+@[rocq_alias pointsto_unpersist]
+theorem pointsTo_unpersist [IsHalfFraction F] {l : L} {v : V} :
+    ⊢@{IProp GF} (l ↦{.discard} v) ==∗ ∃ q, (l ↦{.own q} v) := by
+  unfold pointsTo
+  iapply ghost_map_elem_unpersist
 
 /-! ### General properties of `metaInfo` and `metaToken` -/
-
 
 @[rocq_alias meta_token_timeless]
 instance instTimelessMetaToken (l : L) (E : CoPset) :
@@ -245,13 +266,22 @@ instance instCombineSepGivesMetaToken (l : L) (E1 E2 : CoPset) :
     icases metaToken_valid_2 $$ H1 H2 with %H
     itrivial
 
--- TODO: meta_token_ne
+@[rocq_alias meta_token_ne]
+theorem metaToken_ne {l₁ l₂ : L} {E : CoPset} (HE : E ≠ ∅) :
+    metaToken (GF := GF) l₁ ⊤ -∗ metaToken l₂ E -∗ ⌜l₁ ≠ l₂⌝ := by
+  iintro H1 H2
+  iintro %heq; subst heq
+  icases metaToken_valid_2 $$ H1 H2 with %Hdisj
+  have hE : E = ∅ := by
+    ext p
+    exact ⟨fun hp => (Hdisj p ⟨CoPset.mem_full, hp⟩).elim, fun hp => (CoPset.mem_empty hp).elim⟩
+  exact (HE hE).elim
 
 @[rocq_alias meta_token_difference]
 theorem metaToken_difference {l : L} {E1 E2 : CoPset} (he : E1 ⊆ E2) :
     metaToken (GF := GF) l E2 ⊣⊢ metaToken l E1 ∗ metaToken l (E2 \ E1) := by
-  have heq : E1 ∪ (E2 \ E1) = E2 := Iris.Std.LawfulSet.subset_union_diff he
-  refine .trans (.of_eq ?_) (metaToken_union (l := l) Iris.Std.LawfulSet.disjoint_diff_right)
+  have heq : E1 ∪ (E2 \ E1) = E2 := Std.LawfulSet.subset_union_diff he
+  refine .trans (.of_eq ?_) (metaToken_union (l := l) Std.LawfulSet.disjoint_diff_right)
   rw [heq]
 
 @[rocq_alias meta_agree]
@@ -283,8 +313,52 @@ theorem meta_set {A : Type _} [Pos.Countable A] {l : L} {E : CoPset} {N : Namesp
   iexists γm
   iframe Hγm Hm
 
--- TODO meta_meta_token_valid
--- TODO meta_meta_token_valid'
+@[rocq_alias meta_meta_token_valid]
+theorem meta_metaToken_valid {A : Type _} [Pos.Countable A] {l : L} {N : Namespace} {x : A}
+    {E : CoPset} :
+    metaInfo (GF := GF) l N x -∗ metaToken l E -∗ ⌜¬ (↑N : CoPset) ⊆ E⌝ := by
+  unfold metaInfo metaToken
+  iintro ⟨%γm1, #Hγm1, Hm1⟩ ⟨%γm2, #Hγm2, Hm2⟩
+  icombine Hγm1 Hγm2 gives ⟨%_, %heq⟩
+  subst heq
+  icombine Hm1 Hm2 gives %Hvalid
+  ipureintro
+  intro hsub
+  have hmem : CoPset.pick (↑N) ∈ E := hsub _ (coPpick_nclose N)
+  have h := ReservationMap.disj_of_valid_data_op_token _ E Hvalid (CoPset.pick (↑N))
+  cases h with
+  | inl hnone =>
+    rw [LawfulPartialMap.get?_singleton_eq rfl] at hnone
+    cases hnone
+  | inr hnin => exact hnin hmem
+
+@[rocq_alias meta_meta_token_valid']
+theorem meta_metaToken_valid' {A : Type _} [Pos.Countable A] {l : L} {N : Namespace} {x : A}
+    {E : CoPset} (he : (↑N : CoPset) ⊆ E) :
+    metaInfo (GF := GF) l N x -∗ metaToken l E -∗ False := by
+  iintro H1 H2
+  icases meta_metaToken_valid $$ H1 H2 with %hnot
+  exact (hnot he).elim
+
+@[rocq_alias combine_sep_gives_meta_meta_token_1]
+instance instCombineSepGivesMetaMetaToken1 {A : Type _} [Pos.Countable A]
+    (l : L) (N : Namespace) (x : A) (E : CoPset) :
+    CombineSepGives (PROP := IProp GF) (metaInfo l N x) (metaToken l E)
+      iprop(⌜¬ (↑N : CoPset) ⊆ E⌝) where
+  combine_sep_gives := by
+    iintro ⟨H1, H2⟩
+    icases meta_metaToken_valid $$ H1 H2 with %H
+    itrivial
+
+@[rocq_alias combine_sep_gives_meta_meta_token_2]
+instance instCombineSepGivesMetaMetaToken2 {A : Type _} [Pos.Countable A]
+    (l : L) (N : Namespace) (x : A) (E : CoPset) :
+    CombineSepGives (PROP := IProp GF) (metaToken l E) (metaInfo l N x)
+      iprop(⌜¬ (↑N : CoPset) ⊆ E⌝) where
+  combine_sep_gives := by
+    iintro ⟨H1, H2⟩
+    icases meta_metaToken_valid $$ H2 H1 with %H
+    itrivial
 
 /-! ### Update lemmas -/
 
@@ -326,7 +400,80 @@ theorem genHeap_alloc {σ : H V} {l : L} {v : V} (Hσl : get? σ l = .none) :
     · iexists γm
       iframe Hlm Hγm
 
--- TODO: gen_heap_alloc_big
+/-- `genHeapInterp` is monotone under map equivalence. -/
+private theorem genHeapInterp_eqv [DecidableEq L] {σ₁ σ₂ : H V}
+    (h : σ₁ ≡ₘ σ₂) : genHeapInterp (GF := GF) σ₁ ⊢ genHeapInterp σ₂ := by
+  unfold genHeapInterp
+  refine BI.exists_mono (fun m => ?_)
+  refine BI.sep_mono ?_ (BI.sep_mono ?_ BIBase.Entails.rfl)
+  · refine BI.pure_mono ?_
+    intro H k hk
+    simp only [dom] at hk ⊢; rw [← h k]; exact H k hk
+  · refine iOwn_mono (HeapView.auth_inc_of_pmap_eqv _ ?_)
+    exact LawfulPartialMap.map_equiv h.symm
+
+@[rocq_alias gen_heap_alloc_big]
+theorem genHeap_alloc_big [DecidableEq L] (σ' σ : H V) (Hdisj : σ' ##ₘ σ) :
+    genHeapInterp σ ⊢ |==>
+      (genHeapInterp (σ' ∪ σ) ∗ ([∗map] l↦v ∈ σ', l ↦ v) ∗
+        ([∗map] l↦_v ∈ σ', metaToken l ⊤)) := by
+  revert σ Hdisj
+  induction σ' using LawfulFiniteMap.induction_on with
+  | hequiv σ₁ σ₂ heqv IH =>
+    intro σ Hdisj
+    have Hdisj₁ : σ₁ ##ₘ σ := by
+      intro k ⟨h1, h2⟩
+      exact Hdisj k ⟨by rw [← heqv k]; exact h1, h2⟩
+    have heqv_union : (σ₁ ∪ σ) ≡ₘ (σ₂ ∪ σ) :=
+      LawfulPartialMap.union_equiv heqv Std.PartialMap.equiv.refl
+    refine (IH σ Hdisj₁).trans ?_
+    refine bupd_mono (PROP := IProp GF) ?_
+    refine BI.sep_mono (genHeapInterp_eqv heqv_union) ?_
+    refine BI.sep_mono
+      ((BigSepM.bigSepM_eqv_of_perm (Φ := fun l v => iprop(l ↦ v)) heqv).1) ?_
+    exact (BigSepM.bigSepM_eqv_of_perm
+      (Φ := fun l (_v : V) => iprop(metaToken l ⊤)) heqv).1
+  | hemp =>
+    intro σ _
+    iintro Hσ
+    iapply (bupd_intro (PROP := IProp GF))
+    isplitl [Hσ]
+    · iapply genHeapInterp_eqv (σ₁ := σ) (σ₂ := ∅ ∪ σ)
+        LawfulPartialMap.union_empty_left.symm
+      iexact Hσ
+    · isplitr
+      · iapply BigSepM.bigSepM_empty.mpr; itrivial
+      · iapply BigSepM.bigSepM_empty.mpr; itrivial
+  | hins l v σ' Hl IH =>
+    intro σ Hdisj
+    have Hdisj' : σ' ##ₘ σ := by
+      intro k ⟨h1, h2⟩
+      apply Hdisj k
+      refine ⟨?_, h2⟩
+      by_cases hkl : l = k
+      · subst hkl; rw [LawfulPartialMap.get?_insert_eq rfl]; simp
+      · rw [LawfulPartialMap.get?_insert_ne hkl]; exact h1
+    have Hσl : get? σ l = none := by
+      rcases hσl : get? σ l with _ | w
+      · rfl
+      · exfalso; apply Hdisj l
+        refine ⟨?_, by rw [hσl]; simp⟩
+        rw [LawfulPartialMap.get?_insert_eq rfl]; simp
+    have Hunion_l : get? (σ' ∪ σ) l = none :=
+      LawfulPartialMap.get?_union_none.mpr ⟨Hl, Hσl⟩
+    refine (IH σ Hdisj').trans (bupd_mono ?_ |>.trans bupd_trans)
+    iintro ⟨Hinterp, Hpts, Htok⟩
+    imod genHeap_alloc Hunion_l $$ Hinterp with ⟨Hinterp', Hl_pts, Hl_tok⟩
+    imodintro
+    isplitl [Hinterp']
+    · iapply (genHeapInterp_eqv (σ₁ := insert (σ' ∪ σ) l v)
+        (σ₂ := insert σ' l v ∪ σ) LawfulPartialMap.union_insert_left)
+      iexact Hinterp'
+    · isplitl [Hl_pts Hpts]
+      · iapply (BigSepM.bigSepM_insert Hl).mpr
+        iframe Hl_pts Hpts
+      · iapply (BigSepM.bigSepM_insert Hl).mpr
+        iframe Hl_tok Htok
 
 @[rocq_alias gen_heap_valid]
 theorem genHeap_valid {σ : H V} {l : L} {dq : DFrac F} {v : V} :
@@ -360,5 +507,71 @@ theorem genHeap_update {σ : H V} {l : L} {v₁ v₂ : V} :
 end updateLemmas
 
 end lemmas
+
+/-! ### Initialization lemmas
+
+These build a fresh `genHeapGS` from a `genHeapPreS` and an initial heap.
+-/
+
+section init
+
+variable {F : Type _} [UFraction F] {GF : BundledGFunctors}
+variable {L V : Type _} {H : Type _ → Type _} [Std.LawfulFiniteMap H L]
+
+open Std.PartialMap Std.FiniteMap
+
+/-- Initialize `genHeapGS` with explicit ghost names.  The names of the heap
+and the meta-data tables are exposed in the conclusion. -/
+@[rocq_alias gen_heap_init_names]
+theorem genHeap_init_names [DecidableEq L] [genHeapPreS F L V GF H] (σ : H V) :
+    ⊢@{IProp GF} |==> ∃ γh γm : GName,
+      genHeapInterp (G := (⟨γh, γm⟩ : genHeapGS F L V GF H)) σ ∗
+      ([∗map] l ↦ v ∈ σ,
+        pointsTo (G := (⟨γh, γm⟩ : genHeapGS F L V GF H)) l (.own 1) v) ∗
+      ([∗map] l ↦ _v ∈ σ,
+        metaToken (G := (⟨γh, γm⟩ : genHeapGS F L V GF H)) l ⊤) := by
+  imod (ghost_map_alloc_empty (K := L) (V := V)) with ⟨%γh, Hh⟩
+  imod (ghost_map_alloc_empty (K := L) (V := GName)) with ⟨%γm, Hm⟩
+  letI G : genHeapGS F L V GF H := ⟨γh, γm⟩
+  -- Build `genHeapInterp ∅` from the empty ghost maps.
+  have Hinterp_empty : (γh ↪●MAP (∅ : H V)) ∗ (γm ↪●MAP (∅ : H GName)) ⊢@{IProp GF}
+      genHeapInterp (G := G) ∅ := by
+    unfold genHeapInterp
+    iintro ⟨Hh, Hm⟩
+    iexists (∅ : H GName)
+    isplitr
+    · ipureintro
+      intro k hk
+      simp only [dom, Std.LawfulPartialMap.get?_empty] at hk
+      exact Bool.false_ne_true (Option.isSome_none.symm.trans hk) |>.elim
+    iframe Hh Hm
+  ihave Hinterp0 : genHeapInterp (G := G) ∅ $$ [Hh Hm]
+  · iapply Hinterp_empty
+    iframe Hh Hm
+  imod (genHeap_alloc_big σ ∅
+    (Std.LawfulPartialMap.disjoint_empty_right σ)) $$ Hinterp0
+    with ⟨Hinterp, Hpts, Htok⟩
+  imodintro
+  iexists γh, γm
+  isplitl [Hinterp]
+  · iapply (genHeapInterp_eqv (σ₁ := σ ∪ ∅) (σ₂ := σ)
+      Std.LawfulPartialMap.union_empty_right)
+    iexact Hinterp
+  iframe Hpts Htok
+
+/-- Initialize `genHeapGS` from a `genHeapPreS`, hiding the freshly allocated
+ghost names. -/
+@[rocq_alias gen_heap_init]
+theorem genHeap_init [DecidableEq L] [genHeapPreS F L V GF H] (σ : H V) :
+    ⊢@{IProp GF} |==> ∃ G : genHeapGS F L V GF H,
+      genHeapInterp (G := G) σ ∗
+      ([∗map] l ↦ v ∈ σ, pointsTo (G := G) l (.own 1) v) ∗
+      ([∗map] l ↦ _v ∈ σ, metaToken (G := G) l ⊤) := by
+  imod genHeap_init_names σ with ⟨%γh, %γm, H⟩
+  imodintro
+  iexists (⟨γh, γm⟩ : genHeapGS F L V GF H)
+  iexact H
+
+end init
 
 end Iris

--- a/Iris/Iris/BI/Lib/GenHeap.lean
+++ b/Iris/Iris/BI/Lib/GenHeap.lean
@@ -47,11 +47,11 @@ variable (F : outParam (Type _)) [UFraction F]
 class genHeapPreS (L V : Type _) (GF : BundledGFunctors) (H : outParam <| Type _ → Type _)
     [Std.LawfulFiniteMap H L] where
   heap : GhostMapG GF F L V H
-  «meta» : GhostMapG GF F L GName H
+  metaInfo : GhostMapG GF F L GName H
   metaData : ElemG GF (constOF MetaUR)
 
 attribute [reducible, instance] genHeapPreS.heap
-attribute [reducible, instance] genHeapPreS.«meta»
+attribute [reducible, instance] genHeapPreS.metaInfo
 attribute [reducible, instance] genHeapPreS.metaData
 attribute [instance] GhostMapG.elem
 
@@ -217,8 +217,7 @@ theorem metaToken_union_1 {l : L} {E1 E2 : CoPset} (he : E1 ## E2) :
       iOwn (E := genHeapPreS.metaData (L := L) (V := V)) γm (ReservationMap.mkToken E1) ∗
       iOwn (E := genHeapPreS.metaData (L := L) (V := V)) γm (ReservationMap.mkToken E2)) $$ [Hm]
   · iapply iOwn_op.mp
-    iapply (BI.equiv_iff.mp (iOwn_ne.eqv (ReservationMap.token_union he))).mp
-    iexact Hm
+    iapply (BI.equiv_iff.mp (iOwn_ne.eqv (ReservationMap.token_union he))).mp $$ [$]
   isplitl [Hm1]
   · iexists γm
     iframe Hγm Hm1
@@ -375,42 +374,41 @@ theorem genHeap_alloc {σ : H V} {l : L} {v : V} (Hσl : get? σ l = .none) :
   have Hml : get? m l = .none := by
     rcases h : get? m l with _ | _
     · rfl
-    · exfalso
-      have : dom m l := by simp [dom, h]
-      have := Hdom l this
-      simp [dom, Hσl] at this
+    · specialize Hdom l
+      simp [dom, Hσl, h] at Hdom
   imod ghost_map_insert_persist l γm Hml $$ Hm with ⟨Hm, Hlm⟩
   imodintro
   isplitl [Hσ Hm]
   · iexists (insert m l γm)
-    isplitr
-    · ipureintro
-      intro k hk
-      simp only [dom] at hk ⊢
-      by_cases hkl : k = l
-      · subst hkl
-        rw [LawfulPartialMap.get?_insert_eq rfl]
-        rfl
-      · rw [LawfulPartialMap.get?_insert_ne (Ne.symm hkl)] at hk
-        rw [LawfulPartialMap.get?_insert_ne (Ne.symm hkl)]
-        exact Hdom k hk
-    · iframe
-  · isplitl [Hl]
-    · iframe
-    · iexists γm
-      iframe Hlm Hγm
+    iframe
+    ipureintro
+    intro k hk
+    simp only [dom] at hk ⊢
+    by_cases hkl : k = l
+    · subst hkl
+      rw [LawfulPartialMap.get?_insert_eq rfl]
+      rfl
+    · rw [LawfulPartialMap.get?_insert_ne (Ne.symm hkl)] at hk
+      rw [LawfulPartialMap.get?_insert_ne (Ne.symm hkl)]
+      exact Hdom k hk
+  · iframe
+    iexists γm
+    iframe Hlm Hγm
 
-/-- `genHeapInterp` is monotone under map equivalence. -/
-private theorem genHeapInterp_eqv [DecidableEq L] {σ₁ σ₂ : H V}
-    (h : σ₁ ≡ₘ σ₂) : genHeapInterp (GF := GF) σ₁ ⊢ genHeapInterp σ₂ := by
+/-- The state interpretation respects pointwise equivalence of the value
+heap. -/
+private theorem genHeapInterp_eqv {σ₁ σ₂ : H V} (h : σ₁ ≡ₘ σ₂) :
+    genHeapInterp (GF := GF) σ₁ ⊢ genHeapInterp σ₂ := by
   unfold genHeapInterp
-  refine BI.exists_mono (fun m => ?_)
-  refine BI.sep_mono ?_ (BI.sep_mono ?_ BIBase.Entails.rfl)
-  · refine BI.pure_mono ?_
-    intro H k hk
-    simp only [dom] at hk ⊢; rw [← h k]; exact H k hk
-  · refine iOwn_mono (HeapView.auth_inc_of_pmap_eqv _ ?_)
-    exact LawfulPartialMap.map_equiv h.symm
+  iintro ⟨%m, %Hdom, Hh, Hm⟩
+  iexists m
+  isplitr
+  · ipureintro
+    intro k hk
+    unfold dom; rw [← h k]
+    exact Hdom k hk
+  refine sep_mono_left ?_
+  exact iOwn_mono (HeapView.auth_inc_of_pmap_eqv _ (LawfulPartialMap.map_equiv h.symm))
 
 @[rocq_alias gen_heap_alloc_big]
 theorem genHeap_alloc_big [DecidableEq L] (σ' σ : H V) (Hdisj : σ' ##ₘ σ) :
@@ -421,59 +419,50 @@ theorem genHeap_alloc_big [DecidableEq L] (σ' σ : H V) (Hdisj : σ' ##ₘ σ) 
   induction σ' using LawfulFiniteMap.induction_on with
   | hequiv σ₁ σ₂ heqv IH =>
     intro σ Hdisj
-    have Hdisj₁ : σ₁ ##ₘ σ := by
-      intro k ⟨h1, h2⟩
-      exact Hdisj k ⟨by rw [← heqv k]; exact h1, h2⟩
-    have heqv_union : (σ₁ ∪ σ) ≡ₘ (σ₂ ∪ σ) :=
-      LawfulPartialMap.union_equiv heqv Std.PartialMap.equiv.refl
-    refine (IH σ Hdisj₁).trans ?_
-    refine bupd_mono (PROP := IProp GF) ?_
-    refine BI.sep_mono (genHeapInterp_eqv heqv_union) ?_
-    refine BI.sep_mono
-      ((BigSepM.bigSepM_eqv_of_perm (Φ := fun l v => iprop(l ↦ v)) heqv).1) ?_
-    exact (BigSepM.bigSepM_eqv_of_perm
-      (Φ := fun l (_v : V) => iprop(metaToken l ⊤)) heqv).1
+    have Hdisj₁ : σ₁ ##ₘ σ := fun k ⟨h1, h2⟩ => Hdisj k ⟨by rw [← heqv k]; exact h1, h2⟩
+    have hUnion : (σ₁ ∪ σ) ≡ₘ (σ₂ ∪ σ) := LawfulPartialMap.union_equiv heqv Std.PartialMap.equiv.refl
+    iintro Hσ
+    imod IH σ Hdisj₁ $$ Hσ with ⟨Hint, Hpts, Htok⟩
+    imodintro
+    isplitl [Hint]
+    · iapply genHeapInterp_eqv hUnion; iexact Hint
+    isplitl [Hpts]
+    · iapply (BigSepM.bigSepM_eqv_of_perm (Φ := fun l v => iprop(l ↦ v)) heqv).mp
+      iexact Hpts
+    iapply (BigSepM.bigSepM_eqv_of_perm (Φ := fun l _ => iprop(metaToken l ⊤)) heqv).mp
+    iexact Htok
   | hemp =>
     intro σ _
     iintro Hσ
-    iapply (bupd_intro (PROP := IProp GF))
-    isplitl [Hσ]
-    · iapply genHeapInterp_eqv (σ₁ := σ) (σ₂ := ∅ ∪ σ)
-        LawfulPartialMap.union_empty_left.symm
-      iexact Hσ
-    · isplitr
-      · iapply BigSepM.bigSepM_empty.mpr; itrivial
-      · iapply BigSepM.bigSepM_empty.mpr; itrivial
-  | hins l v σ' Hl IH =>
-    intro σ Hdisj
-    have Hdisj' : σ' ##ₘ σ := by
-      intro k ⟨h1, h2⟩
-      apply Hdisj k
-      refine ⟨?_, h2⟩
-      by_cases hkl : l = k
-      · subst hkl; rw [LawfulPartialMap.get?_insert_eq rfl]; simp
-      · rw [LawfulPartialMap.get?_insert_ne hkl]; exact h1
-    have Hσl : get? σ l = none := by
-      rcases hσl : get? σ l with _ | w
-      · rfl
-      · exfalso; apply Hdisj l
-        refine ⟨?_, by rw [hσl]; simp⟩
-        rw [LawfulPartialMap.get?_insert_eq rfl]; simp
-    have Hunion_l : get? (σ' ∪ σ) l = none :=
-      LawfulPartialMap.get?_union_none.mpr ⟨Hl, Hσl⟩
-    refine (IH σ Hdisj').trans (bupd_mono ?_ |>.trans bupd_trans)
-    iintro ⟨Hinterp, Hpts, Htok⟩
-    imod genHeap_alloc Hunion_l $$ Hinterp with ⟨Hinterp', Hl_pts, Hl_tok⟩
     imodintro
-    isplitl [Hinterp']
-    · iapply (genHeapInterp_eqv (σ₁ := insert (σ' ∪ σ) l v)
-        (σ₂ := insert σ' l v ∪ σ) LawfulPartialMap.union_insert_left)
-      iexact Hinterp'
-    · isplitl [Hl_pts Hpts]
-      · iapply (BigSepM.bigSepM_insert Hl).mpr
-        iframe Hl_pts Hpts
-      · iapply (BigSepM.bigSepM_insert Hl).mpr
-        iframe Hl_tok Htok
+    isplitl [Hσ]
+    · iapply genHeapInterp_eqv LawfulPartialMap.union_empty_left.symm
+      iexact Hσ
+    isplit <;> · iapply BigSepM.bigSepM_empty.mpr; itrivial
+  | hins l v σ'' Hl IH =>
+    intro σ Hdisj
+    have Hσl : get? σ l = .none := by
+      rcases h : get? σ l with _ | w
+      · rfl
+      · exact absurd
+          (Hdisj l ⟨by simp [LawfulPartialMap.get?_insert_eq rfl], by rw [h]; simp⟩) id
+    have Hdisj' : σ'' ##ₘ σ := fun k ⟨h1, h2⟩ => Hdisj k ⟨by
+      by_cases hkl : l = k
+      · subst hkl; simp [Hl] at h1
+      · rw [LawfulPartialMap.get?_insert_ne hkl]; exact h1, h2⟩
+    have Hunion_l : get? (σ'' ∪ σ) l = .none := LawfulPartialMap.get?_union_none.mpr ⟨Hl, Hσl⟩
+    iintro Hσ
+    imod IH σ Hdisj' $$ Hσ with ⟨Hint, Hpts, Htok⟩
+    imod genHeap_alloc Hunion_l $$ Hint with ⟨Hint', Hl_pts, Hl_tok⟩
+    imodintro
+    isplitl [Hint']
+    · iapply genHeapInterp_eqv LawfulPartialMap.union_insert_left
+      iexact Hint'
+    isplitl [Hl_pts Hpts]
+    · iapply (BigSepM.bigSepM_insert Hl).mpr
+      iframe Hl_pts Hpts
+    iapply (BigSepM.bigSepM_insert (Φ := fun l _ => iprop(metaToken l ⊤)) Hl).mpr
+    iframe Hl_tok Htok
 
 @[rocq_alias gen_heap_valid]
 theorem genHeap_valid {σ : H V} {l : L} {dq : DFrac F} {v : V} :
@@ -489,20 +478,18 @@ theorem genHeap_update {σ : H V} {l : L} {v₁ v₂ : V} :
   iintro ⟨⟨%m, %Hdom, Hσ, Hm⟩, Hl⟩
   imod ghost_map_update l v₁ v₂ $$ Hσ Hl with ⟨Hσ, Hl⟩
   imodintro
-  isplitl [Hσ Hm]
-  · iexists m
-    isplitr
-    · ipureintro
-      intro k hk
-      simp only [dom] at hk ⊢
-      by_cases hkl : k = l
-      · subst hkl
-        rw [LawfulPartialMap.get?_insert_eq rfl]
-        rfl
-      · rw [LawfulPartialMap.get?_insert_ne (Ne.symm hkl)]
-        exact Hdom k hk
-    · iframe
-  · iframe
+  iframe
+  iexists m
+  iframe
+  ipureintro
+  intro k hk
+  simp only [dom] at hk ⊢
+  by_cases hkl : k = l
+  · subst hkl
+    rw [LawfulPartialMap.get?_insert_eq rfl]
+    rfl
+  · rw [LawfulPartialMap.get?_insert_ne (Ne.symm hkl)]
+    exact Hdom k hk
 
 end updateLemmas
 
@@ -533,7 +520,6 @@ theorem genHeap_init_names [DecidableEq L] [genHeapPreS F L V GF H] (σ : H V) :
   imod (ghost_map_alloc_empty (K := L) (V := V)) with ⟨%γh, Hh⟩
   imod (ghost_map_alloc_empty (K := L) (V := GName)) with ⟨%γm, Hm⟩
   letI G : genHeapGS F L V GF H := ⟨γh, γm⟩
-  -- Build `genHeapInterp ∅` from the empty ghost maps.
   have Hinterp_empty : (γh ↪●MAP (∅ : H V)) ∗ (γm ↪●MAP (∅ : H GName)) ⊢@{IProp GF}
       genHeapInterp (G := G) ∅ := by
     unfold genHeapInterp
@@ -541,23 +527,20 @@ theorem genHeap_init_names [DecidableEq L] [genHeapPreS F L V GF H] (σ : H V) :
     iexists (∅ : H GName)
     isplitr
     · ipureintro
-      intro k hk
-      simp only [dom, Std.LawfulPartialMap.get?_empty] at hk
-      exact Bool.false_ne_true (Option.isSome_none.symm.trans hk) |>.elim
+      simp only [dom, Std.LawfulPartialMap.get?_empty]
+      grind
     iframe Hh Hm
   ihave Hinterp0 : genHeapInterp (G := G) ∅ $$ [Hh Hm]
   · iapply Hinterp_empty
-    iframe Hh Hm
+    iframe
   imod (genHeap_alloc_big σ ∅
     (Std.LawfulPartialMap.disjoint_empty_right σ)) $$ Hinterp0
     with ⟨Hinterp, Hpts, Htok⟩
   imodintro
   iexists γh, γm
-  isplitl [Hinterp]
-  · iapply (genHeapInterp_eqv (σ₁ := σ ∪ ∅) (σ₂ := σ)
-      Std.LawfulPartialMap.union_empty_right)
-    iexact Hinterp
-  iframe Hpts Htok
+  iframe
+  iapply genHeapInterp_eqv LawfulPartialMap.union_empty_right
+  iexact Hinterp
 
 /-- Initialize `genHeapGS` from a `genHeapPreS`, hiding the freshly allocated
 ghost names. -/

--- a/Iris/Iris/BI/Lib/GenHeap.lean
+++ b/Iris/Iris/BI/Lib/GenHeap.lean
@@ -213,11 +213,11 @@ theorem metaToken_union_1 {l : L} {E1 E2 : CoPset} (he : E1 ## E2) :
     metaToken (GF := GF) l (E1 ∪ E2) ⊢ metaToken l E1 ∗ metaToken l E2 := by
   unfold metaToken
   iintro ⟨%γm, #Hγm, Hm⟩
-  ihave ⟨Hm1, Hm2⟩ : iprop(
-      iOwn (E := genHeapPreS.metaData (L := L) (V := V)) γm (ReservationMap.mkToken E1) ∗
-      iOwn (E := genHeapPreS.metaData (L := L) (V := V)) γm (ReservationMap.mkToken E2)) $$ [Hm]
-  · iapply iOwn_op.mp
-    iapply (BI.equiv_iff.mp (iOwn_ne.eqv (ReservationMap.token_union he))).mp $$ [$]
+  -- TODO: ideally, the following should work
+  -- rewrite [(iOwn_ne.eqv (ReservationMap.token_union he)).to_eq, iOwn_op.to_eq]
+  -- One way to do it
+  -- ieval (<lean tactic>) [selector]
+  icases (equiv_iff.mp (iOwn_ne.eqv (ReservationMap.token_union he))).mp $$ Hm with ⟨Hm1, Hm2⟩
   isplitl [Hm1]
   · iexists γm
     iframe Hγm Hm1
@@ -235,8 +235,8 @@ theorem metaToken_union_2 {l : L} {E1 E2 : CoPset} :
   have hdisj : E1 ## E2 := ReservationMap.valid_token_op_iff_disj.mp Hvalid
   iexists γm1
   iframe Hγm1
-  iapply (BI.equiv_iff.mp (iOwn_ne.eqv (ReservationMap.token_union hdisj))).mpr
-  iapply iOwn_op.mpr
+  iapply (equiv_iff.mp (iOwn_ne.eqv (ReservationMap.token_union hdisj))).mpr
+  iapply iOwn_op
   iframe
 
 @[rocq_alias meta_token_union]
@@ -271,16 +271,16 @@ theorem metaToken_ne {l₁ l₂ : L} {E : CoPset} (HE : E ≠ ∅) :
   iintro H1 H2
   iintro %heq; subst heq
   icases metaToken_valid_2 $$ H1 H2 with %Hdisj
-  have hE : E = ∅ := by
-    ext p
-    exact ⟨fun hp => (Hdisj p ⟨CoPset.mem_full, hp⟩).elim, fun hp => (CoPset.mem_empty hp).elim⟩
-  exact (HE hE).elim
+  ipureintro
+  refine HE ?_
+  ext p
+  exact ⟨fun hp => (Hdisj p ⟨CoPset.mem_full, hp⟩).elim, fun hp => (CoPset.mem_empty hp).elim⟩
 
 @[rocq_alias meta_token_difference]
 theorem metaToken_difference {l : L} {E1 E2 : CoPset} (he : E1 ⊆ E2) :
     metaToken (GF := GF) l E2 ⊣⊢ metaToken l E1 ∗ metaToken l (E2 \ E1) := by
-  have heq : E1 ∪ (E2 \ E1) = E2 := Std.LawfulSet.subset_union_diff he
-  refine .trans (.of_eq ?_) (metaToken_union (l := l) Std.LawfulSet.disjoint_diff_right)
+  have heq : E1 ∪ (E2 \ E1) = E2 := LawfulSet.subset_union_diff he
+  refine .trans (.of_eq ?_) (metaToken_union (l := l) LawfulSet.disjoint_diff_right)
   rw [heq]
 
 @[rocq_alias meta_agree]
@@ -292,14 +292,9 @@ theorem meta_agree {A : Type _} [Pos.Countable A] {l : L} {N : Namespace} {x1 x2
   subst Heq
   icombine Hm1 Hm2 gives %Hvalid
   ipureintro
-  have hop : ✓ ReservationMap.singleton (H := MetaResMap) (CoPset.pick (↑N))
-      ((toAgree ⟨Pos.Countable.encode x1⟩ : Agree (LeibnizO Pos)) •
-        (toAgree ⟨Pos.Countable.encode x2⟩ : Agree (LeibnizO Pos))) :=
-    (OFE.Equiv.valid (ReservationMap.singleton_op _ _ _)).mpr Hvalid
-  rw [ReservationMap.valid_singleton] at hop
-  have hag : (⟨Pos.Countable.encode x1⟩ : LeibnizO Pos) = ⟨Pos.Countable.encode x2⟩ :=
-    toAgree_op_valid_iff_eq.mp hop
-  exact Pos.encode_inj (congrArg LeibnizO.car hag)
+  rw [valid_iff (ReservationMap.singleton_op _ _ _).symm
+    , ReservationMap.valid_singleton, toAgree_op_valid_iff_eq] at Hvalid
+  exact Pos.encode_inj (LeibnizO.eqv_inj Hvalid)
 
 @[rocq_alias meta_set]
 theorem meta_set {A : Type _} [Pos.Countable A] {l : L} {E : CoPset} {N : Namespace} (x : A)
@@ -323,13 +318,11 @@ theorem meta_metaToken_valid {A : Type _} [Pos.Countable A] {l : L} {N : Namespa
   icombine Hm1 Hm2 gives %Hvalid
   ipureintro
   intro hsub
-  have hmem : CoPset.pick (↑N) ∈ E := hsub _ (coPpick_nclose N)
-  have h := ReservationMap.disj_of_valid_data_op_token _ E Hvalid (CoPset.pick (↑N))
-  cases h with
+  cases ReservationMap.disj_of_valid_data_op_token _ E Hvalid (CoPset.pick (↑N)) with
   | inl hnone =>
     rw [LawfulPartialMap.get?_singleton_eq rfl] at hnone
     cases hnone
-  | inr hnin => exact hnin hmem
+  | inr hnin => exact hnin (hsub _ (coPpick_nclose N))
 
 @[rocq_alias meta_meta_token_valid']
 theorem meta_metaToken_valid' {A : Type _} [Pos.Countable A] {l : L} {N : Namespace} {x : A}
@@ -373,8 +366,8 @@ theorem genHeapInterp_eqv {σ₁ σ₂ : H V} (h : σ₁ ≡ₘ σ₂) :
   isplitr
   · ipureintro
     exact fun k hk => by unfold dom; rw [← h k]; exact Hdom k hk
-  refine sep_mono_left ?_
-  exact iOwn_mono (HeapView.auth_inc_of_pmap_eqv _ (LawfulPartialMap.map_equiv h.symm))
+  iframe Hm
+  apply iOwn_mono (HeapView.auth_inc_of_pmap_eqv _ (LawfulPartialMap.map_equiv h.symm))
 
 @[rocq_alias gen_heap_alloc]
 theorem genHeap_alloc [DecidableEq L] {σ : H V} {l : L} {v : V} (Hσl : get? σ l = .none) :
@@ -386,7 +379,7 @@ theorem genHeap_alloc [DecidableEq L] {σ : H V} {l : L} {v : V} (Hσl : get? σ
     · rfl
     · exact absurd (Hdom l (by simp [dom, h])) (by simp [dom, Hσl])
   imod ghost_map_insert l v Hσl $$ Hσ with ⟨Hσ, Hl⟩
-  imod (iOwn_alloc (E := genHeapPreS.metaData (L := L) (V := V))
+  imod (iOwn_alloc (E := genHeapPreS.metaData L V)
     (ReservationMap.mkToken ⊤) ReservationMap.valid_token) with ⟨%γm, Hγm⟩
   imod ghost_map_insert_persist l γm Hml $$ Hm with ⟨Hm, Hlm⟩
   imodintro
@@ -416,19 +409,17 @@ theorem genHeap_alloc_big [DecidableEq L] (σ' σ : H V) (Hdisj : σ' ##ₘ σ) 
     imod IH σ Hdisj₁ $$ Hσ with ⟨Hint, Hpts, Htok⟩
     imodintro
     isplitl [Hint]
-    · iapply genHeapInterp_eqv hUnion; iexact Hint
+    · iapply genHeapInterp_eqv hUnion $$ Hint
     isplitl [Hpts]
-    · iapply (BigSepM.bigSepM_eqv_of_perm (Φ := fun l v => iprop(l ↦ v)) heqv).mp
-      iexact Hpts
-    iapply (BigSepM.bigSepM_eqv_of_perm (Φ := fun l _ => iprop(metaToken l ⊤)) heqv).mp
-    iexact Htok
+    · iapply (BigSepM.bigSepM_eqv_of_perm (Φ := fun l v => iprop(l ↦ v)) heqv) $$ Hpts
+    iapply (BigSepM.bigSepM_eqv_of_perm (Φ := fun l _ => iprop(metaToken l ⊤)) heqv) $$ Htok
   | hemp =>
     intro σ _
     iintro Hσ
     imodintro
     isplitl [Hσ]
-    · iapply genHeapInterp_eqv LawfulPartialMap.union_empty_left.symm; iexact Hσ
-    isplit <;> · iapply BigSepM.bigSepM_empty.mpr; itrivial
+    · iapply genHeapInterp_eqv LawfulPartialMap.union_empty_left.symm $$ Hσ
+    isplit <;> (iapply BigSepM.bigSepM_empty; itrivial)
   | hins l v σ'' Hl IH =>
     intro σ Hdisj
     obtain ⟨Hσl, Hdisj'⟩ := (LawfulPartialMap.disjoint_insert_left_iff Hl).mp Hdisj
@@ -439,11 +430,10 @@ theorem genHeap_alloc_big [DecidableEq L] (σ' σ : H V) (Hdisj : σ' ##ₘ σ) 
     imod genHeap_alloc Hunion_l $$ Hint with ⟨Hint', Hl_pts, Hl_tok⟩
     imodintro
     isplitl [Hint']
-    · iapply genHeapInterp_eqv LawfulPartialMap.union_insert_left; iexact Hint'
+    · iapply genHeapInterp_eqv LawfulPartialMap.union_insert_left $$ Hint'
     isplitl [Hl_pts Hpts]
-    · iapply (BigSepM.bigSepM_insert Hl).mpr; iframe Hl_pts Hpts
-    iapply (BigSepM.bigSepM_insert (Φ := fun l _ => iprop(metaToken l ⊤)) Hl).mpr
-    iframe Hl_tok Htok
+    · iapply (BigSepM.bigSepM_insert Hl) $$ [$Hpts $Hl_pts]
+    iapply (BigSepM.bigSepM_insert (Φ := fun l _ => iprop(metaToken l ⊤)) Hl) $$ [$Hl_tok $Htok]
 
 @[rocq_alias gen_heap_valid]
 theorem genHeap_valid {σ : H V} {l : L} {dq : DFrac F} {v : V} :
@@ -463,7 +453,7 @@ theorem genHeap_update [DecidableEq L] {σ : H V} {l : L} {v₁ v₂ : V} :
   iexists m
   iframe
   ipureintro
-  exact fun k hk => LawfulPartialMap.dom_insert_iff.mpr (Or.inr (Hdom k hk))
+  exact fun k hk => LawfulPartialMap.dom_insert_iff.mpr (.inr (Hdom k hk))
 
 end updateLemmas
 
@@ -485,7 +475,7 @@ open Std.PartialMap Std.FiniteMap
 and the meta-data tables are exposed in the conclusion. -/
 @[rocq_alias gen_heap_init_names]
 theorem genHeap_init_names [DecidableEq L] [genHeapPreS F L V GF H] (σ : H V) :
-    ⊢@{IProp GF} |==> ∃ γh γm : GName,
+    ⊢ |==> ∃ γh γm : GName,
       genHeapInterp (G := (⟨γh, γm⟩ : genHeapGS F L V GF H)) σ ∗
       ([∗map] l ↦ v ∈ σ,
         pointsTo (G := (⟨γh, γm⟩ : genHeapGS F L V GF H)) l (.own 1) v) ∗
@@ -507,14 +497,13 @@ theorem genHeap_init_names [DecidableEq L] [genHeapPreS F L V GF H] (σ : H V) :
   imodintro
   iexists γh, γm
   iframe Hpts Htok
-  iapply genHeapInterp_eqv LawfulPartialMap.union_empty_right
-  iexact Hinterp
+  iapply genHeapInterp_eqv LawfulPartialMap.union_empty_right $$ Hinterp
 
 /-- Initialize `genHeapGS` from a `genHeapPreS`, hiding the freshly allocated
 ghost names. -/
 @[rocq_alias gen_heap_init]
 theorem genHeap_init [DecidableEq L] [genHeapPreS F L V GF H] (σ : H V) :
-    ⊢@{IProp GF} |==> ∃ G : genHeapGS F L V GF H,
+    ⊢ |==> ∃ G : genHeapGS F L V GF H,
       genHeapInterp (G := G) σ ∗
       ([∗map] l ↦ v ∈ σ, pointsTo (G := G) l (.own 1) v) ∗
       ([∗map] l ↦ _v ∈ σ, metaToken (G := G) l ⊤) := by

--- a/Iris/Iris/BI/Lib/GenHeap.lean
+++ b/Iris/Iris/BI/Lib/GenHeap.lean
@@ -1,98 +1,66 @@
 module
 public import Iris.Algebra
+public import Iris.Algebra.ReservationMap
 public import Iris.BI.Lib.Fractional
 public import Iris.Instances.Lib.GhostMap
 public import Iris.Instances.IProp
+public import Iris.Std.HeapInstances
+public import Iris.Std.Namespaces
 
 @[expose] public section
 
 namespace Iris
 
-/-
-  NOTE:
+open Std Iris.Algebra CMRA BI ProofMode
 
-  This file is based on an old version of `gen_heap.v`, which does not depend on a
-  `reservation_map`. In particular, the API offered here is much more restricted,
-  and mostly mirrors that of `GhostMap`. In the future, we'd need to port the
-  `reservation_map`s and port the rest of the lemmas.
+/-! This file provides a generic mechanism for a language-level points-to
+connective `l ↦{dq} v` reflecting the physical heap.  This library is designed
+to be used as a singleton (i.e., with only a single instance existing in any
+proof), with the `genHeapGS` typeclass providing the ghost names of that
+unique instance.  That way, `pointsTo` does not need an explicit `gname`
+parameter.  This mechanism can be plugged into a language and related to the
+physical heap by using `genHeapInterp σ` in the state interpretation of the
+weakest precondition.  See heap-lang for an example.
 
--/
+In addition to the points-to connective, this library also provides a way to
+attach "meta" or "ghost" data to locations via `metaToken l E` and
+`metaInfo l N x`.  See the original Rocq `gen_heap.v` for the full design
+rationale.  To implement the meta machinery we use two extra pieces of ghost
+state in addition to the value map:
 
-/-! (TODO: Adapt to Iris Lean implementation)
+- a `ghost_map L gname`, which associates a ghost name with each location;
+- for each such ghost name, a `ReservationMap (Agree (LeibnizO Pos))` storing
+  the actual meta data.  The indirection is required so that `meta_set` is a
+  frame-preserving update that does not need to inspect `genHeapInterp`. -/
 
-This file provides a generic mechanism for a language-level point-to
-connective `l ↦{dq} v` reflecting the physical heap.  This library is designed to
-be used as a singleton (i.e., with only a single instance existing in any
-proof), with the `gen_heapGS` typeclass providing the ghost names of that unique
-instance.  That way, `pointsto` does not need an explicit `gname` parameter.
-This mechanism can be plugged into a language and related to the physical heap
-by using `gen_heap_interp σ` in the state interpretation of the weakest
-precondition. See heap-lang for an example.
+/-- Underlying partial-map type used inside the per-location reservation map.
+Following the convention from `WSat`, we fix the representation to extensional
+tree maps over positives. -/
+abbrev MetaResMap (x : Type) : Type := Std.ExtTreeMap Pos x compare
 
-If you are looking for a library providing "ghost heaps" independent of the
-physical state, you will likely want explicit ghost names to disambiguate
-multiple heaps and are thus better off using `ghost_map`, or (if you need more
-flexibility), directly using the underlying `algebra.lib.gmap_view`.
+/-- The CMRA used to store the meta-data attached to a single location. -/
+abbrev MetaUR : Type := ReservationMap (Agree (LeibnizO Pos)) MetaResMap
 
-This library is generic in the types `L` for locations and `V` for values and
-supports fractional permissions.  Next to the point-to connective `l ↦{dq} v`,
-which keeps track of the value `v` of a location `l`, this library also provides
-a way to attach "meta" or "ghost" data to locations. This is done as follows:
+variable (F : outParam (Type _)) [UFraction F]
 
-- When one allocates a location, in addition to the point-to connective `l ↦ v`,
-  one also obtains the token `meta_token l ⊤`. This token is an exclusive
-  resource that denotes that no meta data has been associated with the
-  namespaces in the mask `⊤` for the location `l`.
-
-- Meta data tokens can be split w.r.t. namespace masks, i.e.
-  `meta_token l (E1 ∪ E2) ⊣⊢ meta_token l E1 ∗ meta_token l E2` if `E1 ## E2`.
-
-- Meta data can be set using the update `meta_token l E ==∗ meta l N x` provided
-  `↑N ⊆ E`, and `x : A` for any countable `A`. The `meta l N x` connective is
-  persistent and denotes the knowledge that the meta data `x` has been
-  associated with namespace `N` to the location `l`.
-
-To make the mechanism as flexible as possible, the `x : A` in `meta l N x` can
-be of any countable type `A`. This means that you can associate e.g. single
-ghost names, but also tuples of ghost names, etc.
-
-To further increase flexibility, the `meta l N x` and `meta_token l E`
-connectives are annotated with a namespace `N` and mask `E`. That way, one can
-assign a map of meta information to a location. This is particularly useful when
-building abstractions, then one can gradually assign more ghost information to a
-location instead of having to do all of this at once. We use namespaces so that
-these can be matched up with the invariant namespaces.
-
-To implement this mechanism, we use three pieces of ghost state:
-
-- A `ghost_map L V`, which keeps track of the values of locations.
-- A `ghost_map L gname`, which keeps track of the meta information of
-  locations. More specifically, this RA introduces an indirection: it keeps
-  track of a ghost name for each location.
-- The ghost names in the aforementioned authoritative RA refer to namespace maps
-  `reservation_map (agree positive)`, which store the actual meta information.
-  This indirection is needed because we cannot perform frame preserving updates
-  in an authoritative fragment without owning the full authoritative element
-  (in other words, without the indirection `meta_set` would need `gen_heap_interp`
-  as a premise).
--/
-
-variable (F: outParam (Type _)) [UFraction F]
-
+@[rocq_alias gen_heapGpreS]
 class genHeapPreS (L V : Type _) (GF : BundledGFunctors) (H : outParam <| Type _ → Type _)
     [Std.LawfulFiniteMap H L] where
   heap : GhostMapG GF F L V H
-  -- TODO: `meta` field blocked by `reservation_mapR`
-  -- TODO: `metaData` field blocked by `reservation_mapR`
+  «meta» : GhostMapG GF F L GName H
+  metaData : ElemG GF (constOF MetaUR)
 
 attribute [reducible, instance] genHeapPreS.heap
+attribute [reducible, instance] genHeapPreS.«meta»
+attribute [reducible, instance] genHeapPreS.metaData
 attribute [instance] GhostMapG.elem
 
+@[rocq_alias gen_heapGS]
 class genHeapGS (L V : outParam <| Type _) (GF : outParam <| BundledGFunctors)
     (H : outParam <| Type _ → Type _) [Std.LawfulFiniteMap H L]
     extends genHeapPreS F L V GF H where
   heapName : GName
-  -- TODO: Metadata not supported yet
+  metaName : GName
 
 #rocq_ignore «gen_heapΣ» "Subsumed by BundledGFunctors typeclass synthesis"
 #rocq_ignore «subG_gen_heapGpreS» "Subsumed by BundledGFunctors typeclass synthesis"
@@ -101,74 +69,277 @@ section definitions
 
 variable {GF : BundledGFunctors} {L V : Type _}
 variable {H : outParam <| Type _ → Type _} [Std.LawfulFiniteMap H L]
-variable {F: outParam (Type _)} [UFraction F]
+variable {F : outParam (Type _)} [UFraction F]
 variable [genHeapGS F L V GF H]
 
-open Std.FiniteMap genHeapGS
+open Std.FiniteMap Std.PartialMap genHeapGS
 
-def genHeapInterp (σ : H V) : IProp GF := heapName ↪●MAP σ
+/-- State interpretation for the generalized heap.  Owns the value map `σ`
+together with an existentially quantified map of ghost names whose domain is
+contained in that of `σ`; the latter is used as the indirection table for the
+meta data. -/
+@[rocq_alias gen_heap_interp]
+def genHeapInterp (σ : H V) : IProp GF := iprop(
+  ∃ m : H GName,
+    ⌜∀ k, dom m k → dom σ k⌝ ∗
+    (heapName ↪●MAP σ) ∗
+    (metaName ↪●MAP m))
 
-def pointsTo (l : L) (dq : DFrac F)(v : V) : IProp GF := heapName ↪◯MAP[l]{dq} v
+@[rocq_alias pointsto]
+def pointsTo (l : L) (dq : DFrac F) (v : V) : IProp GF := heapName ↪◯MAP[l]{dq} v
 
 notation l " ↦{" dq "} " v => pointsTo l dq v
 notation l " ↦ " v => pointsTo l (DFrac.own 1) v
+
+/-- The token witnessing that no meta data has been associated with the
+namespace mask `E` at location `l`. -/
+@[rocq_alias meta_token]
+def metaToken (l : L) (E : CoPset) : IProp GF := iprop(
+  ∃ γm, (metaName ↪◯MAP[l]{.discard} γm) ∗
+    iOwn (E := genHeapPreS.metaData (L := L) (V := V)) γm (ReservationMap.mkToken E))
+
+/-- Persistent assertion that the meta-data `x : A` has been associated with
+namespace `N` to the location `l`.  The type `A` must be `Pos.Countable`.
+
+The Rocq name is `meta`, but that token is reserved in Lean, so the Lean
+identifier is `metaInfo`. -/
+@[rocq_alias «meta»]
+def metaInfo {A : Type _} [Pos.Countable A] (l : L) (N : Namespace) (x : A) : IProp GF := iprop(
+  ∃ γm, (metaName ↪◯MAP[l]{.discard} γm) ∗
+    iOwn (E := genHeapPreS.metaData (L := L) (V := V)) γm
+      (ReservationMap.singleton (CoPset.pick (↑N))
+        (toAgree ⟨Pos.Countable.encode x⟩ : Agree (LeibnizO Pos))))
 
 end definitions
 
 section lemmas
 
-variable {F: outParam (Type _)} [UFraction F]  {GF : BundledGFunctors}
+variable {F : outParam (Type _)} [UFraction F] {GF : BundledGFunctors}
 variable {L V : Type _} {H : outParam <| Type _ → Type _} [Std.LawfulFiniteMap H L]
 variable [genHeapGS F L V GF H]
 
-open genHeapGS
+open genHeapGS Std.PartialMap Std.FiniteMap
 
+/-! ### General properties of `pointsTo` -/
+
+@[rocq_alias pointsto_timeless]
 instance instTimelessPointsTo : BI.Timeless (l ↦{dq} v) :=
   inferInstanceAs (BI.Timeless (heapName ↪◯MAP[l]{dq} v))
 
+@[rocq_alias pointsto_fractional]
 instance instFractionalPointsTo : Fractional (l ↦{.own ·} v) :=
   inferInstanceAs (Fractional (heapName ↪◯MAP[l]{.own ·} v))
 
+@[rocq_alias pointsto_as_fractional]
 instance instAsFractionalPointsTo : AsFractional (l ↦{.own q} v) (l ↦{.own ·} v) q :=
   inferInstanceAs (AsFractional (heapName ↪◯MAP[l]{.own q} v) (heapName ↪◯MAP[l]{.own ·} v) q)
 
+@[rocq_alias pointsto_valid]
 theorem pointsTo_cmraValid : (l ↦{dq} v) ⊢@{IProp GF} internalCmraValid dq := by
   simp [pointsTo, ghost_map_elem_valid]
 
+@[rocq_alias pointsto_valid_2]
 theorem pointsTo_op_cmraValid :
     (l ↦{dq₁} v₁) ∗ (l ↦{dq₂} v₂) ⊢@{IProp GF} internalCmraValid (dq₁ • dq₂) ∧ ⌜v₁ = v₂⌝ := by
   unfold pointsTo
   iapply ghost_map_elem_valid_2
 
+@[rocq_alias pointsto_agree]
 theorem pointsTo_agree : (l ↦{dq₁} v₁) ∗ (l ↦{dq₂} v₂) ⊢@{IProp GF} ⌜v₁ = v₂⌝ := by
   unfold pointsTo
   iapply ghost_map_elem_agree
 
-open Std.PartialMap
+/-! ### General properties of `metaInfo` and `metaToken` -/
+
+@[rocq_alias meta_token_timeless]
+instance instTimelessMetaToken (l : L) (E : CoPset) :
+    BI.Timeless (PROP := IProp GF) (metaToken l E) := by
+  unfold metaToken
+  refine @BI.exists_timeless _ _ _ _ ?_
+  intro γm
+  infer_instance
+
+@[rocq_alias meta_timeless]
+instance instTimelessMeta {A : Type _} [Pos.Countable A] (l : L) (N : Namespace) (x : A) :
+    BI.Timeless (PROP := IProp GF) (metaInfo l N x) := by
+  unfold metaInfo
+  refine @BI.exists_timeless _ _ _ _ ?_
+  intro γm
+  infer_instance
+
+@[rocq_alias meta_persistent]
+instance instPersistentMeta {A : Type _} [Pos.Countable A] (l : L) (N : Namespace) (x : A) :
+    BI.Persistent (PROP := IProp GF) (metaInfo l N x) := by
+  unfold metaInfo
+  refine @BI.exists_persistent _ _ _ _ ?_
+  intro γm
+  infer_instance
+
+@[rocq_alias meta_token_union_1]
+theorem metaToken_union_1 {l : L} {E1 E2 : CoPset} (he : E1 ## E2) :
+    metaToken (GF := GF) l (E1 ∪ E2) ⊢ metaToken l E1 ∗ metaToken l E2 := by
+  unfold metaToken
+  iintro ⟨%γm, #Hγm, Hm⟩
+  ihave ⟨Hm1, Hm2⟩ : iprop(
+      iOwn (E := genHeapPreS.metaData (L := L) (V := V)) γm (ReservationMap.mkToken E1) ∗
+      iOwn (E := genHeapPreS.metaData (L := L) (V := V)) γm (ReservationMap.mkToken E2)) $$ [Hm]
+  · iapply iOwn_op.mp
+    iapply (BI.equiv_iff.mp (iOwn_ne.eqv (ReservationMap.token_union he))).mp
+    iexact Hm
+  isplitl [Hm1]
+  · iexists γm
+    iframe Hγm Hm1
+  · iexists γm
+    iframe Hγm Hm2
+
+@[rocq_alias meta_token_union_2]
+theorem metaToken_union_2 {l : L} {E1 E2 : CoPset} :
+    metaToken (GF := GF) l E1 -∗ metaToken l E2 -∗ metaToken l (E1 ∪ E2) := by
+  unfold metaToken
+  iintro ⟨%γm1, #Hγm1, Hm1⟩ ⟨%γm2, #Hγm2, Hm2⟩
+  icombine Hγm1 Hγm2 gives ⟨%_, %Heq⟩
+  subst Heq
+  icombine Hm1 Hm2 gives %Hvalid
+  have hdisj : E1 ## E2 := ReservationMap.valid_token_op_iff_disj.mp Hvalid
+  iexists γm1
+  iframe Hγm1
+  iapply (BI.equiv_iff.mp (iOwn_ne.eqv (ReservationMap.token_union hdisj))).mpr
+  iapply iOwn_op.mpr
+  iframe
+
+@[rocq_alias meta_token_union]
+theorem metaToken_union {l : L} {E1 E2 : CoPset} (he : E1 ## E2) :
+    metaToken (GF := GF) l (E1 ∪ E2) ⊣⊢ metaToken l E1 ∗ metaToken l E2 := by
+  refine ⟨metaToken_union_1 he, ?_⟩
+  iintro ⟨H1, H2⟩
+  iapply metaToken_union_2 $$ H1 H2
+
+@[rocq_alias meta_token_valid_2]
+theorem metaToken_valid_2 {l : L} {E1 E2 : CoPset} :
+    metaToken (GF := GF) l E1 -∗ metaToken l E2 -∗ ⌜E1 ## E2⌝ := by
+  unfold metaToken
+  iintro ⟨%γm1, #Hγm1, Hm1⟩ ⟨%γm2, #Hγm2, Hm2⟩
+  icombine Hγm1 Hγm2 gives ⟨%_, %Heq⟩
+  subst Heq
+  icombine Hm1 Hm2 gives %Hvalid
+  ipureintro
+  exact ReservationMap.valid_token_op_iff_disj.mp Hvalid
+
+@[rocq_alias meta_token_combine_as]
+instance instCombineSepGivesMetaToken (l : L) (E1 E2 : CoPset) :
+    CombineSepGives (PROP := IProp GF) (metaToken l E1) (metaToken l E2) iprop(⌜E1 ## E2⌝) where
+  combine_sep_gives := by
+    iintro ⟨H1, H2⟩
+    icases metaToken_valid_2 $$ H1 H2 with %H
+    itrivial
+
+@[rocq_alias meta_token_difference]
+theorem metaToken_difference {l : L} {E1 E2 : CoPset} (he : E1 ⊆ E2) :
+    metaToken (GF := GF) l E2 ⊣⊢ metaToken l E1 ∗ metaToken l (E2 \ E1) := by
+  have heq : E1 ∪ (E2 \ E1) = E2 := Iris.Std.LawfulSet.subset_union_diff he
+  refine .trans (.of_eq ?_) (metaToken_union (l := l) Iris.Std.LawfulSet.disjoint_diff_right)
+  rw [heq]
+
+@[rocq_alias meta_agree]
+theorem meta_agree {A : Type _} [Pos.Countable A] {l : L} {N : Namespace} {x1 x2 : A} :
+    metaInfo (GF := GF) l N x1 -∗ metaInfo l N x2 -∗ ⌜x1 = x2⌝ := by
+  unfold metaInfo
+  iintro ⟨%γm1, #Hγm1, Hm1⟩ ⟨%γm2, #Hγm2, Hm2⟩
+  icombine Hγm1 Hγm2 gives ⟨%_, %Heq⟩
+  subst Heq
+  icombine Hm1 Hm2 gives %Hvalid
+  ipureintro
+  have hop : ✓ ReservationMap.singleton (H := MetaResMap) (CoPset.pick (↑N))
+      ((toAgree ⟨Pos.Countable.encode x1⟩ : Agree (LeibnizO Pos)) •
+        (toAgree ⟨Pos.Countable.encode x2⟩ : Agree (LeibnizO Pos))) :=
+    (OFE.Equiv.valid (ReservationMap.singleton_op _ _ _)).mpr Hvalid
+  rw [ReservationMap.valid_singleton] at hop
+  have hag : (⟨Pos.Countable.encode x1⟩ : LeibnizO Pos) = ⟨Pos.Countable.encode x2⟩ :=
+    toAgree_op_valid_iff_eq.mp hop
+  exact Pos.encode_inj (congrArg LeibnizO.car hag)
+
+@[rocq_alias meta_set]
+theorem meta_set {A : Type _} [Pos.Countable A] {l : L} {E : CoPset} {N : Namespace} (x : A)
+    (he : (↑N : CoPset) ⊆ E) : metaToken (GF := GF) l E ==∗ metaInfo l N x := by
+  unfold metaToken metaInfo
+  iintro ⟨%γm, #Hγm, Hm⟩
+  imod iOwn_update (ReservationMap.alloc (a := toAgree (⟨Pos.Countable.encode x⟩ : LeibnizO Pos))
+    (he _ (coPpick_nclose N)) Agree.toAgree_valid) $$ Hm with Hm
+  imodintro
+  iexists γm
+  iframe Hγm Hm
+
+/-! ### Update lemmas -/
 
 section updateLemmas
 
-theorem genHeap_alloc (Hσl : get? σ l = .none) :
-    genHeapInterp σ ⊢ |==> (genHeapInterp (insert σ l v) ∗ (l ↦ v)) := by
-  unfold genHeapInterp pointsTo
-  iapply ghost_map_insert _ v Hσl
+@[rocq_alias gen_heap_alloc]
+theorem genHeap_alloc {σ : H V} {l : L} {v : V} (Hσl : get? σ l = .none) :
+    genHeapInterp σ ⊢ |==> (genHeapInterp (insert σ l v) ∗ (l ↦ v) ∗ metaToken l ⊤) := by
+  unfold genHeapInterp pointsTo metaToken
+  iintro ⟨%m, %Hdom, Hσ, Hm⟩
+  imod ghost_map_insert l v Hσl $$ Hσ with ⟨Hσ, Hl⟩
+  imod (iOwn_alloc (E := genHeapPreS.metaData (L := L) (V := V))
+    (ReservationMap.mkToken ⊤) ReservationMap.valid_token) with ⟨%γm, Hγm⟩
+  have Hml : get? m l = .none := by
+    rcases h : get? m l with _ | _
+    · rfl
+    · exfalso
+      have : dom m l := by simp [dom, h]
+      have := Hdom l this
+      simp [dom, Hσl] at this
+  imod ghost_map_insert_persist l γm Hml $$ Hm with ⟨Hm, Hlm⟩
+  imodintro
+  isplitl [Hσ Hm]
+  · iexists (insert m l γm)
+    isplitr
+    · ipureintro
+      intro k hk
+      simp only [dom] at hk ⊢
+      by_cases hkl : k = l
+      · subst hkl
+        rw [LawfulPartialMap.get?_insert_eq rfl]
+        rfl
+      · rw [LawfulPartialMap.get?_insert_ne (Ne.symm hkl)] at hk
+        rw [LawfulPartialMap.get?_insert_ne (Ne.symm hkl)]
+        exact Hdom k hk
+    · iframe
+  · isplitl [Hl]
+    · iframe
+    · iexists γm
+      iframe Hlm Hγm
 
-theorem genHeap_dealloc : (genHeapInterp σ ∗ l ↦ v) ==∗ genHeapInterp (delete σ l) := by
+@[rocq_alias gen_heap_valid]
+theorem genHeap_valid {σ : H V} {l : L} {dq : DFrac F} {v : V} :
+    (genHeapInterp σ ∗ l ↦{dq} v) ==∗ ⌜get? σ l = .some v⌝ := by
   unfold genHeapInterp pointsTo
-  iintro ⟨H₁,H₂⟩
-  iapply ghost_map_delete _ v $$ H₁ H₂
+  iintro ⟨⟨%m, -, Hσ, -⟩, Hl⟩
+  iapply ghost_map_lookup $$ Hσ Hl
 
-theorem genHeap_valid : (genHeapInterp σ ∗ l ↦{dq} v) ==∗ ⌜get? σ l = .some v⌝ := by
-  unfold genHeapInterp pointsTo
-  iintro ⟨H₁,H₂⟩
-  iapply ghost_map_lookup $$ H₁ H₂
-
-theorem genHeap_update :
+@[rocq_alias gen_heap_update]
+theorem genHeap_update {σ : H V} {l : L} {v₁ v₂ : V} :
     (genHeapInterp σ ∗ l ↦ v₁) ==∗ (genHeapInterp (insert σ l v₂) ∗ l ↦ v₂) := by
   unfold genHeapInterp pointsTo
-  iintro ⟨H₁,H₂⟩
-  iapply ghost_map_update _ _ v₂ $$ H₁ H₂
+  iintro ⟨⟨%m, %Hdom, Hσ, Hm⟩, Hl⟩
+  imod ghost_map_update l v₁ v₂ $$ Hσ Hl with ⟨Hσ, Hl⟩
+  imodintro
+  isplitl [Hσ Hm]
+  · iexists m
+    isplitr
+    · ipureintro
+      intro k hk
+      simp only [dom] at hk ⊢
+      by_cases hkl : k = l
+      · subst hkl
+        rw [LawfulPartialMap.get?_insert_eq rfl]
+        rfl
+      · rw [LawfulPartialMap.get?_insert_ne (Ne.symm hkl)]
+        exact Hdom k hk
+    · iframe
+  · iframe
 
 end updateLemmas
 
 end lemmas
+
+end Iris

--- a/Iris/Iris/BI/Lib/GenHeap.lean
+++ b/Iris/Iris/BI/Lib/GenHeap.lean
@@ -363,52 +363,42 @@ instance instCombineSepGivesMetaMetaToken2 {A : Type _} [Pos.Countable A]
 
 section updateLemmas
 
-@[rocq_alias gen_heap_alloc]
-theorem genHeap_alloc {σ : H V} {l : L} {v : V} (Hσl : get? σ l = .none) :
-    genHeapInterp σ ⊢ |==> (genHeapInterp (insert σ l v) ∗ (l ↦ v) ∗ metaToken l ⊤) := by
-  unfold genHeapInterp pointsTo metaToken
-  iintro ⟨%m, %Hdom, Hσ, Hm⟩
-  imod ghost_map_insert l v Hσl $$ Hσ with ⟨Hσ, Hl⟩
-  imod (iOwn_alloc (E := genHeapPreS.metaData (L := L) (V := V))
-    (ReservationMap.mkToken ⊤) ReservationMap.valid_token) with ⟨%γm, Hγm⟩
-  have Hml : get? m l = .none := by
-    rcases h : get? m l with _ | _
-    · rfl
-    · specialize Hdom l
-      simp [dom, Hσl, h] at Hdom
-  imod ghost_map_insert_persist l γm Hml $$ Hm with ⟨Hm, Hlm⟩
-  imodintro
-  isplitl [Hσ Hm]
-  · iexists (insert m l γm)
-    iframe
-    ipureintro
-    intro k hk
-    simp only [dom] at hk ⊢
-    by_cases hkl : k = l
-    · subst hkl
-      rw [LawfulPartialMap.get?_insert_eq rfl]
-      rfl
-    · rw [LawfulPartialMap.get?_insert_ne (Ne.symm hkl)] at hk
-      rw [LawfulPartialMap.get?_insert_ne (Ne.symm hkl)]
-      exact Hdom k hk
-  · iframe
-    iexists γm
-    iframe Hlm Hγm
-
-/-- The state interpretation respects pointwise equivalence of the value
-heap. -/
-private theorem genHeapInterp_eqv {σ₁ σ₂ : H V} (h : σ₁ ≡ₘ σ₂) :
+/-- The state interpretation transports along a pointwise equivalence of
+the value heap. -/
+theorem genHeapInterp_eqv {σ₁ σ₂ : H V} (h : σ₁ ≡ₘ σ₂) :
     genHeapInterp (GF := GF) σ₁ ⊢ genHeapInterp σ₂ := by
   unfold genHeapInterp
   iintro ⟨%m, %Hdom, Hh, Hm⟩
   iexists m
   isplitr
   · ipureintro
-    intro k hk
-    unfold dom; rw [← h k]
-    exact Hdom k hk
+    exact fun k hk => by unfold dom; rw [← h k]; exact Hdom k hk
   refine sep_mono_left ?_
   exact iOwn_mono (HeapView.auth_inc_of_pmap_eqv _ (LawfulPartialMap.map_equiv h.symm))
+
+@[rocq_alias gen_heap_alloc]
+theorem genHeap_alloc [DecidableEq L] {σ : H V} {l : L} {v : V} (Hσl : get? σ l = .none) :
+    genHeapInterp σ ⊢ |==> (genHeapInterp (insert σ l v) ∗ (l ↦ v) ∗ metaToken l ⊤) := by
+  unfold genHeapInterp pointsTo metaToken
+  iintro ⟨%m, %Hdom, Hσ, Hm⟩
+  have Hml : get? m l = .none := by
+    rcases h : get? m l with _ | _
+    · rfl
+    · exact absurd (Hdom l (by simp [dom, h])) (by simp [dom, Hσl])
+  imod ghost_map_insert l v Hσl $$ Hσ with ⟨Hσ, Hl⟩
+  imod (iOwn_alloc (E := genHeapPreS.metaData (L := L) (V := V))
+    (ReservationMap.mkToken ⊤) ReservationMap.valid_token) with ⟨%γm, Hγm⟩
+  imod ghost_map_insert_persist l γm Hml $$ Hm with ⟨Hm, Hlm⟩
+  imodintro
+  iframe Hl
+  isplitl [Hσ Hm]
+  · iexists (insert m l γm)
+    iframe
+    ipureintro
+    exact fun k hk =>
+      LawfulPartialMap.dom_insert_iff.mpr <|
+        (LawfulPartialMap.dom_insert_iff.mp hk).imp_right (Hdom k)
+  iexists γm; iframe Hlm Hγm
 
 @[rocq_alias gen_heap_alloc_big]
 theorem genHeap_alloc_big [DecidableEq L] (σ' σ : H V) (Hdisj : σ' ##ₘ σ) :
@@ -420,7 +410,8 @@ theorem genHeap_alloc_big [DecidableEq L] (σ' σ : H V) (Hdisj : σ' ##ₘ σ) 
   | hequiv σ₁ σ₂ heqv IH =>
     intro σ Hdisj
     have Hdisj₁ : σ₁ ##ₘ σ := fun k ⟨h1, h2⟩ => Hdisj k ⟨by rw [← heqv k]; exact h1, h2⟩
-    have hUnion : (σ₁ ∪ σ) ≡ₘ (σ₂ ∪ σ) := LawfulPartialMap.union_equiv heqv Std.PartialMap.equiv.refl
+    have hUnion : (σ₁ ∪ σ) ≡ₘ (σ₂ ∪ σ) :=
+      LawfulPartialMap.union_equiv heqv Std.PartialMap.equiv.refl
     iintro Hσ
     imod IH σ Hdisj₁ $$ Hσ with ⟨Hint, Hpts, Htok⟩
     imodintro
@@ -436,31 +427,21 @@ theorem genHeap_alloc_big [DecidableEq L] (σ' σ : H V) (Hdisj : σ' ##ₘ σ) 
     iintro Hσ
     imodintro
     isplitl [Hσ]
-    · iapply genHeapInterp_eqv LawfulPartialMap.union_empty_left.symm
-      iexact Hσ
+    · iapply genHeapInterp_eqv LawfulPartialMap.union_empty_left.symm; iexact Hσ
     isplit <;> · iapply BigSepM.bigSepM_empty.mpr; itrivial
   | hins l v σ'' Hl IH =>
     intro σ Hdisj
-    have Hσl : get? σ l = .none := by
-      rcases h : get? σ l with _ | w
-      · rfl
-      · exact absurd
-          (Hdisj l ⟨by simp [LawfulPartialMap.get?_insert_eq rfl], by rw [h]; simp⟩) id
-    have Hdisj' : σ'' ##ₘ σ := fun k ⟨h1, h2⟩ => Hdisj k ⟨by
-      by_cases hkl : l = k
-      · subst hkl; simp [Hl] at h1
-      · rw [LawfulPartialMap.get?_insert_ne hkl]; exact h1, h2⟩
-    have Hunion_l : get? (σ'' ∪ σ) l = .none := LawfulPartialMap.get?_union_none.mpr ⟨Hl, Hσl⟩
+    obtain ⟨Hσl, Hdisj'⟩ := (LawfulPartialMap.disjoint_insert_left_iff Hl).mp Hdisj
+    have Hunion_l : get? (σ'' ∪ σ) l = .none :=
+      LawfulPartialMap.get?_union_none.mpr ⟨Hl, Hσl⟩
     iintro Hσ
     imod IH σ Hdisj' $$ Hσ with ⟨Hint, Hpts, Htok⟩
     imod genHeap_alloc Hunion_l $$ Hint with ⟨Hint', Hl_pts, Hl_tok⟩
     imodintro
     isplitl [Hint']
-    · iapply genHeapInterp_eqv LawfulPartialMap.union_insert_left
-      iexact Hint'
+    · iapply genHeapInterp_eqv LawfulPartialMap.union_insert_left; iexact Hint'
     isplitl [Hl_pts Hpts]
-    · iapply (BigSepM.bigSepM_insert Hl).mpr
-      iframe Hl_pts Hpts
+    · iapply (BigSepM.bigSepM_insert Hl).mpr; iframe Hl_pts Hpts
     iapply (BigSepM.bigSepM_insert (Φ := fun l _ => iprop(metaToken l ⊤)) Hl).mpr
     iframe Hl_tok Htok
 
@@ -472,24 +453,17 @@ theorem genHeap_valid {σ : H V} {l : L} {dq : DFrac F} {v : V} :
   iapply ghost_map_lookup $$ Hσ Hl
 
 @[rocq_alias gen_heap_update]
-theorem genHeap_update {σ : H V} {l : L} {v₁ v₂ : V} :
+theorem genHeap_update [DecidableEq L] {σ : H V} {l : L} {v₁ v₂ : V} :
     (genHeapInterp σ ∗ l ↦ v₁) ==∗ (genHeapInterp (insert σ l v₂) ∗ l ↦ v₂) := by
   unfold genHeapInterp pointsTo
   iintro ⟨⟨%m, %Hdom, Hσ, Hm⟩, Hl⟩
   imod ghost_map_update l v₁ v₂ $$ Hσ Hl with ⟨Hσ, Hl⟩
   imodintro
-  iframe
+  iframe Hl
   iexists m
   iframe
   ipureintro
-  intro k hk
-  simp only [dom] at hk ⊢
-  by_cases hkl : k = l
-  · subst hkl
-    rw [LawfulPartialMap.get?_insert_eq rfl]
-    rfl
-  · rw [LawfulPartialMap.get?_insert_ne (Ne.symm hkl)]
-    exact Hdom k hk
+  exact fun k hk => LawfulPartialMap.dom_insert_iff.mpr (Or.inr (Hdom k hk))
 
 end updateLemmas
 
@@ -520,25 +494,19 @@ theorem genHeap_init_names [DecidableEq L] [genHeapPreS F L V GF H] (σ : H V) :
   imod (ghost_map_alloc_empty (K := L) (V := V)) with ⟨%γh, Hh⟩
   imod (ghost_map_alloc_empty (K := L) (V := GName)) with ⟨%γm, Hm⟩
   letI G : genHeapGS F L V GF H := ⟨γh, γm⟩
-  have Hinterp_empty : (γh ↪●MAP (∅ : H V)) ∗ (γm ↪●MAP (∅ : H GName)) ⊢@{IProp GF}
-      genHeapInterp (G := G) ∅ := by
-    unfold genHeapInterp
-    iintro ⟨Hh, Hm⟩
+  ihave Hinterp0 : genHeapInterp (G := G) ∅ $$ [Hh Hm]
+  · unfold genHeapInterp
     iexists (∅ : H GName)
     isplitr
     · ipureintro
-      simp only [dom, Std.LawfulPartialMap.get?_empty]
-      grind
+      intro k hk
+      simp [dom, LawfulPartialMap.get?_empty] at hk
     iframe Hh Hm
-  ihave Hinterp0 : genHeapInterp (G := G) ∅ $$ [Hh Hm]
-  · iapply Hinterp_empty
-    iframe
-  imod (genHeap_alloc_big σ ∅
-    (Std.LawfulPartialMap.disjoint_empty_right σ)) $$ Hinterp0
+  imod genHeap_alloc_big σ ∅ (LawfulPartialMap.disjoint_empty_right _) $$ Hinterp0
     with ⟨Hinterp, Hpts, Htok⟩
   imodintro
   iexists γh, γm
-  iframe
+  iframe Hpts Htok
   iapply genHeapInterp_eqv LawfulPartialMap.union_empty_right
   iexact Hinterp
 

--- a/Iris/Iris/BI/Lib/GenHeap.lean
+++ b/Iris/Iris/BI/Lib/GenHeap.lean
@@ -36,10 +36,10 @@ state in addition to the value map:
 /-- Underlying partial-map type used inside the per-location reservation map.
 Following the convention from `WSat`, we fix the representation to extensional
 tree maps over positives. -/
-abbrev MetaResMap (x : Type) : Type := Std.ExtTreeMap Pos x compare
+abbrev MetaResMap (x : Sort _) : Sort _ := Std.ExtTreeMap Pos x compare
 
 /-- The CMRA used to store the meta-data attached to a single location. -/
-abbrev MetaUR : Type := ReservationMap (Agree (LeibnizO Pos)) MetaResMap
+abbrev MetaUR : Sort _ := ReservationMap (Agree (LeibnizO Pos)) MetaResMap
 
 variable (F : outParam (Type _)) [UFraction F]
 
@@ -79,11 +79,8 @@ together with an existentially quantified map of ghost names whose domain is
 contained in that of `σ`; the latter is used as the indirection table for the
 meta data. -/
 @[rocq_alias gen_heap_interp]
-def genHeapInterp (σ : H V) : IProp GF := iprop(
-  ∃ m : H GName,
-    ⌜∀ k, dom m k → dom σ k⌝ ∗
-    (heapName ↪●MAP σ) ∗
-    (metaName ↪●MAP m))
+def genHeapInterp (σ : H V) : IProp GF := iprop%
+  ∃ m : H GName, ⌜∀ k, dom m k → dom σ k⌝ ∗ (heapName ↪●MAP σ) ∗ (metaName ↪●MAP m)
 
 @[rocq_alias pointsto]
 def pointsTo (l : L) (dq : DFrac F) (v : V) : IProp GF := heapName ↪◯MAP[l]{dq} v
@@ -94,21 +91,17 @@ notation l " ↦ " v => pointsTo l (DFrac.own 1) v
 /-- The token witnessing that no meta data has been associated with the
 namespace mask `E` at location `l`. -/
 @[rocq_alias meta_token]
-def metaToken (l : L) (E : CoPset) : IProp GF := iprop(
+def metaToken (l : L) (E : CoPset) : IProp GF := iprop%
   ∃ γm, (metaName ↪◯MAP[l]{.discard} γm) ∗
-    iOwn (E := genHeapPreS.metaData (L := L) (V := V)) γm (ReservationMap.mkToken E))
+    iOwn (E := genHeapPreS.metaData (L := L) (V := V)) γm (ReservationMap.mkToken E)
 
 /-- Persistent assertion that the meta-data `x : A` has been associated with
-namespace `N` to the location `l`.  The type `A` must be `Pos.Countable`.
-
-The Rocq name is `meta`, but that token is reserved in Lean, so the Lean
-identifier is `metaInfo`. -/
+namespace `N` to the location `l`.  The type `A` must be `Pos.Countable`. -/
 @[rocq_alias «meta»]
-def metaInfo {A : Type _} [Pos.Countable A] (l : L) (N : Namespace) (x : A) : IProp GF := iprop(
+def metaInfo [Pos.Countable A] (l : L) (N : Namespace) (x : A) : IProp GF := iprop%
   ∃ γm, (metaName ↪◯MAP[l]{.discard} γm) ∗
     iOwn (E := genHeapPreS.metaData (L := L) (V := V)) γm
-      (ReservationMap.singleton (CoPset.pick (↑N))
-        (toAgree ⟨Pos.Countable.encode x⟩ : Agree (LeibnizO Pos))))
+      (.singleton (CoPset.pick (↑N)) (toAgree ⟨Pos.Countable.encode x⟩))
 
 end definitions
 
@@ -132,24 +125,43 @@ instance instFractionalPointsTo : Fractional (l ↦{.own ·} v) :=
 
 @[rocq_alias pointsto_as_fractional]
 instance instAsFractionalPointsTo : AsFractional (l ↦{.own q} v) (l ↦{.own ·} v) q :=
-  inferInstanceAs (AsFractional (heapName ↪◯MAP[l]{.own q} v) (heapName ↪◯MAP[l]{.own ·} v) q)
+  inferInstanceAs
+    (AsFractional (heapName ↪◯MAP[l]{.own q} v) (heapName ↪◯MAP[l]{.own ·} v) q)
 
 @[rocq_alias pointsto_valid]
-theorem pointsTo_cmraValid : (l ↦{dq} v) ⊢@{IProp GF} internalCmraValid dq := by
-  simp [pointsTo, ghost_map_elem_valid]
+theorem pointsTo_cmraValid : (l ↦{dq} v) ⊢@{IProp GF} ⌜✓ dq⌝ := by
+  unfold pointsTo
+  iintro H
+  ihave %_ := ghost_map_elem_valid $$ H
+  itrivial
 
 @[rocq_alias pointsto_valid_2]
 theorem pointsTo_op_cmraValid :
-    (l ↦{dq₁} v₁) ∗ (l ↦{dq₂} v₂) ⊢@{IProp GF} internalCmraValid (dq₁ • dq₂) ∧ ⌜v₁ = v₂⌝ := by
+    (l ↦{dq₁} v₁) ∗ (l ↦{dq₂} v₂) ⊢@{IProp GF} ⌜✓ (dq₁ • dq₂)⌝ ∧ ⌜v₁ = v₂⌝ := by
   unfold pointsTo
-  iapply ghost_map_elem_valid_2
+  iintro H
+  ihave %_ := ghost_map_elem_valid_2 $$ H
+  itrivial
 
 @[rocq_alias pointsto_agree]
 theorem pointsTo_agree : (l ↦{dq₁} v₁) ∗ (l ↦{dq₂} v₂) ⊢@{IProp GF} ⌜v₁ = v₂⌝ := by
   unfold pointsTo
   iapply ghost_map_elem_agree
 
+@[rocq_alias pointsto_combine]
+theorem pointsTo_combine :
+    (l ↦{dq₁} v₁) ∗ (l ↦{dq₂} v₂) ⊢@{IProp GF} (l ↦{dq₁ • dq₂} v₁) ∗ ⌜v₁ = v₂⌝ := by
+  unfold pointsTo
+  iintro ⟨H₁, H₂⟩
+  iapply ghost_map_elem_combine $$ H₁ H₂
+
+-- TODO: pointsto_frac_ne
+-- TODO: pointsto_ne
+-- TODO: pointsto_persist
+-- TODO: pointsto_unpersist
+
 /-! ### General properties of `metaInfo` and `metaToken` -/
+
 
 @[rocq_alias meta_token_timeless]
 instance instTimelessMetaToken (l : L) (E : CoPset) :
@@ -233,6 +245,8 @@ instance instCombineSepGivesMetaToken (l : L) (E1 E2 : CoPset) :
     icases metaToken_valid_2 $$ H1 H2 with %H
     itrivial
 
+-- TODO: meta_token_ne
+
 @[rocq_alias meta_token_difference]
 theorem metaToken_difference {l : L} {E1 E2 : CoPset} (he : E1 ⊆ E2) :
     metaToken (GF := GF) l E2 ⊣⊢ metaToken l E1 ∗ metaToken l (E2 \ E1) := by
@@ -268,6 +282,9 @@ theorem meta_set {A : Type _} [Pos.Countable A] {l : L} {E : CoPset} {N : Namesp
   imodintro
   iexists γm
   iframe Hγm Hm
+
+-- TODO meta_meta_token_valid
+-- TODO meta_meta_token_valid'
 
 /-! ### Update lemmas -/
 
@@ -308,6 +325,8 @@ theorem genHeap_alloc {σ : H V} {l : L} {v : V} (Hσl : get? σ l = .none) :
     · iframe
     · iexists γm
       iframe Hlm Hγm
+
+-- TODO: gen_heap_alloc_big
 
 @[rocq_alias gen_heap_valid]
 theorem genHeap_valid {σ : H V} {l : L} {dq : DFrac F} {v : V} :

--- a/Iris/Iris/HeapLang/PrimitiveLaws.lean
+++ b/Iris/Iris/HeapLang/PrimitiveLaws.lean
@@ -47,18 +47,30 @@ theorem heap_adequacy [HeapLangGpreS .hasLC GF] (e : Exp) σ (φ : Val → Prop)
     adequate .NotStuck e σ (fun v _ => φ v) := by
   refine wp_adequacy (GF := GF) .NotStuck e σ φ ?_
   intro inst κs
-  imod iOwn_alloc (E := GhostMapG.elem)
+  imod iOwn_alloc (E := GhostMapG.elem (K := Loc) (V := Option Val) (F := PNat) (H := HeapF))
     (HeapView.Auth (H := HeapF) (.own One.one)
-    (Std.PartialMap.map (fun v => toAgree $ LeibnizO.mk v) σ.heap))
-    HeapView.auth_one_valid with ⟨%γ, H⟩
-  letI _ : HeapLangGS .hasLC GF := ⟨⟨γ⟩⟩
+      (Std.PartialMap.map (fun v : Option Val => toAgree (LeibnizO.mk v)) σ.heap))
+    HeapView.auth_one_valid with ⟨%γh, Hh⟩
+  imod iOwn_alloc (E := GhostMapG.elem (K := Loc) (V := GName) (F := PNat) (H := HeapF))
+    (HeapView.Auth (H := HeapF) (.own One.one)
+      (Std.PartialMap.map (fun g : GName => toAgree (LeibnizO.mk g))
+        (∅ : HeapF GName)))
+    HeapView.auth_one_valid with ⟨%γm, Hm⟩
+  letI _ : HeapLangGS .hasLC GF := ⟨⟨γh, γm⟩⟩
   imodintro
-  iexists (fun σ _ => iOwn (E := GhostMapG.elem) γ
-    (HeapView.Auth (H := HeapF) (.own One.one)
-    (Std.PartialMap.map (fun v => toAgree $ LeibnizO.mk v) σ.heap)))
+  iexists (fun σ _ => Iris.genHeapInterp (F := PNat) (GF := GF) (H := HeapF) σ.heap)
   iexists (fun _ => iprop(True))
-  iframe H
-  exact Hwp
+  isplitl [Hh Hm]
+  · simp only [Iris.genHeapInterp]
+    iexists (∅ : HeapF GName)
+    isplitr
+    · ipureintro
+      intro k hk
+      simp [Std.PartialMap.dom, LawfulPartialMap.get?_empty] at hk
+    unfold ghost_map_auth
+    simp only [Std.PartialMap.map, Std.PartialMap.bindAlter]
+    iframe Hh Hm
+  · exact Hwp
 
 end Adequacy
 
@@ -126,10 +138,10 @@ theorem wp_alloc (v : Val) :
   rcases baseStep_of_primStep_of_baseStep_reducible Hred Heq
   rename_i l' Hpo Hi
   simp only [Int.cast_ofNat_Int, Algebra.BigOpL.bigOpL_nil, Int.toNat_one, List.range_one,
-    List.foldl_cons, Int.cast_ofNat_Int, List.foldl_nil]
+    List.foldl_cons, List.foldl_nil]
   specialize Hi 0 (by simp) (by simp)
   rw [show l' + (0 : Int) = l' by cases l'; simp only [HAdd.hAdd, Loc.mk.injEq]; grind] at Hi ⊢
-  imod genHeap_alloc (v := some v) Hi $$ Hσ with ⟨Hσ, Hpt⟩
+  imod genHeap_alloc (v := some v) Hi $$ Hσ with ⟨Hσ, Hpt, _Hmt⟩
   imodintro
   -- FIXME: can iframe should solve emp?
   iframe Hσ

--- a/Iris/Iris/HeapLang/PrimitiveLaws.lean
+++ b/Iris/Iris/HeapLang/PrimitiveLaws.lean
@@ -68,7 +68,6 @@ theorem heap_adequacy [HeapLangGpreS .hasLC GF] (e : Exp) σ (φ : Val → Prop)
       intro k hk
       simp [Std.PartialMap.dom, LawfulPartialMap.get?_empty] at hk
     unfold ghost_map_auth
-    simp only [Std.PartialMap.map, Std.PartialMap.bindAlter]
     iframe Hh Hm
   · exact Hwp
 

--- a/Iris/Iris/Std/Namespaces.lean
+++ b/Iris/Iris/Std/Namespaces.lean
@@ -69,16 +69,13 @@ theorem nclose_not_finite (N : Namespace) : ¬CoPset.isFinite (↑N) := by
   simp only [nclose]
   exact CoPset.suffixes_not_finite (Pos.flatten N)
 
-@[rocq_alias nclose_infinite]
 theorem nclose_infinite (N : Namespace) : ¬Iris.Std.LawfulSet.setFinite (↑N : CoPset) :=
   fun h => nclose_not_finite N (isFinite_setFinite.mpr h)
 
-@[rocq_alias nclose_non_empty]
 theorem nclose_non_empty (N : Namespace) : (↑N : CoPset) ≠ ∅ := by
   intro h
   exact nclose_infinite N (h ▸ Iris.Std.LawfulSet.empty_finite)
 
-@[rocq_alias coPpick_elem_of]
 theorem coPpick_nclose (N : Namespace) : CoPset.pick (↑N) ∈ (↑N : CoPset) :=
   CoPset.mem_pick _ (nclose_non_empty N)
 

--- a/Iris/Iris/Std/Namespaces.lean
+++ b/Iris/Iris/Std/Namespaces.lean
@@ -69,6 +69,19 @@ theorem nclose_not_finite (N : Namespace) : ¬CoPset.isFinite (↑N) := by
   simp only [nclose]
   exact CoPset.suffixes_not_finite (Pos.flatten N)
 
+@[rocq_alias nclose_infinite]
+theorem nclose_infinite (N : Namespace) : ¬Iris.Std.LawfulSet.setFinite (↑N : CoPset) :=
+  fun h => nclose_not_finite N (isFinite_setFinite.mpr h)
+
+@[rocq_alias nclose_non_empty]
+theorem nclose_non_empty (N : Namespace) : (↑N : CoPset) ≠ ∅ := by
+  intro h
+  exact nclose_infinite N (h ▸ Iris.Std.LawfulSet.empty_finite)
+
+@[rocq_alias coPpick_elem_of]
+theorem coPpick_nclose (N : Namespace) : CoPset.pick (↑N) ∈ (↑N : CoPset) :=
+  CoPset.mem_pick _ (nclose_non_empty N)
+
 @[rocq_alias fresh_inv_name]
 theorem fresh_name {S : Type _} [Iris.Std.LawfulFiniteSet S Pos] (E : S) (N : Namespace) :
   ∃ i, i ∉ E ∧ i ∈ (↑N : CoPset) := by

--- a/Iris/Iris/Std/Namespaces.lean
+++ b/Iris/Iris/Std/Namespaces.lean
@@ -88,12 +88,8 @@ theorem fresh_name {S : Type _} [Iris.Std.LawfulFiniteSet S Pos] (E : S) (N : Na
   exists (CoPset.pick (↑N \ set_to_coPset E))
   have hne : ↑N \ set_to_coPset E ≠ ∅ := by
     apply Iris.Std.LawfulSet.diff_not_finite_finite_ne_empty
-    · simp [Iris.Std.LawfulSet.setInfinite]
-      intro l
-      have : ¬CoPset.isFinite (↑N) := nclose_not_finite N
-      rw [isFinite_setFinite] at this
-      simp [Iris.Std.LawfulSet.setFinite] at this
-      exact this l
+    · rw [←Iris.Std.LawfulSet.not_finite_infinite]
+      exact nclose_infinite N
     · rw [← isFinite_setFinite]
       exact set_to_coPset_finite E
   have ⟨hiN, hiE⟩ := CoPset.in_diff.mp (CoPset.mem_pick (↑N \ set_to_coPset E) hne)

--- a/Iris/Iris/Std/PartialMap.lean
+++ b/Iris/Iris/Std/PartialMap.lean
@@ -277,6 +277,11 @@ theorem get?_insert [DecidableEq K] {m : M V} {k k' : K} {v : V} :
   · exact get?_insert_eq h
   · exact get?_insert_ne h
 
+theorem dom_insert_iff [DecidableEq K] {m : M V} {k k' : K} {v : V} :
+    PartialMap.dom (insert m k v) k' ↔ k = k' ∨ PartialMap.dom m k' := by
+  simp only [PartialMap.dom, get?_insert]
+  by_cases h : k = k' <;> simp [h]
+
 theorem get?_delete [DecidableEq K] {m : M V} {k k' : K} :
     get? (delete m k) k' = if k = k' then none else get? m k' := by
   split <;> rename_i h
@@ -546,6 +551,18 @@ theorem disjoint_insert_left {m₁ m₂ : M V} {i : K} {x : V}
     simp [hi] at hs2
   · simp [get?_insert_ne hik] at hs1
     exact hdisj k ⟨hs1, hs2⟩
+
+/-- Disjointness of `insert m₁ i x` and `m₂` decomposes into freshness of `i`
+in `m₂` and the disjointness of `m₁` and `m₂`. -/
+theorem disjoint_insert_left_iff {m₁ m₂ : M V} {i : K} {x : V} (hi : get? m₁ i = none) :
+    insert m₁ i x ##ₘ m₂ ↔ get? m₂ i = none ∧ m₁ ##ₘ m₂ := by
+  refine ⟨fun hd => ⟨?_, fun k ⟨hs1, hs2⟩ => ?_⟩, fun ⟨h1, h2⟩ => disjoint_insert_left h1 h2⟩
+  · rcases h : get? m₂ i with _ | _
+    · rfl
+    · exact absurd (hd i ⟨by simp [get?_insert_eq rfl], by simp [h]⟩) id
+  · by_cases hik : i = k
+    · subst hik; simp [hi] at hs1
+    · exact hd k ⟨by simp [get?_insert_ne hik, hs1], hs2⟩
 
 theorem disjoint_insert_right {m₁ m₂ : M V} {i : K} {x : V}
     (hi : get? m₁ i = none) (hdisj : m₁ ##ₘ m₂) : m₁ ##ₘ insert m₂ i x := by


### PR DESCRIPTION
## Description
Updates `GenHeap` to be incude reservation maps, and ports `meta_token`. 


## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
