### PR TITLE
feat: add Texan triple syntax

### DIFF
--- a/Iris/Iris/BI/WeakestPre.lean
+++ b/Iris/Iris/BI/WeakestPre.lean
@@ -70,6 +70,16 @@ syntax " 〖 " wpPostcondInner " 〗 "  : wpPostcond
 
 syntax (name := wp) "WP " wpExpr wpPostcond : term
 
+syntax texanPostcondInner := (ident+ ", ")? " RET " term:min "; " term:min
+declare_syntax_cat texanPostcond
+syntax " {" "{ " texanPostcondInner " }" "} " : texanPostcond
+syntax " ⦃ " texanPostcondInner " ⦄ " : texanPostcond
+declare_syntax_cat texanPrecond
+syntax " {" "{ " term:min " }" "} " : texanPrecond
+syntax " ⦃ " term:min " ⦄ " : texanPrecond
+
+syntax (name := texanTriple) texanPrecond wpExpr texanPostcond : term
+
 open Lean in
 meta def parseWpExpr : Lean.TSyntax ``wpExpr → Lean.MacroM (TSyntax `term × TSyntax `term × TSyntax `term) := fun
   | `(wpExpr| $e @ $s ; $E) =>
@@ -114,6 +124,16 @@ meta def wpMacro : Lean.Macro := fun stx => do
       `(Wp.wp $s $E $e $Φ)
   | _ => Lean.Macro.throwUnsupported
 
+@[macro texanTriple]
+meta def wpTexanTriple : Lean.Macro
+  | `(⦃ $P:term ⦄ $wpExpr ⦃ $[$[$xs:ident]* ,]? RET $pat ; $Q:term ⦄)
+  | `({{ $P:term }} $wpExpr {{ $[$[$xs:ident]* ,]? RET $pat ; $Q:term }}) => do
+    let k ← match xs with
+            | some xs => `(∀ $xs*, $Q:term → Φ $pat)
+            | none => `($Q:term → Φ $pat)
+    `(iprop(∀ Φ, $P -∗ ▷ $k -∗ (WP $wpExpr {{ Φ }})))
+  | _ => Lean.Macro.throwUnsupported
+
 meta def unexpandWpPostcondInner : TSyntax `term → PrettyPrinter.UnexpandM (TSyntax `wpPostcondInner)
   | `(fun $v:ident => iprop($Φ:term)) => `(wpPostcondInner|$v:ident, $Φ:term)
   | `(iprop($Φ:term)) => `(wpPostcondInner| $Φ:term)
