### PR TITLE
docs: add proof debt surface audit script

### DIFF
--- a/docs/status/PROOF_DEBT_SURFACE_AUDIT.md
+++ b/docs/status/PROOF_DEBT_SURFACE_AUDIT.md
@@ -1,0 +1,20 @@
+# Proof-debt surface audit
+
+This repository-local audit records a block-comment-aware scan of Lean source files under `Iris/` and `IrisMath/`.
+
+The audit checks for active visible occurrences of:
+
+```text
+sorry
+admit
+axiom
+opaque
+unsafe
+The intended interpretation is deliberately narrow:
+NO_ACTIVE_SORRY_ADMIT_AXIOM_OPAQUE_SURFACE
+means only that the scanned Lean source surface contains no active visible occurrences of sorry, admit, axiom, or opaque outside comments.
+It does not claim repository-wide semantic soundness, upstream endorsement, theorem ownership, or proof replacement.
+Run:
+python3 scripts/audit_proof_debt_surface.py
+Machine-readable output:
+docs/status/proof_debt_surface_audit_latest.json

--- a/docs/status/proof_debt_surface_audit_latest.json
+++ b/docs/status/proof_debt_surface_audit_latest.json
@@ -1,0 +1,43 @@
+{
+  "audit": "block_comment_aware_visible_proof_debt_surface",
+  "proof_debt_findings": [],
+  "proof_debt_tokens": [
+    "sorry",
+    "admit",
+    "axiom",
+    "opaque"
+  ],
+  "repository": "leanprover-community/iris-lean",
+  "scanned_roots": [
+    "Iris",
+    "IrisMath"
+  ],
+  "status": "NO_ACTIVE_SORRY_ADMIT_AXIOM_OPAQUE_SURFACE",
+  "unsafe_findings": [
+    {
+      "file": "Iris/Iris/ProofMode/SynthInstanceAttr.lean",
+      "line": 283,
+      "text": "unsafe def SynthTacticEntrySerialized.deserialize (e : SynthTacticEntrySerialized) (compile : Bool)",
+      "token": "unsafe"
+    },
+    {
+      "file": "Iris/Iris/ProofMode/SynthInstanceAttr.lean",
+      "line": 298,
+      "text": "unsafe initialize synthTacticExt : ScopedEnvExtension (SynthTacticEntrySerialized \u00d7 Array DiscrTree.Key)",
+      "token": "unsafe"
+    },
+    {
+      "file": "Iris/Iris/ProofMode/SynthInstanceAttr.lean",
+      "line": 312,
+      "text": "unsafe initialize registerBuiltinAttribute {",
+      "token": "unsafe"
+    },
+    {
+      "file": "Iris/Iris/Std/DumpPortingData.lean",
+      "line": 81,
+      "text": "public meta unsafe def main (args : List String) : IO Unit := do",
+      "token": "unsafe"
+    }
+  ],
+  "unsafe_token": "unsafe"
+}

--- a/scripts/audit_proof_debt_surface.py
+++ b/scripts/audit_proof_debt_surface.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+SCAN_DIRS = [ROOT / "Iris", ROOT / "IrisMath"]
+EXCLUDED_PARTS = {".git", ".lake", "lake-packages", "build"}
+
+TOKENS = {
+    "sorry": re.compile(r"\bsorry\b"),
+    "admit": re.compile(r"\badmit\b"),
+    "axiom": re.compile(r"\baxiom\b"),
+    "opaque": re.compile(r"\bopaque\b"),
+    "unsafe": re.compile(r"\bunsafe\b"),
+}
+
+def strip_comments(src: str) -> str:
+    out: list[str] = []
+    i = 0
+    depth = 0
+    while i < len(src):
+        if depth == 0 and src.startswith("--", i):
+            j = src.find("\n", i)
+            if j == -1:
+                break
+            out.append("\n")
+            i = j + 1
+        elif src.startswith("/-", i):
+            depth += 1
+            out.append(" ")
+            i += 2
+        elif depth > 0 and src.startswith("-/", i):
+            depth -= 1
+            out.append(" ")
+            i += 2
+        elif depth > 0:
+            out.append("\n" if src[i] == "\n" else " ")
+            i += 1
+        else:
+            out.append(src[i])
+            i += 1
+    return "".join(out)
+
+def lean_files() -> list[Path]:
+    files: list[Path] = []
+    for base in SCAN_DIRS:
+        if base.exists():
+            for path in base.rglob("*.lean"):
+                if not EXCLUDED_PARTS.intersection(path.parts):
+                    files.append(path)
+    return sorted(files)
+
+def main() -> int:
+    findings: list[dict[str, object]] = []
+    for path in lean_files():
+        cleaned = strip_comments(path.read_text(encoding="utf-8"))
+        for lineno, line in enumerate(cleaned.splitlines(), start=1):
+            for token, pattern in TOKENS.items():
+                if pattern.search(line):
+                    findings.append({
+                        "file": str(path.relative_to(ROOT)),
+                        "line": lineno,
+                        "token": token,
+                        "text": line.strip(),
+                    })
+
+    proof_debt = [f for f in findings if f["token"] in {"sorry", "admit", "axiom", "opaque"}]
+    unsafe = [f for f in findings if f["token"] == "unsafe"]
+
+    report = {
+        "repository": "leanprover-community/iris-lean",
+        "audit": "block_comment_aware_visible_proof_debt_surface",
+        "scanned_roots": [str(p.relative_to(ROOT)) for p in SCAN_DIRS if p.exists()],
+        "proof_debt_tokens": ["sorry", "admit", "axiom", "opaque"],
+        "unsafe_token": "unsafe",
+        "proof_debt_findings": proof_debt,
+        "unsafe_findings": unsafe,
+        "status": "NO_ACTIVE_SORRY_ADMIT_AXIOM_OPAQUE_SURFACE" if not proof_debt else "ACTIVE_PROOF_DEBT_SURFACE_FOUND",
+    }
+
+    out = ROOT / "docs" / "status" / "proof_debt_surface_audit_latest.json"
+    out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    print(report["status"])
+    print(f"unsafe_findings={len(unsafe)}")
+    print(f"wrote={out.relative_to(ROOT)}")
+
+    return 0 if not proof_debt else 1
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a repository-local, block-comment-aware Lean proof-debt surface audit script and a narrow status document.

Boundary:
- checks active visible occurrences of sorry/admit/axiom/opaque/unsafe under Iris/ and IrisMath/
- records machine-readable output in docs/status/proof_debt_surface_audit_latest.json
- validation run: python3 scripts/audit_proof_debt_surface.py and git diff --check
- does not claim semantic soundness, theorem ownership, proof replacement, or endorsement