### PR TITLE
feat: support multiple argument functions with wp_rec

### DIFF
--- a/Iris/Iris/HeapLang/Lib/Quicksort.lean
+++ b/Iris/Iris/HeapLang/Lib/Quicksort.lean
@@ -11,37 +11,33 @@ open BI Iris ProgramLogic List
 
 namespace Quicksort
 
-def nil : Val := hl_val% none()
+def nil : Val := hl_val% λ _, none()
 
-def cons : Val := hl_val% λ x, some(ref(x))
+def cons : Val := hl_val% λ hd tl, some(ref((hd, tl)))
 
 def append : Val := hl_val%
-  rec append x :=
-    let l1 := fst(x);
-    let l2 := snd(x);
+  rec append l1 l2 :=
     match l1 with
     | none() => l2
     | some(x) =>
       let p := !x;
       let head := fst(p);
       let tail := snd(p);
-      &cons (head, append (tail, l2))
+      &cons head (append tail l2)
 
 def partition : Val := hl_val%
-  rec partition arg :=
-    let x := fst(arg);
-    let l := snd(arg);
+  rec partition x l :=
     match l with
     | none() => (none(), none())
     | some(lx) =>
       let p := !lx;
       let head := fst(p);
       let tail := snd(p);
-      let part := partition (x, tail);
+      let part := partition x tail;
       if head ≤ x then
-        (&cons (head, fst(part)), snd(part))
+        (&cons head (fst(part)), snd(part))
       else
-        (fst(part), &cons (head, snd(part)))
+        (fst(part), &cons head (snd(part)))
 
 def quicksort : Val := hl_val%
   rec quicksort l :=
@@ -51,18 +47,18 @@ def quicksort : Val := hl_val%
       let p := !x;
       let head := fst(p);
       let tail := snd(p);
-      let part := &partition (head, tail);
+      let part := &partition head tail;
       let a := quicksort (fst(part));
       let b := quicksort (snd(part));
-      let e := &cons (head, b);
-      &append (a, e)
+      let e := &cons head b;
+      &append a e
 
 /-- Construct a HeapLang version of a Lean list -/
 def makeList : List Int → Exp
-  | [] => nil
+  | [] => hl% &nil #()
   | l::ls => hl%
     let vls := &(makeList ls);
