### PR TITLE
feat: free variables linter for HeapLang

### DIFF
--- a/Iris/Iris/Examples/HeapLang.lean
+++ b/Iris/Iris/Examples/HeapLang.lean
@@ -11,8 +11,6 @@ namespace Iris.Examples.HeapLang
 
 open Iris.HeapLang
 
-set_option linter.heapLang.freeVars true
-
 /-! ## Basic functions -/
 
 def identity : Exp := hl(λ x, x)

--- a/Iris/Iris/Examples/HeapLang.lean
+++ b/Iris/Iris/Examples/HeapLang.lean
@@ -11,6 +11,8 @@ namespace Iris.Examples.HeapLang
 
 open Iris.HeapLang
 
+set_option linter.heapLang.freeVars true
+
 /-! ## Basic functions -/
 
 def identity : Exp := hl(λ x, x)
@@ -149,8 +151,8 @@ def listSumIncremented : Exp :=
 
 def casIncrementTwice : Exp :=
   hl(λ l,
-    &casIncrement l;
-    &casIncrement l)
+    (&casIncrement l;
+    &casIncrement l))
 
 def factorialOfCounter : Exp :=
   hl(let c := ref(#0);
@@ -226,7 +228,7 @@ def lockedCounter : Exp :=
 /-! ## Prophecy variables -/
 
 def nondetBool : Exp :=
-  hl(λ _, let l := ref #true; fork (l ← #false); !l)
+  hl(λ _, let l := ref(#true); fork(l ← #false); !l)
 
 def newCoin : Exp :=
   hl(λ _, (ref(injl(#())), &Exp.newProph))

--- a/Iris/Iris/Examples/HeapLang.lean
+++ b/Iris/Iris/Examples/HeapLang.lean
@@ -149,8 +149,8 @@ def listSumIncremented : Exp :=
 
 def casIncrementTwice : Exp :=
   hl(λ l,
-    (&casIncrement l;
-    &casIncrement l))
+    &casIncrement l;
+    &casIncrement l)
 
 def factorialOfCounter : Exp :=
   hl(let c := ref(#0);

--- a/Iris/Iris/HeapLang.lean
+++ b/Iris/Iris/HeapLang.lean
@@ -2,3 +2,4 @@ module
 
 public import Iris.HeapLang.Syntax
 public import Iris.HeapLang.Notation
+public import Iris.HeapLang.Linter

--- a/Iris/Iris/HeapLang/Lib/Quicksort.lean
+++ b/Iris/Iris/HeapLang/Lib/Quicksort.lean
@@ -2,6 +2,7 @@ module
 
 public import Iris.HeapLang.PrimitiveLaws
 public import Iris.HeapLang.ProofMode
+public import Iris.HeapLang.Linter
 
 namespace Iris.HeapLang
 

--- a/Iris/Iris/HeapLang/Lib/Quicksort.lean
+++ b/Iris/Iris/HeapLang/Lib/Quicksort.lean
@@ -2,7 +2,6 @@ module
 
 public import Iris.HeapLang.PrimitiveLaws
 public import Iris.HeapLang.ProofMode
-public import Iris.HeapLang.Linter
 
 namespace Iris.HeapLang
 

--- a/Iris/Iris/HeapLang/Linter.lean
+++ b/Iris/Iris/HeapLang/Linter.lean
@@ -17,10 +17,10 @@ open Lean Lean.Elab Lean.Elab.Command Lean.Linter
 The `linter.heapLang.freeVars` linter warns about unbound variables appearing
 in a HeapLang expression written with the `hl(...)` / `hl_val(...)` notation.
 
-Default value is `false`.
+Default value is `true`.
 -/
 register_option linter.heapLang.freeVars : Bool := {
-  defValue := false
+  defValue := true
   descr := "warn about unbound variables in HeapLang `hl(...)` expressions"
 }
 

--- a/Iris/Iris/HeapLang/Linter.lean
+++ b/Iris/Iris/HeapLang/Linter.lean
@@ -1,0 +1,122 @@
+/-
+Copyright (c) 2026 Markus de Medeiros. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Iris.HeapLang.Notation
+public meta import Lean.Elab.Command
+public meta import Lean.Linter.Util
+
+public meta section
+namespace Iris.HeapLang.Linter
+
+open Lean Lean.Elab Lean.Elab.Command Lean.Linter
+
+/--
+The `linter.heapLang.freeVars` linter warns about unbound variables appearing
+in a HeapLang expression written with the `hl(...)` / `hl_val(...)` notation.
+
+Default value is `false`.
+-/
+register_option linter.heapLang.freeVars : Bool := {
+  defValue := false
+  descr := "warn about unbound variables in HeapLang `hl(...)` expressions"
+}
+
+/-- The result of inspecting a single `hl_binder`. -/
+inductive BinderInfo where
+  /-- A named binder `x`, which brings `name` into scope. -/
+  | named (name : String)
+  /-- The anonymous binder `_`; brings nothing into scope. -/
+  | anon
+  /-- An escaped binder `&t` whose name is a meta-level value we cannot inspect. We cannot
+      tell whether a variable in the body it scopes refers to it, so that body is left
+      unchecked entirely (see `extendScope`). -/
+  | escaped
+deriving Inhabited
+
+/-- Classify a `hl_binder` syntax node. -/
+def classifyBinder (stx : Syntax) : BinderInfo :=
+  match stx with
+  | `(hl_binder| & $_) => .escaped
+  | `(hl_binder| $i:ident) => .named i.getId.toString
+  | _ => .anon -- `_`
+
+/-- Extend `scope` with the names bound by `bs`, returning the scope under which the body of
+the binder should be analyzed. If `bs` binds an escaped binder, returns `none` to flag
+the analysis as incomplete. -/
+def extendScope (scope : List String) (bs : Array Syntax) : Option (List String) := Id.run do
+  let mut scope := scope
+  for b in bs do
+    match classifyBinder b with
+    | .named n => scope := n :: scope
+    | .anon => pure ()
+    | .escaped => return none
+  return some scope
+
+def matchArmBinder (stx : Syntax) : Option Syntax :=
+  match stx with
+  | `(hl_match_arm| injl($b)) => some b
+  | `(hl_match_arm| injr($b)) => some b
+  | `(hl_match_arm| some($b)) => some b
+  | _ => none -- `none()`
+
+partial def analyze (scope : List String) (stx : Syntax) :
+    CommandElabM Unit := do
+  let underBinders (bs : Array Syntax) (body : Syntax) : CommandElabM Unit := do
+    if let some scope := extendScope scope bs then analyze scope body
+  match stx with
+  | `(hl_exp| $i:ident) =>
+    let name := i.getId.toString
+    unless scope.contains name do
+      logLint linter.heapLang.freeVars i m!"\
+        unbound HeapLang variable `{name}`.\n\n\
+        • If you meant a meta-level (Lean) definition, escape it: `&{name}`.\n\
+        • Otherwise `{name}` is a free variable, and likely a typo.\n\
+        You can suppress this warning with `set_option linter.heapLang.freeVars false`"
+  | `(hl_exp| & $_) => pure ()
+  | `(hl_exp| # $_) => pure ()
+  | `(hl_exp| v($_)) => pure ()
+  | `(hl_val| & $_) => pure ()
+  | `(hl_val| # $_) => pure ()
+  | `(hl_exp| λ $bs*, $e) => underBinders (bs.map (·.raw)) e
+  | `(hl_exp| rec $f $xs* := $e) => underBinders (#[f.raw] ++ xs.map (·.raw)) e
+  | `(hl_exp| let $b := $e1; $e2) =>
+    analyze scope e1
+    underBinders #[b.raw] e2
+  | `(hl_exp| match $e with | $a1 => $e1 | $a2 => $e2) =>
+    analyze scope e
+    underBinders (matchArmBinder a1.raw).toArray e1.raw
+    underBinders (matchArmBinder a2.raw).toArray e2.raw
+  | `(hl_val| λ $bs*, $e) => underBinders (bs.map (·.raw)) e
+  | `(hl_val| rec $f $xs* := $e) => underBinders (#[f.raw] ++ xs.map (·.raw)) e
+  | _ => for arg in stx.getArgs do analyze scope arg
+
+/--
+Collect every *outermost* `hl(...)` / `hl_val(...)` embedding in a command's syntax.
+This does not descend into nested `&(hl(...))` forms.
+-/
+partial def collectEntries (stx : Syntax) (acc : Array Syntax) : Array Syntax := Id.run do
+  match stx with
+  | `(hl($e)) => return acc.push e
+  | `(hl% $e) => return acc.push e
+  | `(hl_val($v)) => return acc.push v
+  | `(hl_val% $v) => return acc.push v
+  | _ =>
+    let mut acc := acc
+    for arg in stx.getArgs do
+      acc := collectEntries arg acc
+    return acc
+
+/-- The HeapLang free-variable linter. -/
+def freeVarsLinter : Linter where
+  run := fun stx => do
+    unless getLinterValue linter.heapLang.freeVars (← getLinterOptions) do return
+    for entry in collectEntries stx #[] do
+      analyze [] entry
+  name := `Iris.HeapLang.freeVars
+
+initialize addLinter freeVarsLinter
+
+end Iris.HeapLang.Linter

--- a/Iris/Iris/HeapLang/Notation.lean
+++ b/Iris/Iris/HeapLang/Notation.lean
@@ -108,13 +108,13 @@ syntax:10 "let " hl_binder " := " hl_exp:10 "; " hl_exp:1 : hl_exp
 /-- sequencing -/
 syntax:5 hl_exp:6 "; " hl_exp:5 : hl_exp
 /-- lambda -/
-syntax:10 "λ " hl_binder+ ", " hl_exp:10 : hl_exp
+syntax:10 "λ " hl_binder+ ", " hl_exp:1 : hl_exp
 /-- lambda -/
-syntax:10 "λ " hl_binder+ ", " hl_exp:10 : hl_val
+syntax:10 "λ " hl_binder+ ", " hl_exp:1 : hl_val
 /-- recursive function -/
-syntax:10 "rec " hl_binder ppSpace hl_binder+ " := " hl_exp:10 : hl_exp
+syntax:10 "rec " hl_binder ppSpace hl_binder+ " := " hl_exp:1 : hl_exp
 /-- recursive function -/
-syntax:10 "rec " hl_binder ppSpace hl_binder+ " := " hl_exp:10 : hl_val
+syntax:10 "rec " hl_binder ppSpace hl_binder+ " := " hl_exp:1 : hl_val
 
 /-- pairs -/
 syntax:max "(" hl_exp ", " hl_exp,+ ")" : hl_exp

--- a/Iris/Iris/HeapLang/Semantics.lean
+++ b/Iris/Iris/HeapLang/Semantics.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Iris.HeapLang.Syntax
+public import Iris.HeapLang.Linter
 public import Std.Data.ExtTreeMap
 public import Std.Data.ExtTreeSet
 public import Iris.Std.BitOp

--- a/Iris/Iris/Tests/HeapLang.lean
+++ b/Iris/Iris/Tests/HeapLang.lean
@@ -2,3 +2,4 @@ module
 
 public import Iris.Tests.HeapLang.Notation
 public import Iris.Tests.HeapLang.WeakestPre
+public import Iris.Tests.HeapLang.Linter

--- a/Iris/Iris/Tests/HeapLang/Linter.lean
+++ b/Iris/Iris/Tests/HeapLang/Linter.lean
@@ -1,0 +1,102 @@
+/-
+Copyright (c) 2026 Markus de Medeiros. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Iris.HeapLang
+
+@[expose] public section
+namespace Iris.Tests.HeapLang.Linter
+
+open Iris.HeapLang
+
+set_option linter.heapLang.freeVars true
+
+#guard_msgs(drop info, check warning) in
+#check hl(λ x, x + #1)
+
+#guard_msgs(drop info, check warning) in
+#check hl(rec f x := f x)
+
+#guard_msgs(drop info, check warning) in
+#check hl(let z := #1; z + z)
+
+#guard_msgs(drop info, check warning) in
+#check hl(λ x y, let z := #1; #2; x + y + z)
+
+#guard_msgs(drop info, check warning) in
+#check hl(match injl(#1) with | injl(a) => a | injr(b) => b)
+
+section
+variable (e : Exp)
+#guard_msgs(drop info, check warning) in
+#check hl(&e + #1)
+end
+
+-- Escaped binder taints the scope (partial analysis)
+section
+variable (b : Binder)
+#guard_msgs(drop info, check warning) in
+#check hl(λ &b, y)
+end
+
+/--
+warning: unbound HeapLang variable `foo`.
+
+• If you meant a meta-level (Lean) definition, escape it: `&foo`.
+• Otherwise `foo` is a free variable, and likely a typo.
+You can suppress this warning with `set_option linter.heapLang.freeVars false`
+
+Note: This linter can be disabled with `set_option linter.heapLang.freeVars false`
+-/
+#guard_msgs(drop info, check warning) in
+#check hl(foo #1)
+
+/--
+warning: unbound HeapLang variable `y`.
+
+• If you meant a meta-level (Lean) definition, escape it: `&y`.
+• Otherwise `y` is a free variable, and likely a typo.
+You can suppress this warning with `set_option linter.heapLang.freeVars false`
+
+Note: This linter can be disabled with `set_option linter.heapLang.freeVars false`
+-/
+#guard_msgs(drop info, check warning) in
+#check hl(λ x, x + y)
+
+/--
+warning: unbound HeapLang variable `x`.
+
+• If you meant a meta-level (Lean) definition, escape it: `&x`.
+• Otherwise `x` is a free variable, and likely a typo.
+You can suppress this warning with `set_option linter.heapLang.freeVars false`
+
+Note: This linter can be disabled with `set_option linter.heapLang.freeVars false`
+-/
+#guard_msgs(drop info, check warning) in
+#check hl((let x := #1; x) + x)
+
+-- Opt-out
+set_option linter.heapLang.freeVars false in
+#guard_msgs(drop info, check warning) in
+#check hl(bar #1)
+
+-- Keyword without parens
+/--
+warning: unbound HeapLang variable `ref`.
+
+• If you meant a meta-level (Lean) definition, escape it: `&ref`.
+• Otherwise `ref` is a free variable, and likely a typo.
+You can suppress this warning with `set_option linter.heapLang.freeVars false`
+
+Note: This linter can be disabled with `set_option linter.heapLang.freeVars false`
+-/
+#guard_msgs(drop info, check warning) in
+#check hl(λ _, ref #true)
+
+-- Partiality: nested exprs not inspected
+#guard_msgs(drop info, check warning) in
+#check hl(let c := ref(#0); &(hl(c ← #1)))
+
+end Iris.Tests.HeapLang.Linter

--- a/Iris/Iris/Tests/HeapLang/Notation.lean
+++ b/Iris/Iris/Tests/HeapLang/Notation.lean
@@ -35,9 +35,12 @@ set_option pp.explicit true in
 #guard_msgs in
 #check hl((#1 + #1) + &v)
 
+set_option linter.heapLang.freeVars false in
 /-- info: hl((#1 = (v + (v(&v) + &e)))) : Exp -/
 #guard_msgs in
 #check hl(#1 = v + &v + &e)
+
+set_option linter.heapLang.freeVars false in
 /--
 info: Exp.binop BinOp.eq
   (@ProgramLogic.ToVal.ofVal Exp Val instToVal (Val.lit ↑(@OfNat.ofNat Int (nat_lit 1) (@instOfNat (nat_lit 1)))))
@@ -182,12 +185,14 @@ set_option pp.explicit true in
 #check hl(λ x y, #1 + #2 +ₗ #3 - #4 * #5 / #6 % #7 &&& #8 ||| #9 ^^^ #10 <<< #11 >>> #12 <= #13 ≤ #14 < #15 = #16 + (-#17) + (~#18))
 
 /--
-info: Exp.binop BinOp.shiftl (Exp.var "x").load
-  (@ProgramLogic.ToVal.ofVal Exp Val instToVal (Val.lit ↑(@OfNat.ofNat Int (nat_lit 1) (@instOfNat (nat_lit 1))))) : Exp
+info: Exp.rec_ Binder.anon (Binder.named "x")
+  (Exp.binop BinOp.shiftl (Exp.var "x").load
+    (@ProgramLogic.ToVal.ofVal Exp Val instToVal
+      (Val.lit ↑(@OfNat.ofNat Int (nat_lit 1) (@instOfNat (nat_lit 1)))))) : Exp
 -/
 #guard_msgs in
 set_option pp.explicit true in
-#check hl(!x <<< #1)
+#check hl(λ x, !x <<< #1)
 
 /-- info: hl(if #1 then #2 else #3) : Exp -/
 #guard_msgs in
@@ -197,6 +202,7 @@ set_option pp.explicit true in
 #guard_msgs in
 #check hl(#1)
 
+set_option linter.heapLang.freeVars false in
 /-- info: hl(if if a then b else #false then #true else if c then d else #false) : Exp -/
 #guard_msgs in
 #check hl(a && b || c && d)


### PR DESCRIPTION
## Description
Adds a free variables linter for HeapLang. It's opt-in and partial, but it caught two bugs in our HeapLang example programs file! 

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
