### PR TITLE
fix: make Entails' a def

### DIFF
--- a/Iris/Iris/Instances/Lib/WSat.lean
+++ b/Iris/Iris/Instances/Lib/WSat.lean
@@ -376,7 +376,7 @@ theorem wsat_alloc [WP : WsatGpreS GF] :
       rw [invMap, H]
       iassumption
     · iapply bigSepM_empty
-      simp
+      itrivial
   · unfold ownE
     iexact He
 

--- a/Iris/Iris/ProgramLogic/Adequacy.lean
+++ b/Iris/Iris/ProgramLogic/Adequacy.lean
@@ -344,7 +344,7 @@ theorem wp_invariance_gen [InvGpreS GF] (s : Stuckness) (e1 : Expr) (σ1 σ2 : S
   icases BigSepL2.bigSepL2_nil_inv_right $$ H with %Heq
   subst Heq
   icases Hcont $$ [Hst] with ⟨%_, >Hcont⟩
-  · simp only [List.nil_append, refl]
+  · simp only [List.nil_append]; itrivial
   iapply fupd_mask_intro_discard empty_subset
   iframe Hcont
 

--- a/Iris/Iris/ProgramLogic/Lifting.lean
+++ b/Iris/Iris/ProgramLogic/Lifting.lean
@@ -186,15 +186,16 @@ theorem wp_lift_pure_det_step_no_fork [Inhabited State] (E₂ : CoPset)
 theorem wp_pure_step_fupd [Inhabited State] (E₂ : CoPset)
     [Hexec : PureExec φ n e₁ e₂] (Hφ : φ) :
     (|={E}[E₂]▷=>^[n] £ n -∗ WP e₂ @ s; E {{ Φ }}) ⊢ WP e₁ @ s; E {{ Φ }} := by
-  iintro Hwp
   replace Hexec := Hexec.pureExec Hφ
   induction Hexec using Relation.Iterate.head_induction_on with
   | rfl =>
+    iintro Hwp
     simp only [Nat.repeat]
     rw (occs := [2]) [fupd_wp_iff.to_eq]
     icases lc_zero with >Hz
     iapply Hwp $$ Hz
   | @head n e₁ e₃ _ _ IH =>
+    iintro Hwp
     obtain ⟨Hsafe, Hdet⟩ := ‹e₁ -ᵖ-> e₃›
     iapply wp_lift_pure_det_step_no_fork E₂ (e₂ := e₃) ?Hred (by grind)
     case Hred =>

--- a/Iris/Iris/ProgramLogic/WeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/WeakestPre.lean
@@ -327,7 +327,7 @@ theorem wp_credit_access {s : Stuckness} {E : CoPset} {e : Expr} {Φ} {P: IProp 
   icombine Hm Hone as Hm
   dsimp only [Nat.repeat]
   ihave Hwp := Hwp $$ [//] [Hm]
-  · simp [lc_split.to_eq]
+  · simp [lc_split.to_eq]; itrivial
   iapply step_fupd_wand $$ Hwp; iintro Hwp
   iapply step_fupdN_le (n := ι.numLatersPerStep m) (by grind only) LawfulSet.subset_refl
   iapply step_fupdN_wand $$ Hwp; iintro >⟨SI, Hwp, $⟩
@@ -383,7 +383,9 @@ theorem wp_step_fupdN_strong {s : Stuckness} {E1 E2 : CoPset} {e : Expr} {P : IP
         obtain ⟨n0, rfl⟩ : ∃ n0', n0 = n0' + 1 := by cases n0 <;> grind
         dsimp only [Nat.repeat]
         imod Hp; imod H; imodintro; imodintro; imod Hp; imod H; imodintro
-        iapply IH n0 (Nat.le_of_succ_le_succ Hn) $$ [$];
+        -- TODO: remove this once we have iinduction
+        unfold ProofMode.Entails' at IH
+        iapply IH n0 (Nat.le_of_succ_le_succ Hn) $$ [$]
     · icases H with ⟨interp, -⟩
       imod interp $$ Hσ₁ with %h
       grind only
@@ -530,7 +532,8 @@ theorem wp_step_fupdN {s : Stuckness} {E₁ E₂ : CoPset} {e : Expr} {P : IProp
   iapply fupd_mask_frame LawfulSet.empty_subset
   imod H
   imodintro
-  simp [LawfulSet.diff_empty, ←LawfulSet.diff_subset_decomp E₂E₁, fupd_intro]
+  simp [LawfulSet.diff_empty, ←LawfulSet.diff_subset_decomp E₂E₁]
+  itrivial
 
 @[rocq_alias wp_step_fupd]
 theorem wp_step_fupd {s : Stuckness} {E₁ E₂ : CoPset} {e : Expr} {P : IProp GF} {Φ : Val → IProp GF}
@@ -542,7 +545,7 @@ theorem wp_step_fupd {s : Stuckness} {E₁ E₂ : CoPset} {e : Expr} {P : IProp 
   isplit
   · iintro %σ %ns %obj %nt interp
     iapply fupd_mask_intro_discard LawfulSet.empty_subset $$ [HR]
-    simp [BI.true_intro]
+    itrivial
   · imod HR
     dsimp only [Nat.repeat]
     iframe

--- a/Iris/Iris/ProofMode/Expr.lean
+++ b/Iris/Iris/ProofMode/Expr.lean
@@ -472,7 +472,8 @@ end hyps
 
 /-- This is the same as `Entails`, but it takes a `BI` instead.
 This constant is used to detect iris proof goals. -/
-abbrev Entails' [BI PROP] : PROP → PROP → Prop := Entails
+@[expose]
+def Entails' [BI PROP] : PROP → PROP → Prop := Entails
 
 structure IrisGoal where
   u : Level


### PR DESCRIPTION
This prevents some cases where simp exits the proofmode. It partly addresses #469 , but does not fully fix it. See #469 
