### PR TITLE
feat: quicksort adequacy example

### DIFF
--- a/Iris/Iris/HeapLang/Lib/Quicksort.lean
+++ b/Iris/Iris/HeapLang/Lib/Quicksort.lean
@@ -102,6 +102,16 @@ section Specs
 
 variable {GF : BundledGFunctors} [HeapLangGS hlc GF]
 
+theorem nil_spec (Φ : Val → IProp GF) :
+    (∀ v, isList v [] -∗ Φ v) -∗
+    WP hl(v(&nil)) {{ Φ }} := by
+  iintro Hl
+  unfold nil; wp_finish
+  imodintro
+  iapply Hl
+  iapply isList_nil
+  itrivial
+
 theorem cons_spec x l ls Φ :
     isList (GF:=GF) l ls -∗
     (∀ v, isList v (x :: ls) -∗ Φ v) -∗
@@ -278,12 +288,8 @@ theorem wp_makeList (l : List Int) (Φ : Val → IProp GF) :
   induction l generalizing Φ with
   | nil =>
     iintro HΦ
-    unfold makeList nil
-    wp_value_head
-    imodintro
-    iapply HΦ
-    unfold isList
-    itrivial
+    unfold makeList
+    iapply nil_spec $$ HΦ
   | cons l ls ih =>
     iintro HΦ
     rw [makeList]
@@ -292,9 +298,7 @@ theorem wp_makeList (l : List Int) (Φ : Val → IProp GF) :
     iapply ih
     iintro %v Hv
     wp_pures
-    iapply cons_spec $$ Hv
-    iintro %v Hv
-    iapply HΦ $$ Hv
+    iapply cons_spec $$ Hv HΦ
 
 /- When a HeapLang list is sorted, checkSorted returns true -/
 theorem wp_checkSorted (v vacc : Val) (l : List Int) (Φ : Val → IProp GF) :

--- a/Iris/Iris/HeapLang/Lib/Quicksort.lean
+++ b/Iris/Iris/HeapLang/Lib/Quicksort.lean
@@ -11,6 +11,8 @@ open BI Iris ProgramLogic List
 
 namespace Quicksort
 
+def nil : Val := hl_val% none()
+
 def cons : Val := hl_val% λ x, some(ref(x))
 
 def append : Val := hl_val%
@@ -54,6 +56,29 @@ def quicksort : Val := hl_val%
       let b := quicksort (snd(part));
       let e := &cons (head, b);
       &append (a, e)