-    &cons (#l, vls)
+    &cons #l vls
 
 /-- Returns a boolean witnessing the sortedness of a HeapLang list.
 `acc` is an option of the last value in the list. -/
@@ -104,9 +100,10 @@ variable {GF : BundledGFunctors} [HeapLangGS hlc GF]
 
 theorem nil_spec (Φ : Val → IProp GF) :
     (∀ v, isList v [] -∗ Φ v) -∗
-    WP hl(v(&nil)) {{ Φ }} := by
+    WP hl(v(&nil) #()) {{ Φ }} := by
   iintro Hl
-  unfold nil; wp_finish
+  wp_rec
+  wp_pures
   imodintro
   iapply Hl
   iapply isList_nil
@@ -115,9 +112,9 @@ theorem nil_spec (Φ : Val → IProp GF) :
 theorem cons_spec x l ls Φ :
     isList (GF:=GF) l ls -∗
     (∀ v, isList v (x :: ls) -∗ Φ v) -∗
-    WP hl(&cons v((#x, &l))) {{ Φ }} := by
+    WP hl(&cons #x &l) {{ Φ }} := by
   iintro Hl HΦ
-  wp_rec
+  wp_rec; wp_pures
   wp_bind ref(_)
   iapply wp_alloc
   iintro !> %l Hl
@@ -132,7 +129,7 @@ theorem append_spec l1 ls1 l2 ls2 Φ :
     isList (GF:=GF) l1 ls1 -∗
     isList l2 ls2 -∗
     (∀ v, isList v (ls1 ++ ls2) -∗ Φ v) -∗
-    WP hl(&append v((&l1, &l2))) {{ Φ }} := by
+    WP hl(&append &l1 &l2) {{ Φ }} := by
   iintro Hl1 Hl2 HΦ
   iloeb as IH generalizing %l1 %ls1 %Φ
   wp_rec; wp_pures
@@ -149,7 +146,7 @@ theorem append_spec l1 ls1 l2 ls2 Φ :
     iapply wp_load $$ Hpt
     iintro !> Hpt
     wp_pures
-    wp_bind &append _
+    wp_bind &append _ _
     iapply IH $$ Hl Hl2
     iintro %_ Hl
     wp_pures
@@ -165,7 +162,7 @@ theorem partition_spec x l ls Φ :
       isList l1 (ls.filter (· ≤ x)) -∗
       isList l2 (ls.filter (x < ·)) -∗
       Φ hl_val((&l1, &l2))) -∗
-    WP hl(&partition v((#x, &l))) {{ Φ }} := by
+    WP hl(&partition #x &l) {{ Φ }} := by
   iintro Hl HΦ
   iloeb as IH generalizing %l %ls %Φ
   wp_rec; wp_pures
@@ -184,20 +181,20 @@ theorem partition_spec x l ls Φ :
     iapply wp_load $$ [$]
     iintro !> Hpt
     wp_pures
-    wp_bind &partition _
+    wp_bind &partition _ _
     iapply IH $$ Hl
     iintro %l1 %l2 Hl1 Hl2
     wp_pures
     by_cases hd ≤ x <;> simp [*]
     · wp_pures
-      wp_bind &cons _
+      wp_bind &cons _ _
       iapply cons_spec $$ Hl1
       iintro %_ _
       wp_pures
       imodintro
       iapply HΦ $$ [$] [$]
     · wp_pures
-      wp_bind &cons _
+      wp_bind &cons _ _
       iapply cons_spec $$ Hl2
       iintro %_ _
       wp_pures
@@ -238,7 +235,7 @@ theorem quicksort_spec l ls Φ :
     iapply wp_load $$ [$]
     iintro !> Hpt
     wp_pures
-    wp_bind &partition _
+    wp_bind &partition _ _
     iapply partition_spec $$ [$]
     iintro %l1 %l2 Hl1 Hl2
     wp_pures
@@ -250,7 +247,7 @@ theorem quicksort_spec l ls Φ :
     iapply IH $$ [$]
     iintro %l2' %ls2' Hl2 %_ %_
     wp_pures
-    wp_bind &cons _
+    wp_bind &cons _ _
     iapply cons_spec $$ Hl2
     iintro %_ _
     wp_pures
@@ -309,8 +306,7 @@ theorem wp_checkSorted (v vacc : Val) (l : List Int) (Φ : Val → IProp GF) :
     WP hl(&checkSorted &vacc &v) {{ Φ }} := by
   iintro H %hsorted %hinv HΦ
   iloeb as IH generalizing %vacc %l %v %hsorted %hinv
-  rw (occs:=[2]) [checkSorted]
-  wp_pures
+  wp_rec; wp_pures
   cases l with
   | nil =>
     icases isList_nil $$ H with %heq; subst heq
@@ -326,8 +322,7 @@ theorem wp_checkSorted (v vacc : Val) (l : List Int) (Φ : Val → IProp GF) :
     iapply wp_load $$ Hpt
     iintro !> Hpt
     rcases hinv with rfl | ⟨va, rfl, hva⟩
-    · iterate 15 wp_pure
-      rw [← checkSorted]
+    · wp_pures
       iapply IH $$ %_ %tl %_ %((List.pairwise_cons.mp hsorted).2)
         %(Or.inr ⟨hd, rfl, fun lv h => (List.pairwise_cons.mp hsorted).1 lv h⟩) Htl
       iintro %bv Hl %hb
@@ -339,8 +334,7 @@ theorem wp_checkSorted (v vacc : Val) (l : List Int) (Φ : Val → IProp GF) :
       itrivial
     · wp_pures
       rw [decide_eq_true (hva hd List.mem_cons_self)]
-      iterate 2 wp_pure
-      rw [← checkSorted]
+      wp_pures
       iapply IH $$ %_ %tl %_ %((List.pairwise_cons.mp hsorted).2)
         %(.inr ⟨hd, rfl, (List.pairwise_cons.mp hsorted).1⟩) Htl
       iintro %bv Hl %hb
@@ -368,7 +362,7 @@ theorem wp_sortAndCheck [HeapLangGS hlc GF] (l : List Int) :
   iapply wp_makeList
   iintro %v Hv
   wp_pures
-  wp_bind v(&quicksort) _
+  wp_bind &quicksort _
   iapply quicksort_spec $$ Hv
   iintro %v %l' Hv %Hsorted %Heqv
   wp_pures

--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -301,7 +301,8 @@ public theorem tac_wp_bind [ι : IrisGS_gen hlc Exp GF] {Δ} {s : Stuckness} {E 
     (Δ ⊢ WP (ProgramLogic.fill K e') @ s ; E {{ Φ }}) :=
   H.trans (wp_bind (ProgramLogic.fill K))
 
-elab "wp_bind" colGt ppSpace focus:hl_exp : tactic =>
+-- level of hl_exp should be above the level of ; in the heaplang notation to make `wp_bind _ _; wp_rec` work
+elab "wp_bind" colGt ppSpace focus:hl_exp:10 : tactic =>
   ProofModeM.runTacticWp fun mvar {GF, hyps, s, E, e, Φ, ..} => do
     let focus ← elabTermEnsuringTypeQ (←`(hl($focus))) q(HeapLang.Exp)
     trace[wp_bind] s!"Context to bind over: {←ppExpr focus}"
@@ -313,15 +314,20 @@ elab "wp_bind" colGt ppSpace focus:hl_exp : tactic =>
       | throwTacticEx `wp_bind mvar s!"Cannot unify {←ppExpr focus} with any possible evaluation context"
     trace[wp_bind] s!"Found context {←ppExpr K} with expression {←ppExpr e'} matching our focus"
 
-    -- construct the new postcondition
-    let Φ' : Q(Val → IProp $GF) ←
-      Qq.withLocalDeclDQ `v q(Val) fun v => do
-        mkLambdaFVars #[v] <|
-          q(Wp.wp $s $E $(← HeapLang.fill K q(.ofVal $v)) $Φ)
-    have _ : $Φ' =Q (fun v : Val => Wp.wp (PROP := IProp $GF) $s $E (ProgramLogic.fill $K (v : Exp)) $Φ) := ⟨⟩
+    match K with
+    | ~q([]) =>
+      -- don't do anything for empty evaluation context
+      addMVarGoal mvar
+    | _ =>
+      -- construct the new postcondition
+      let Φ' : Q(Val → IProp $GF) ←
+        Qq.withLocalDeclDQ `v q(Val) fun v => do
+          mkLambdaFVars #[v] <|
+            q(Wp.wp $s $E $(← HeapLang.fill K q(.ofVal $v)) $Φ)
+      have _ : $Φ' =Q (fun v : Val => Wp.wp (PROP := IProp $GF) $s $E (ProgramLogic.fill $K (v : Exp)) $Φ) := ⟨⟩
 
-    let pf ← addBIGoal hyps q(Wp.wp $s $E $e' $Φ')
-    mvar.assign q(tac_wp_bind $pf)
+      let pf ← addBIGoal hyps q(Wp.wp $s $E $e' $Φ')
+      mvar.assign q(tac_wp_bind $pf)
 
 public theorem tac_wp_pure [ι : IrisGS_gen hlc Exp GF] {Δ Δ'} {s : Stuckness} {E : CoPset} {K : List ECtxItem} {e₁ e₂ : Exp} {φ : Prop} {n : Nat} {Φ : Val → IProp GF} :
     ProgramLogic.Language.PureExec φ n e₁ e₂ →
@@ -367,7 +373,7 @@ elab "wp_pure " colGt ppSpace focus:hl_exp : tactic =>
 macro "wp_pure" : tactic => `(tactic| wp_pure _)
 macro "wp_pures" : tactic => `(tactic| repeat wp_pure)
 
-macro "wp_rec" : tactic => `(tactic | (iapply $(mkIdent `wp_rec):ident; rfl; imodintro; wp_finish))
+macro "wp_rec" : tactic => `(tactic | (wp_bind _ _; iapply $(mkIdent `wp_rec):ident; rfl; imodintro; wp_finish))
 
 initialize registerTraceClass `wp_bind
 initialize registerTraceClass `wp_pure

--- a/Iris/Iris/Tests/HeapLang/WeakestPre.lean
+++ b/Iris/Iris/Tests/HeapLang/WeakestPre.lean
@@ -120,7 +120,7 @@ hlc : HasLC
 GF : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF
 ⊢ ⏎
-  ⊢ WP hl((#2 + (#1 + #2))) {{ v, WP hl(v(&v)) {{ v, True }} }}
+  ⊢ WP hl((#2 + (#1 + #2))) {{ v, True }}
 -/
 #guard_msgs in
 example : ⊢@{IProp GF}  WP hl(#2 + (#1 + #2)) {{ v, True }} := by


### PR DESCRIPTION
Also make wp_bind a no-op when binding the top-level expression as in Rocq.
