### PR TITLE
feat: HeapLang instances for completeness

### DIFF
--- a/Iris/Iris/HeapLang/Instances.lean
+++ b/Iris/Iris/HeapLang/Instances.lean
@@ -64,11 +64,17 @@ theorem fill_isSome_empty {K : List ECtxItem} {e : Exp}
     have h2 := EctxLanguage.fill_val (K := K') (e := fillItem Ki e) h
     simp [fillItem_expToVal_none] at h2
 
-macro "solve_subredex_values" : tactic =>
+local macro "solve_subredex_values" : tactic =>
   `(tactic|
     (apply subredexes_are_values
      intro Ki e_inner heq
      cases Ki <;> cases heq <;> try rfl <;> try done))
+
+local macro "solve_atomic" hstep:ident : tactic =>
+  `(tactic| (cases baseStep_of_primStep $hstep (by solve_subredex_values)
+             split
+             · exact val_irreducible rfl _
+             · rfl))
 
 theorem mk_pure_prim_step {e1 e2 : Exp} (hstep : ∀ σ, BaseStep e1 σ [] e2 σ [])
     (hpure : ∀ {σ1 κs e2' σ2 efs}, BaseStep e1 σ1 κs e2' σ2 efs → κs = [] ∧ σ1 = σ2 ∧ e2 = e2' ∧ efs = [])
@@ -188,82 +194,37 @@ instance (priority := default + 10) instPureExecEqOp {v1 v2 : Val} :
     · solve_subredex_values
 
 instance instAtomicLoad {s} {v : Val} : Atomic s hl(!&v) where
-  atomic {σ obs e' σ' eₜ} Hstep := by
-    cases baseStep_of_primStep Hstep (by solve_subredex_values)
-    cases s
-    · exact val_irreducible rfl _
-    · rfl
+  atomic {σ obs e' σ' eₜ} Hstep := by solve_atomic Hstep
 
 instance instAtomicStore {s} {v1 v2 : Val} : Atomic s hl(&v1 ← &v2) where
-  atomic {σ obs e' σ' eₜ} Hstep := by
-    cases baseStep_of_primStep Hstep (by solve_subredex_values)
-    rename_i l v Heq
-    cases s
-    · exact val_irreducible rfl _
-    · rfl
+  atomic {σ obs e' σ' eₜ} Hstep := by solve_atomic Hstep
 
 instance instAtomicFst {s} {v1 : Val} : Atomic s hl(fst(&v1)) where
-  atomic {σ obs e' σ' eₜ} Hstep := by
-    cases baseStep_of_primStep Hstep (by solve_subredex_values)
-    cases s
-    · exact val_irreducible rfl _
-    · rfl
+  atomic {σ obs e' σ' eₜ} Hstep := by solve_atomic Hstep
 
 instance instAtomicSnd {s} {v1 : Val} : Atomic s hl(snd(&v1)) where
-  atomic {σ obs e' σ' eₜ} Hstep := by
-    cases baseStep_of_primStep Hstep (by solve_subredex_values)
-    cases s
-    · exact val_irreducible rfl _
-    · rfl
+  atomic {σ obs e' σ' eₜ} Hstep := by solve_atomic Hstep
 
 instance instAtomicAllocN {s} {v1 v2 : Val} : Atomic s hl(allocn(&v1, &v2)) where
-  atomic {σ obs e' σ' eₜ} Hstep := by
-    cases baseStep_of_primStep Hstep (by solve_subredex_values)
-    cases s
-    · exact val_irreducible rfl _
-    · rfl
+  atomic {σ obs e' σ' eₜ} Hstep := by solve_atomic Hstep
 
 instance instAtomicFree {s} {v : Val} : Atomic s hl(free(&v)) where
-  atomic {σ obs e' σ' eₜ} Hstep := by
-    cases baseStep_of_primStep Hstep (by solve_subredex_values)
-    cases s
-    · exact val_irreducible rfl _
-    · rfl
+  atomic {σ obs e' σ' eₜ} Hstep := by solve_atomic Hstep
 
 instance instAtomicXchg {s} {v1 v2 : Val} : Atomic s hl(xchg(&v1, &v2)) where
-  atomic {σ obs e' σ' eₜ} Hstep := by
-    cases baseStep_of_primStep Hstep (by solve_subredex_values)
-    cases s
-    · exact val_irreducible rfl _
-    · rfl
+  atomic {σ obs e' σ' eₜ} Hstep := by solve_atomic Hstep
 
 instance instAtomicFaa {s} {v1 v2 : Val} : Atomic s hl(faa(&v1, &v2)) where
-  atomic {σ obs e' σ' eₜ} Hstep := by
-    cases baseStep_of_primStep Hstep (by solve_subredex_values)
-    cases s
-    · exact val_irreducible rfl _
-    · rfl
+  atomic {σ obs e' σ' eₜ} Hstep := by solve_atomic Hstep
 
 instance instAtomicFork {s} {e : Exp} : Atomic s hl(fork(&e)) where
-  atomic {σ obs e' σ' eₜ} Hstep := by
-    cases baseStep_of_primStep Hstep (by solve_subredex_values)
-    cases s
-    · exact val_irreducible rfl _
-    · rfl
+  atomic {σ obs e' σ' eₜ} Hstep := by solve_atomic Hstep
 
 instance instAtomicNewProph {s} : Atomic s (State := State) Exp.newProph where
-  atomic {σ obs e' σ' eₜ} Hstep := by
-    cases baseStep_of_primStep Hstep (by solve_subredex_values)
-    cases s
-    · exact val_irreducible rfl _
-    · rfl
+  atomic {σ obs e' σ' eₜ} Hstep := by solve_atomic Hstep
 
 instance instAtomicCmpXChg {s} {v1 v2 v3 : Val} : Atomic s hl(cmpXchg(&v1, &v2, &v3)) where
-  atomic {σ obs e' σ' eₜ} Hstep := by
-    cases baseStep_of_primStep Hstep (by solve_subredex_values)
-    cases s
-    · exact val_irreducible rfl _
-    · rfl
+  atomic {σ obs e' σ' eₜ} Hstep := by solve_atomic Hstep
 
 theorem primStep_val_baseStep {e : Exp} {σ : State} {obs : List Observation}
     {v : Val} {σ' : State} {efs : List Exp}
@@ -284,7 +245,7 @@ theorem base_step_to_val_always_to_val
     (h₁ : BaseStep e₁ σ₁ₐ κsₐ (Exp.val v₂ₐ) σ₂ₐ efsₐ)
     (h₂ : BaseStep e₁ σ₁ᵦ κsᵦ e₂ᵦ σ₂ᵦ efsᵦ) :
     (toVal e₂ᵦ).isSome := by
-  cases h₁ <;> cases h₂ <;> simp_all [] <;> grind
+  cases h₁ <;> cases h₂ <;> simp_all <;> grind
 
 theorem prim_step_to_val_always_to_val
     {e₁ : Exp} {σ₁ₐ : State} {κsₐ : List Observation} {v₂ₐ : Val} {σ₂ₐ : State}

--- a/Iris/Iris/HeapLang/Instances.lean
+++ b/Iris/Iris/HeapLang/Instances.lean
@@ -394,8 +394,6 @@ theorem base_step_to_val_atomic {e₁ : Exp} {σ₁ₐ : State} {κsₐ : List O
    No Lean equivalent — `BaseStep` is not a typeclass, so we can't make this
    a real instance. At use sites, manually apply `base_step_to_val_atomic`. -/
 
-/-- One cannot deallocate prophecy variables: any base step preserves
-`usedProphId` modulo extension. Mirrors Rocq's `base_step_more_proph_ids`. -/
 @[rocq_alias base_step_more_proph_ids]
 theorem base_step_more_proph_ids {e : Exp} {σ : State} {κs : List Observation}
     {e' : Exp} {σ' : State} {efs : List Exp} (h : BaseStep e σ κs e' σ' efs) :
@@ -423,10 +421,10 @@ theorem step_resolve {e : Exp} {vp vt : Val} {σ₁ σ₂ : State} {κ : List Ob
       simp only [fillItem, ECtxItem.fill, fill_append, fill_cons, fill_nil,
         Exp.resolve.injEq, reduceCtorEq] at hsrc
     case resolveL K_inner _ _ =>
-      have hp : PrimStep.primStep (e, σ₁) κ (fillItem K_inner (fill K' e₂'), σ₂, efs) := by
-        rw [hsrc.1]
-        exact fill_primStep [K_inner] (fill_primStep K' (primStep_of_baseStep Hbase))
-      exact absurd (hatom.atomic hp) (by simp [fillItem_expToVal_none])
+      suffices hp : PrimStep.primStep (e, σ₁) κ (fillItem K_inner (fill K' e₂'), σ₂, efs) by
+        exact absurd (hatom.atomic hp) (by simp [fillItem_expToVal_none])
+      rw [hsrc.1]
+      exact fill_primStep [K_inner] (fill_primStep K' (primStep_of_baseStep Hbase))
     case resolveM => exact baseStep_fill_eq_val_absurd Hbase hsrc.2.1
     case resolveR => exact baseStep_fill_eq_val_absurd Hbase hsrc.2.2
 
@@ -453,9 +451,8 @@ theorem resolve_reducible {e : Exp} {σ : State} {p : ProphId} {v : Val}
     (hin : σ.usedProphId.contains p) :
     BaseStep.Reducible (Exp.resolve e (.val (.lit (.prophecy p))) (.val v), σ) := by
   obtain ⟨κ, e', σ', efs, hstep⟩ := hred
-  have hprim : PrimStep.primStep (e, σ) κ (e', σ', efs) := primStep_of_baseStep hstep
-  have hval : (toVal e').isSome := hatom.atomic hprim
   obtain ⟨w', rfl⟩ : ∃ w', e' = Exp.val w' := by
+    have hval : (toVal e').isSome := hatom.atomic (primStep_of_baseStep hstep)
     cases e' with | val w' => exact ⟨w', rfl⟩ | _ => simp [toVal] at hval
   refine ⟨κ ++ [(p, (w', v))], Exp.val w', σ', efs, ?_⟩
   exact .resolveS p w' e σ v σ' κ efs hstep hin
@@ -465,9 +462,8 @@ theorem prim_step_reducible_resolve {e : Exp} {σ : State} {p : ProphId} {w : Va
     (hred : PrimStep.Reducible (e, σ)) :
     PrimStep.Reducible (Exp.resolve e (.val (.lit (.prophecy p))) (.val w), σ) := by
   obtain ⟨κ, e', σ', efs, hprim⟩ := hred
-  have hval : (toVal e').isSome := hatom.atomic hprim
   obtain ⟨v, rfl⟩ : ∃ v, e' = Exp.val v := by
-    match e', hval with | .val v, _ => exact ⟨v, rfl⟩
+    match e', (hatom.atomic hprim) with | .val v, _ => exact ⟨v, rfl⟩
   exact primStep_reducible_of_baseStep_reducible
     (resolve_reducible ⟨κ, _, σ', efs, primStep_val_baseStep hprim⟩ hp_contains)
 

--- a/Iris/Iris/HeapLang/Instances.lean
+++ b/Iris/Iris/HeapLang/Instances.lean
@@ -64,6 +64,12 @@ theorem fill_isSome_empty {K : List ECtxItem} {e : Exp}
     have h2 := EctxLanguage.fill_val (K := K') (e := fillItem Ki e) h
     simp [fillItem_expToVal_none] at h2
 
+macro "solve_subredex_values" : tactic =>
+  `(tactic|
+    (apply subredexes_are_values
+     intro Ki e_inner heq
+     cases Ki <;> cases heq <;> try rfl <;> try done))
+
 theorem mk_pure_prim_step {e1 e2 : Exp} (hstep : ∀ σ, BaseStep e1 σ [] e2 σ [])
     (hpure : ∀ {σ1 κs e2' σ2 efs}, BaseStep e1 σ1 κs e2' σ2 efs → κs = [] ∧ σ1 = σ2 ∧ e2 = e2' ∧ efs = [])
     (hsub : SubredexesAreValues e1) : PurePrimStep e1 e2 := by
@@ -76,20 +82,14 @@ instance instPureExecIfTrue: PureExec True 1 hl(if #true then &e1 else &e2) e1 w
     refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor
     · cases hs <;> simp
-    · apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> cases heq
-      rfl
+    · solve_subredex_values
 
 instance instPureExecIfFalse : PureExec True 1 hl(if #false then &e1 else &e2) e2 where
   pureExec _ := by
     refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor
     · cases hs <;> simp
-    · apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> cases heq
-      rfl
+    · solve_subredex_values
 
 instance instPureExecCaseInjl {v e1 e2} :
     PureExec True 1 (Exp.case hl(v(injl(&v))) e1 e2) (.app e1 (.ofVal v)) where
@@ -97,10 +97,7 @@ instance instPureExecCaseInjl {v e1 e2} :
     refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor
     · cases hs <;> simp
-    · apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> cases heq
-      rfl
+    · solve_subredex_values
 
 instance instPureExecCaseInjr {v e1 e2} :
     PureExec True 1 (Exp.case hl(v(injr(&v))) e1 e2) (.app e2 (.ofVal v)) where
@@ -108,30 +105,21 @@ instance instPureExecCaseInjr {v e1 e2} :
     refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor
     · cases hs <;> simp
-    · apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> cases heq
-      rfl
+    · solve_subredex_values
 
 instance instPureExecInjl {v : Val} : PureExec True 1 hl(injl(&v)) hl(v(injl(&v)))  where
   pureExec _ := by
     refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor
     · cases hs <;> simp
-    · apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> cases heq
-      rfl
+    · solve_subredex_values
 
 instance instPureExecInjr {v : Val} : PureExec True 1 hl(injr(&v)) hl(v(injr(&v)))  where
   pureExec _ := by
     refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor
     · cases hs <;> simp
-    · apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> cases heq
-      rfl
+    · solve_subredex_values
 
 instance instPureExecBeta {f x : Binder} {e : Exp} {v : Val} :
     PureExec True 1 hl(v(rec &f &x := &e) &v) ((e.subst f (.rec_ f x e)).subst x v) where
@@ -139,9 +127,7 @@ instance instPureExecBeta {f x : Binder} {e : Exp} {v : Val} :
     refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor <;> simp
     · cases hs <;> simp [*]
-    · apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> cases heq <;> rfl
+    · solve_subredex_values
 
 instance instPureExecRec {f x e} :
     PureExec True 1 hl(rec &f &x := &e) hl(v(rec &f &x := &e)) where
@@ -149,36 +135,28 @@ instance instPureExecRec {f x e} :
     refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor <;> simp
     · cases hs <;> simp [*]
-    · apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> cases heq <;> rfl
+    · solve_subredex_values
 
 instance instPureExecFst {v1 v2 : Val} : PureExec True 1 hl(fst(v((&v1, &v2)))) v1 where
   pureExec _ := by
     refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor <;> simp
     · cases hs <;> simp [*]
-    · apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> cases heq <;> rfl
+    · solve_subredex_values
 
 instance instPureExecSnd {v1 v2 : Val} : PureExec True 1 hl(snd(v((&v1, &v2)))) v2 where
   pureExec _ := by
     refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor <;> simp
     · cases hs <;> simp [*]
-    · apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> cases heq <;> rfl
+    · solve_subredex_values
 
 instance instPureExecPair {v1 v2 : Val} : PureExec True 1 hl((&v1, &v2)) hl(v((&v1, &v2)))  where
   pureExec _ := by
     refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor <;> simp
     · cases hs <;> simp [*]
-    · apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> cases heq <;> rfl
+    · solve_subredex_values
 
 set_option synthInstance.checkSynthOrder false in
 instance instPureExecUnOp {op : UnOp} {v v' : Val} :
@@ -187,9 +165,7 @@ instance instPureExecUnOp {op : UnOp} {v v' : Val} :
     refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor <;> simp [*]
     · cases hs <;> simp_all [UnOp.eval]
-    · apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> cases heq <;> rfl
+    · solve_subredex_values
 
 set_option synthInstance.checkSynthOrder false in
 instance instPureExecBinOp {op : BinOp} {v1 v2 v' : Val} :
@@ -199,9 +175,7 @@ instance instPureExecBinOp {op : BinOp} {v1 v2 v' : Val} :
     refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor <;> simp [*]
     · cases hs <;> simp_all [BinOp.eval]
-    · apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> cases heq <;> rfl
+    · solve_subredex_values
 
 -- higher priority than the generic binop instance
 instance (priority := default + 10) instPureExecEqOp {v1 v2 : Val} :
@@ -211,30 +185,18 @@ instance (priority := default + 10) instPureExecEqOp {v1 v2 : Val} :
     refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor <;> simp [BinOp.eval, *]
     · cases hs <;> simp_all [BinOp.eval]
-    · apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> cases heq <;> rfl
+    · solve_subredex_values
 
 instance instAtomicLoad {s} {v : Val} : Atomic s hl(!&v) where
   atomic {σ obs e' σ' eₜ} Hstep := by
-    have hsr : SubredexesAreValues hl(!&v) := by
-      apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> try (cases heq; done)
-      all_goals (cases heq; rfl)
-    cases (baseStep_of_primStep Hstep hsr)
+    cases baseStep_of_primStep Hstep (by solve_subredex_values)
     cases s
     · exact val_irreducible rfl _
     · rfl
 
 instance instAtomicStore {s} {v1 v2 : Val} : Atomic s hl(&v1 ← &v2) where
   atomic {σ obs e' σ' eₜ} Hstep := by
-    have hsr : SubredexesAreValues hl(&v1 ← &v2) := by
-      apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> try (cases heq; done)
-      all_goals (cases heq; rfl)
-    cases (baseStep_of_primStep Hstep hsr)
+    cases baseStep_of_primStep Hstep (by solve_subredex_values)
     rename_i l v Heq
     cases s
     · exact val_irreducible rfl _
@@ -242,108 +204,63 @@ instance instAtomicStore {s} {v1 v2 : Val} : Atomic s hl(&v1 ← &v2) where
 
 instance instAtomicFst {s} {v1 : Val} : Atomic s hl(fst(&v1)) where
   atomic {σ obs e' σ' eₜ} Hstep := by
-    have hsr : SubredexesAreValues hl(fst(&v1)) := by
-      apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> try (cases heq; done)
-      · cases heq; rfl
-    cases (baseStep_of_primStep Hstep hsr)
+    cases baseStep_of_primStep Hstep (by solve_subredex_values)
     cases s
     · exact val_irreducible rfl _
     · rfl
 
 instance instAtomicSnd {s} {v1 : Val} : Atomic s hl(snd(&v1)) where
   atomic {σ obs e' σ' eₜ} Hstep := by
-    have hsr : SubredexesAreValues hl(snd(&v1)) := by
-      apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> try (cases heq; done)
-      · cases heq; rfl
-    cases (baseStep_of_primStep Hstep hsr)
+    cases baseStep_of_primStep Hstep (by solve_subredex_values)
     cases s
     · exact val_irreducible rfl _
     · rfl
 
 instance instAtomicAllocN {s} {v1 v2 : Val} : Atomic s hl(allocn(&v1, &v2)) where
   atomic {σ obs e' σ' eₜ} Hstep := by
-    have hsr : SubredexesAreValues hl(allocn(&v1, &v2)) := by
-      apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> try (cases heq; done)
-      all_goals (cases heq; rfl)
-    cases (baseStep_of_primStep Hstep hsr)
+    cases baseStep_of_primStep Hstep (by solve_subredex_values)
     cases s
     · exact val_irreducible rfl _
     · rfl
 
 instance instAtomicFree {s} {v : Val} : Atomic s hl(free(&v)) where
   atomic {σ obs e' σ' eₜ} Hstep := by
-    have hsr : SubredexesAreValues hl(free(&v)) := by
-      apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> try (cases heq; done)
-      all_goals (cases heq; rfl)
-    cases (baseStep_of_primStep Hstep hsr)
+    cases baseStep_of_primStep Hstep (by solve_subredex_values)
     cases s
     · exact val_irreducible rfl _
     · rfl
 
 instance instAtomicXchg {s} {v1 v2 : Val} : Atomic s hl(xchg(&v1, &v2)) where
   atomic {σ obs e' σ' eₜ} Hstep := by
-    have hsr : SubredexesAreValues hl(xchg(&v1, &v2)) := by
-      apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> try (cases heq; done)
-      all_goals (cases heq; rfl)
-    cases (baseStep_of_primStep Hstep hsr)
+    cases baseStep_of_primStep Hstep (by solve_subredex_values)
     cases s
     · exact val_irreducible rfl _
     · rfl
 
 instance instAtomicFaa {s} {v1 v2 : Val} : Atomic s hl(faa(&v1, &v2)) where
   atomic {σ obs e' σ' eₜ} Hstep := by
-    have hsr : SubredexesAreValues hl(faa(&v1, &v2)) := by
-      apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> try (cases heq; done)
-      all_goals (cases heq; rfl)
-    cases (baseStep_of_primStep Hstep hsr)
+    cases baseStep_of_primStep Hstep (by solve_subredex_values)
     cases s
     · exact val_irreducible rfl _
     · rfl
 
 instance instAtomicFork {s} {e : Exp} : Atomic s hl(fork(&e)) where
   atomic {σ obs e' σ' eₜ} Hstep := by
-    have hsr : SubredexesAreValues hl(fork(&e)) := by
-      apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> try (cases heq; done)
-      all_goals (cases heq; rfl)
-    cases (baseStep_of_primStep Hstep hsr)
+    cases baseStep_of_primStep Hstep (by solve_subredex_values)
     cases s
     · exact val_irreducible rfl _
     · rfl
 
 instance instAtomicNewProph {s} : Atomic s (State := State) Exp.newProph where
   atomic {σ obs e' σ' eₜ} Hstep := by
-    have hsr : SubredexesAreValues (Exp.newProph) := by
-      apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> try (cases heq; done)
-      all_goals (cases heq; rfl)
-    cases (baseStep_of_primStep Hstep hsr)
+    cases baseStep_of_primStep Hstep (by solve_subredex_values)
     cases s
     · exact val_irreducible rfl _
     · rfl
 
 instance instAtomicCmpXChg {s} {v1 v2 v3 : Val} : Atomic s hl(cmpXchg(&v1, &v2, &v3)) where
   atomic {σ obs e' σ' eₜ} Hstep := by
-    have hsr : SubredexesAreValues hl(cmpXchg(&v1, &v2, &v3)) := by
-      apply subredexes_are_values
-      intro Ki e_inner heq
-      cases Ki <;> try (cases heq; done)
-      all_goals (cases heq; rfl)
-    cases (baseStep_of_primStep Hstep hsr)
+    cases baseStep_of_primStep Hstep (by solve_subredex_values)
     cases s
     · exact val_irreducible rfl _
     · rfl
@@ -376,13 +293,11 @@ theorem prim_step_to_val_always_to_val
     (h₁ : PrimStep.primStep (e₁, σ₁ₐ) κsₐ (Exp.val v₂ₐ, σ₂ₐ, efsₐ))
     (h₂ : PrimStep.primStep (e₁, σ₁ᵦ) κsᵦ (e₂ᵦ, σ₂ᵦ, efsᵦ)) :
     (toVal e₂ᵦ).isSome := by
-  have Hbase₁ := primStep_val_baseStep h₁
-  have hsr : SubredexesAreValues e₁ := by
-    intro K e' heq hnv
-    rcases base_ctx_step_val (K := K) (e := e') (heq ▸ Hbase₁) with h | h
-    · rw [hnv] at h; simp at h
-    · exact h
-  exact base_step_to_val_always_to_val Hbase₁ (baseStep_of_primStep h₂ hsr)
+  refine base_step_to_val_always_to_val (primStep_val_baseStep h₁) (baseStep_of_primStep h₂ ?_)
+  intro K e' heq hnv
+  rcases base_ctx_step_val (K := K) (e := e') (heq ▸primStep_val_baseStep h₁) with h | h
+  · rw [hnv] at h; simp at h
+  · exact h
 
 theorem base_step_to_val_atomic {e₁ : Exp} {σ₁ₐ : State} {κsₐ : List Observation} {v₂ₐ : Val}
     {σ₂ₐ : State} {efsₐ : List Exp} (a : Atomicity) (h : BaseStep e₁ σ₁ₐ κsₐ (Exp.val v₂ₐ) σ₂ₐ efsₐ) :

--- a/Iris/Iris/HeapLang/Instances.lean
+++ b/Iris/Iris/HeapLang/Instances.lean
@@ -348,7 +348,6 @@ instance instAtomicCmpXChg {s} {v1 v2 v3 : Val} : Atomic s hl(cmpXchg(&v1, &v2, 
     · exact val_irreducible rfl _
     · rfl
 
-@[rocq_alias prim_step_to_val_is_base_step]
 theorem primStep_val_baseStep {e : Exp} {σ : State} {obs : List Observation}
     {v : Val} {σ' : State} {efs : List Exp}
     (h : PrimStep.primStep (e, σ) obs (Exp.val v, σ', efs)) :
@@ -394,7 +393,6 @@ theorem base_step_to_val_atomic {e₁ : Exp} {σ₁ₐ : State} {κsₐ : List O
    No Lean equivalent — `BaseStep` is not a typeclass, so we can't make this
    a real instance. At use sites, manually apply `base_step_to_val_atomic`. -/
 
-@[rocq_alias base_step_more_proph_ids]
 theorem base_step_more_proph_ids {e : Exp} {σ : State} {κs : List Observation}
     {e' : Exp} {σ' : State} {efs : List Exp} (h : BaseStep e σ κs e' σ' efs) :
     σ.usedProphId ⊆ σ'.usedProphId := by
@@ -404,7 +402,6 @@ theorem base_step_more_proph_ids {e : Exp} {σ : State} {κs : List Observation}
   | cmpXchgS _ _ _ _ _ b _ _ _ => cases b <;> intro _ hx <;> exact hx
   | _ => intro _ hx; exact hx
 
-@[rocq_alias step_resolve]
 theorem step_resolve {e : Exp} {vp vt : Val} {σ₁ σ₂ : State} {κ : List Observation} {e₂ : Exp} {efs : List Exp}
     [hatom : Atomic .StronglyAtomic e]
     (hprim : PrimStep.primStep (Exp.resolve e (.val vp) (.val vt), σ₁) κ (e₂, σ₂, efs)) :
@@ -445,7 +442,6 @@ theorem step_resolve_decompose {e : Exp} {p : ProphId} {w : Val} {σ₁ σ₂ : 
   match step_resolve hstep with
   | .resolveS _ v_n _ _ _ _ κs_n _ hb _ => ⟨κs_n, v_n, rfl, rfl, hb⟩
 
-@[rocq_alias resolve_reducible]
 theorem resolve_reducible {e : Exp} {σ : State} {p : ProphId} {v : Val}
     [hatom : Atomic .StronglyAtomic e] (hred : BaseStep.Reducible (e, σ))
     (hin : σ.usedProphId.contains p) :
@@ -467,7 +463,6 @@ theorem prim_step_reducible_resolve {e : Exp} {σ : State} {p : ProphId} {w : Va
   exact primStep_reducible_of_baseStep_reducible
     (resolve_reducible ⟨κ, _, σ', efs, primStep_val_baseStep hprim⟩ hp_contains)
 
-@[rocq_alias prim_step_more_proph_ids]
 theorem prim_step_more_proph_ids {e : Exp} {σ : State} {κs : List Observation} {e' : Exp}
     {σ' : State} {efs : List Exp} (h : PrimStep.primStep (e, σ) κs (e', σ', efs)) :
     σ.usedProphId ⊆ σ'.usedProphId := by

--- a/Iris/Iris/HeapLang/Instances.lean
+++ b/Iris/Iris/HeapLang/Instances.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 Sergei Stepanenko. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sergei Stepanenko, Markus de Medeiros
 -/
 module
 
@@ -11,11 +12,12 @@ public import Iris.ProgramLogic.EctxiLanguage
 public import Std.Data.ExtTreeMap
 public import Std.Data.ExtTreeSet
 public import Iris.Std.FromMathlib
+public import Iris.Std.GenSetsInstances
 
 @[expose] public section
 namespace Iris.HeapLang
 
-open ProgramLogic
+open ProgramLogic ProgramLogic.Language FromMathlib EctxItemLanguage EctxLanguage
 
 instance instEctxItemLanguageExp : EctxItemLanguage Exp ECtxItem State Observation Val where
   baseStep := fun ⟨e, σ⟩ obs ⟨e', σ', eps⟩ => BaseStep e σ obs e' σ' eps
@@ -49,210 +51,443 @@ instance instEctxItemLanguageExp : EctxItemLanguage Exp ECtxItem State Observati
       intro σ obs e' σ' eps h
       cases h <;> rfl
 
-theorem mk_pure_prim_step {e1 e2 : Exp}
-  (hstep : ∀ σ, BaseStep e1 σ [] e2 σ [])
-  (hpure : ∀ σ1 κs e2' σ2 efs, BaseStep e1 σ1 κs e2' σ2 efs → κs = [] ∧ σ1 = σ2 ∧ e2 = e2' ∧ efs = [])
-  (hsub : EctxLanguage.SubredexesAreValues e1) :
-  Language.PurePrimStep e1 e2 := by
-    constructor
-    · intro σ
-      exists e2, σ, []
-      refine BaseStep.ContextStep.intro (K := []) (hstep _)
-    · intro σ1 σ2 κs e2' efs Hstep
-      have h := (EctxLanguage.baseStep_of_primStep Hstep hsub)
-      apply hpure; apply h
+@[simp]
+theorem fillItem_expToVal_none (Ki : ECtxItem) (e : Exp) : toVal (fillItem Ki e) = none := by
+  cases Ki <;> rfl
 
-instance instPureExecIfTrue: Language.PureExec True 1 hl(if #true then &e1 else &e2) e1 where
+theorem fill_isSome_empty {K : List ECtxItem} {e : Exp}
+    (h : (toVal (fill K e)).isSome) : K = [] := by
+  cases K with
+  | nil => rfl
+  | cons Ki K' =>
+    rw [fill_cons] at h
+    have h2 := EctxLanguage.fill_val (K := K') (e := fillItem Ki e) h
+    simp [fillItem_expToVal_none] at h2
+
+theorem mk_pure_prim_step {e1 e2 : Exp} (hstep : ∀ σ, BaseStep e1 σ [] e2 σ [])
+    (hpure : ∀ {σ1 κs e2' σ2 efs}, BaseStep e1 σ1 κs e2' σ2 efs → κs = [] ∧ σ1 = σ2 ∧ e2 = e2' ∧ efs = [])
+    (hsub : SubredexesAreValues e1) : PurePrimStep e1 e2 := by
+  refine ⟨fun σ => ?_, fun Hstep => ?_⟩
+  · exact ⟨e2, σ, [], BaseStep.ContextStep.intro (K := []) (hstep _)⟩
+  · exact hpure (baseStep_of_primStep Hstep hsub)
+
+instance instPureExecIfTrue: PureExec True 1 hl(if #true then &e1 else &e2) e1 where
   pureExec _ := by
-    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun _ _ _ _ _ hs => ?_) ?_
+    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor
     · cases hs <;> simp
-    · apply EctxItemLanguage.subredexes_are_values
+    · apply subredexes_are_values
       intro Ki e_inner heq
       cases Ki <;> cases heq
       rfl
 
-instance instPureExecIfFalse : Language.PureExec True 1 hl(if #false then &e1 else &e2) e2 where
+instance instPureExecIfFalse : PureExec True 1 hl(if #false then &e1 else &e2) e2 where
   pureExec _ := by
-    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun _ _ _ _ _ hs => ?_) ?_
+    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor
     · cases hs <;> simp
-    · apply EctxItemLanguage.subredexes_are_values
+    · apply subredexes_are_values
       intro Ki e_inner heq
       cases Ki <;> cases heq
       rfl
 
 instance instPureExecCaseInjl {v e1 e2} :
-    Language.PureExec True 1 (Exp.case hl(v(injl(&v))) e1 e2) (.app e1 (.ofVal v)) where
+    PureExec True 1 (Exp.case hl(v(injl(&v))) e1 e2) (.app e1 (.ofVal v)) where
   pureExec _ := by
-    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun _ _ _ _ _ hs => ?_) ?_
+    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor
     · cases hs <;> simp
-    · apply EctxItemLanguage.subredexes_are_values
+    · apply subredexes_are_values
       intro Ki e_inner heq
       cases Ki <;> cases heq
       rfl
 
 instance instPureExecCaseInjr {v e1 e2} :
-    Language.PureExec True 1 (Exp.case hl(v(injr(&v))) e1 e2) (.app e2 (.ofVal v)) where
+    PureExec True 1 (Exp.case hl(v(injr(&v))) e1 e2) (.app e2 (.ofVal v)) where
   pureExec _ := by
-    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun _ _ _ _ _ hs => ?_) ?_
+    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor
     · cases hs <;> simp
-    · apply EctxItemLanguage.subredexes_are_values
+    · apply subredexes_are_values
       intro Ki e_inner heq
       cases Ki <;> cases heq
       rfl
 
-instance PureExec_injl {v : Val} : Language.PureExec True 1 hl(injl(&v)) hl(v(injl(&v)))  where
+instance instPureExecInjl {v : Val} : PureExec True 1 hl(injl(&v)) hl(v(injl(&v)))  where
   pureExec _ := by
-    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun _ _ _ _ _ hs => ?_) ?_
+    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor
     · cases hs <;> simp
-    · apply EctxItemLanguage.subredexes_are_values
+    · apply subredexes_are_values
       intro Ki e_inner heq
       cases Ki <;> cases heq
       rfl
 
-instance PureExec_injr {v : Val} : Language.PureExec True 1 hl(injr(&v)) hl(v(injr(&v)))  where
+instance instPureExecInjr {v : Val} : PureExec True 1 hl(injr(&v)) hl(v(injr(&v)))  where
   pureExec _ := by
-    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun _ _ _ _ _ hs => ?_) ?_
+    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor
     · cases hs <;> simp
-    · apply EctxItemLanguage.subredexes_are_values
+    · apply subredexes_are_values
       intro Ki e_inner heq
       cases Ki <;> cases heq
       rfl
 
 instance instPureExecBeta {f x : Binder} {e : Exp} {v : Val} :
-    Language.PureExec True 1 hl(v(rec &f &x := &e) &v) ((e.subst f (.rec_ f x e)).subst x v) where
+    PureExec True 1 hl(v(rec &f &x := &e) &v) ((e.subst f (.rec_ f x e)).subst x v) where
   pureExec _ := by
-    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun _ _ _ _ _ hs => ?_) ?_
+    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor <;> simp
     · cases hs <;> simp [*]
-    · apply EctxItemLanguage.subredexes_are_values
+    · apply subredexes_are_values
       intro Ki e_inner heq
       cases Ki <;> cases heq <;> rfl
 
-instance instPureExecRec {f x e} : Language.PureExec True 1 hl(rec &f &x := &e) hl(v(rec &f &x := &e)) where
+instance instPureExecRec {f x e} :
+    PureExec True 1 hl(rec &f &x := &e) hl(v(rec &f &x := &e)) where
   pureExec _ := by
-    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun _ _ _ _ _ hs => ?_) ?_
+    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor <;> simp
     · cases hs <;> simp [*]
-    · apply EctxItemLanguage.subredexes_are_values
+    · apply subredexes_are_values
       intro Ki e_inner heq
       cases Ki <;> cases heq <;> rfl
 
-instance PureExec_fst {v1 v2 : Val} : Language.PureExec True 1 hl(fst(v((&v1, &v2)))) v1 where
+instance instPureExecFst {v1 v2 : Val} : PureExec True 1 hl(fst(v((&v1, &v2)))) v1 where
   pureExec _ := by
-    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun _ _ _ _ _ hs => ?_) ?_
+    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor <;> simp
     · cases hs <;> simp [*]
-    · apply EctxItemLanguage.subredexes_are_values
+    · apply subredexes_are_values
       intro Ki e_inner heq
       cases Ki <;> cases heq <;> rfl
 
-instance PureExec_snd {v1 v2 : Val} : Language.PureExec True 1 hl(snd(v((&v1, &v2)))) v2 where
+instance instPureExecSnd {v1 v2 : Val} : PureExec True 1 hl(snd(v((&v1, &v2)))) v2 where
   pureExec _ := by
-    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun _ _ _ _ _ hs => ?_) ?_
+    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor <;> simp
     · cases hs <;> simp [*]
-    · apply EctxItemLanguage.subredexes_are_values
+    · apply subredexes_are_values
       intro Ki e_inner heq
       cases Ki <;> cases heq <;> rfl
 
-instance PureExec_pair {v1 v2 : Val} : Language.PureExec True 1 hl((&v1, &v2)) hl(v((&v1, &v2)))  where
+instance instPureExecPair {v1 v2 : Val} : PureExec True 1 hl((&v1, &v2)) hl(v((&v1, &v2)))  where
   pureExec _ := by
-    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun _ _ _ _ _ hs => ?_) ?_
+    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor <;> simp
     · cases hs <;> simp [*]
-    · apply EctxItemLanguage.subredexes_are_values
+    · apply subredexes_are_values
       intro Ki e_inner heq
       cases Ki <;> cases heq <;> rfl
 
 set_option synthInstance.checkSynthOrder false in
 instance instPureExecUnOp {op : UnOp} {v v' : Val} :
-    Language.PureExec (op.eval v = some v') 1 (Exp.unop op (.ofVal v)) (.ofVal v') where
+    PureExec (op.eval v = some v') 1 (Exp.unop op (.ofVal v)) (.ofVal v') where
   pureExec h := by
-    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun _ _ _ _ _ hs => ?_) ?_
+    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor <;> simp [*]
     · cases hs <;> simp_all [UnOp.eval]
-    · apply EctxItemLanguage.subredexes_are_values
+    · apply subredexes_are_values
       intro Ki e_inner heq
       cases Ki <;> cases heq <;> rfl
 
 set_option synthInstance.checkSynthOrder false in
 instance instPureExecBinOp {op : BinOp} {v1 v2 v' : Val} :
-    Language.PureExec (op.eval v1 v2 = some v') 1
+    PureExec (op.eval v1 v2 = some v') 1
       (Exp.binop op (.ofVal v1) (.ofVal v2)) (.ofVal v') where
   pureExec h := by
-    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun _ _ _ _ _ hs => ?_) ?_
+    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor <;> simp [*]
     · cases hs <;> simp_all [BinOp.eval]
-    · apply EctxItemLanguage.subredexes_are_values
+    · apply subredexes_are_values
       intro Ki e_inner heq
       cases Ki <;> cases heq <;> rfl
 
 -- higher priority than the generic binop instance
 instance (priority := default + 10) instPureExecEqOp {v1 v2 : Val} :
-    Language.PureExec (v1.compareSafe v2) 1
+    PureExec (v1.compareSafe v2) 1
       (Exp.binop .eq (.ofVal v1) (.ofVal v2)) (.ofVal (.lit (.bool (v1 == v2)))) where
   pureExec h := by
-    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun _ _ _ _ _ hs => ?_) ?_
+    refine .once <| mk_pure_prim_step (fun _ => ?_) (fun hs => ?_) ?_
     · constructor <;> simp [BinOp.eval, *]
     · cases hs <;> simp_all [BinOp.eval]
-    · apply EctxItemLanguage.subredexes_are_values
+    · apply subredexes_are_values
       intro Ki e_inner heq
       cases Ki <;> cases heq <;> rfl
 
-instance instAtomicLoad {s} {v : Val} : Language.Atomic s hl(!&v) where
+instance instAtomicLoad {s} {v : Val} : Atomic s hl(!&v) where
   atomic {σ obs e' σ' eₜ} Hstep := by
-    have hsr : EctxLanguage.SubredexesAreValues hl(!&v) := by
-      apply EctxItemLanguage.subredexes_are_values
+    have hsr : SubredexesAreValues hl(!&v) := by
+      apply subredexes_are_values
       intro Ki e_inner heq
       cases Ki <;> try (cases heq; done)
       all_goals (cases heq; rfl)
-    cases (EctxLanguage.baseStep_of_primStep Hstep hsr)
+    cases (baseStep_of_primStep Hstep hsr)
     cases s
-    · exact Language.val_irreducible rfl _
+    · exact val_irreducible rfl _
     · rfl
 
-
-instance instAtomicStore {s} {v1 v2 : Val} : Language.Atomic s hl(&v1 ← &v2) where
+instance instAtomicStore {s} {v1 v2 : Val} : Atomic s hl(&v1 ← &v2) where
   atomic {σ obs e' σ' eₜ} Hstep := by
-    have hsr : EctxLanguage.SubredexesAreValues hl(&v1 ← &v2) := by
-      apply EctxItemLanguage.subredexes_are_values
+    have hsr : SubredexesAreValues hl(&v1 ← &v2) := by
+      apply subredexes_are_values
       intro Ki e_inner heq
       cases Ki <;> try (cases heq; done)
       all_goals (cases heq; rfl)
-    cases (EctxLanguage.baseStep_of_primStep Hstep hsr)
+    cases (baseStep_of_primStep Hstep hsr)
     rename_i l v Heq
     cases s
-    · exact Language.val_irreducible rfl _
+    · exact val_irreducible rfl _
     · rfl
 
-instance instAtomicSnd {s} {v1 : Val} : Language.Atomic s hl(snd(&v1)) where
+instance instAtomicFst {s} {v1 : Val} : Atomic s hl(fst(&v1)) where
   atomic {σ obs e' σ' eₜ} Hstep := by
-    have hsr : EctxLanguage.SubredexesAreValues hl(snd(&v1)) := by
-      apply EctxItemLanguage.subredexes_are_values
+    have hsr : SubredexesAreValues hl(fst(&v1)) := by
+      apply subredexes_are_values
       intro Ki e_inner heq
       cases Ki <;> try (cases heq; done)
       · cases heq; rfl
-    cases (EctxLanguage.baseStep_of_primStep Hstep hsr)
+    cases (baseStep_of_primStep Hstep hsr)
     cases s
-    · exact Language.val_irreducible rfl _
+    · exact val_irreducible rfl _
     · rfl
 
-instance instAtomicCmpXChg {s} {v1 v2 v3 : Val} : Language.Atomic s hl(cmpXchg(&v1, &v2, &v3)) where
+instance instAtomicSnd {s} {v1 : Val} : Atomic s hl(snd(&v1)) where
   atomic {σ obs e' σ' eₜ} Hstep := by
-    have hsr : EctxLanguage.SubredexesAreValues hl(cmpXchg(&v1, &v2, &v3)) := by
-      apply EctxItemLanguage.subredexes_are_values
+    have hsr : SubredexesAreValues hl(snd(&v1)) := by
+      apply subredexes_are_values
+      intro Ki e_inner heq
+      cases Ki <;> try (cases heq; done)
+      · cases heq; rfl
+    cases (baseStep_of_primStep Hstep hsr)
+    cases s
+    · exact val_irreducible rfl _
+    · rfl
+
+instance instAtomicAllocN {s} {v1 v2 : Val} : Atomic s hl(allocn(&v1, &v2)) where
+  atomic {σ obs e' σ' eₜ} Hstep := by
+    have hsr : SubredexesAreValues hl(allocn(&v1, &v2)) := by
+      apply subredexes_are_values
       intro Ki e_inner heq
       cases Ki <;> try (cases heq; done)
       all_goals (cases heq; rfl)
-    cases (EctxLanguage.baseStep_of_primStep Hstep hsr)
+    cases (baseStep_of_primStep Hstep hsr)
     cases s
-    · exact Language.val_irreducible rfl _
+    · exact val_irreducible rfl _
     · rfl
+
+instance instAtomicFree {s} {v : Val} : Atomic s hl(free(&v)) where
+  atomic {σ obs e' σ' eₜ} Hstep := by
+    have hsr : SubredexesAreValues hl(free(&v)) := by
+      apply subredexes_are_values
+      intro Ki e_inner heq
+      cases Ki <;> try (cases heq; done)
+      all_goals (cases heq; rfl)
+    cases (baseStep_of_primStep Hstep hsr)
+    cases s
+    · exact val_irreducible rfl _
+    · rfl
+
+instance instAtomicXchg {s} {v1 v2 : Val} : Atomic s hl(xchg(&v1, &v2)) where
+  atomic {σ obs e' σ' eₜ} Hstep := by
+    have hsr : SubredexesAreValues hl(xchg(&v1, &v2)) := by
+      apply subredexes_are_values
+      intro Ki e_inner heq
+      cases Ki <;> try (cases heq; done)
+      all_goals (cases heq; rfl)
+    cases (baseStep_of_primStep Hstep hsr)
+    cases s
+    · exact val_irreducible rfl _
+    · rfl
+
+instance instAtomicFaa {s} {v1 v2 : Val} : Atomic s hl(faa(&v1, &v2)) where
+  atomic {σ obs e' σ' eₜ} Hstep := by
+    have hsr : SubredexesAreValues hl(faa(&v1, &v2)) := by
+      apply subredexes_are_values
+      intro Ki e_inner heq
+      cases Ki <;> try (cases heq; done)
+      all_goals (cases heq; rfl)
+    cases (baseStep_of_primStep Hstep hsr)
+    cases s
+    · exact val_irreducible rfl _
+    · rfl
+
+instance instAtomicFork {s} {e : Exp} : Atomic s hl(fork(&e)) where
+  atomic {σ obs e' σ' eₜ} Hstep := by
+    have hsr : SubredexesAreValues hl(fork(&e)) := by
+      apply subredexes_are_values
+      intro Ki e_inner heq
+      cases Ki <;> try (cases heq; done)
+      all_goals (cases heq; rfl)
+    cases (baseStep_of_primStep Hstep hsr)
+    cases s
+    · exact val_irreducible rfl _
+    · rfl
+
+instance instAtomicNewProph {s} : Atomic s (State := State) Exp.newProph where
+  atomic {σ obs e' σ' eₜ} Hstep := by
+    have hsr : SubredexesAreValues (Exp.newProph) := by
+      apply subredexes_are_values
+      intro Ki e_inner heq
+      cases Ki <;> try (cases heq; done)
+      all_goals (cases heq; rfl)
+    cases (baseStep_of_primStep Hstep hsr)
+    cases s
+    · exact val_irreducible rfl _
+    · rfl
+
+instance instAtomicCmpXChg {s} {v1 v2 v3 : Val} : Atomic s hl(cmpXchg(&v1, &v2, &v3)) where
+  atomic {σ obs e' σ' eₜ} Hstep := by
+    have hsr : SubredexesAreValues hl(cmpXchg(&v1, &v2, &v3)) := by
+      apply subredexes_are_values
+      intro Ki e_inner heq
+      cases Ki <;> try (cases heq; done)
+      all_goals (cases heq; rfl)
+    cases (baseStep_of_primStep Hstep hsr)
+    cases s
+    · exact val_irreducible rfl _
+    · rfl
+
+@[rocq_alias prim_step_to_val_is_base_step]
+theorem primStep_val_baseStep {e : Exp} {σ : State} {obs : List Observation}
+    {v : Val} {σ' : State} {efs : List Exp}
+    (h : PrimStep.primStep (e, σ) obs (Exp.val v, σ', efs)) :
+    BaseStep e σ obs (Exp.val v) σ' efs := by
+  generalize hg : (Exp.val v : Exp) = g at h
+  obtain ⟨Hbase⟩ := h
+  rename_i a b K
+  obtain rfl : K = [] := fill_isSome_empty (e := b) (by simp [← hg])
+  simp only [EvContext.fill, List.foldl_nil] at hg ⊢
+  subst hg
+  exact Hbase
+
+theorem base_step_to_val_always_to_val
+    {e₁ : Exp} {σ₁ₐ : State} {κsₐ : List Observation} {v₂ₐ : Val} {σ₂ₐ : State}
+    {efsₐ : List Exp} {σ₁ᵦ : State} {κsᵦ : List Observation}
+    {e₂ᵦ : Exp} {σ₂ᵦ : State} {efsᵦ : List Exp}
+    (h₁ : BaseStep e₁ σ₁ₐ κsₐ (Exp.val v₂ₐ) σ₂ₐ efsₐ)
+    (h₂ : BaseStep e₁ σ₁ᵦ κsᵦ e₂ᵦ σ₂ᵦ efsᵦ) :
+    (toVal e₂ᵦ).isSome := by
+  cases h₁ <;> cases h₂ <;> simp_all [] <;> grind
+
+theorem prim_step_to_val_always_to_val
+    {e₁ : Exp} {σ₁ₐ : State} {κsₐ : List Observation} {v₂ₐ : Val} {σ₂ₐ : State}
+    {efsₐ : List Exp} {σ₁ᵦ : State} {κsᵦ : List Observation}
+    {e₂ᵦ : Exp} {σ₂ᵦ : State} {efsᵦ : List Exp}
+    (h₁ : PrimStep.primStep (e₁, σ₁ₐ) κsₐ (Exp.val v₂ₐ, σ₂ₐ, efsₐ))
+    (h₂ : PrimStep.primStep (e₁, σ₁ᵦ) κsᵦ (e₂ᵦ, σ₂ᵦ, efsᵦ)) :
+    (toVal e₂ᵦ).isSome := by
+  have Hbase₁ := primStep_val_baseStep h₁
+  have hsr : SubredexesAreValues e₁ := by
+    intro K e' heq hnv
+    rcases base_ctx_step_val (K := K) (e := e') (heq ▸ Hbase₁) with h | h
+    · rw [hnv] at h; simp at h
+    · exact h
+  exact base_step_to_val_always_to_val Hbase₁ (baseStep_of_primStep h₂ hsr)
+
+theorem base_step_to_val_atomic {e₁ : Exp} {σ₁ₐ : State} {κsₐ : List Observation} {v₂ₐ : Val}
+    {σ₂ₐ : State} {efsₐ : List Exp} (a : Atomicity) (h : BaseStep e₁ σ₁ₐ κsₐ (Exp.val v₂ₐ) σ₂ₐ efsₐ) :
+    Atomic (State := State) a e₁ :=
+  stronglyAtomic_atomic ⟨prim_step_to_val_always_to_val (primStep_of_baseStep h)⟩
+
+/- TODO: Coq has a `Hint Extern (Atomic _ _) => by eapply base_step_to_val_atomic`.
+   No Lean equivalent — `BaseStep` is not a typeclass, so we can't make this
+   a real instance. At use sites, manually apply `base_step_to_val_atomic`. -/
+
+/-- One cannot deallocate prophecy variables: any base step preserves
+`usedProphId` modulo extension. Mirrors Rocq's `base_step_more_proph_ids`. -/
+@[rocq_alias base_step_more_proph_ids]
+theorem base_step_more_proph_ids {e : Exp} {σ : State} {κs : List Observation}
+    {e' : Exp} {σ' : State} {efs : List Exp} (h : BaseStep e σ κs e' σ' efs) :
+    σ.usedProphId ⊆ σ'.usedProphId := by
+  induction h with
+  | newProphS _ p _ => intro x hx; rw [Std.ExtTreeSet.mem_insert]; right; exact hx
+  | resolveS _ _ _ _ _ _ _ _ _ _ IH => exact IH
+  | cmpXchgS _ _ _ _ _ b _ _ _ => cases b <;> intro _ hx <;> exact hx
+  | _ => intro _ hx; exact hx
+
+@[rocq_alias step_resolve]
+theorem step_resolve {e : Exp} {vp vt : Val} {σ₁ σ₂ : State} {κ : List Observation} {e₂ : Exp} {efs : List Exp}
+    [hatom : Atomic .StronglyAtomic e]
+    (hprim : PrimStep.primStep (Exp.resolve e (.val vp) (.val vt), σ₁) κ (e₂, σ₂, efs)) :
+    BaseStep (Exp.resolve e (.val vp) (.val vt)) σ₁ κ e₂ σ₂ efs := by
+  generalize hsrc : Exp.resolve e (.val vp) (.val vt) = src at hprim
+  obtain ⟨Hbase⟩ := hprim
+  rename_i e₁' e₂' K
+  cases K using List.reverseRec with
+  | nil => simp only [fill_nil] at hsrc ⊢; subst hsrc; exact Hbase
+  | append_singleton K' Ki ih =>
+    clear ih
+    exfalso
+    cases Ki <;>
+      simp only [fillItem, ECtxItem.fill, fill_append, fill_cons, fill_nil,
+        Exp.resolve.injEq, reduceCtorEq] at hsrc
+    case resolveL K_inner _ _ =>
+      have hp : PrimStep.primStep (e, σ₁) κ (fillItem K_inner (fill K' e₂'), σ₂, efs) := by
+        rw [hsrc.1]
+        exact fill_primStep [K_inner] (fill_primStep K' (primStep_of_baseStep Hbase))
+      exact absurd (hatom.atomic hp) (by simp [fillItem_expToVal_none])
+    case resolveM => exact baseStep_fill_eq_val_absurd Hbase hsrc.2.1
+    case resolveR => exact baseStep_fill_eq_val_absurd Hbase hsrc.2.2
+
+theorem prim_step_resolve_of_inner {e : Exp} {σ σ_e : State} {κ_e : List Observation}
+    {v_e w : Val} {efs_e : List Exp} {p : ProphId} (Hbase_e : BaseStep e σ κ_e (.val v_e) σ_e efs_e)
+    (hp_contains : σ.usedProphId.contains p) :
+    PrimStep.primStep (Exp.resolve e (.val (.lit (.prophecy p))) (.val w), σ)
+        (κ_e ++ [(p, (v_e, w))]) (Exp.val v_e, σ_e, efs_e) :=
+  primStep_of_baseStep (BaseStep.resolveS p v_e e σ w σ_e κ_e efs_e Hbase_e hp_contains)
+
+theorem step_resolve_decompose {e : Exp} {p : ProphId} {w : Val} {σ₁ σ₂ : State} {κ : List Observation}
+    {e₂ : Exp} {efs : List Exp} [hatom : Atomic .StronglyAtomic e]
+    (hstep : PrimStep.primStep (Exp.resolve e (.val (.lit (.prophecy p))) (.val w), σ₁) κ (e₂, σ₂, efs)) :
+    ∃ (κ_inner : List Observation) (v_inner : Val),
+      κ = κ_inner ++ [(p, (v_inner, w))] ∧
+      e₂ = Exp.val v_inner ∧
+      BaseStep e σ₁ κ_inner (.val v_inner) σ₂ efs :=
+  match step_resolve hstep with
+  | .resolveS _ v_n _ _ _ _ κs_n _ hb _ => ⟨κs_n, v_n, rfl, rfl, hb⟩
+
+@[rocq_alias resolve_reducible]
+theorem resolve_reducible {e : Exp} {σ : State} {p : ProphId} {v : Val}
+    [hatom : Atomic .StronglyAtomic e] (hred : BaseStep.Reducible (e, σ))
+    (hin : σ.usedProphId.contains p) :
+    BaseStep.Reducible (Exp.resolve e (.val (.lit (.prophecy p))) (.val v), σ) := by
+  obtain ⟨κ, e', σ', efs, hstep⟩ := hred
+  have hprim : PrimStep.primStep (e, σ) κ (e', σ', efs) := primStep_of_baseStep hstep
+  have hval : (toVal e').isSome := hatom.atomic hprim
+  obtain ⟨w', rfl⟩ : ∃ w', e' = Exp.val w' := by
+    cases e' with | val w' => exact ⟨w', rfl⟩ | _ => simp [toVal] at hval
+  refine ⟨κ ++ [(p, (w', v))], Exp.val w', σ', efs, ?_⟩
+  exact .resolveS p w' e σ v σ' κ efs hstep hin
+
+theorem prim_step_reducible_resolve {e : Exp} {σ : State} {p : ProphId} {w : Val}
+    [hatom : Atomic .StronglyAtomic e] (hp_contains : σ.usedProphId.contains p)
+    (hred : PrimStep.Reducible (e, σ)) :
+    PrimStep.Reducible (Exp.resolve e (.val (.lit (.prophecy p))) (.val w), σ) := by
+  obtain ⟨κ, e', σ', efs, hprim⟩ := hred
+  have hval : (toVal e').isSome := hatom.atomic hprim
+  obtain ⟨v, rfl⟩ : ∃ v, e' = Exp.val v := by
+    match e', hval with | .val v, _ => exact ⟨v, rfl⟩
+  exact primStep_reducible_of_baseStep_reducible
+    (resolve_reducible ⟨κ, _, σ', efs, primStep_val_baseStep hprim⟩ hp_contains)
+
+@[rocq_alias prim_step_more_proph_ids]
+theorem prim_step_more_proph_ids {e : Exp} {σ : State} {κs : List Observation} {e' : Exp}
+    {σ' : State} {efs : List Exp} (h : PrimStep.primStep (e, σ) κs (e', σ', efs)) :
+    σ.usedProphId ⊆ σ'.usedProphId := by
+  obtain ⟨hbase⟩ := h
+  exact base_step_more_proph_ids hbase
+
+/-- `resolve e &vp &vt` is atomic whenever its subexpression `e` is strongly
+atomic: any step of the whole expression is a `resolveS` base step, which runs
+`e` to a value and produces a value. Mirrors `resolve_atomic` in Rocq. -/
+instance instAtomicResolve {s} {e : Exp} {vp vt : Val} [hatom : Atomic .StronglyAtomic e] :
+    Atomic s (Exp.resolve e (.val vp) (.val vt)) where
+  atomic {σ obs e' σ' eₜ} Hstep := by
+    cases step_resolve Hstep with
+    | resolveS _ v _ _ _ _ _ _ _ _ =>
+      cases s
+      · exact val_irreducible rfl _
+      · rfl
 
 end Iris.HeapLang

--- a/Iris/Iris/ProgramLogic/EctxiLanguage.lean
+++ b/Iris/Iris/ProgramLogic/EctxiLanguage.lean
@@ -81,6 +81,15 @@ theorem fill_append (K₁ K₂ : Λ.Ectx) (e : Expr) : fill (K₁ ++ K₂) e = f
 theorem fill_val {K} {e : Expr} : (toVal (fill K e)).isSome = true → (toVal e).isSome = true := by
   induction K generalizing e <;> grind [fillItem_val]
 
+theorem baseStep_fill_eq_val_absurd {K : Ectx} {e e' : Expr} {σ σ' : State}
+    {obs : List Obs} {efs : List Expr} {v : Val}
+    (hbase : (e, σ) -<obs>->ᵇ (e', σ', efs))
+    (heq : (v : Expr) = fill K e) : False := by
+  have hfill_isval : (toVal (fill K e)).isSome := heq ▸ by simp
+  have h_e_val : (toVal e).isSome := fill_val hfill_isval
+  rw [val_stuck hbase] at h_e_val
+  simp at h_e_val
+
 -- NOTE: Would it be worth having an `isVal` predicate for `Expr`, basically defined
 -- as `toVal e |>.isSome`, so that we could rephrase all instances of `(toVal e).isSome`
 -- as `isVal e` and `toVal e = none` as `¬ isVal e`. That way tactics like `grind` would


### PR DESCRIPTION
## Description
Atomicity instances, used by the completeness PR, plus some general cleanup 

Fixes # (issue number)

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