@@ -144,3 +164,5 @@ meta def unexpanderTotalWp : PrettyPrinter.Unexpander
     let wpPostcondInner ← unexpandWpPostcondInner Φ
     `(WP $wpExpr [{ $wpPostcondInner }])
   | _ => throw ()
+
+-- TODO: Consider adding unexpanders for texan triples

--- a/Iris/Iris/Tests.lean
+++ b/Iris/Iris/Tests.lean
@@ -6,4 +6,4 @@ public import Iris.Tests.Notation
 public import Iris.Tests.Tactics
 public import Iris.Tests.HeapLang
 public import Iris.Tests.Language
-public import Iris.Tests.WP
+public import Iris.Tests.WeakestPre

--- a/Iris/Iris/Tests/WeakestPre.lean
+++ b/Iris/Iris/Tests/WeakestPre.lean
@@ -171,6 +171,80 @@ variable (Φ : Val → PROP)
 
 end TestWP
 
+section TestTexanTriple
+
+set_option linter.unusedVariables false
+
+variable (PROP Expr : Type _) (A : Type _)
+variable [Wp PROP Expr Nat A]
+variable [Wp PROP Expr Nat Stuckness]
+variable [BI PROP]
+
+variable (e : Expr)(s : A)(E : CoPset)
+variable (P Q : PROP)
+
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q → Φ (x + y)) -∗ WP e @ s ; E {{ Φ }} ) : PROP -/
+#guard_msgs in #check {{ P }} e @ s ; E {{ x y , RET (x+y) ; Q }}
+
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q → Φ (x + y)) -∗ WP e @ E {{ Φ }} ) : PROP -/
+#guard_msgs in #check {{ P }} e @ E {{ x y , RET (x+y) ; Q }}
+
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q → Φ (x + y)) -∗ WP e @ E ? {{ Φ }} ) : PROP -/
+#guard_msgs in #check {{ P }} e @ E ? {{ x y , RET (x+y) ; Q }}
+
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q → Φ (x + y)) -∗ WP e {{ Φ }} ) : PROP -/
+#guard_msgs in #check {{ P }} e {{ x y , RET (x+y) ; Q }}
+
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q → Φ (x + y)) -∗ WP e ? {{ Φ }} ) : PROP -/
+#guard_msgs in #check {{ P }} e ? {{ x y , RET (x+y) ; Q }}
+
+/-- info: iprop(∀ Φ, P -∗ ▷ (Q → Φ 0) -∗ WP e @ s ; E {{ Φ }} ) : PROP -/
+#guard_msgs in #check {{ P }} e @ s ; E {{ RET 0 ; Q }}
+
+/-- info: iprop(∀ Φ, P -∗ ▷ (Q → Φ 0) -∗ WP e @ E {{ Φ }} ) : PROP -/
+#guard_msgs in #check {{ P }} e @ E {{ RET 0 ; Q }}
+
+/-- info: iprop(∀ Φ, P -∗ ▷ (Q → Φ 0) -∗ WP e @ E ? {{ Φ }} ) : PROP -/
+#guard_msgs in #check {{ P }} e @ E ? {{ RET 0 ; Q }}
+
+/-- info: iprop(∀ Φ, P -∗ ▷ (Q → Φ 0) -∗ WP e {{ Φ }} ) : PROP -/
+#guard_msgs in #check {{ P }} e {{ RET 0 ; Q }}
+
+/-- info: iprop(∀ Φ, P -∗ ▷ (Q → Φ 0) -∗ WP e ? {{ Φ }} ) : PROP -/
+#guard_msgs in #check {{ P }} e ? {{ RET 0 ; Q }}
+
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q → Φ (x + y)) -∗ WP e @ s ; E {{ Φ }} ) : PROP -/
+#guard_msgs in #check ⦃ P ⦄ e @ s ; E ⦃ x y , RET (x+y) ; Q ⦄
+
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q → Φ (x + y)) -∗ WP e @ E {{ Φ }} ) : PROP -/
+#guard_msgs in #check ⦃ P ⦄ e @ E ⦃ x y , RET (x+y) ; Q ⦄
+
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q → Φ (x + y)) -∗ WP e @ E ? {{ Φ }} ) : PROP -/
+#guard_msgs in #check ⦃ P ⦄ e @ E ? ⦃ x y , RET (x+y) ; Q ⦄
+
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q → Φ (x + y)) -∗ WP e {{ Φ }} ) : PROP -/
+#guard_msgs in #check ⦃ P ⦄ e ⦃ x y , RET (x+y) ; Q ⦄
+
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q → Φ (x + y)) -∗ WP e ? {{ Φ }} ) : PROP -/
+#guard_msgs in #check ⦃ P ⦄ e ? ⦃ x y , RET (x+y) ; Q ⦄
+
+/-- info: iprop(∀ Φ, P -∗ ▷ (Q → Φ 0) -∗ WP e @ s ; E {{ Φ }} ) : PROP -/
+#guard_msgs in #check ⦃ P ⦄ e @ s ; E ⦃ RET 0 ; Q ⦄
+
+/-- info: iprop(∀ Φ, P -∗ ▷ (Q → Φ 0) -∗ WP e @ E {{ Φ }} ) : PROP -/
+#guard_msgs in #check ⦃ P ⦄ e @ E ⦃ RET 0 ; Q ⦄
+
+/-- info: iprop(∀ Φ, P -∗ ▷ (Q → Φ 0) -∗ WP e @ E ? {{ Φ }} ) : PROP -/
+#guard_msgs in #check ⦃ P ⦄ e @ E ? ⦃ RET 0 ; Q ⦄
+
+/-- info: iprop(∀ Φ, P -∗ ▷ (Q → Φ 0) -∗ WP e {{ Φ }} ) : PROP -/
+#guard_msgs in #check ⦃ P ⦄ e ⦃ RET 0 ; Q ⦄
+
+/-- info: iprop(∀ Φ, P -∗ ▷ (Q → Φ 0) -∗ WP e ? {{ Φ }} ) : PROP -/
+#guard_msgs in #check ⦃ P ⦄ e ? ⦃ RET 0 ; Q ⦄
+
+end TestTexanTriple
+
 section HeapLangTestWP
 set_option linter.unusedVariables false
 
@@ -204,3 +278,43 @@ variable (E : CoPset) (Φ : Val → PROP) (P : PROP)
 #guard_msgs in #check (WP hl(#1) {{ v, ⌜v = hl_val(#1)⌝ }} : PROP)
 
 end HeapLangTestWP
+
+section HeapLangTestTexanTriple
+set_option linter.unusedVariables false
+
+open Iris.HeapLang
+
+variable (PROP : Type _) [BI PROP]
+variable [Wp PROP Exp Val Stuckness]
+variable (E : CoPset) (P Q : PROP)
+
+/-- info: iprop(∀ Φ, P -∗ ▷ (Q → Φ hl_val(#1)) -∗ WP hl(#1) {{ Φ }} ) : PROP -/
+#guard_msgs in #check {{ P }} hl(#1) {{ RET hl_val(#1); Q }}
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q → Φ x) -∗ WP hl((#1 + #2)) {{ Φ }} ) : PROP -/
+#guard_msgs in #check {{ P }} hl(#1 + #2) {{ x, RET x; Q }}
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q → Φ x) -∗ WP hl((#1 < #2)) {{ Φ }} ) : PROP -/
+#guard_msgs in #check {{ P }} hl(#1 < #2) {{ x, RET x; Q }}
+/--
+info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q → Φ x) -∗ WP hl(if (#0 < #1) then #1 else #2) {{ Φ }} ) : PROP
+-/
+#guard_msgs in #check {{ P }} hl(if #0 < #1 then #1 else #2) {{ x, RET x; Q }}
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q → Φ x) -∗ WP hl((λ x, x)) {{ Φ }} ) : PROP -/
+#guard_msgs in #check {{ P }} hl(λ x, x) {{ x, RET x; Q }}
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q → Φ x) -∗ WP hl((rec f x := f x)) {{ Φ }} ) : PROP -/
+#guard_msgs in #check {{ P }} hl(rec f x := f x) {{ x, RET x; Q }}
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q → Φ x) -∗ WP hl(#1; #2) {{ Φ }} ) : PROP -/
+#guard_msgs in #check {{ P }} hl(#1; #2) {{ x, RET x; Q }}
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q → Φ x) -∗ WP hl((#1, #2)) {{ Φ }} ) : PROP -/
+#guard_msgs in #check {{ P }} hl((#1, #2)) {{ x, RET x; Q }}
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q → Φ x) -∗ WP hl(ref(#0)) {{ Φ }} ) : PROP -/
+#guard_msgs in #check {{ P }} hl(ref(#0)) {{ x, RET x; Q }}
+/--
+info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q → Φ x) -∗ WP hl(if (#1 < #2) then (#1 + #1) else #0) {{ Φ }} ) : PROP
+-/
+#guard_msgs in #check {{ P }} hl(if #1 < #2 then #1 + #1 else #0) {{ x, RET x; Q }}
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ v, ⌜v = hl_val(#1)⌝ → Φ v) -∗ WP hl(#1) {{ Φ }} ) : PROP -/
+#guard_msgs in #check ({{ P }} hl(#1) {{ v, RET v; ⌜v = hl_val(#1)⌝ }} : PROP)
+
+end HeapLangTestTexanTriple
+
+


### PR DESCRIPTION
## Description
Adds syntax for Texan triples.

> [!NOTE] 
> I changed the syntax for Texan triples to use `{{` instead of `{{{`. I believe at some point I heard someone in the Iris Workshop 2026 say something along the lines of:
> > Will we be able to finally have Texan triples that don't require having three brackets to make them parse correctly?
> 
>I believe this PR answers the question in a positive way, but (1) I am unaware of what issues `{{{` was working around in the Rocq implementation, so I couldn't say for certain, and (2) we may want to stay close to Rocq's notation anyways. 

## Checklist
* [X] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [X] I have added my name to the `authors` section of any appropriate files