+
+/-- Construct a HeapLang version of a Lean list -/
+def makeList : List Int → Exp
+  | [] => nil
+  | l::ls => hl%
+    let vls := &(makeList ls);
+    &cons (#l, vls)
+
+/-- Returns a boolean witnessing the sortedness of a HeapLang list.
+`acc` is an option of the last value in the list. -/
+def checkSorted : Val := hl_val%
+  rec check acc l :=
+    match l with
+    | none() => #true
+    | some(x) =>
+      let p := !x;
+      let head := fst(p);
+      let tail := snd(p);
+      let ok :=
+        (match acc with
+         | none() => #true
+         | some(v) => acc ≤ v);
+      ok && check (some(head)) tail
 
 section Predicates
 
@@ -246,3 +271,64 @@ theorem quicksort_spec l ls Φ :
 --     intro h1 h2 h3 h4
 --     have : l2.all (x < ·) := by grind [Perm.mem_iff]
 --     grind [pairwise_cons]
+
+theorem wp_makeList (l : List Int) :
+    ⊢@{IProp GF} WP hl(&(makeList l)) {{ (isList · l) }} := by
+  istart
+  induction l
+  · unfold makeList nil isList
+    wp_value_head
+    itrivial
+  · rename_i l ls ih
+    rw [makeList]
+    wp_pures
+    wp_bind &(makeList _)
+    -- Promote inductive hypothesis (Lean) to Iris context
+    -- Clean after iinduction lands
+    ihave IH : WP (makeList ls) {{ x, isList x ls }} $$ []; iapply ih; itrivial
+    clear ih
+    iapply wp_mono $$ IH
+    iintro %v Hv
+    wp_pures
+    iapply cons_spec $$ [$]
+    iintro %v Hv
+    itrivial
+
+/- When a HeapLang list is sorted, checkSorted returns true -/
+theorem wp_checkSorted (v vacc : Val) (l : List Int) :
+    isList (GF := GF) v l ∗ ⌜List.Pairwise (· ≤ ·) l⌝ ∗
+    ⌜vacc = hl_val(none()) ∨ ∃ va : Int, vacc = hl_val(some(#va)) ∧ ∀ lv ∈ l, va ≤ lv⌝
+    ⊢ WP hl(&checkSorted &vacc &v) {{ fun bv => iprop% isList v l ∗ ⌜bv = hl_val(#true)⌝}} := by
+  iintro ⟨H, %hsorted, %hinv⟩
+  iloeb as IH generalizing %l %v %hsorted %hinv
+  rw (occs:=[2]) [checkSorted]
+  wp_pures
+  sorry
+
+end Specs
+
+section Closed
+
+/-- Construct a HeapLang list, quicksort it, and check that it is sorted. -/
+def sortAndCheck (l : List Int) : Exp := hl%
+  let v := &(makeList l);
+  let v' := &quicksort v;
+  checkSorted (none()) v'
+
+theorem wp_sortAndCheck [HeapLangGS hlc GF] (l : List Int) :
+    ⊢@{IProp GF} WP (sortAndCheck l) {{ fun bv => iprop% ⌜bv = hl_val(#true)⌝}} := by
+  sorry
+
+
+def HeapLangS : BundledGFunctors := sorry
+
+instance instHeapLangGS_HeapLangS : HeapLangGpreS HasLC.hasLC HeapLangS := sorry
+
+/-- Full application of adequacy: sortAndCheck is safe in any state and only ever return true. -/
+theorem sortAndCheckAdequate (l : List Int) (σ : State) :
+    adequate .NotStuck (sortAndCheck l) σ (fun v _ => v = hl_val(#true)) := by
+  apply heap_adequacy (GF := HeapLangS)
+  intro _
+  apply wp_sortAndCheck
+
+end Closed

--- a/Iris/Iris/HeapLang/Lib/Quicksort.lean
+++ b/Iris/Iris/HeapLang/Lib/Quicksort.lean
@@ -319,10 +319,33 @@ theorem wp_sortAndCheck [HeapLangGS hlc GF] (l : List Int) :
     ⊢@{IProp GF} WP (sortAndCheck l) {{ fun bv => iprop% ⌜bv = hl_val(#true)⌝}} := by
   sorry
 
+-- TODO: Move (potentially after the demo? Depends on if/how Michael wants to show this)
+def HeapLangS : BundledGFunctors
+  | 0 => ⟨InvMapF, by infer_instance⟩
+  | 1 => ⟨constOF (DisjointLeibnizSet CoPset), by infer_instance⟩
+  | 2 => ⟨constOF (DisjointLeibnizSet PosSet), by infer_instance⟩
+  | 3 => ⟨Auth.AuthURF (F := PNat) (constOF Credit), by infer_instance⟩
+  | 4 => ⟨constOF (HeapView PNat Loc (Agree (LeibnizO (Option Val))) HeapF), by infer_instance⟩
+  | 5 => ⟨constOF (HeapView PNat Loc (Agree (LeibnizO GName)) HeapF), by infer_instance⟩
+  | 6 => ⟨constOF MetaUR, by infer_instance⟩
+  | _ => ⟨constOF Unit, by infer_instance⟩
 
-def HeapLangS : BundledGFunctors := sorry
-
-instance instHeapLangGS_HeapLangS : HeapLangGpreS HasLC.hasLC HeapLangS := sorry
+instance instHeapLangGS_HeapLangS : HeapLangGpreS HasLC.hasLC HeapLangS where
+  toWsatGpreS := by
+    constructor
+    · exists 0
+    · exists 1
+    · exists 2
+  toLcGpreS := by
+    constructor
+    · exists 3
+  heap_pre := by
+    constructor
+    · constructor
+      exists 4
+    · constructor
+      exists 5
+    · exists 6
 
 /-- Full application of adequacy: sortAndCheck is safe in any state and only ever return true. -/
 theorem sortAndCheckAdequate (l : List Int) (σ : State) :

--- a/Iris/Iris/HeapLang/Lib/Quicksort.lean
+++ b/Iris/Iris/HeapLang/Lib/Quicksort.lean
@@ -77,7 +77,7 @@ def checkSorted : Val := hl_val%
       let ok :=
         (match acc with
          | none() => #true
-         | some(v) => acc ≤ v);
+         | some(v) => v ≤ head);
       ok && check (some(head)) tail
 
 section Predicates
@@ -272,38 +272,80 @@ theorem quicksort_spec l ls Φ :
 --     have : l2.all (x < ·) := by grind [Perm.mem_iff]
 --     grind [pairwise_cons]
 
-theorem wp_makeList (l : List Int) :
-    ⊢@{IProp GF} WP hl(&(makeList l)) {{ (isList · l) }} := by
-  istart
-  induction l
-  · unfold makeList nil isList
+theorem wp_makeList (l : List Int) (Φ : Val → IProp GF) :
+    (∀ v, isList v l -∗ Φ v) -∗
+    WP hl(&(makeList l)) {{ Φ }} := by
+  induction l generalizing Φ with
+  | nil =>
+    iintro HΦ
+    unfold makeList nil
     wp_value_head
+    imodintro
+    iapply HΦ
+    unfold isList
     itrivial
-  · rename_i l ls ih
+  | cons l ls ih =>
+    iintro HΦ
     rw [makeList]
     wp_pures
     wp_bind &(makeList _)
-    -- Promote inductive hypothesis (Lean) to Iris context
-    -- Clean after iinduction lands
-    ihave IH : WP (makeList ls) {{ x, isList x ls }} $$ []; iapply ih; itrivial
-    clear ih
-    iapply wp_mono $$ IH
+    iapply ih
     iintro %v Hv
     wp_pures
-    iapply cons_spec $$ [$]
+    iapply cons_spec $$ Hv
     iintro %v Hv
-    itrivial
+    iapply HΦ $$ Hv
 
 /- When a HeapLang list is sorted, checkSorted returns true -/
-theorem wp_checkSorted (v vacc : Val) (l : List Int) :
-    isList (GF := GF) v l ∗ ⌜List.Pairwise (· ≤ ·) l⌝ ∗
-    ⌜vacc = hl_val(none()) ∨ ∃ va : Int, vacc = hl_val(some(#va)) ∧ ∀ lv ∈ l, va ≤ lv⌝
-    ⊢ WP hl(&checkSorted &vacc &v) {{ fun bv => iprop% isList v l ∗ ⌜bv = hl_val(#true)⌝}} := by
-  iintro ⟨H, %hsorted, %hinv⟩
-  iloeb as IH generalizing %l %v %hsorted %hinv
+theorem wp_checkSorted (v vacc : Val) (l : List Int) (Φ : Val → IProp GF) :
+    isList (GF := GF) v l -∗
+    ⌜List.Pairwise (· ≤ ·) l⌝ -∗
+    ⌜vacc = hl_val(none()) ∨ ∃ va : Int, vacc = hl_val(some(#va)) ∧ ∀ lv ∈ l, va ≤ lv⌝ -∗
+    (∀ bv, isList v l -∗ ⌜bv = hl_val(#true)⌝ -∗ Φ bv) -∗
+    WP hl(&checkSorted &vacc &v) {{ Φ }} := by
+  iintro H %hsorted %hinv HΦ
+  iloeb as IH generalizing %vacc %l %v %hsorted %hinv
   rw (occs:=[2]) [checkSorted]
   wp_pures
-  sorry
+  cases l with
+  | nil =>
+    icases isList_nil $$ H with %heq; subst heq
+    wp_pures
+    imodintro
+    iapply HΦ $$ H
+    itrivial
+  | cons hd tl =>
+    icases isList_cons $$ H with ⟨%loc, %tlv, %heq, Hpt, Htl⟩
+    subst heq
+    wp_pures
+    wp_bind !_
+    iapply wp_load $$ Hpt
+    iintro !> Hpt
+    rcases hinv with rfl | ⟨va, rfl, hva⟩
+    · iterate 15 wp_pure
+      rw [← checkSorted]
+      iapply IH $$ %_ %tl %_ %((List.pairwise_cons.mp hsorted).2)
+        %(Or.inr ⟨hd, rfl, fun lv h => (List.pairwise_cons.mp hsorted).1 lv h⟩) Htl
+      iintro %bv Hl %hb
+      iapply HΦ $$ [Hpt Hl]
+      · rw [isList]
+        iexists loc, tlv
+        iframe
+        itrivial
+      itrivial
+    · wp_pures
+      rw [decide_eq_true (hva hd List.mem_cons_self)]
+      iterate 2 wp_pure
+      rw [← checkSorted]
+      iapply IH $$ %_ %tl %_ %((List.pairwise_cons.mp hsorted).2)
+        %(.inr ⟨hd, rfl, (List.pairwise_cons.mp hsorted).1⟩) Htl
+      iintro %bv Hl %hb
+      iapply HΦ $$ [Hpt Hl]
+      · rw [isList]
+        iexists loc, tlv
+        iframe
+        itrivial
+      itrivial
 
 end Specs
 
@@ -313,39 +355,22 @@ section Closed
 def sortAndCheck (l : List Int) : Exp := hl%
   let v := &(makeList l);
   let v' := &quicksort v;
-  checkSorted (none()) v'
+  &checkSorted (none()) v'
 
 theorem wp_sortAndCheck [HeapLangGS hlc GF] (l : List Int) :
     ⊢@{IProp GF} WP (sortAndCheck l) {{ fun bv => iprop% ⌜bv = hl_val(#true)⌝}} := by
-  sorry
-
--- TODO: Move (potentially after the demo? Depends on if/how Michael wants to show this)
-def HeapLangS : BundledGFunctors
-  | 0 => ⟨InvMapF, by infer_instance⟩
-  | 1 => ⟨constOF (DisjointLeibnizSet CoPset), by infer_instance⟩
-  | 2 => ⟨constOF (DisjointLeibnizSet PosSet), by infer_instance⟩
-  | 3 => ⟨Auth.AuthURF (F := PNat) (constOF Credit), by infer_instance⟩
-  | 4 => ⟨constOF (HeapView PNat Loc (Agree (LeibnizO (Option Val))) HeapF), by infer_instance⟩
-  | 5 => ⟨constOF (HeapView PNat Loc (Agree (LeibnizO GName)) HeapF), by infer_instance⟩
-  | 6 => ⟨constOF MetaUR, by infer_instance⟩
-  | _ => ⟨constOF Unit, by infer_instance⟩
-
-instance instHeapLangGS_HeapLangS : HeapLangGpreS HasLC.hasLC HeapLangS where
-  toWsatGpreS := by
-    constructor
-    · exists 0
-    · exists 1
-    · exists 2
-  toLcGpreS := by
-    constructor
-    · exists 3
-  heap_pre := by
-    constructor
-    · constructor
-      exists 4
-    · constructor
-      exists 5
-    · exists 6
+  unfold sortAndCheck
+  wp_bind &(makeList _)
+  iapply wp_makeList
+  iintro %v Hv
+  wp_pures
+  wp_bind v(&quicksort) _
+  iapply quicksort_spec $$ Hv
+  iintro %v %l' Hv %Hsorted %Heqv
+  wp_pures
+  iapply wp_checkSorted $$ Hv %Hsorted %(Or.inl rfl)
+  iintro %bv Hv' %hbv
+  itrivial
 
 /-- Full application of adequacy: sortAndCheck is safe in any state and only ever return true. -/
 theorem sortAndCheckAdequate (l : List Int) (σ : State) :

--- a/Iris/Iris/HeapLang/PrimitiveLaws.lean
+++ b/Iris/Iris/HeapLang/PrimitiveLaws.lean
@@ -38,6 +38,33 @@ instance HeapLang [HeapLangGS hlc GF] : IrisGS_gen hlc Exp GF where
   forkPost v := iprop(True)
   stateInterp_mono σ ns obs nt := by iintro $
 
+def HeapLangS : BundledGFunctors
+  | 0 => ⟨InvMapF, by infer_instance⟩
+  | 1 => ⟨constOF (DisjointLeibnizSet CoPset), by infer_instance⟩
+  | 2 => ⟨constOF (DisjointLeibnizSet PosSet), by infer_instance⟩
+  | 3 => ⟨Auth.AuthURF (F := PNat) (constOF Credit), by infer_instance⟩
+  | 4 => ⟨constOF (HeapView PNat Loc (Agree (LeibnizO (Option Val))) HeapF), by infer_instance⟩
+  | 5 => ⟨constOF (HeapView PNat Loc (Agree (LeibnizO GName)) HeapF), by infer_instance⟩
+  | 6 => ⟨constOF MetaUR, by infer_instance⟩
+  | _ => ⟨constOF Unit, by infer_instance⟩
+
+instance instHeapLangGS_HeapLangS : HeapLangGpreS HasLC.hasLC HeapLangS where
+  toWsatGpreS := by
+    constructor
+    · exists 0
+    · exists 1
+    · exists 2
+  toLcGpreS := by
+    constructor
+    · exists 3
+  heap_pre := by
+    constructor
+    · constructor
+      exists 4
+    · constructor
+      exists 5
+    · exists 6
+
 end HeapLangGS
 
 section Adequacy


### PR DESCRIPTION
## Description
Example of applying adequacy to a quicksort client 

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
