### PR TITLE
doc: tactic descriptions with docstrings

### DIFF
--- a/Iris/Iris/ProofMode/Classes.lean
+++ b/Iris/Iris/ProofMode/Classes.lean
@@ -215,6 +215,7 @@ export CombineSepAs (combine_sep_as)
 
 #rocq_ignore MaybeCombineSepAs "No need for progress_indicator"
 #rocq_ignore progress_indicator "No longer required as it is only used by the type class MaybeCombineSepAs"
+#rocq_ignore maybe_combine_sep_as_combine_sep_as "No longer required along with MaybeCombineSepAs"
 
 /-- `CombineSepGives` combines two propositions `P` and `Q` for a proposition
     with the `<pers>` modality -/

--- a/Iris/Iris/ProofMode/Classes.lean
+++ b/Iris/Iris/ProofMode/Classes.lean
@@ -208,14 +208,17 @@ class IntoLaterN {PROP} [BI PROP] (only_head : Bool) (n : Nat) (P : PROP) (Q : o
 export IntoLaterN (into_laterN)
 
 /-- `CombineSepAs` combines two propositions `P` and `Q` into `R` -/
-@[ipm_class]
+@[ipm_class, rocq_alias CombineSepAs]
 class CombineSepAs [BI PROP] (P Q : PROP) (R : outParam PROP) where
   combine_sep_as : P ∗ Q ⊢ R
 export CombineSepAs (combine_sep_as)
 
+#rocq_ignore MaybeCombineSepAs "No need for progress_indicator"
+#rocq_ignore progress_indicator "No longer required as it is only used by the type class MaybeCombineSepAs"
+
 /-- `CombineSepGives` combines two propositions `P` and `Q` for a proposition
     with the `<pers>` modality -/
-@[ipm_class]
+@[ipm_class, rocq_alias CombineSepGives]
 class CombineSepGives [BI PROP] (P Q : PROP) (R : outParam PROP) where
   combine_sep_gives : P ∗ Q ⊢ <pers> R
 export CombineSepGives (combine_sep_gives)

--- a/Iris/Iris/ProofMode/Patterns/ProofModeTerm.lean
+++ b/Iris/Iris/ProofMode/Patterns/ProofModeTerm.lean
@@ -16,7 +16,7 @@ open Lean
 declare_syntax_cat pmTerm
 
 syntax term : pmTerm
-syntax term "$$" (colGt specPat)+ : pmTerm
+syntax term colGt " $$ " (colGt specPat)+ : pmTerm
 
 @[rocq_alias iTrm]
 structure PMTerm where

--- a/Iris/Iris/ProofMode/Tactics/Apply.lean
+++ b/Iris/Iris/ProofMode/Tactics/Apply.lean
@@ -54,6 +54,14 @@ private partial def iApplyCore {prop : Q(Type u)} {bi : Q(BI $prop)} {e} (hyps :
   let pf' ← iApplyCore hyps' pb B goal
   return q($(pf).trans $pf')
 
+/--
+  `iapply pmt` matches the conclusion of `pmt : pmTerm` against the goal and
+  generate goals for each premise.
+
+  `iapply pmt H $$ [pat1] [pat2]` uses the specialisation patterns `pat1`
+  and `pat2`, which specifies how the wand premises of `H` are discharged.
+  This is analogous to `iApply (H with "pat pat2")` in Rocq.
+-/
 elab "iapply" colGt pmt:pmTerm : tactic => do
   let pmt ← liftMacroM <| PMTerm.parse pmt
   ProofModeM.runTactic λ mvar { hyps, goal, .. } => do

--- a/Iris/Iris/ProofMode/Tactics/Apply.lean
+++ b/Iris/Iris/ProofMode/Tactics/Apply.lean
@@ -66,7 +66,7 @@ private partial def iApplyCore {prop : Q(Type u)} {bi : Q(BI $prop)} {e} (hyps :
   given hypotheses `∗HP: □ P` and `∗H : P -∗ Q`, as well as the proof goal `Q`,
   `iapply H $$ HP` solves the goal.
 -/
-elab "iapply" colGt pmt:pmTerm : tactic => do
+elab "iapply " colGt pmt:pmTerm : tactic => do
   let pmt ← liftMacroM <| PMTerm.parse pmt
   ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
   -- elaborate the proof mode term `pmt` to the hypothesis `out`

--- a/Iris/Iris/ProofMode/Tactics/Apply.lean
+++ b/Iris/Iris/ProofMode/Tactics/Apply.lean
@@ -56,14 +56,14 @@ private partial def iApplyCore {prop : Q(Type u)} {bi : Q(BI $prop)} {e} (hyps :
 
 /--
   `iapply pmt` matches the conclusion of `pmt : pmTerm` against the goal and
-  generate goals for each premise. For example, given a proof goal `R` and
-  a hypothesis `H : P -∗ Q -∗ R`, `iapply H` generates two new proof goals,
+  generate goals for each premise. For example, given a goal `R` and
+  a hypothesis `H : P -∗ Q -∗ R`, `iapply H` generates two new goals,
   one with the conclusion `P` and another with the conclusion `Q`.
 
-  `iapply pmt H $$ [pat1] [pat2]` uses the specialisation patterns `pat1`
+  `iapply pmt H $$ pat1 pat2` uses the specialisation patterns `pat1`
   and `pat2`, which specifies how the wand premises of `H` are discharged.
   This is analogous to `iApply (H with "pat1 pat2")` in Rocq. For example,
-  given hypotheses `∗HP: □ P` and `∗H : P -∗ Q`, as well as the proof goal `Q`,
+  given hypotheses `∗HP: □ P` and `∗H : P -∗ Q`, as well as the goal `Q`,
   `iapply H $$ HP` solves the goal.
 -/
 elab "iapply " colGt pmt:pmTerm : tactic => do

--- a/Iris/Iris/ProofMode/Tactics/Apply.lean
+++ b/Iris/Iris/ProofMode/Tactics/Apply.lean
@@ -56,11 +56,15 @@ private partial def iApplyCore {prop : Q(Type u)} {bi : Q(BI $prop)} {e} (hyps :
 
 /--
   `iapply pmt` matches the conclusion of `pmt : pmTerm` against the goal and
-  generate goals for each premise.
+  generate goals for each premise. For example, given a proof goal `R` and
+  a hypothesis `H : P -∗ Q -∗ R`, `iapply H` generates two new proof goals,
+  one with the conclusion `P` and another with the conclusion `Q`.
 
   `iapply pmt H $$ [pat1] [pat2]` uses the specialisation patterns `pat1`
   and `pat2`, which specifies how the wand premises of `H` are discharged.
-  This is analogous to `iApply (H with "pat pat2")` in Rocq.
+  This is analogous to `iApply (H with "pat1 pat2")` in Rocq. For example,
+  given hypotheses `∗HP: □ P` and `∗H : P -∗ Q`, as well as the proof goal `Q`,
+  `iapply H $$ HP` solves the goal.
 -/
 elab "iapply" colGt pmt:pmTerm : tactic => do
   let pmt ← liftMacroM <| PMTerm.parse pmt

--- a/Iris/Iris/ProofMode/Tactics/Assumption.lean
+++ b/Iris/Iris/ProofMode/Tactics/Assumption.lean
@@ -21,8 +21,8 @@ public meta section
 open Lean Elab Tactic Meta Qq
 
 /--
-  `iassumption` solves the goal with a matching hypothesis from any context
-  (pure, intuitionistic or spatial).
+  `iassumption` solves the goal with a matching hypothesis from the
+   intuitionistic or spatial context.
 -/
 elab "iassumption" : tactic => do
   ProofModeM.runTactic λ mvar { hyps, goal, .. } => do

--- a/Iris/Iris/ProofMode/Tactics/Assumption.lean
+++ b/Iris/Iris/ProofMode/Tactics/Assumption.lean
@@ -20,6 +20,10 @@ theorem assumption [BI PROP] {p : Bool} {P P' A Q : PROP} [inst : FromAssumption
 public meta section
 open Lean Elab Tactic Meta Qq
 
+/--
+  `iassumption` solves the goal with a matching hypothesis from any context
+  (pure, intuitionistic or spatial).
+-/
 elab "iassumption" : tactic => do
   ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
 

--- a/Iris/Iris/ProofMode/Tactics/Basic.lean
+++ b/Iris/Iris/ProofMode/Tactics/Basic.lean
@@ -18,7 +18,7 @@ open Lean Elab.Tactic Meta Qq BI Std
 /-- `itrivial` collects tactics to solve trivial Iris goals. It is used by the `//` specialization
 and introduction patterns. One can add new tactics using
 ```
-macro_rules | `(tactic| itrivial) => `(tactic|mytac)
+macro_rules | `(tactic| itrivial) => `(tactic| mytac)
 ```
 -/
 syntax "itrivial" : tactic
@@ -37,10 +37,17 @@ def iSolveSidecondition (target : Q(Prop)) (failOnUnsolved := true) : ProofModeM
           for g in gs do addMVarGoal g
       return mvar
 
+/--
+  `istart` starts the Iris Proof Mode (IPM).
+-/
 elab "istart" : tactic => do
   let (mvar, _) ← startProofMode (← getMainGoal)
   replaceMainGoal [mvar]
 
+/--
+  `istop` stops the Iris Proof Mode (IPM) by turning the proof goal back
+  into plain entailment.
+-/
 elab "istop" : tactic => do
   -- parse goal
   let mvar ← getMainGoal

--- a/Iris/Iris/ProofMode/Tactics/Basic.lean
+++ b/Iris/Iris/ProofMode/Tactics/Basic.lean
@@ -38,14 +38,14 @@ def iSolveSidecondition (target : Q(Prop)) (failOnUnsolved := true) : ProofModeM
       return mvar
 
 /--
-  `istart` starts the Iris Proof Mode (IPM).
+  `istart` starts the Iris Proof Mode.
 -/
 elab "istart" : tactic => do
   let (mvar, _) ← startProofMode (← getMainGoal)
   replaceMainGoal [mvar]
 
 /--
-  `istop` stops the Iris Proof Mode (IPM) by turning the proof goal back
+  `istop` stops the Iris Proof Mode by turning the goal back
   into plain entailment.
 -/
 elab "istop" : tactic => do

--- a/Iris/Iris/ProofMode/Tactics/Cases.lean
+++ b/Iris/Iris/ProofMode/Tactics/Cases.lean
@@ -257,9 +257,6 @@ partial def iCasesCore {P} (hyps : Hyps bi P) (goal : Q($prop)) (pat : iCasesPat
 
 /--
   `icases pmt with pat` destructs `pmt : pmTerm` using the cases pattern `pat`.
-
-  Provided that `pmt` is intuitionistic or duplicable,
-  `icases +keep pmt with pat` keeps the original hypothesis upon case destruction.
 -/
 elab "icases" keep:("+keep ")? colGt pmt:pmTerm " with " colGt pat:icasesPat : tactic => do
   -- parse syntax

--- a/Iris/Iris/ProofMode/Tactics/Cases.lean
+++ b/Iris/Iris/ProofMode/Tactics/Cases.lean
@@ -261,7 +261,7 @@ partial def iCasesCore {P} (hyps : Hyps bi P) (goal : Q($prop)) (pat : iCasesPat
   Provided that `pmt` is intuitionistic or duplicable,
   `icases +keep pmt with pat` keeps the original hypothesis upon case destruction.
 -/
-elab "icases" keep:("+keep")? colGt pmt:pmTerm "with" colGt pat:icasesPat : tactic => do
+elab "icases" keep:("+keep ")? colGt pmt:pmTerm " with " colGt pat:icasesPat : tactic => do
   -- parse syntax
   let pmt ← liftMacroM <| PMTerm.parse pmt
   let pat ← liftMacroM <| iCasesPat.parse pat
@@ -281,7 +281,7 @@ elab "icases" keep:("+keep")? colGt pmt:pmTerm "with" colGt pat:icasesPat : tact
   `imod pmt with pat` eliminates the modality at the top of `pmt : pmTerm` into
   the goal and destructs the result with case pattern `pat`.
 -/
-macro "imod" colGt pmt:pmTerm "with" colGt pat:icasesPat : tactic => `(tactic | icases $pmt with >$pat)
+macro "imod" colGt pmt:pmTerm " with " colGt pat:icasesPat : tactic => `(tactic | icases $pmt with >$pat)
 
 /--
   `imod pmt` eliminates the modality at the top of `pmt : pmTerm` into the goal.
@@ -298,10 +298,10 @@ macro "imod" colGt pmt:pmTerm : tactic =>
   `iintuitionistic H` removes hypothesis `H` into the intuitionistic context.
   Equivalent to `icases H with #H`.
 -/
-macro "iintuitionistic" hyp:ident : tactic => `(tactic | icases $hyp:ident with #$hyp:ident)
+macro "iintuitionistic " colGt hyp:ident : tactic => `(tactic | icases $hyp:ident with #$hyp:ident)
 
 /--
   `ispatial H` removes hypothesis `H` into the spatial context.
   Equivalent to `icases H with ∗H`.
 -/
-macro "ispatial" hyp:ident : tactic => `(tactic | icases $hyp:ident with ∗$hyp:ident)
+macro "ispatial " colGt hyp:ident : tactic => `(tactic | icases $hyp:ident with ∗$hyp:ident)

--- a/Iris/Iris/ProofMode/Tactics/Cases.lean
+++ b/Iris/Iris/ProofMode/Tactics/Cases.lean
@@ -255,6 +255,12 @@ partial def iCasesCore {P} (hyps : Hyps bi P) (goal : Q($prop)) (pat : iCasesPat
     iModCore bi P goal p A λ p' A goal' =>
       iCasesCore hyps goal' arg p' A @k
 
+/--
+  `icases pmt with pat` destructs `pmt : pmTerm` using the cases pattern `pat`.
+
+  Provided that `pmt` is intuitionistic or duplicable,
+  `icases +keep pmt with pat` keeps the original hypothesis upon case destruction.
+-/
 elab "icases" keep:("+keep")? colGt pmt:pmTerm "with" colGt pat:icasesPat : tactic => do
   -- parse syntax
   let pmt ← liftMacroM <| PMTerm.parse pmt
@@ -271,7 +277,15 @@ elab "icases" keep:("+keep")? colGt pmt:pmTerm "with" colGt pat:icasesPat : tact
 
   mvar.assign q(($pf).trans $pf2)
 
+/--
+  `imod pmt with pat` eliminates the modality at the top of `pmt : pmTerm` into
+  the goal and destructs the result with case pattern `pat`.
+-/
 macro "imod" colGt pmt:pmTerm "with" colGt pat:icasesPat : tactic => `(tactic | icases $pmt with >$pat)
+
+/--
+  `imod pmt` eliminates the modality at the top of `pmt : pmTerm` into the goal.
+-/
 macro "imod" colGt pmt:pmTerm : tactic =>
   match pmt with
   | `(pmTerm | $hyp:ident) => `(tactic | imod $pmt with $hyp:ident)
@@ -279,5 +293,15 @@ macro "imod" colGt pmt:pmTerm : tactic =>
   | _ => `(tactic | imod $pmt with _)
 
 -- TODO: remove these shortcuts if they are not used
+
+/--
+  `iintuitionistic H` removes hypothesis `H` into the intuitionistic context.
+  Equivalent to `icases H with #H`.
+-/
 macro "iintuitionistic" hyp:ident : tactic => `(tactic | icases $hyp:ident with #$hyp:ident)
+
+/--
+  `ispatial H` removes hypothesis `H` into the spatial context.
+  Equivalent to `icases H with ∗H`.
+-/
 macro "ispatial" hyp:ident : tactic => `(tactic | icases $hyp:ident with ∗$hyp:ident)

--- a/Iris/Iris/ProofMode/Tactics/Clear.lean
+++ b/Iris/Iris/ProofMode/Tactics/Clear.lean
@@ -49,7 +49,7 @@ private def ClearState.clearProofModeHyp {u prop bi origE goal} :
       return {  e := e', hyps := hyps', pf := pf' }
 
 /--
-  `iclear pats` discards the hypotheses selected by the selection patterns `pats`.
+  `iclear pats` discards the hypotheses selected by the selection pattern `pats`.
 -/
 elab "iclear" pats:(colGt selPat)+ : tactic => do
   let pats ← liftMacroM <| SelPat.parse pats

--- a/Iris/Iris/ProofMode/Tactics/Clear.lean
+++ b/Iris/Iris/ProofMode/Tactics/Clear.lean
@@ -51,7 +51,7 @@ private def ClearState.clearProofModeHyp {u prop bi origE goal} :
 /--
   `iclear pats` discards the hypotheses selected by the selection pattern `pats`.
 -/
-elab "iclear " pats:(colGt selPat)+ : tactic => do
+elab "iclear " pats:(colGt ppSpace selPat)+ : tactic => do
   let pats ← liftMacroM <| SelPat.parse pats
 
   ProofModeM.runTactic λ mvar { e, hyps, goal, .. } => do

--- a/Iris/Iris/ProofMode/Tactics/Clear.lean
+++ b/Iris/Iris/ProofMode/Tactics/Clear.lean
@@ -48,6 +48,9 @@ private def ClearState.clearProofModeHyp {u prop bi origE goal} :
       let pf' : Q(($e' ⊢ $goal) → ($origE ⊢ $goal)) := q(λ h => $pf ($step h))
       return {  e := e', hyps := hyps', pf := pf' }
 
+/--
+  `iclear pats` discards the hypotheses selected by the selection patterns `pats`.
+-/
 elab "iclear" pats:(colGt selPat)+ : tactic => do
   let pats ← liftMacroM <| SelPat.parse pats
 

--- a/Iris/Iris/ProofMode/Tactics/Clear.lean
+++ b/Iris/Iris/ProofMode/Tactics/Clear.lean
@@ -51,7 +51,7 @@ private def ClearState.clearProofModeHyp {u prop bi origE goal} :
 /--
   `iclear pats` discards the hypotheses selected by the selection pattern `pats`.
 -/
-elab "iclear" pats:(colGt selPat)+ : tactic => do
+elab "iclear " pats:(colGt selPat)+ : tactic => do
   let pats ← liftMacroM <| SelPat.parse pats
 
   ProofModeM.runTactic λ mvar { e, hyps, goal, .. } => do

--- a/Iris/Iris/ProofMode/Tactics/Combine.lean
+++ b/Iris/Iris/ProofMode/Tactics/Combine.lean
@@ -220,7 +220,7 @@ private def throwNoInstanceForGives : ProofModeM Unit := do
   If no other type class instance for `CombineSepAs` is found, the separating
   conjunction is used as the connective.
 -/
-elab "icombine " patSels:(colGt selPat)*
+elab "icombine " patSels:(colGt ppSpace selPat)*
     " as " colGt patAs:icasesPat : tactic => do
   let pat ← liftMacroM <| iCasesPat.parse patAs
 
@@ -240,7 +240,7 @@ elab "icombine " patSels:(colGt selPat)*
   The tactic fails if no applicable type class instance of `CombineSepGives` is
   found.
 -/
-elab "icombine " patSels:(colGt selPat)*
+elab "icombine " patSels:(colGt ppSpace selPat)*
     " gives " colGt patGives:icasesPat : tactic => do
   let pat ← liftMacroM <| iCasesPat.parse patGives
 
@@ -268,7 +268,7 @@ elab "icombine " patSels:(colGt selPat)*
   The tactic fails if no applicable type class instance of `CombineSepGives` is
   found.
 -/
-elab "icombine " patSels:(colGt selPat)*
+elab "icombine " patSels:(colGt ppSpace selPat)*
     " as " colGt patAs:icasesPat " gives " colGt patGives:icasesPat : tactic => do
   let pat1 ← liftMacroM <| iCasesPat.parse patAs
   let pat2 ← liftMacroM <| iCasesPat.parse patGives

--- a/Iris/Iris/ProofMode/Tactics/Combine.lean
+++ b/Iris/Iris/ProofMode/Tactics/Combine.lean
@@ -212,9 +212,14 @@ private def iCombineParseSelPats {u} {prop : Q(Type $u)} {bi} {e : Q($prop)}
 private def throwNoInstanceForGives : ProofModeM Unit := do
   throwError "icombine: no type class instance to combine propositions"
 
-/-- The tactic `icombine` with the `as` syntax combines propositions into one
-    using the type class `CombineSepAs`. If no other type class instance is
-    found, the separating conjunction is used as the connective. -/
+/--
+  `icombine patSels as patAs` combines the hypotheses specified by the selection
+  pattern `patSels` into one using the `CombineSepAs` type class. The combined
+  hypothesis is then destructed using the case pattern `patAs`
+
+  If no other type class instance for `CombineSepAs` is found, the separating
+  conjunction is used as the connective.
+-/
 elab "icombine" patSels:(colGt selPat)* "as" colGt patAs:icasesPat : tactic => do
   let pat ← liftMacroM <| iCasesPat.parse patAs
 
@@ -225,10 +230,15 @@ elab "icombine" patSels:(colGt selPat)* "as" colGt patAs:icasesPat : tactic => d
     let pf ← iCasesCore _ st.newHyps goal pat q($(st.p)) st.outAs addBIGoal
     mvar.assign q($(st.pfAs).trans $pf)
 
-/-- The tactic `icombine` with `gives` syntax combines propositions to derive
-    new information in the intutionisitic context using the type class
-    `CombineSepGives`. It is possible that no type class instance is
-    applicable. -/
+/--
+  `icombine patSels gives patAs` combines the hypotheses specified by the
+  selection pattern `patSels` to derive new information into the intuitionistic
+  context using the type class `CombineSepGives`. The new intuitionistic
+  hypothesis is then destructed using the case pattern `patGives`.
+
+  The tactic fails if no applicable type class instance of `CombineSepGives` is
+  found.
+-/
 elab "icombine" patSels:(colGt selPat)* "gives" colGt patGives:icasesPat : tactic => do
   let pat ← liftMacroM <| iCasesPat.parse patGives
 
@@ -242,7 +252,20 @@ elab "icombine" patSels:(colGt selPat)* "gives" colGt patGives:icasesPat : tacti
       mvar.assign q($(pfGives).trans $pf)
     | none, _ => throwNoInstanceForGives
 
-/-- The tactic with both `as` and `gives` -/
+/--
+  `icombine patSels as patAs gives patGives` combines the hypotheses specified
+  by the selection pattern `patSels` into one using the `CombineSepAs` type
+  class. The combined hypothesis is then destructed using the case pattern
+  `patAs`. Meanwhile, it also combines the hypotheses to derive new information
+  into the intuitionistic context using the type class `CombineSepGives` and
+  destructs the new intuitionistic hypothesis using the case pattern `patGives`.
+
+  This is equivalent to using the tactic `icombine patSels gives patGives` and
+  then `icombine patSels as patAs`.
+
+  The tactic fails if no applicable type class instance of `CombineSepGives` is
+  found.
+-/
 elab "icombine" patSels:(colGt selPat)* "as" colGt patAs:icasesPat "gives" colGt patGives:icasesPat : tactic => do
   let pat1 ← liftMacroM <| iCasesPat.parse patAs
   let pat2 ← liftMacroM <| iCasesPat.parse patGives

--- a/Iris/Iris/ProofMode/Tactics/Combine.lean
+++ b/Iris/Iris/ProofMode/Tactics/Combine.lean
@@ -220,7 +220,8 @@ private def throwNoInstanceForGives : ProofModeM Unit := do
   If no other type class instance for `CombineSepAs` is found, the separating
   conjunction is used as the connective.
 -/
-elab "icombine" patSels:(colGt selPat)* "as" colGt patAs:icasesPat : tactic => do
+elab "icombine " patSels:(colGt selPat)*
+    " as " colGt patAs:icasesPat : tactic => do
   let pat ← liftMacroM <| iCasesPat.parse patAs
 
   ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
@@ -239,7 +240,8 @@ elab "icombine" patSels:(colGt selPat)* "as" colGt patAs:icasesPat : tactic => d
   The tactic fails if no applicable type class instance of `CombineSepGives` is
   found.
 -/
-elab "icombine" patSels:(colGt selPat)* "gives" colGt patGives:icasesPat : tactic => do
+elab "icombine " patSels:(colGt selPat)*
+    " gives " colGt patGives:icasesPat : tactic => do
   let pat ← liftMacroM <| iCasesPat.parse patGives
 
   ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
@@ -266,7 +268,8 @@ elab "icombine" patSels:(colGt selPat)* "gives" colGt patGives:icasesPat : tacti
   The tactic fails if no applicable type class instance of `CombineSepGives` is
   found.
 -/
-elab "icombine" patSels:(colGt selPat)* "as" colGt patAs:icasesPat "gives" colGt patGives:icasesPat : tactic => do
+elab "icombine " patSels:(colGt selPat)*
+    " as " colGt patAs:icasesPat " gives " colGt patGives:icasesPat : tactic => do
   let pat1 ← liftMacroM <| iCasesPat.parse patAs
   let pat2 ← liftMacroM <| iCasesPat.parse patGives
 

--- a/Iris/Iris/ProofMode/Tactics/ExFalso.lean
+++ b/Iris/Iris/ProofMode/Tactics/ExFalso.lean
@@ -18,6 +18,9 @@ theorem exfalso [BI PROP] {P Q : PROP} (h : P ⊢ False) : P ⊢ Q := h.trans fa
 public meta section
 open Lean Elab.Tactic Meta Qq
 
+/--
+  `iexfalso` changes the proof goal to `False`.
+-/
 elab "iexfalso" : tactic => do
   ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
   let m ← addBIGoal hyps q(iprop(False))

--- a/Iris/Iris/ProofMode/Tactics/ExFalso.lean
+++ b/Iris/Iris/ProofMode/Tactics/ExFalso.lean
@@ -19,7 +19,7 @@ public meta section
 open Lean Elab.Tactic Meta Qq
 
 /--
-  `iexfalso` changes the proof goal to `False`.
+  `iexfalso` changes the goal to `False`.
 -/
 elab "iexfalso" : tactic => do
   ProofModeM.runTactic λ mvar { hyps, goal, .. } => do

--- a/Iris/Iris/ProofMode/Tactics/Exact.lean
+++ b/Iris/Iris/ProofMode/Tactics/Exact.lean
@@ -12,6 +12,9 @@ namespace Iris.ProofMode
 public meta section
 open Lean Elab Tactic Meta Qq BI Std
 
+/--
+  `iexact H` solves the goal with the hypothesis `H`.
+-/
 elab "iexact" colGt hyp:ident : tactic => do
   ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
   let ivar ← hyps.findWithInfo hyp

--- a/Iris/Iris/ProofMode/Tactics/Exact.lean
+++ b/Iris/Iris/ProofMode/Tactics/Exact.lean
@@ -15,7 +15,7 @@ open Lean Elab Tactic Meta Qq BI Std
 /--
   `iexact H` solves the goal with the hypothesis `H`.
 -/
-elab "iexact" colGt hyp:ident : tactic => do
+elab "iexact " colGt hyp:ident : tactic => do
   ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
   let ivar ← hyps.findWithInfo hyp
   let ⟨e', _, _, out, p, _, pf⟩ := hyps.remove true ivar

--- a/Iris/Iris/ProofMode/Tactics/Exists.lean
+++ b/Iris/Iris/ProofMode/Tactics/Exists.lean
@@ -21,6 +21,11 @@ theorem from_exists_intro [BI PROP] {Φ : α → PROP} {P Q : PROP} [inst : From
 public meta section
 open Lean Elab Tactic Meta Qq
 
+/--
+  `iexists x₁, …, xₙ` instantiates existential quantifiers in the goal with
+  the terms `x₁, …, xₙ`. For each term, one can also use named metavariables
+  `?m` or holes (`_`) for unnamed metavariables.
+-/
 elab "iexists" xs:term,+ : tactic => do
   -- resolve existential quantifier with the given argument
   ProofModeM.runTactic λ mvar { prop, e, hyps, goal, .. } => do

--- a/Iris/Iris/ProofMode/Tactics/Exists.lean
+++ b/Iris/Iris/ProofMode/Tactics/Exists.lean
@@ -26,7 +26,7 @@ open Lean Elab Tactic Meta Qq
   the terms `x₁, …, xₙ`. For each term, one can also use named metavariables
   `?m` or holes (`_`) for unnamed metavariables.
 -/
-elab "iexists" xs:term,+ : tactic => do
+elab "iexists " xs:term,+ : tactic => do
   -- resolve existential quantifier with the given argument
   ProofModeM.runTactic λ mvar { prop, e, hyps, goal, .. } => do
 

--- a/Iris/Iris/ProofMode/Tactics/Frame.lean
+++ b/Iris/Iris/ProofMode/Tactics/Frame.lean
@@ -128,7 +128,11 @@ def FrameResult.finishClose {u prop bi origE origGoal} (res : @FrameResult u pro
     return ⟨e, hyps, q(frame_finish_close_true $pf)⟩
   | _ => throwError "iframe: cannot solve {origGoal} by framing"
 
-
+/--
+  `iframe pats` cancels the hypotheses specified by the selection pattern `pats`
+  against the matching parts of the goal. Solves the goal completely if the
+  leftover is `True` or `emp` with affine context.
+-/
 elab "iframe" pats:(colGt selPat)+ : tactic => do
   let pats ← liftMacroM <| SelPat.parse pats
 
@@ -138,4 +142,9 @@ elab "iframe" pats:(colGt selPat)+ : tactic => do
   let res ← iFrame bi e hyps goal pats
   mvar.assign (← res.finish (addBIGoal · ·))
 
+/--
+  `iframe` cancels the spatial hypotheses and solves the goal completely if
+  the leftover is `True` or `emp` with affine context. This is equivalent to
+  `iframe ∗`.
+-/
 macro "iframe" : tactic => `(tactic | iframe ∗)

--- a/Iris/Iris/ProofMode/Tactics/Frame.lean
+++ b/Iris/Iris/ProofMode/Tactics/Frame.lean
@@ -133,7 +133,7 @@ def FrameResult.finishClose {u prop bi origE origGoal} (res : @FrameResult u pro
   against the matching parts of the goal. Solves the goal completely if the
   leftover is `True` or `emp` with affine context.
 -/
-elab "iframe" pats:(colGt selPat)+ : tactic => do
+elab "iframe " pats:(colGt ppSpace selPat)+ : tactic => do
   let pats ← liftMacroM <| SelPat.parse pats
 
   ProofModeM.runTactic λ mvar { bi, e, hyps, goal, .. } => do

--- a/Iris/Iris/ProofMode/Tactics/Have.lean
+++ b/Iris/Iris/ProofMode/Tactics/Have.lean
@@ -26,7 +26,6 @@ open Lean Elab Tactic Meta Qq
 /--
   `ihave pat := pmt` brings `pmt : pmTerm` into the context and destructs it
   with the case pattern `pat` without consuming the original hypotheses.
-  This is equivalent to `icases +keep pmt with pat`.
 -/
 macro "ihave " colGt pat:icasesPat " := " pmt:pmTerm : tactic => `(tactic | icases +keep $pmt with $pat)
 

--- a/Iris/Iris/ProofMode/Tactics/Have.lean
+++ b/Iris/Iris/ProofMode/Tactics/Have.lean
@@ -23,8 +23,17 @@ theorem ihave_assert [BI PROP] {A B C : PROP}
 public meta section
 open Lean Elab Tactic Meta Qq
 
+/--
+  `ihave pat := pmt` brings `pmt : pmTerm` into the context and destructs it
+  with the case pattern `pat` without consuming the original hypotheses.
+  This is equivalent to `icases +keep pmt with pat`.
+-/
 macro "ihave" colGt pat:icasesPat " := " pmt:pmTerm : tactic => `(tactic | icases +keep $pmt with $pat)
 
+/--
+  `ihave pat : P $$ spat` asserts `P`, proves it with a subgoal built from the
+  specification pattern `spat` and destructs it with the case pattern `pat`.
+-/
 elab "ihave" colGt pat:icasesPat " : " P:term "$$" spat:specPat : tactic => do
   let spat ← liftMacroM <| SpecPat.parse spat
   let pat ← liftMacroM <| iCasesPat.parse pat

--- a/Iris/Iris/ProofMode/Tactics/Have.lean
+++ b/Iris/Iris/ProofMode/Tactics/Have.lean
@@ -28,13 +28,13 @@ open Lean Elab Tactic Meta Qq
   with the case pattern `pat` without consuming the original hypotheses.
   This is equivalent to `icases +keep pmt with pat`.
 -/
-macro "ihave" colGt pat:icasesPat " := " pmt:pmTerm : tactic => `(tactic | icases +keep $pmt with $pat)
+macro "ihave " colGt pat:icasesPat " := " pmt:pmTerm : tactic => `(tactic | icases +keep $pmt with $pat)
 
 /--
   `ihave pat : P $$ spat` asserts `P`, proves it with a subgoal built from the
   specification pattern `spat` and destructs it with the case pattern `pat`.
 -/
-elab "ihave" colGt pat:icasesPat " : " P:term "$$" spat:specPat : tactic => do
+elab "ihave " colGt pat:icasesPat " : " P:term " $$ " spat:specPat : tactic => do
   let spat ← liftMacroM <| SpecPat.parse spat
   let pat ← liftMacroM <| iCasesPat.parse pat
   ProofModeM.runTactic λ mvar { prop, bi, hyps, goal, .. } => do

--- a/Iris/Iris/ProofMode/Tactics/Intro.lean
+++ b/Iris/Iris/ProofMode/Tactics/Intro.lean
@@ -127,6 +127,9 @@ partial def iIntroCore {prop : Q(Type u)} {bi : Q(BI $prop)}
       let pf ← iCasesCore bi hyps A2 pat q(false) A1 (iIntroCore · · pats k)
       return q(wand_intro_spatial (A1 := $A1) (Q := $Q) $pf)
 
+/--
+  `iintro pats` introduces hypotheses using the introduction pattern `pats`.
+-/
 elab "iintro" pats:(colGt introPat)* : tactic => do
   -- parse syntax
   let pats ← liftMacroM <| pats.mapM <| IntroPat.parse

--- a/Iris/Iris/ProofMode/Tactics/Intro.lean
+++ b/Iris/Iris/ProofMode/Tactics/Intro.lean
@@ -130,7 +130,7 @@ partial def iIntroCore {prop : Q(Type u)} {bi : Q(BI $prop)}
 /--
   `iintro pats` introduces hypotheses using the introduction pattern `pats`.
 -/
-elab "iintro" pats:(colGt introPat)* : tactic => do
+elab "iintro " pats:(colGt ppSpace introPat)* : tactic => do
   -- parse syntax
   let pats ← liftMacroM <| pats.mapM <| IntroPat.parse
 

--- a/Iris/Iris/ProofMode/Tactics/LeftRight.lean
+++ b/Iris/Iris/ProofMode/Tactics/LeftRight.lean
@@ -27,7 +27,7 @@ open Lean Elab.Tactic Meta Qq Std
 
 /--
   `ileft` choose the left side of the disjunction in the goal.
-  Given a proof goal of the form `P ∨ Q`, the new goal is `P`.
+  Given a goal of the form `P ∨ Q`, the new goal is `P`.
 -/
 elab "ileft" : tactic => do
   ProofModeM.runTactic λ mvar { prop, e, hyps, goal, .. } => do
@@ -41,8 +41,8 @@ elab "ileft" : tactic => do
   mvar.assign q(from_or_l (Q := $goal) $m)
 
 /--
-  `ileft` choose the right side of the disjunction in the goal.
-  Given a proof goal of the form `P ∨ Q`, the new goal is `Q`.
+  `iright` choose the right side of the disjunction in the goal.
+  Given a goal of the form `P ∨ Q`, the new goal is `Q`.
 -/
 elab "iright" : tactic => do
   ProofModeM.runTactic λ mvar { prop, e, hyps, goal, .. } => do

--- a/Iris/Iris/ProofMode/Tactics/LeftRight.lean
+++ b/Iris/Iris/ProofMode/Tactics/LeftRight.lean
@@ -25,6 +25,10 @@ theorem from_or_r [BI PROP] {P Q A1 A2 : PROP} [inst : FromOr Q A1 A2]
 public meta section
 open Lean Elab.Tactic Meta Qq Std
 
+/--
+  `ileft` choose the left side of the disjunction in the goal.
+  Given a proof goal of the form `P ∨ Q`, the new goal is `P`.
+-/
 elab "ileft" : tactic => do
   ProofModeM.runTactic λ mvar { prop, e, hyps, goal, .. } => do
   -- choose left side of disjunction
@@ -36,6 +40,10 @@ elab "ileft" : tactic => do
   let m : Q($e ⊢ $A1) ← addBIGoal hyps A1
   mvar.assign q(from_or_l (Q := $goal) $m)
 
+/--
+  `ileft` choose the right side of the disjunction in the goal.
+  Given a proof goal of the form `P ∨ Q`, the new goal is `Q`.
+-/
 elab "iright" : tactic => do
   ProofModeM.runTactic λ mvar { prop, e, hyps, goal, .. } => do
   -- choose right side of disjunction

--- a/Iris/Iris/ProofMode/Tactics/Loeb.lean
+++ b/Iris/Iris/ProofMode/Tactics/Loeb.lean
@@ -13,15 +13,14 @@ open Lean Meta Elab.Tactic Qq
 public meta section
 
 /--
-  Apply Löb induction in the current goal.
+  `iloeb as IH genealizing hs` applies Löb induction in the current goal
+  using the induction hypothesis `IH`, optionally with other variables can be
+  generalized over through the `generalizing selPat*` syntax.
 
   All spatial hypothesis are generalized in the induction hypothesis so that
   this one can be included in the intuitionistic context.
-
-  Optionally, other variables can be generalized over through the
-  `generalizing selPat*` syntax.
 -/
-elab  "iloeb" "as" IH:binderIdent "generalizing" hs:(colGt selPat)* : tactic => do
+elab "iloeb" "as" IH:binderIdent "generalizing" hs:(colGt selPat)* : tactic => do
   let pats ← Elab.liftMacroM <| SelPat.parse hs
   ProofModeM.runTactic fun mvid {hyps, goal, ..} => do
     let targets : List SelTarget ← SelPat.resolve hyps (pats ++ [.spatial])
@@ -38,4 +37,11 @@ elab  "iloeb" "as" IH:binderIdent "generalizing" hs:(colGt selPat)* : tactic => 
 
     mvid.assign expr
 
+/--
+  `iloeb as IH genealizing hs` applies Löb induction in the current goal
+  using the induction hypothesis `IH`.
+
+  All spatial hypothesis are generalized in the induction hypothesis so that
+  this one can be included in the intuitionistic context.
+-/
 macro "iloeb" "as" IH:binderIdent : tactic => `(tactic | iloeb as $IH generalizing)

--- a/Iris/Iris/ProofMode/Tactics/Loeb.lean
+++ b/Iris/Iris/ProofMode/Tactics/Loeb.lean
@@ -13,12 +13,11 @@ open Lean Meta Elab.Tactic Qq
 public meta section
 
 /--
-  `iloeb as IH genealizing hs` applies Löb induction in the current goal
+  `iloeb as IH generalizing hs` applies Löb induction in the current goal
   using the induction hypothesis `IH`, optionally with other variables can be
   generalized over through the `generalizing selPat*` syntax.
 
-  All spatial hypothesis are generalized in the induction hypothesis so that
-  this one can be included in the intuitionistic context.
+  All spatial hypothesis are generalized in the induction hypothesis.
 -/
 elab "iloeb" " as " colGt IH:binderIdent " generalizing " hs:(colGt ppSpace selPat)* : tactic => do
   let pats ← Elab.liftMacroM <| SelPat.parse hs
@@ -38,10 +37,9 @@ elab "iloeb" " as " colGt IH:binderIdent " generalizing " hs:(colGt ppSpace selP
     mvid.assign expr
 
 /--
-  `iloeb as IH genealizing hs` applies Löb induction in the current goal
+  `iloeb as IH` applies Löb induction in the current goal
   using the induction hypothesis `IH`.
 
-  All spatial hypothesis are generalized in the induction hypothesis so that
-  this one can be included in the intuitionistic context.
+  All spatial hypothesis are generalized in the induction hypothesis.
 -/
 macro "iloeb" " as " colGt IH:binderIdent : tactic => `(tactic | iloeb as $IH generalizing)

--- a/Iris/Iris/ProofMode/Tactics/Loeb.lean
+++ b/Iris/Iris/ProofMode/Tactics/Loeb.lean
@@ -20,7 +20,7 @@ public meta section
   All spatial hypothesis are generalized in the induction hypothesis so that
   this one can be included in the intuitionistic context.
 -/
-elab "iloeb" "as" IH:binderIdent "generalizing" hs:(colGt selPat)* : tactic => do
+elab "iloeb" " as " colGt IH:binderIdent " generalizing " hs:(colGt ppSpace selPat)* : tactic => do
   let pats ← Elab.liftMacroM <| SelPat.parse hs
   ProofModeM.runTactic fun mvid {hyps, goal, ..} => do
     let targets : List SelTarget ← SelPat.resolve hyps (pats ++ [.spatial])
@@ -44,4 +44,4 @@ elab "iloeb" "as" IH:binderIdent "generalizing" hs:(colGt selPat)* : tactic => d
   All spatial hypothesis are generalized in the induction hypothesis so that
   this one can be included in the intuitionistic context.
 -/
-macro "iloeb" "as" IH:binderIdent : tactic => `(tactic | iloeb as $IH generalizing)
+macro "iloeb" " as " colGt IH:binderIdent : tactic => `(tactic | iloeb as $IH generalizing)

--- a/Iris/Iris/ProofMode/Tactics/ModIntro.lean
+++ b/Iris/Iris/ProofMode/Tactics/ModIntro.lean
@@ -179,11 +179,26 @@ def iModIntroCore {e} (hyps : @Hyps u prop bi e) (goal : Q($prop)) (sel : TSynta
     let pf' ← k hyps' Q
     return q(modintro (sel:=$sel) $pf $pf' $hΦ)
 
+/--
+  `imodintro sel` introduces the modality at the top of the goal (e.g., `□`,
+  `<pers>`, `▷`, `|==>`), adjusting the context as required by the modality.
+  The tactic succeeds only when the selector term `sel` matches the modality.
+-/
 elab "imodintro" colGt sel:term : tactic => do
   ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
   let pf ← iModIntroCore hyps goal sel
 
   mvar.assign pf
 
+
+/--
+  `imodintro sel` introduces the modality at the top of the goal (e.g., `□`,
+  `<pers>`, `▷`, `|==>`), adjusting the context as required by the modality.
+-/
 macro "imodintro" : tactic => `(tactic | imodintro _)
+
+/--
+  `inext` introduces the later modality (`▷`), adjusting the context as
+  required by the modality. The tactic is equivalent to `imodintro (▷^[_] _)`.
+-/
 macro "inext" : tactic => `(tactic | imodintro (▷^[_] _))

--- a/Iris/Iris/ProofMode/Tactics/ModIntro.lean
+++ b/Iris/Iris/ProofMode/Tactics/ModIntro.lean
@@ -184,7 +184,7 @@ def iModIntroCore {e} (hyps : @Hyps u prop bi e) (goal : Q($prop)) (sel : TSynta
   `<pers>`, `▷`, `|==>`), adjusting the context as required by the modality.
   The tactic succeeds only when the selector term `sel` matches the modality.
 -/
-elab "imodintro" colGt sel:term : tactic => do
+elab "imodintro " colGt sel:term : tactic => do
   ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
   let pf ← iModIntroCore hyps goal sel
 

--- a/Iris/Iris/ProofMode/Tactics/Pure.lean
+++ b/Iris/Iris/ProofMode/Tactics/Pure.lean
@@ -113,8 +113,4 @@ elab "ipureintro" : tactic => do
 
 -- TODO: what is the best lean automation tactic to call here?
 -- `assumption` is necessary if the goal contains mvars
-/--
-  `itrivial` tries to solve the goal with simple tactics such as `iassumption`,
-  `ipureintro` followed by `simp`/`assumption`, and so on.
--/
 macro_rules | `(tactic| itrivial) => `(tactic| (first | ipureintro | exfalso) <;> (first | simp [*] | assumption) <;> done)

--- a/Iris/Iris/ProofMode/Tactics/Pure.lean
+++ b/Iris/Iris/ProofMode/Tactics/Pure.lean
@@ -53,6 +53,10 @@ def iPureCore {prop : Q(Type u)} (_bi : Q(BI $prop))
         | throwError "ipure: {A} is not affine and the goal not absorbing"
       return q(pure_elim_spatial (A:=$A) $pf $f)
 
+/--
+  `ipure H` moves a pure hypothesis `H` from the Iris context into the regular
+  Lean context.
+-/
 elab "ipure" colGt hyp:ident : tactic => do
   ProofModeM.runTactic λ mvar { bi, e, hyps, goal, .. } => do
 
@@ -63,6 +67,9 @@ elab "ipure" colGt hyp:ident : tactic => do
 
   mvar.assign pf
 
+/--
+  `iempintro` solves an `emp` goal, provided that the spatial context is affine.
+-/
 elab "iempintro" : tactic => do
   ProofModeM.runTactic λ mvar { prop, e, goal, .. } => do
 
@@ -79,6 +86,9 @@ theorem pure_intro_spatial [BI PROP] {Q : PROP} {φ : Prop}
     (h : FromPure false Q .out φ) (hφ : φ) : P ⊢ Q :=
   (pure_intro hφ).trans h.1
 
+/--
+  `ipureintro` turns a goal of the form `⌜φ⌝` into the Lean goal `φ`.
+-/
 elab "ipureintro" : tactic => do
   ProofModeM.runTactic λ mvar { e, goal, .. } => do
 
@@ -103,4 +113,8 @@ elab "ipureintro" : tactic => do
 
 -- TODO: what is the best lean automation tactic to call here?
 -- `assumption` is necessary if the goal contains mvars
+/--
+  `itrivial` tries to solve the goal with simple tactics such as `iassumption`,
+  `ipureintro` followed by `simp`/`assumption`, and so on.
+-/
 macro_rules | `(tactic| itrivial) => `(tactic| (first | ipureintro | exfalso) <;> (first | simp [*] | assumption) <;> done)

--- a/Iris/Iris/ProofMode/Tactics/Pure.lean
+++ b/Iris/Iris/ProofMode/Tactics/Pure.lean
@@ -57,7 +57,7 @@ def iPureCore {prop : Q(Type u)} (_bi : Q(BI $prop))
   `ipure H` moves a pure hypothesis `H` from the Iris context into the regular
   Lean context.
 -/
-elab "ipure" colGt hyp:ident : tactic => do
+elab "ipure " colGt hyp:ident : tactic => do
   ProofModeM.runTactic λ mvar { bi, e, hyps, goal, .. } => do
 
   let ivar ← hyps.findWithInfo hyp

--- a/Iris/Iris/ProofMode/Tactics/Rename.lean
+++ b/Iris/Iris/ProofMode/Tactics/Rename.lean
@@ -15,7 +15,7 @@ open Lean Elab Tactic Qq
 /--
   `irename H => H'` renames the hypothesis `H` as `H'`.
 -/
-elab "irename" colGt nameFrom:ident " => " colGt nameTo:ident : tactic => do
+elab "irename " colGt nameFrom:ident " => " colGt nameTo:ident : tactic => do
   ProofModeM.runTactic λ mvar { prop, bi, hyps, goal, .. } => do
 
   -- find hypothesis index
@@ -30,7 +30,7 @@ elab "irename" colGt nameFrom:ident " => " colGt nameTo:ident : tactic => do
 /--
   `irename: ty => H'` renames the hypothesis whose statement matches `ty` as `H`.
 -/
-elab "irename" ":" colGt ty:term " => " colGt nameTo:ident : tactic => do
+elab "irename" " : " colGt ty:term " => " colGt nameTo:ident : tactic => do
   -- parse syntax
   if nameTo.getId.isAnonymous then
     throwUnsupportedSyntax

--- a/Iris/Iris/ProofMode/Tactics/Rename.lean
+++ b/Iris/Iris/ProofMode/Tactics/Rename.lean
@@ -12,6 +12,9 @@ namespace Iris.ProofMode
 public meta section
 open Lean Elab Tactic Qq
 
+/--
+  `irename H => H'` renames the hypothesis `H` as `H'`.
+-/
 elab "irename" colGt nameFrom:ident " => " colGt nameTo:ident : tactic => do
   ProofModeM.runTactic λ mvar { prop, bi, hyps, goal, .. } => do
 
@@ -24,6 +27,9 @@ elab "irename" colGt nameFrom:ident " => " colGt nameTo:ident : tactic => do
   mvar.setType (IrisGoal.toExpr { prop, bi, hyps := hyps', goal, .. })
   addMVarGoal mvar
 
+/--
+  `irename: ty => H'` renames the hypothesis whose statement matches `ty` as `H`.
+-/
 elab "irename" ":" colGt ty:term " => " colGt nameTo:ident : tactic => do
   -- parse syntax
   if nameTo.getId.isAnonymous then

--- a/Iris/Iris/ProofMode/Tactics/Revert.lean
+++ b/Iris/Iris/ProofMode/Tactics/Revert.lean
@@ -106,6 +106,10 @@ def iRevertCore (targets : List SelTarget) {u : Level}{prop: Q(Type $u)}{bi : Q(
   let pf' : Q($(st.e) ⊢ $(st.goal)) ← withoutFVars (u:=0) st.reverted (k st.hyps st.goal)
   return q($(st.pf) $pf')
 
+/--
+  `irevert pats` reverts the hypotheses specified by the selection pattern `pats`
+  from the Iris contexts back into the regular Lean context.
+-/
 elab "irevert" pats:(colGt selPat)+ : tactic => do
   let pats ← liftMacroM <| SelPat.parse pats
 

--- a/Iris/Iris/ProofMode/Tactics/Revert.lean
+++ b/Iris/Iris/ProofMode/Tactics/Revert.lean
@@ -110,7 +110,7 @@ def iRevertCore (targets : List SelTarget) {u : Level}{prop: Q(Type $u)}{bi : Q(
   `irevert pats` reverts the hypotheses specified by the selection pattern `pats`
   from the Iris contexts back into the regular Lean context.
 -/
-elab "irevert" pats:(colGt selPat)+ : tactic => do
+elab "irevert " pats:(colGt ppSpace selPat)+ : tactic => do
   let pats ← liftMacroM <| SelPat.parse pats
 
   ProofModeM.runTactic fun mvar {hyps, goal, ..} => do

--- a/Iris/Iris/ProofMode/Tactics/Rewrite.lean
+++ b/Iris/Iris/ProofMode/Tactics/Rewrite.lean
@@ -179,6 +179,17 @@ def iRewriteHyp {prop : Q(Type u)} {bi : Q(BI $prop)}
     | throwError "irewrite: cannot find hyp" -- should never happen
   return r
 
+/--
+  `irewrite [rules] at loc` applies a sequence `rules` of internal equalities
+  (`≡`) to the locations (`loc`). The locations `loc` may contain hypothesis
+  names and/or the goal, represented by `⊢`.
+
+  Each rule is a proof mode term, optionally prefixed with `←` for
+  right-to-left rewriting.
+
+  Optionally, one can use `irewrite (occs := …) [rules] at H` such that the
+  configuration options for the tactic are specified.
+-/
 elab "irewrite" cfg:optConfig "[" rules:(IRewrite.irwRule),* "]" loc:(location)? : tactic => do
   let config ← IRewrite.elabIRewriteConfig cfg
   let location ← IRewrite.Location.parse loc

--- a/Iris/Iris/ProofMode/Tactics/Rewrite.lean
+++ b/Iris/Iris/ProofMode/Tactics/Rewrite.lean
@@ -187,8 +187,7 @@ def iRewriteHyp {prop : Q(Type u)} {bi : Q(BI $prop)}
   Each rule is a proof mode term, optionally prefixed with `←` for
   right-to-left rewriting.
 
-  Optionally, one can use `irewrite (occs := …) [rules] at H` such that the
-  configuration options for the tactic are specified.
+  Optionally, one can use `irewrite (occs := …) [rules] at H` to specify the occurrences.
 -/
 elab "irewrite " cfg:optConfig " [" rules:(IRewrite.irwRule),* "] " loc:(location)? : tactic => do
   let config ← IRewrite.elabIRewriteConfig cfg

--- a/Iris/Iris/ProofMode/Tactics/Rewrite.lean
+++ b/Iris/Iris/ProofMode/Tactics/Rewrite.lean
@@ -190,7 +190,7 @@ def iRewriteHyp {prop : Q(Type u)} {bi : Q(BI $prop)}
   Optionally, one can use `irewrite (occs := …) [rules] at H` such that the
   configuration options for the tactic are specified.
 -/
-elab "irewrite" cfg:optConfig "[" rules:(IRewrite.irwRule),* "]" loc:(location)? : tactic => do
+elab "irewrite " cfg:optConfig " [" rules:(IRewrite.irwRule),* "] " loc:(location)? : tactic => do
   let config ← IRewrite.elabIRewriteConfig cfg
   let location ← IRewrite.Location.parse loc
   let rules ← liftMacroM <| IRewrite.Rule.parse rules.getElems

--- a/Iris/Iris/ProofMode/Tactics/Specialize.lean
+++ b/Iris/Iris/ProofMode/Tactics/Specialize.lean
@@ -180,6 +180,9 @@ def iSpecializeCore {e} (hyps : @Hyps u prop bi e) (pa : Q(Bool)) (A : Q($prop))
     return ⟨_, hyps, q(true), B', q(specialize_dup_context $pf $af)⟩
   return ⟨_, hyps', pb, B, pf⟩
 
+/--
+  `ispecialize pmt` specialises a hypothesis according to `pmt : pmTerm`.
+-/
 elab "ispecialize" colGt pmt:pmTerm : tactic => do
   let pmt ← liftMacroM <| PMTerm.parse pmt
   ProofModeM.runTactic λ mvar { bi, hyps, goal, .. } => do

--- a/Iris/Iris/ProofMode/Tactics/Specialize.lean
+++ b/Iris/Iris/ProofMode/Tactics/Specialize.lean
@@ -183,7 +183,7 @@ def iSpecializeCore {e} (hyps : @Hyps u prop bi e) (pa : Q(Bool)) (A : Q($prop))
 /--
   `ispecialize pmt` specialises a hypothesis according to `pmt : pmTerm`.
 -/
-elab "ispecialize" colGt pmt:pmTerm : tactic => do
+elab "ispecialize " colGt pmt:pmTerm : tactic => do
   let pmt ← liftMacroM <| PMTerm.parse pmt
   ProofModeM.runTactic λ mvar { bi, hyps, goal, .. } => do
   -- hypothesis must be in the context, otherwise use ihave

--- a/Iris/Iris/ProofMode/Tactics/Split.lean
+++ b/Iris/Iris/ProofMode/Tactics/Split.lean
@@ -25,6 +25,10 @@ theorem sep_split [BI PROP] {P P1 P2 Q Q1 Q2 : PROP} [inst : FromSep Q Q1 Q2]
 public meta section
 open Lean Elab Tactic Meta Qq
 
+/--
+  `isplit` splits a conjunction (`∧`) into two goals, both keeping the
+  entire context.
+-/
 elab "isplit" : tactic => do
   ProofModeM.runTactic λ mvar { prop, hyps, goal, .. } => do
 
@@ -62,11 +66,36 @@ private def isplitCore (side : splitSide) (names : Array (TSyntax `ident)) : Tac
   let m2 ← addBIGoal rhs Q2
   mvar.assign q(sep_split (Q := $goal) $pf $m1 $m2)
 
+/--
+  `isplitl [H₁ … Hₙ]` splits a separating conjunction (`∗`) into two goals,
+  with spatial hypotheses `H₁ … Hₙ` assigned to the left goal and all other
+  spatial hypotheses assigned to the right goal.
+-/
 elab "isplitl" "[" names:(colGt ident)* "]": tactic => do
   isplitCore .splitLeft names
 
+/--
+  `isplitr [H₁ … Hₙ]` splits a separating conjunction (`∗`) into two goals,
+  with spatial hypotheses `H₁ … Hₙ` assigned to the right goal and all other
+  spatial hypotheses assigned to the left goal.
+-/
 elab "isplitr" "[" names:(colGt ident)* "]": tactic => do
   isplitCore .splitRight names
 
+/--
+  `isplitl` splits a separating conjunction (`∗`) into two goals,
+  with all spatial hypotheses assigned to the right goal.
+
+  To assign some hypotheses `H₁ … Hₙ` to the left goal, use `isplitl [H₁ … Hₙ]`
+  instead.
+-/
 macro "isplitl" : tactic => `(tactic| isplitr [])
+
+/--
+  `isplitr` splits a separating conjunction (`∗`) into two goals,
+  with all spatial hypotheses assigned to the left goal.
+
+  To assign some hypotheses `H₁ … Hₙ` to the right goal, use `isplitr [H₁ … Hₙ]`
+  instead.
+-/
 macro "isplitr" : tactic => `(tactic| isplitl [])

--- a/Iris/Iris/ProofMode/Tactics/Split.lean
+++ b/Iris/Iris/ProofMode/Tactics/Split.lean
@@ -29,7 +29,7 @@ open Lean Elab Tactic Meta Qq
   `isplit` splits a conjunction (`∧`) into two goals, both keeping the
   entire context.
 -/
-elab "isplit" : tactic => do
+elab "isplit " : tactic => do
   ProofModeM.runTactic λ mvar { prop, hyps, goal, .. } => do
 
   let A1 ← mkFreshExprMVarQ prop
@@ -71,7 +71,7 @@ private def isplitCore (side : splitSide) (names : Array (TSyntax `ident)) : Tac
   with spatial hypotheses `H₁ … Hₙ` assigned to the left goal and all other
   spatial hypotheses assigned to the right goal.
 -/
-elab "isplitl" "[" names:(colGt ident)* "]": tactic => do
+elab "isplitl " colGt "[" names:(colGt ident)* "]": tactic => do
   isplitCore .splitLeft names
 
 /--
@@ -79,7 +79,7 @@ elab "isplitl" "[" names:(colGt ident)* "]": tactic => do
   with spatial hypotheses `H₁ … Hₙ` assigned to the right goal and all other
   spatial hypotheses assigned to the left goal.
 -/
-elab "isplitr" "[" names:(colGt ident)* "]": tactic => do
+elab "isplitr " colGt "[" names:(colGt ident)* "]": tactic => do
   isplitCore .splitRight names
 
 /--

--- a/Iris/Iris/ProofMode/Tactics/Split.lean
+++ b/Iris/Iris/ProofMode/Tactics/Split.lean
@@ -26,8 +26,7 @@ public meta section
 open Lean Elab Tactic Meta Qq
 
 /--
-  `isplit` splits a conjunction (`∧`) into two goals, both keeping the
-  entire context.
+  `isplit` turns the goal into a conjunction (`∧`) and splits it into two goals, both keeping the entire context.
 -/
 elab "isplit " : tactic => do
   ProofModeM.runTactic λ mvar { prop, hyps, goal, .. } => do

--- a/Iris/Iris/Tests/Tactics.lean
+++ b/Iris/Iris/Tests/Tactics.lean
@@ -2448,14 +2448,14 @@ example [BI PROP] {P1 P2 P3 Q : PROP} :
   iapply H
   iexact HNew
 
-/- Tests `icomine` failure: using a non-existent hypothesis as an argument -/
+/- Tests `icombine` failure: using a non-existent hypothesis as an argument -/
 /-- error: unknown hypothesis HP2 -/
 #guard_msgs in
 example [BI PROP] {P : PROP} : ⊢ P -∗ P ∗ P := by
   iintro HP1
   icombine HP1 HP2 as HNew
 
-/- Tests `icomine` failure: combining a proposition in the spatial context twice -/
+/- Tests `icombine` failure: combining a proposition in the spatial context twice -/
 /-- error: icombine: propositions in the spatial context cannot be used as arguments multiple times -/
 #guard_msgs in
 example [BI PROP] {P Q R : PROP} : ⊢ P -∗ Q -∗ R -∗ P ∗ Q ∗ R ∗ P := by

--- a/Iris/tactics.md
+++ b/Iris/tactics.md
@@ -1,80 +1,154 @@
 # Tactics
 
-| Syntax                                     | Description                                                                                                                                                                                                                          |
-|--------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `istart`                                   | Start the proof mode.                                                                                                                                                                                                                |
-| `istop`                                    | Stop the proof mode.                                                                                                                                                                                                                 |
-| `irename` *nameFrom* `into` *nameTo*       | Rename the hypothesis *nameFrom* to *nameTo*.                                                                                                                                                                                        |
-| `iclear` *hyp*                             | Discard the hypothesis *hyp*.                                                                                                                                                                                                        |
-| `iexists` *x*                              | Instantiate an existential quantifier in the goal with *x*.                                                                                                                                                                          |
-| `iexact` *hyp*                             | Solve the goal with the hypothesis *hyp*.                                                                                                                                                                                            |
-| `iassumption`                              | Solve the goal with a hypothesis from any context (pure, intuitionistic or spatial).                                                                                                                                                 |
-| `iexfalso`                                | Change the goal to `False`.                                                                                                                                                                                                          |
-| `ipure` *hyp*                              | Move the hypothesis *hyp* to the pure context.                                                                                                                                                                                       |
-| `iintuitionistic` *hyp*                    | Move the hypothesis *hyp* to the intuitionistic context. Equivalent to `icases hyp with #hyp`.                                       |
-| `ispatial` *hyp*                           | Move the hypothesis *hyp* to the spatial context.                                                                                                                                                                                    |
-| `iempintro`                               | Solve the goal if it is `emp` and discard all hypotheses.                                                                                                                                                                            |
-| `ipureintro`                              | Turn a goal of the form `⌜φ⌝` into a Lean goal `φ`.                                                                                                                                                                                  |
-| `ispecialize` *pmTerm*                     | Specialize an hypothesis according to the proof mode term *pmTerm*.                                                                                                                                                                  |
-| `isplit`                                   | Split a conjunction (e.g. `∧`) into two goals, using the entire spatial context for both of them.                                                                                                                                    |
-| `isplit`{`l`\|`r`}                         | Split a separating conjunction (e.g. `∗`) into two goals, using the entire spatial context for the left (`l`) or right (`r`) side.                                                                                                   |
-| `isplit`{`l`\|`r`} `[`*hyps*`]`            | Split a separating conjunction (e.g. `∗`) into two goals, using the hypotheses *hyps* as the spatial context for the left (`l`) or right (`r`) side. The remaining hypotheses in the spatial context are used for the opposite side. |
-| `ileft`<br>`iright`                        | Choose to prove the left (`ileft`) or right (`iright`) side of a disjunction in the goal.                                                                                                                                            |
-| `icases` *pmTerm* `with` *cases-pat*       | Destruct *pmTerm* using the cases pattern *cases-pat*.                                                                                                                                                                               |
-| `imod` *pmTerm* with *cases-pat*           | Eliminate the modality at the top of *pmTerm* and destruct the result using *cases-pat*.                                                                                                                                             |
-| `iintro` *intro-pats*                      | Introduce up to multiple hypotheses using the intro patterns *intro-pats*.                                                                                                                                                           |
-| `imodintro`                                | Introduce the modality at the top of goal.                                                                                                                                                                                           |
-| `inext`                                    | Introduce a later modality at the top of goal.                                                                                                                                                                                       |
-| `iapply` *pmTerm*                          | Match the conclusion of the current goal against the conclusion of the *pmTerm* and generates goals for each of its premises, moving all unused spatial hypotheses to the last premise.                                              |
-| `ihave` *cases-pat* := *pmTerm*            | Move *pmTerm* into the Iris context using *cases-pat*. (In contrast to `icases`, `ihave` does not remove the hypothesis from the Iris context.)                                                                                      |
-| `ihave` *cases-pat* : *term* $$ *spec-pat* | Assert *term* as *cases-pat* and prove it using *spec-pat*.                                                                                                                                                                          |
-| `irevert` *hyp*                        | Revert the hypothesis *hyp*.                                                                                                                                                                                                         |
+The proof mode maintains three contexts: the *pure* (Lean) context, the *intuitionistic* context (hypotheses prefixed with `□`, usable multiple times), and the *spatial* context (hypotheses that are owned and can be used only once).
+
+## Proof Mode Management
+
+| Syntax   | Description                                                                                  |
+|----------|----------------------------------------------------------------------------------------------|
+| `istart` | Start the proof mode. (Most tactics start the proof mode automatically.)                     |
+| `istop`  | Stop the proof mode, turning the goal back into a plain entailment.                          |
+
+## Context Management
+
+| Syntax                                | Description                                                                                                                                  |
+|---------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| `irename` *H* `=>` *H'*               | Rename the hypothesis *H* to *H'*.                                                                                                           |
+| `irename :` *term* `=>` *H'*          | Rename the hypothesis whose statement matches *term* to *H'*.                                                                                |
+| `iclear` *selPats*                    | Discard the hypotheses selected by the [selection patterns](#selection-patterns) *selPats*.                                                  |
+| `irevert` *selPats*                   | Revert the selected hypotheses (proof mode or pure Lean hypotheses) into the goal.                                                           |
+| `ipure` *H*                           | Move the pure hypothesis *H* into the Lean context.                                                                                          |
+| `iintuitionistic` *H*                 | Move *H* to the intuitionistic context. Equivalent to `icases H with #H`.                                                                    |
+| `ispatial` *H*                        | Move *H* to the spatial context. Equivalent to `icases H with ∗H`.                                                                           |
+
+## Introduction and Destruction
+
+| Syntax                                     | Description                                                                                                                                         |
+|--------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `iintro` *intro-pats*                      | Introduce universal quantifiers, wands and implications using the [intro patterns](#intro-patterns) *intro-pats*.                                   |
+| `icases` *pmTerm* `with` *cases-pat*       | Destruct *pmTerm* using the [cases pattern](#cases-patterns) *cases-pat*, consuming the hypothesis.                                                 |
+| `icases +keep` *pmTerm* `with` *cases-pat* | Like `icases`, but keep the original hypothesis (requires it to be intuitionistic or duplicable).                                                   |
+| `ihave` *cases-pat* `:=` *pmTerm*          | Bring *pmTerm* (e.g. a Lean lemma or specialized hypothesis) into the context and destruct it with *cases-pat* without consuming the original. Equivalent to `icases +keep`. |
+| `ihave` *cases-pat* `:` *term* `$$` *spec-pats* | Assert the proposition *term*, prove it in a subgoal built from *spec-pats*, and destruct it with *cases-pat*.                                  |
+| `iexists` *x₁*`,` ...`,` *xₙ*              | Instantiate existential quantifiers in the goal with the terms *xᵢ*. Holes (`_`) and named metavariables (`?m`) are allowed.                        |
+| `ileft` / `iright`                         | Choose the left/right side of a disjunction in the goal.                                                                                            |
+
+## Splitting and Framing
+
+| Syntax                            | Description                                                                                                                                            |
+|-----------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `isplit`                          | Split a conjunction (`∧`) into two goals, both keeping the entire context.                                                                             |
+| `isplitl [`*H₁* ... *Hₙ*`]`       | Split a separating conjunction (`∗`); the hypotheses *Hᵢ* go to the left goal, all remaining spatial hypotheses to the right.                          |
+| `isplitr [`*H₁* ... *Hₙ*`]`       | Like `isplitl`, but the listed hypotheses go to the right goal.                                                                                        |
+| `isplitl` / `isplitr`             | Split a separating conjunction, giving *all* spatial hypotheses to the left (`isplitl`) or right (`isplitr`) goal.                                     |
+| `iframe` *selPats*                | Cancel the selected hypotheses against matching parts of the goal. Solves the goal completely if the leftover is `True` or `emp` (with affine context). |
+| `iframe`                          | Equivalent to `iframe ∗` (frame all spatial hypotheses).                                       |
+| `icombine` *selPats* `as` *cases-pat* | Combine the selected hypotheses into one using the `CombineSepAs` type class (defaults to `∗`) and destruct the result with *cases-pat*.           |
+| `icombine` *selPats* `gives` *cases-pat* | Derive persistent information (e.g. validity of combined ghost state) from the selected hypotheses via `CombineSepGives`, keeping the originals. |
+| `icombine` *selPats* `as` *pat₁* `gives` *pat₂* | Do both at once.                                                                                                                            |
+
+## Applying and Specializing
+
+| Syntax                  | Description                                                                                                                                                          |
+|-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `iapply` *pmTerm*       | Match the conclusion of *pmTerm* against the goal and generate goals for each premise, moving all unused spatial hypotheses into the last premise.                    |
+| `ispecialize` *pmTerm*  | Specialize a hypothesis according to *pmTerm*.                                          |
+| `iexact` *H*            | Solve the goal with the hypothesis *H*.                                                                                                                              |
+| `iassumption`           | Solve the goal with a matching hypothesis from any context (pure, intuitionistic or spatial).                                                                        |
+
+## Modalities
+
+| Syntax                          | Description                                                                                                                                                    |
+|---------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `imodintro`                     | Introduce the modality at the top of the goal (e.g. `□`, `<pers>`, `▷`, `\|==>`), adjusting the context as required by the modality.                           |
+| `imodintro` *sel*               | Like `imodintro`, but only succeed if the modality matches the selector term *sel*, e.g. `imodintro (<pers> _)` or `imodintro (□ _)`.                          |
+| `inext`                         | Introduce one or more later modalities; equivalent to `imodintro (▷^[_] _)`.                                                                                   |
+| `imod` *pmTerm* `with` *cases-pat* | Eliminate the modality at the top of *pmTerm* into the goal and destruct the result with *cases-pat*. Equivalent to `icases ... with >pat`. |
+| `imod` *pmTerm*                 | Like above; if *pmTerm* is a hypothesis, its name is kept.                                                                                                     |
+
+## Rewriting and Induction
+
+| Syntax                                       | Description                                                                                                                                       |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `irewrite [`*rules*`]` (`at` *H* \| `at ⊢`)? | Rewrite with internal equalities (`≡`). Each rule is a proof mode term, optionally prefixed with `←` for right-to-left rewriting. Rewrites in the goal by default or in hypothesis *H*. Supports `(occs := ...)` config. Example: `irewrite [← Heq $$ %b] at H`. |
+| `iloeb as` *IH* (`generalizing` *selPats*)?  | Löb induction: adds the induction hypothesis *IH* (guarded by `▷`) to the intuitionistic context. All spatial hypotheses — plus anything selected by *selPats*, including pure variables via `%x` — are generalized into the induction hypothesis. |
+
+## Solving Simple Goals
+
+| Syntax       | Description                                                                                                                                                       |
+|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `ipureintro` | Turn a goal of the form `⌜φ⌝` into the Lean goal `φ`.                                                                                                             |
+| `iempintro`  | Solve an `emp` goal, requiring the spatial context to be affine.                                                                                                  |
+| `iexfalso`   | Change the goal to `False`.                                                                                                                                       |
+| `itrivial`   | Try to solve the goal with simple tactics (`iassumption`, `ipureintro` followed by `simp`/`assumption`, ...). Used by the `//` patterns. Extensible by adding `macro_rules` for `itrivial`. |
 
 ## Cases Patterns
 
-| Pattern                         | Description                                                                                                                                                                         |
-|---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| *name*                          | Rename the hypothesis to *name*.                                                                                                                                                    |
-| `-`                             | Drop the hypothesis.                                                                                                                                                                |
-| `⟨`*pat_1* [`,` *pat_2*]...`⟩`  | Destruct a (separating) conjunction and recursively destruct its arguments using the patterns *pat_i*.                                                                              |
-| `(`*pat_1* [`\|` *pat_2*]...`)` | Destruct a disjunction and recursively destruct its arguments in separate goals using the patterns *pat_i*. The parentheses can be omitted if this pattern is not on the top level. |
-| `%`*name*                       | Move the hypothesis to the pure context and rename it to *name*.                                                                                                                    |
-| `#`*pat*                        | Move the hypothesis to the intuitionistic context and further destruct it using the pattern *pat*.                                                                                  |
-| `∗`*pat*                        | Move the hypothesis to the spatial context and further destruct it using the pattern *pat*.                                                                                         |
-| `>`*pat*                        | Eliminate the modality at the top of the hypothesis and further destruct the result using the pattern *pat*.                                                                        |
+| Pattern                         | Description                                                                                                                                                         |
+|---------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| *name* / `_`                    | Name the hypothesis *name* (or keep it anonymous).                                                                                                                  |
+| `-`                             | Drop the hypothesis.                                                                                                                                                |
+| `$`                             | Frame the hypothesis: immediately cancel it against the goal (like `iframe`).                                                                                       |
+| `⟨`*pat₁*`,` ... `,` *patₙ*`⟩`  | Destruct a (separating) conjunction or existential; an existential variable is bound with `%`*x*, e.g. `⟨%x, H⟩`.                                                   |
+| `(`*pat₁* `\|` ... `\|` *patₙ*`)` | Destruct a disjunction, one goal per disjunct. Parentheses can be omitted when nested inside `⟨⟩`.                                                                |
+| `%`*name*                       | Move the (pure) hypothesis into the Lean context as *name*.                                                                                                         |
+| `#`*pat*                        | Move the hypothesis to the intuitionistic context, then destruct with *pat*.                                                                                        |
+| `∗`*pat*                        | Move the hypothesis to the spatial context, then destruct with *pat*.                                                                                               |
+| `>`*pat*                        | Eliminate the modality at the top of the hypothesis, then destruct with *pat*.                                                                                      |
 
 Example:
 ```lean
 -- the hypothesis:
-P1 ∗ (□ P2 ∨ P2) ∗ (P3 ∧ P3')
+∃ x, P1 x ∗ (□ P2 ∨ P2) ∗ (P3 ∧ ⌜φ⌝)
 -- can be destructed using the pattern:
-⟨HP1, #HP2 | HP2, ⟨HP3, -⟩⟩
--- (there are of course other valid patterns for destructing the shown hypothesis)
+⟨%x, HP1, #HP2 | HP2, ⟨HP3, -⟩⟩
 ```
 
 ## Intro Patterns
 
-| Pattern                         | Description                                                                                                                                                                         |
-|---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| *cases-pat*                     | Introduce an hypothesis and destruct it following *cases-pat*.                                                                                                                      |
-| `!>`                            | Introduce the modality at the top of the goal.                                                                                                                                      |
+| Pattern     | Description                                                                                                       |
+|-------------|---------------------------------------------------------------------------------------------------------------------|
+| *cases-pat* | Introduce a hypothesis and destruct it with *cases-pat*. In particular, `%x` introduces a universally quantified variable or pure premise into the Lean context. |
+| `!>`        | Introduce the modality at the top of the goal (like `imodintro`).                                                 |
+| `//`        | Try to close the goal with `itrivial` (and continue with the remaining patterns if it fails).                     |
+
+Example: `iintro %x ⟨HP, #HQ⟩ !> //`.
+
+## Selection Patterns
+
+| Pattern   | Description                                                  |
+|-----------|------------------------------------------------------------------|
+| *H*       | The proof mode hypothesis *H*.                               |
+| `%`*h*    | The Lean hypothesis *h* from the pure context.               |
+| `%`       | All pure (`Prop`) hypotheses in the Lean context.            |
+| `#`       | All hypotheses in the intuitionistic context.                |
+| `∗`       | All hypotheses in the spatial context.                       |
 
 ## Specialization Patterns
 
-| Pattern                         | Description                                                                                                                                                                         |
-|---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `H`                             | Use the hypothesis `H`, which should match the premise exactly.                                                                                                                     |
-| `[H1 ... HN]`                   | Generate a goal with the hypotheses `[H1, ..., HN]`                                                                                                                                 |
-| `[H1 ... HN]` as *str*          | Generate a goal named *str* with the hypotheses `[H1, ..., HN]`.                                                                                                                    |
-| `%t`                            | Use the pure term `t` to instantiate the hypothesis.                                                                                                                                |
+Used in proof mode terms after `$$` to eliminate the premises of a wand or universal quantifier.
 
-In general, the hypotheses passed to a subgoal are not available for proving the main goal.
-However, if one uses the `icases` tactic with a persistent cases pattern or the `ihave` tactic with a persistent cases pattern, the hypotheses are available both for the subgoal and the main goal.
+| Pattern                       | Description                                                                                                                                |
+|-------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
+| *H*                           | Use the hypothesis *H*, which must match the premise exactly.                                                                              |
+| `%`*t*                        | Instantiate a universal quantifier with the pure term *t*.                                                                                 |
+| `[`*H₁* ... *Hₙ*`]`           | Generate a subgoal for the premise with exactly the spatial hypotheses *Hᵢ*. Hypotheses written as `$H` are framed instead of forming the context. |
+| `[-` *H₁* ... *Hₙ*`]`         | Like above, but use all spatial hypotheses *except* the listed ones.                                                                       |
+| `[`... `//]`                  | Additionally try to solve the subgoal with `itrivial` and fail if unsuccessful.                                                            |
+| `[`...`] as` *name*           | Name the generated subgoal *name*.                                                                                                         |
+| `[$]`                         | Solve the premise entirely by framing spatial and intuitionistic hypotheses.                                                               |
+If the conclusion of a specialization is persistent, the context can be shared between the subgoal and the main goal (e.g. `ihave #HQ : □ Q $$ [HP]` keeps `HP` usable in the main goal).
 
 ## Proof Mode Terms
 
 Proof mode terms (*pmTerm*) are of the form
 ```
-(H $$ specPat1 ... specPatN)
+H $$ specPat₁ ... specPatₙ
 ```
-where `H` is a hypothesis or Lean term whose conclusion is an entailment, and `specPat1 ... specPatN` are specialization patterns.
+where `H` is a hypothesis or a Lean term whose conclusion is an entailment, and the *specPatᵢ* are specialization patterns applied to its premises. The `$$ ...` part is optional. Examples:
+
+```lean
+iapply (wand_trans HPQ)        -- Lean term as pmTerm
+ispecialize HPQ $$ %x HP [HQ]  -- instantiate ∀ with x, use HP, prove premise from HQ
+imod (own_update ... $$ Hown)  -- specialize and eliminate the update modality
+```


### PR DESCRIPTION
## Description

Currently some IPM tactics are not annotated with comments. As a result, when one hovers over a tactic, only a generic pop-up message is shown.

<img width="1737" height="316" alt="Generic pop-up message 1" src="https://github.com/user-attachments/assets/1f5edc94-b3d8-400c-b3dd-33971bdaebc3" />

With docstrings added for each `elab`/`macro`, we get more specific descriptions about the IPM tactics. This resembles what we get with built-in tactics in Lean and hopefully makes IPM nicer to use.

<img width="1737" height="316" alt="Nice pop-up message with a description of the IPM tactic" src="https://github.com/user-attachments/assets/88fd791c-17ac-42d6-a733-7124e834cdcd" />

I wrote these comments manually based on [`tactics.md`](https://github.com/leanprover-community/iris-lean/blob/update_tactics_md/Iris/tactics.md) and examples from [`Tactics.lean`](https://github.com/leanprover-community/iris-lean/blob/master/Iris/Iris/Tests/Tactics.lean).

If there are some notable differences in terms of syntax or tactic behaviour compared to the Rocq tactics, I think it might also be helpful to highlight them in these comments. Would be great to hear whether others think this would be useful.

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files
