### PR TITLE
feat: laterif through laterN

### DIFF
--- a/Iris/Iris/BI/BIBase.lean
+++ b/Iris/Iris/BI/BIBase.lean
@@ -231,6 +231,19 @@ macro_rules
 delab_rule intuitionistically
   | `($_ $P) => do ``(iprop(□ $(← unpackIprop P)))
 
+/-- Iterated later modality. -/
+syntax:max "▷^[" term:45 "]" term:40 : term
+
+@[rocq_alias bi_laterN]
+def laterN [BIBase PROP] (n : Nat) (P : PROP) : PROP :=
+  match n with | .zero => P | .succ n' => later <| laterN n' P
+
+macro_rules
+  | `(iprop(▷^[$n] $P))   => ``(laterN $n iprop($P))
+
+delab_rule laterN
+  | `($_ $n $P) => do ``(iprop(▷^[$n] $(← unpackIprop P)))
+
 /-- Conditional persistency modality.
 ```
 def persistentlyIf (p : Bool) (P : PROP) := if p then <pers> P else P
@@ -270,7 +283,7 @@ def affinelyIf [BIBase PROP] (p : Bool) (P : PROP) : PROP := iprop(if p then <af
 def absorbinglyIf [BIBase PROP] (p : Bool) (P : PROP) : PROP := iprop(if p then <absorb> P else P)
 @[rocq_alias bi_intuitionistically_if]
 def intuitionisticallyIf [BIBase PROP] (p : Bool) (P : PROP) : PROP := iprop(if p then □ P else P)
-def laterIf [BIBase PROP] (p : Bool) (P : PROP) : PROP := iprop(if p then ▷ P else P)
+def laterIf [BIBase PROP] (p : Bool) (P : PROP) : PROP := iprop(▷^[p.toNat] P)
 
 macro_rules
   | `(iprop(<pers>?$p $P))   => ``(persistentlyIf $p iprop($P))
@@ -300,21 +313,6 @@ def bigSep [BIBase PROP] (Ps : List PROP) : PROP := bigOp sep iprop(emp) Ps
 notation:40 "[∧] " Ps:max => bigAnd Ps
 notation:40 "[∨] " Ps:max => bigOr Ps
 notation:40 "[∗] " Ps:max => bigSep Ps
-
-
-/-- Iterated later modality. -/
-syntax:max "▷^[" term:45 "]" term:40 : term
-
-@[rocq_alias bi_laterN]
-def laterN [BIBase PROP] (n : Nat) (P : PROP) : PROP :=
-  match n with | .zero => P | .succ n' => later <| laterN n' P
-
-macro_rules
-  | `(iprop(▷^[$n] $P))   => ``(laterN $n iprop($P))
-
-delab_rule laterN
-  | `($_ $n $P) => do ``(iprop(▷^[$n] $(← unpackIprop P)))
-
 
 /-- Except-0 modality -/
 syntax:max "◇ " term:40 : term

--- a/Iris/Iris/ProofMode/InstancesLater.lean
+++ b/Iris/Iris/ProofMode/InstancesLater.lean
@@ -289,7 +289,7 @@ instance intoExcept0_later [BI PROP] (P : PROP) [Timeless P] : IntoExcept0 iprop
 @[rocq_alias into_except_0_later_if]
 instance intoExcept0_laterIf [BI PROP] p (P : PROP) [Timeless P] : IntoExcept0 iprop(▷?p P) P where
   into_except0 := match p with
-                  | true => Timeless.timeless
+                  | true => Timeless.timeless (P := P)
                   | false => except0_intro
 
 @[rocq_alias into_except_0_affinely]


### PR DESCRIPTION
## Description

Redefines laterIf through laterN to improve on its support by IPM.

## Checklist
* [ ] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [ ] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
