### PR TITLE
feat: coercion from Lean.Name to Namespace

### DIFF
--- a/Iris/Iris/Std/Namespaces.lean
+++ b/Iris/Iris/Std/Namespaces.lean
@@ -28,6 +28,13 @@ def nclose (N : Namespace) : CoPset :=
 
 instance : CoeOut Namespace CoPset where coe := nclose
 
+def ofName : Lean.Name → Namespace
+  | .anonymous => nroot
+  | .str rest str => ndot (ofName rest) str
+  | .num rest num => ndot (ofName rest) num
+
+instance : Coe Lean.Name Namespace where coe := ofName
+
 infix:80 ".@" => ndot
 
 instance ndisjoint : Iris.Std.Disjoint Namespace where

--- a/Iris/Iris/Std/Positives.lean
+++ b/Iris/Iris/Std/Positives.lean
@@ -431,6 +431,11 @@ instance : Countable Pos where
   decode := some
   decode_encode _ := rfl
 
+instance : Countable Nat where
+  encode := ofNat
+  decode := some ∘ (toNat · - 1)
+  decode_encode _ := by simp [toNat_ofNat]
+
 instance : Pos.Countable Char where
   encode c := Pos.ofNat c.val.toNat
   decode p :=


### PR DESCRIPTION
## Description
There seems to be a quite direct mapping from `Lean.Name` to `Namespace`. This PR implements a coercion from the latter to the former, to allow writing `Namespace` literals using Lean's `Name` literal syntax.

Before:
```lean4
def N : Namespace := nroot.@"oneshot"
```

Now:
```lean4
def N : Namespace := `oneshot
```


## Checklist
* [X] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [X] I have added my name to the `authors` section of any appropriate files