### PR TITLE
Leibniz OFE construction

### DIFF
--- a/Iris/Iris/Algebra/Agree.lean
+++ b/Iris/Iris/Algebra/Agree.lean
@@ -264,6 +264,12 @@ instance instRawSetoid : Setoid (Raw α) :=
 /--
 EXPERIMENT: Leibniz Agree.
 https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/Evaluating.20a.20specialization.20to.20Leibnize.20OFE.27s/with/606745235
+
+Note that the Rocq version of Agree does not require that the agreement type be an OFE. The
+typeclass addition here is trivial: if your [α] type was _not_ an OFE then you should instanstiate
+it with the trivial one. If your type already has a _different_ OFE, and you want agreement
+over the equality relation rather than your OFE equivalence, you should introduce a wrapper type
+with the trivial OFE.
 --/
 @[rocq_alias agree]
 def Agree (α : Type u) [OFE α] : Type u := Quotient (instRawSetoid (α := α))

--- a/Iris/Iris/Algebra/Agree.lean
+++ b/Iris/Iris/Algebra/Agree.lean
@@ -28,7 +28,7 @@ OFE equivalence makes `≡` coincide with `=`, so `Agree α` is `OFE.Leibniz` by
 
 /-! ## The raw representation -/
 
-section raw
+section Raw
 
 variable {α : Type u} {β : Type v}
 
@@ -249,31 +249,34 @@ theorem toAgree_discrete {a : α} [Ha : OFE.DiscreteE a] {y : Raw α}
 
 end Agree.Raw
 
-end raw
+end Raw
 
-/-! ## The quotient -/
+section Quotient
 
-section quotient
+open OFE
+open Agree (Raw)
 
 variable {α : Type u} {β : Type v} [OFE α] [OFE β]
 
-open Agree (Raw)
+instance instRawSetoid : Setoid (Raw α) :=
+  QuotientO Raw.dist fun {_} => Raw.dist_equiv
 
-instance Agree.Raw.instSetoid : Setoid (Raw α) :=
-  OFE.distSetoid Raw.dist fun _ => Raw.dist_equiv
-
+/--
+EXPERIMENT: Leibniz Agree.
+https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/Evaluating.20a.20specialization.20to.20Leibnize.20OFE.27s/with/606745235
+--/
 @[rocq_alias agree]
-def Agree (α : Type u) [OFE α] : Type u := Quotient (Agree.Raw.instSetoid (α := α))
+def Agree (α : Type u) [OFE α] : Type u := Quotient (instRawSetoid (α := α))
 
 namespace Agree
 
-def mk (x : Raw α) : Agree α := Quotient.mk _ x
+def mk (x : Raw α) : Agree α := mkQuotient.mk (heqv := Raw.dist_equiv) x
 
 @[elab_as_elim, induction_eliminator]
 theorem ind {motive : Agree α → Prop} (mk : ∀ x : Raw α, motive (Agree.mk x)) (x : Agree α) :
-    motive x := Quotient.ind mk x
+    motive x := mkQuotient.ind mk x
 
-theorem sound {x y : Raw α} (h : ∀ n, Raw.dist n x y) : mk x = mk y := Quotient.sound h
+theorem sound {x y : Raw α} (h : ∀ n, Raw.dist n x y) : mk x = mk y := mkQuotient.sound h
 
 theorem validN_resp {n} {x y : Raw α} (h : x ≈ y) : Raw.validN n x = Raw.validN n y :=
   propext ⟨Raw.validN_ne (h n), Raw.validN_ne (Raw.dist_equiv.symm (h n))⟩
@@ -283,20 +286,22 @@ theorem valid_resp {x y : Raw α} (h : x ≈ y) : Raw.valid x = Raw.valid y := b
 
 @[rocq_alias agree_ofe_mixin]
 instance instOFE : OFE (Agree α) :=
-  OFE.mkLeibniz Raw.dist (fun _ => Raw.dist_equiv) (fun h hlt => Raw.dist_lt h hlt)
+  OFE.mkQuotient Raw.dist Raw.dist_equiv Raw.dist_lt
 
 #rocq_ignore agreeO "Use Agree with a typeclass instance instead."
 #rocq_ignore agree_equiv "Defined in Agree OFE instance."
 
 instance instLeibniz : OFE.Leibniz (Agree α) :=
-  OFE.mkLeibniz_leibniz Raw.dist (fun _ => Raw.dist_equiv) (fun h hlt => Raw.dist_lt h hlt)
+  OFE.mkQuotient_leibniz Raw.dist Raw.dist_equiv Raw.dist_lt
 
-def validN (n : Nat) : Agree α → Prop := Quotient.lift (Raw.validN n) (fun _ _ h => validN_resp h)
+def validN (n : Nat) : Agree α → Prop :=
+  mkQuotient.lift (heqv := Raw.dist_equiv) (Raw.validN n) (fun _ _ h => validN_resp h)
 
-def valid : Agree α → Prop := Quotient.lift Raw.valid (fun _ _ h => valid_resp h)
+def valid : Agree α → Prop :=
+  mkQuotient.lift (heqv := Raw.dist_equiv) Raw.valid (fun _ _ h => valid_resp h)
 
 def op : Agree α → Agree α → Agree α :=
-  Quotient.lift₂ (fun x y => mk (Raw.op x y))
+  mkQuotient.lift₂ (heqv := Raw.dist_equiv) (fun x y => mk (Raw.op x y))
     (fun _ _ _ _ hx hy => sound fun n => Raw.op_ne₂.ne (hx n) (hy n))
 
 @[simp] theorem dist_mk {n} {x y : Raw α} : mk x ≡{n}≡ mk y ↔ Raw.dist n x y := .rfl
@@ -558,7 +563,7 @@ theorem toAgree_op_valid_iff_eq [OFE.Leibniz α] {a : α} :
 
 #rocq_ignore to_agree_op_inv_L "Use toAgree_op_valid_iff_eq"
 
-end quotient
+end Quotient
 
 /-! ## Functoriality -/
 
@@ -570,8 +575,8 @@ open Agree (Raw)
 
 @[rocq_alias agree_map]
 def Agree.map' (f : α → β) [OFE.NonExpansive f] : Agree α → Agree β :=
-  Quotient.lift (fun a => Agree.mk (Raw.map' f a))
-    (fun _ _ h => Agree.sound fun n => Raw.instNonExpansiveMap'.ne (h n))
+  OFE.mkQuotient.map (heqv := Raw.dist_equiv) (heqv' := Raw.dist_equiv) (Raw.map' f)
+    (fun _ _ _ h => Raw.instNonExpansiveMap'.ne h)
 
 @[simp] theorem Agree.map'_mk (f : α → β) [OFE.NonExpansive f] {x : Raw α} :
     Agree.map' f (Agree.mk x) = Agree.mk (Raw.map' f x) := rfl

--- a/Iris/Iris/Algebra/Agree.lean
+++ b/Iris/Iris/Algebra/Agree.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Leo Stefanesco. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Leo Stefanesco, Puming Liu
+Authors: Leo Stefanesco, Puming Liu, Sergei Stepanenko
 -/
 module
 
@@ -14,35 +14,61 @@ meta import Iris.Std.RocqPorting
 
 namespace Iris
 
-section agree
+/-!
+# The agreement camera
 
-variable {α : Type u}
+The agreement construction is built in two layers. The raw representation `Agree.Raw α` is a
+nonempty list of elements of `α`, together with the step-indexed relation `Agree.Raw.dist` that
+identifies two such lists when they have the same elements up to `≡{n}≡` (essentially, the old definition).
 
-@[rocq_alias agree, ext]
-structure Agree α where
+The interface type `Agree α` is the quotient of `Agree.Raw α` by the relation
+`fun x y => ∀ n, Agree.Raw.dist n x y` (which is exactly the OFE equivalence). Quotienting by the
+OFE equivalence makes `≡` coincide with `=`, so `Agree α` is `OFE.Leibniz` by construction.
+-/
+
+/-! ## The raw representation -/
+
+section raw
+
+variable {α : Type u} {β : Type v}
+
+structure Agree.Raw (α : Type u) where
   car : List α
   not_nil : car ≠ []
-attribute [rocq_alias agree_eq] Agree.ext
-attribute [simp] Agree.not_nil
+attribute [simp] Agree.Raw.not_nil
 
-@[rocq_alias to_agree]
-def toAgree (a : α) : Agree α := ⟨[a], by simp⟩
+namespace Agree.Raw
+
+@[ext] theorem ext {x y : Raw α} (h : x.car = y.car) : x = y := by
+  cases x; cases y; cases h; rfl
+
+def toAgree (a : α) : Raw α := ⟨[a], by simp⟩
 
 @[rocq_alias elem_of_agree]
-theorem mem_of_agree (x : Agree α) : ∃ a, a ∈ x.car := by
+theorem mem (x : Raw α) : ∃ a, a ∈ x.car := by
   rcases x with ⟨as, h⟩
   rcases as
   · contradiction
   · simp_all
 
+def map' (f : α → β) (a : Raw α) : Raw β := ⟨a.car.map f, by simp⟩
+
+@[simp] theorem map'_car {f : α → β} {x : Raw α} : (map' f x).car = x.car.map f := rfl
+
+def op (x y : Raw α) : Raw α :=
+  ⟨x.car ++ y.car, by apply List.append_ne_nil_of_left_ne_nil; exact x.not_nil⟩
+
+theorem map'_op {f : α → β} {x y : Raw α} : map' f (op x y) = op (map' f x) (map' f y) := by
+  apply ext; simp [op, map']
+
 variable [OFE α]
 
 @[rocq_alias agree_dist]
-def Agree.dist (n : Nat) (x y : Agree α) : Prop :=
+def dist (n : Nat) (x y : Raw α) : Prop :=
   (∀ a ∈ x.car, ∃ b ∈ y.car, a ≡{n}≡ b) ∧
   (∀ b ∈ y.car, ∃ a ∈ x.car, a ≡{n}≡ b)
 
-theorem Agree.dist_equiv : Equivalence (dist (α := α) n) where
+theorem dist_equiv : Equivalence (dist (α := α) n) where
   refl := fun ⟨x, h⟩ => by
     constructor
     · intro a ha; exists a
@@ -60,17 +86,16 @@ theorem Agree.dist_equiv : Equivalence (dist (α := α) n) where
     · intro a ha
       obtain ⟨b, hb, hd₁⟩ := h₁ a ha
       obtain ⟨c, hc, hd₂⟩ := h₂ b hb
-      exact ⟨c, hc,  hd₁.trans hd₂⟩
+      exact ⟨c, hc, hd₁.trans hd₂⟩
     · intro c hc
       obtain ⟨b, hb, hd₁⟩ := h₂' c hc
       obtain ⟨a, ha, hd₂⟩ := h₁' b hb
-      exact ⟨a, ha,  hd₂.trans hd₁⟩
+      exact ⟨a, ha, hd₂.trans hd₁⟩
 
-@[rocq_alias agree_ofe_mixin]
-instance instOFE_agree : OFE (Agree α) where
-  Equiv x y := ∀ n, Agree.dist n x y
-  Dist := Agree.dist
-  dist_eqv := Agree.dist_equiv
+instance instOFE : OFE (Raw α) where
+  Equiv x y := ∀ n, dist n x y
+  Dist := dist
+  dist_eqv := dist_equiv
   equiv_dist := by simp
   dist_lt {n x y m} := fun ⟨h₁, h₂⟩ hlt => by
     constructor
@@ -81,45 +106,38 @@ instance instOFE_agree : OFE (Agree α) where
       obtain ⟨a, ha, hd⟩ := h₂ b hb
       exact ⟨a, ha, OFE.Dist.lt hd hlt⟩
 
-#rocq_ignore agreeO "Use Agree with a typeclass instance instead."
-#rocq_ignore agree_equiv "Defined in Agree OFE instance."
+theorem dist_lt {x y : Raw α} (h : dist n x y) (hlt : m < n) : dist m x y :=
+  instOFE.dist_lt h hlt
 
-theorem Agree.equiv_def {x y : Agree α} : x ≡ y ↔ ∀ n, Agree.dist n x y := .rfl
-theorem Agree.dist_def {x y : Agree α} : x ≡{n}≡ y ↔ Agree.dist n x y := .rfl
+theorem equiv_def {x y : Raw α} : x ≡ y ↔ ∀ n, dist n x y := .rfl
+theorem dist_def {x y : Raw α} : x ≡{n}≡ y ↔ dist n x y := .rfl
 
-def Agree.validN (n : Nat) (x : Agree α) : Prop :=
+def validN (n : Nat) (x : Raw α) : Prop :=
   match x.car with
   | [_] => True
   | _ => ∀ a ∈ x.car, ∀ b ∈ x.car, a ≡{n}≡ b
 
 @[rocq_alias agree_validN_def]
-theorem Agree.validN_iff {x : Agree α} :
+theorem validN_iff {x : Raw α} :
     x.validN n ↔ ∀ a ∈ x.car, ∀ b ∈ x.car, a ≡{n}≡ b := by
   rcases x with ⟨⟨⟩ | ⟨a, ⟨⟩| _⟩, _⟩ <;> simp_all [validN, OFE.Dist.rfl]
 
-def Agree.valid (x : Agree α) : Prop := ∀ n, x.validN n
+def valid (x : Raw α) : Prop := ∀ n, x.validN n
 
-def Agree.op (x y : Agree α) : Agree α :=
-  ⟨x.car ++ y.car, by apply List.append_ne_nil_of_left_ne_nil; exact x.not_nil⟩
-
-@[rocq_alias agree_comm]
-theorem Agree.op_comm {x y : Agree α} :  x.op y ≡ y.op x := by
+theorem op_comm {x y : Raw α} : op x y ≡ op y x := by
   intro n; simp_all only [dist, op, List.mem_append]
   constructor <;> exact fun _ ha => ⟨_, ha.symm, .rfl⟩
 
-theorem Agree.op_commN {x y : Agree α} :  x.op y ≡{n}≡ y.op x := op_comm n
+theorem op_commN {x y : Raw α} : op x y ≡{n}≡ op y x := op_comm n
 
-@[rocq_alias agree_assoc]
-theorem Agree.op_assoc {x y z : Agree α} :  x.op (y.op z) ≡ (x.op y).op z := by
+theorem op_assoc {x y z : Raw α} : op x (op y z) ≡ op (op x y) z := by
   intro n; simp_all only [dist, op, List.mem_append, List.append_assoc]
   constructor <;> (intro a ha; exists a)
 
-@[rocq_alias agree_idemp]
-theorem Agree.idemp {x : Agree α} : x.op x ≡ x := by
+theorem idemp {x : Raw α} : op x x ≡ x := by
   intro n; constructor <;> (intro a ha; exists a; simp_all [op])
 
-@[rocq_alias agree_validN_ne]
-theorem Agree.validN_ne {x y : Agree α} : x ≡{n}≡ y → x.validN n → y.validN n := by
+theorem validN_ne {x y : Raw α} : x ≡{n}≡ y → x.validN n → y.validN n := by
   simp only [OFE.Dist, dist, validN_iff, and_imp]
   intro h₁ h₂ hn a ha b hb
   have ⟨a', ha', ha'a⟩ := h₂ _ ha
@@ -127,13 +145,17 @@ theorem Agree.validN_ne {x y : Agree α} : x ≡{n}≡ y → x.validN n → y.va
   have ha'b' := hn _ ha' _ hb'
   exact ha'a.symm.trans (ha'b'.trans hb'b)
 
-#rocq_ignore agree_validN_proper "Derivable from Agree.validN_ne using NonExpansive.eqv"
+theorem validN_succ {x : Raw α} : x.validN (n + 1) → x.validN n := by
+  simp only [validN_iff]; intro hsuc a ha b hb
+  exact OFE.dist_lt (hsuc a ha b hb) (by omega)
 
-@[rocq_alias agree_op_ne']
-theorem Agree.op_ne {x : Agree α} : OFE.NonExpansive x.op := by
+theorem validN_op_left {x y : Raw α} : (op x y).validN n → x.validN n := by
+  simp only [op, validN_iff, List.mem_append]
+  exact fun h a ha b hb => h _ (.inl ha) _ (.inl hb)
+
+theorem op_ne {x : Raw α} : OFE.NonExpansive (op x) := by
   constructor; simp only [OFE.Dist, dist, op, List.mem_append, and_imp]
   intro n y₁ y₂ heq₁ heq₂; constructor
-  -- This would probably be dealt with by aesop easily
   · rintro a (hx | hy)
     · exists a; simp [hx]
     · obtain ⟨b, hb, heq⟩ := heq₁ _ hy
@@ -143,62 +165,238 @@ theorem Agree.op_ne {x : Agree α} : OFE.NonExpansive x.op := by
     · obtain ⟨b, hb, heq⟩ := heq₂ _ hy
       exists b; simp_all
 
-@[rocq_alias agree_op_ne]
-theorem Agree.op_ne₂ : OFE.NonExpansive₂ (Agree.op (α := α)) := by
+theorem op_ne₂ : OFE.NonExpansive₂ (op (α := α)) := by
   constructor
   intro n x₁ x₂ hx y₁ y₂ hy
   exact op_ne.ne hy |>.trans (op_comm n) |>.trans (op_ne.ne hx) |>.trans (op_comm n)
 
-#rocq_ignore agree_op_proper "Derivable from Agree.op_ne₂ using NonExpansive₂.eqv"
-
-@[rocq_alias agree_op_invN]
-theorem Agree.op_invN {x y : Agree α} : (x.op y).validN n → x ≡{n}≡ y := by
+theorem op_invN {x y : Raw α} : (op x y).validN n → x ≡{n}≡ y := by
   simp only [op, validN_iff, List.mem_append, OFE.Dist, dist]
   intro h; constructor
   · intro a ha
-    obtain ⟨b, hb⟩ := mem_of_agree y
+    obtain ⟨b, hb⟩ := mem y
     exists b; simp_all
   · intro a ha
-    obtain ⟨b, hb⟩ := mem_of_agree x
+    obtain ⟨b, hb⟩ := mem x
     exists b; simp_all
 
-#rocq_ignore to_agree_op_inv "Use the general op_invN theorem."
-
-@[rocq_alias agree_op_inv]
-theorem Agree.op_inv {x y : Agree α} : (x.op y).valid → x ≡ y := by
-  simp [valid, equiv_def]
+theorem op_inv {x y : Raw α} : (op x y).valid → x ≡ y := by
+  simp only [valid, equiv_def]
   intro h n
   exact op_invN (h n)
 
-#rocq_ignore to_agree_op_invN "Use the general op_inv theorem."
+@[simp] theorem toAgree_validN {a : α} : (toAgree a).validN n := by
+  simp [validN, toAgree]
+
+theorem toAgree_injN {a b : α} : dist n (toAgree a) (toAgree b) → a ≡{n}≡ b := by
+  intro ⟨h₁, h₂⟩; simp_all [toAgree]
+
+theorem toAgree_uninjN {x : Raw α} : x.validN n → ∃ a, dist n (toAgree a) x := by
+  rw [validN_iff]
+  obtain ⟨a, ha⟩ := mem x
+  intro h; exists a
+  constructor <;> intros
+  · exists a; simp_all [toAgree]
+  · simp_all [toAgree]
+
+theorem toAgree_uninj {x : Raw α} : x.valid → ∃ a, ∀ n, dist n (toAgree a) x := by
+  simp only [valid, validN_iff]
+  obtain ⟨a, ha⟩ := mem x
+  intro h; exists a; intro n
+  constructor <;> intros
+  · exists a; simp_all [toAgree]
+  · simp_all [toAgree]
+
+variable [OFE β] {f : α → β}
+
+instance instNonExpansiveMap' [OFE.NonExpansive f] : OFE.NonExpansive (map' f) where
+  ne := by
+    intro n x₁ x₂ h
+    simp only [map', dist_def, dist, List.mem_map, forall_exists_index, and_imp,
+      forall_apply_eq_imp_iff₂] at h ⊢
+    constructor
+    · intro a ha
+      obtain ⟨b, hb, heq⟩ := h.1 a ha
+      exact ⟨f b, ⟨b, hb, rfl⟩, OFE.NonExpansive.ne heq⟩
+    · intro a ha
+      obtain ⟨b, hb, heq⟩ := h.2 a ha
+      exact ⟨f b, ⟨b, hb, rfl⟩, OFE.NonExpansive.ne heq⟩
+
+theorem map'_validN [OFE.NonExpansive f] {x : Raw α} (h : x.validN n) : (map' f x).validN n := by
+  rw [validN_iff] at h ⊢
+  simp only [map'_car, List.mem_map, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
+  exact fun a ha b hb => OFE.NonExpansive.ne (h a ha b hb)
+
+theorem discrete_0 [OFE.Discrete α] {x y : Raw α} (h : dist 0 x y) (n) : dist n x y := by
+  refine ⟨fun a ha => ?_, fun b hb => ?_⟩
+  · obtain ⟨b, hb, heq⟩ := h.1 a ha; exact ⟨b, hb, OFE.discrete_n heq⟩
+  · obtain ⟨a, ha, heq⟩ := h.2 b hb; exact ⟨a, ha, OFE.discrete_n heq⟩
+
+theorem discrete_valid [OFE.Discrete α] {x : Raw α} (h : x.validN 0) : x.valid := by
+  rw [validN_iff] at h
+  intro n; rw [validN_iff]
+  exact fun a ha b hb => OFE.discrete_n (h a ha b hb)
+
+theorem toAgree_discrete {a : α} [Ha : OFE.DiscreteE a] {y : Raw α}
+    (h : dist 0 (toAgree a) y) (n) : dist n (toAgree a) y := by
+  refine ⟨fun x hx => ?_, fun c hc => ?_⟩
+  · rw [show x = a from by simpa [toAgree] using hx]
+    obtain ⟨b, hb, hd⟩ := h.1 a (by simp [toAgree])
+    exact ⟨b, hb, (Ha.discrete hd).dist⟩
+  · obtain ⟨x, hx, hd⟩ := h.2 c hc
+    rw [show x = a from by simpa [toAgree] using hx] at hd
+    exact ⟨a, by simp [toAgree], (Ha.discrete hd).dist⟩
+
+end Agree.Raw
+
+end raw
+
+/-! ## The quotient -/
+
+section quotient
+
+variable {α : Type u} {β : Type v} [OFE α] [OFE β]
+
+open Agree (Raw)
+
+instance Agree.Raw.instSetoid : Setoid (Raw α) where
+  r x y := ∀ n, Raw.dist n x y
+  iseqv :=
+    ⟨fun _ _ => Raw.dist_equiv.refl _,
+     fun h n => Raw.dist_equiv.symm (h n),
+     fun h₁ h₂ n => Raw.dist_equiv.trans (h₁ n) (h₂ n)⟩
+
+@[rocq_alias agree]
+def Agree (α : Type u) [OFE α] : Type u := Quotient (Agree.Raw.instSetoid (α := α))
+
+namespace Agree
+
+def mk (x : Raw α) : Agree α := Quotient.mk _ x
+
+@[elab_as_elim, induction_eliminator]
+theorem ind {motive : Agree α → Prop} (mk : ∀ x : Raw α, motive (Agree.mk x)) (x : Agree α) :
+    motive x := Quotient.ind mk x
+
+theorem sound {x y : Raw α} (h : ∀ n, Raw.dist n x y) : mk x = mk y := Quotient.sound h
+
+theorem dist_resp {n} {x x' y y' : Raw α} (hx : x ≈ x') (hy : y ≈ y') :
+    Raw.dist n x y = Raw.dist n x' y' := by
+  refine propext ⟨fun h => ?_, fun h => ?_⟩
+  · exact Raw.dist_equiv.trans (Raw.dist_equiv.trans (Raw.dist_equiv.symm (hx n)) h) (hy n)
+  · exact Raw.dist_equiv.trans (Raw.dist_equiv.trans (hx n) h) (Raw.dist_equiv.symm (hy n))
+
+theorem validN_resp {n} {x y : Raw α} (h : x ≈ y) : Raw.validN n x = Raw.validN n y :=
+  propext ⟨Raw.validN_ne (h n), Raw.validN_ne (Raw.dist_equiv.symm (h n))⟩
+
+theorem valid_resp {x y : Raw α} (h : x ≈ y) : Raw.valid x = Raw.valid y := by
+  simp only [Raw.valid, validN_resp h]
+
+def dist (n : Nat) : Agree α → Agree α → Prop :=
+  Quotient.lift₂ (Raw.dist n) (fun _ _ _ _ hx hy => dist_resp hx hy)
+
+def validN (n : Nat) : Agree α → Prop := Quotient.lift (Raw.validN n) (fun _ _ h => validN_resp h)
+
+def valid : Agree α → Prop := Quotient.lift Raw.valid (fun _ _ h => valid_resp h)
+
+def op : Agree α → Agree α → Agree α :=
+  Quotient.lift₂ (fun x y => mk (Raw.op x y))
+    (fun _ _ _ _ hx hy => sound fun n => Raw.op_ne₂.ne (hx n) (hy n))
+
+@[simp] theorem dist_mk {n} {x y : Raw α} : dist n (mk x) (mk y) ↔ Raw.dist n x y := .rfl
+@[simp] theorem validN_mk {n} {x : Raw α} : validN n (mk x) ↔ x.validN n := .rfl
+@[simp] theorem valid_mk {x : Raw α} : valid (mk x) ↔ x.valid := .rfl
+@[simp] theorem op_mk {x y : Raw α} : op (mk x) (mk y) = mk (Raw.op x y) := rfl
+
+theorem dist_equiv : Equivalence (dist (α := α) n) where
+  refl x := by induction x with | _ x => exact Raw.dist_equiv.refl x
+  symm {x y} h := by induction x with | _ x => induction y with | _ y => exact Raw.dist_equiv.symm h
+  trans {x y z} h₁ h₂ := by
+    induction x with | _ x => induction y with | _ y => induction z with | _ z =>
+    exact Raw.dist_equiv.trans h₁ h₂
+
+@[rocq_alias agree_ofe_mixin]
+instance instOFE : OFE (Agree α) where
+  Equiv x y := ∀ n, dist n x y
+  Dist := dist
+  dist_eqv := dist_equiv
+  equiv_dist := Iff.rfl
+  dist_lt {n x y m} h hlt := by
+    induction x with | _ x => induction y with | _ y => exact Raw.dist_lt h hlt
+
+#rocq_ignore agreeO "Use Agree with a typeclass instance instead."
+#rocq_ignore agree_equiv "Defined in Agree OFE instance."
+
+theorem equiv_def {x y : Agree α} : x ≡ y ↔ ∀ n, dist n x y := .rfl
+theorem dist_def {x y : Agree α} : x ≡{n}≡ y ↔ dist n x y := .rfl
+
+instance instLeibniz : OFE.Leibniz (Agree α) where
+  eq_of_eqv {x y} h := by
+    induction x with | _ x => induction y with | _ y => exact sound fun n => h n
+
+@[rocq_alias agree_comm]
+theorem op_comm {x y : Agree α} : op x y ≡ op y x := by
+  induction x with | _ x => induction y with | _ y => exact Raw.op_comm
+
+theorem op_commN {x y : Agree α} : op x y ≡{n}≡ op y x := op_comm n
+
+@[rocq_alias agree_assoc]
+theorem op_assoc {x y z : Agree α} : op x (op y z) ≡ op (op x y) z := by
+  induction x with | _ x => induction y with | _ y => induction z with | _ z => exact Raw.op_assoc
+
+theorem op_idemp {x : Agree α} : op x x ≡ x := by
+  induction x with | _ x => exact Raw.idemp
+
+@[rocq_alias agree_validN_ne]
+theorem validN_ne {x y : Agree α} : x ≡{n}≡ y → validN n x → validN n y := by
+  induction x with | _ x => induction y with | _ y => exact Raw.validN_ne
+
+theorem validN_succ {x : Agree α} : validN (n + 1) x → validN n x := by
+  induction x with | _ x => exact Raw.validN_succ
+
+theorem validN_op_left {x y : Agree α} : validN n (op x y) → validN n x := by
+  induction x with | _ x => induction y with | _ y => exact Raw.validN_op_left
+
+@[rocq_alias agree_op_ne']
+theorem op_ne {x : Agree α} : OFE.NonExpansive (op x) := by
+  refine ⟨fun {n} y₁ y₂ h => ?_⟩
+  induction x with | _ x =>
+  induction y₁ with | _ y₁ => induction y₂ with | _ y₂ => exact Raw.op_ne.ne (dist_mk.mp h)
+
+@[rocq_alias agree_op_ne]
+theorem op_ne₂ : OFE.NonExpansive₂ (op (α := α)) := by
+  refine ⟨fun {n} x₁ x₂ hx y₁ y₂ hy => ?_⟩
+  exact op_ne.ne hy |>.trans (op_comm n) |>.trans (op_ne.ne hx) |>.trans (op_comm n)
+
+@[rocq_alias agree_op_invN]
+theorem op_invN {x y : Agree α} : validN n (op x y) → x ≡{n}≡ y := by
+  induction x with | _ x => induction y with | _ y => exact Raw.op_invN
+
+@[rocq_alias agree_op_inv]
+theorem op_inv {x y : Agree α} : valid (op x y) → x ≡ y := by
+  induction x with | _ x => induction y with | _ y => exact Raw.op_inv
 
 @[rocq_alias agree_cmra_mixin]
-instance : CMRA (Agree α) where
+instance instCMRA : CMRA (Agree α) where
   pcore := some
-  op := Agree.op
-  ValidN := Agree.validN
-  Valid := Agree.valid
-  op_ne := Agree.op_ne
+  op := op
+  ValidN := validN
+  Valid := valid
+  op_ne := op_ne
   pcore_ne := by simp
-  validN_ne := Agree.validN_ne
-  valid_iff_validN := by rfl
-  validN_succ := by
-    simp [Agree.validN_iff]; intro x n hsuc a ha b hb
-    exact (OFE.dist_lt (hsuc a ha b hb) (by omega))
-  assoc := Agree.op_assoc
-  comm := Agree.op_comm
-  pcore_op_left := by simp [Agree.idemp]
-  pcore_idem := by simp [OFE.Equiv.rfl]
-  pcore_op_mono := by simp only [Option.some.injEq]; rintro x _ rfl y; exists y
-  validN_op_left := by
-    intro n x y
-    simp only [Agree.op, Agree.validN_iff, List.mem_append]
-    exact fun h a ha b hb => h _ (.inl ha) _ (.inl hb)
+  validN_ne := validN_ne
+  valid_iff_validN := fun {x} => by induction x with | _ x => exact .rfl
+  validN_succ := validN_succ
+  assoc := op_assoc
+  comm := op_comm
+  pcore_op_left := fun {x cx} h => by obtain rfl := Option.some.inj h; exact op_idemp
+  pcore_idem := fun {x cx} h => by obtain rfl := Option.some.inj h; exact .rfl
+  pcore_op_mono := fun {x cx} h y => by obtain rfl := Option.some.inj h; exact ⟨y, .rfl⟩
+  validN_op_left := validN_op_left
   extend := by
     intro n x y₁ y₂ hval heq₁
-    have heq₂ := Agree.op_invN (Agree.validN_ne heq₁ hval)
-    have heq₃ : y₁.op y₂ ≡{n}≡ y₁ := Agree.op_ne.ne heq₂.symm |>.trans (Agree.idemp n)
-    exact ⟨x, x, Agree.idemp.symm, heq₁.trans heq₃, heq₁.trans heq₃ |>.trans heq₂⟩
+    have heq₂ := op_invN (validN_ne heq₁ hval)
+    have heq₃ : op y₁ y₂ ≡{n}≡ y₁ := op_ne.ne heq₂.symm |>.trans (op_idemp n)
+    exact ⟨x, x, op_idemp.symm, heq₁.trans heq₃, heq₁.trans heq₃ |>.trans heq₂⟩
 
 #rocq_ignore agreeR "Use the plain Agree type with a typeclass instance instead."
 #rocq_ignore agree_op_instance "Use the CMRA instance instead."
@@ -206,72 +404,35 @@ instance : CMRA (Agree α) where
 #rocq_ignore agree_validN_instance "Use the CMRA instance instead."
 #rocq_ignore agree_valid_instance "Use the CMRA instance instead."
 
-theorem Agree.op_def {x y : Agree α} : x • y = x.op y := rfl
-theorem Agree.validN_def {x : Agree α} : ✓{n} x ↔ x.validN n := .rfl
-theorem Agree.valid_def {x : Agree α} : ✓ x ↔ x.valid := .rfl
+theorem op_def {x y : Agree α} : x • y = op x y := rfl
+theorem validN_def {x : Agree α} : ✓{n} x ↔ validN n x := .rfl
+theorem valid_def {x : Agree α} : ✓ x ↔ valid x := .rfl
 
 @[rocq_alias agree_pcore]
-theorem Agree.pcore_some {x : Agree α} : CMRA.pcore x = some x := rfl
+theorem pcore_some {x : Agree α} : CMRA.pcore x = some x := rfl
 
 @[rocq_alias agree_cmra_total]
 instance : CMRA.IsTotal (Agree α) where
   total x := ⟨x, rfl⟩
 
+@[rocq_alias agree_idemp]
+theorem idemp {x : Agree α} : x • x ≡ x := op_idemp
+
+#rocq_ignore agree_validN_proper "Derivable from Agree.validN_ne using NonExpansive.eqv"
+#rocq_ignore agree_op_proper "Derivable from Agree.op_ne₂ using NonExpansive₂.eqv"
+#rocq_ignore to_agree_op_inv "Use the general op_invN theorem."
+#rocq_ignore to_agree_op_invN "Use the general op_inv theorem."
+
 @[rocq_alias agree_cmra_discrete]
-instance [OFE.Discrete α] : CMRA.Discrete (Agree α) where
-  discrete_0 := by
-    intro x y ⟨h₁, h₂⟩ n
-    constructor <;> intro a ha
-    · obtain ⟨b, hb, heq⟩ := h₁ a ha
-      exists b; simp_all [OFE.Discrete.discrete_n]
-    · obtain ⟨b, hb, heq⟩ := h₂ a ha
-      exists b; simp_all [OFE.Discrete.discrete_n]
-  discrete_valid {x} hval n := by
-    rw [Agree.validN_def] at hval
-    rw [Agree.validN_iff] at hval ⊢
-    exact fun a ha b hb => OFE.discrete_n (hval a ha b hb)
+instance instCMRADiscrete [OFE.Discrete α] : CMRA.Discrete (Agree α) where
+  discrete_0 {x y} h := by induction x with | _ x => induction y with | _ y => exact Raw.discrete_0 h
+  discrete_valid {x} h := by induction x with | _ x => exact Raw.discrete_valid h
 
-@[rocq_alias to_agree_ne]
-instance instNonExpansive_toAgree : OFE.NonExpansive (@toAgree α) where
-  ne n x₁ x₂ heq := by constructor <;> simp_all [toAgree]
-
-#rocq_ignore to_agree_proper "Derivable from instNonExpansive_toAgree with NonExpansive.eqv"
-
-@[rocq_alias to_agree_injN]
-theorem Agree.toAgree_injN {a b : α} : toAgree a ≡{n}≡ toAgree b → a ≡{n}≡ b := by
-  intro ⟨h₁, h₂⟩; simp_all [toAgree]
-
-@[rocq_alias to_agree_inj]
-theorem Agree.toAgree_inj {a b : α} : toAgree a ≡ toAgree b → a ≡ b := by
-  simp only [OFE.equiv_dist]
-  exact fun heq n => toAgree_injN (heq n)
-
-@[simp] theorem Agree.toAgree_validN {a : α} : ✓{n} toAgree a := by
-  simp [validN_def, validN, toAgree]
-
-@[simp] theorem Agree.toAgree_valid {a : α} : ✓ toAgree a :=
-  fun _ => Agree.toAgree_validN
-
-@[rocq_alias to_agree_uninjN]
-theorem Agree.toAgree_uninjN {x : Agree α} : ✓{n} x → ∃ a, toAgree a ≡{n}≡ x := by
-  rw [validN_def, validN_iff]
-  obtain ⟨a, ha⟩ := mem_of_agree x
-  intro h; exists a
-  constructor <;> intros
-  · exists a; simp_all [toAgree]
-  · simp_all [toAgree]
-
-@[rocq_alias to_agree_uninj]
-theorem Agree.toAgree_uninj {x : Agree α} : ✓ x → ∃ a, toAgree a ≡ x := by
-  simp only [valid_def, valid, validN_iff, equiv_def]
-  obtain ⟨a, ha⟩ := mem_of_agree x
-  intro h; exists a; intro n
-  constructor <;> intros
-  · exists a; simp_all [toAgree]
-  · simp_all [toAgree]
+instance instDiscrete [OFE.Discrete α] : OFE.Discrete (Agree α) where
+  discrete_0 {x y} h := by induction x with | _ x => induction y with | _ y => exact Raw.discrete_0 h
 
 @[rocq_alias agree_includedN]
-theorem Agree.includedN {x y : Agree α} : x ≼{n} y ↔ y ≡{n}≡ y • x := by
+theorem includedN {x y : Agree α} : x ≼{n} y ↔ y ≡{n}≡ y • x := by
   refine ⟨fun ⟨z, h⟩ => ?_, fun h => ⟨y, h.trans op_commN⟩⟩
   have hid := idemp (x := x) |>.symm
   calc
@@ -282,45 +443,11 @@ theorem Agree.includedN {x y : Agree α} : x ≼{n} y ↔ y ≡{n}≡ y • x :=
     _ ≡{n}≡ y • x := op_commN
 
 @[rocq_alias agree_included]
-theorem Agree.included {x y : Agree α} : x ≼ y ↔ y ≡ y • x :=
+theorem included {x y : Agree α} : x ≼ y ↔ y ≡ y • x :=
   ⟨fun ⟨z, h⟩ n => includedN.mp ⟨z, h n⟩, fun h => ⟨y, h.trans op_comm⟩⟩
 
-@[rocq_alias to_agree_discrete]
-instance Agree.toAgree.is_discrete {a : α} [Ha : OFE.DiscreteE a] : OFE.DiscreteE (toAgree a) := by
-  refine ⟨fun ⟨Hal, Har⟩ _ => ⟨?_, ?_⟩⟩ <;> simp_all [toAgree]
-  · rcases Hal with ⟨b, Hb1, Hb2⟩
-    exact ⟨b, ⟨Hb1, Ha.discrete (Har b Hb1) |>.dist⟩⟩
-  · exact fun H Hb => Ha.discrete (Har H Hb) |>.dist
-
-open OFE OFE.Discrete in
-instance [OFE α] [Discrete α] : Discrete (Agree α) where
-  discrete_0 {x y} H := by
-    refine fun n => ⟨fun a Ha => ?_, fun b Hb => ?_⟩
-    · rcases H.1 a Ha with ⟨c, Hc⟩
-      refine ⟨c, ⟨Hc.1, ?_⟩⟩
-      apply equiv_dist.mp <| discrete_0 (Hc.2.le <| Nat.zero_le 0)
-    · rcases H.2 b Hb with ⟨c, Hc⟩
-      refine ⟨c, ⟨Hc.1, ?_⟩⟩
-      apply equiv_dist.mp <| discrete_0 (Hc.2.le <| Nat.zero_le 0)
-
-instance toAgree.ne [OFE α] : OFE.NonExpansive (toAgree : α → Agree α) where
-  ne n x y H := by
-    refine ⟨?_, ?_⟩
-    · intro a Ha; exists y; revert Ha
-      simp [toAgree]; exact (·▸H)
-    · intro b Hb; exists x; revert Hb
-      simp [toAgree]; exact (·▸H)
-
-theorem toAgree.inj {a1 a2 : α} {n} (H : toAgree a1 ≡{n}≡ toAgree a2) : a1 ≡{n}≡ a2 := by
-  have Hinc : a1 ∈ (toAgree a1).car := by simp [toAgree]
-  rcases H.1 a1 Hinc with ⟨_, ⟨_, _⟩⟩
-  simp_all [toAgree]
-
-instance : CMRA.IsTotal (Agree α) where
-  total := by simp [CMRA.pcore]
-
 @[rocq_alias agree_valid_includedN]
-theorem Agree.valid_includedN {x y : Agree α} : ✓{n} y → x ≼{n} y → x ≡{n}≡ y := by
+theorem valid_includedN {x y : Agree α} : ✓{n} y → x ≼{n} y → x ≡{n}≡ y := by
   intro hval ⟨z, heq⟩
   have : ✓{n} (x • z) := heq.validN.mp hval
   calc
@@ -329,7 +456,7 @@ theorem Agree.valid_includedN {x y : Agree α} : ✓{n} y → x ≼{n} y → x �
     _ ≡{n}≡ y := heq.symm
 
 @[rocq_alias agree_valid_included]
-theorem Agree.valid_included {x y : Agree α} : ✓ y → x ≼ y → x ≡ y := by
+theorem valid_included {x y : Agree α} : ✓ y → x ≼ y → x ≡ y := by
   intro hval ⟨z, heq⟩
   have heq' : x ≡ z := op_inv <| (CMRA.valid_iff heq).mp hval
   calc
@@ -337,31 +464,53 @@ theorem Agree.valid_included {x y : Agree α} : ✓ y → x ≼ y → x ≡ y :=
     _ ≡ x • z := .op_r heq'
     _ ≡ y := heq.symm
 
-@[simp, rocq_alias to_agree_includedN]
-theorem Agree.toAgree_includedN {a b : α} : toAgree a ≼{n} toAgree b ↔ a ≡{n}≡ b := by
-  constructor <;> intro h
-  · exact toAgree_injN (valid_includedN trivial h)
-  · exists toAgree a
-    calc
-      toAgree b ≡{n}≡ toAgree a := OFE.NonExpansive.ne h.symm
-      _         ≡{n}≡ toAgree a • toAgree a := .symm (idemp n)
+set_option synthInstance.checkSynthOrder false in
+instance {x : Agree α} : IsOp io1 x io2 x io3 x where
+  is_op := idemp.symm
 
-@[simp, rocq_alias to_agree_included]
-theorem Agree.toAgree_included {a b : α} : toAgree a ≼ toAgree b ↔ a ≡ b := by
-  constructor <;> intro h
-  · exact toAgree_inj (valid_included (fun _ => trivial) h)
-  · exists toAgree a
-    calc
-      toAgree b ≡ toAgree a := OFE.NonExpansive.eqv (OFE.Equiv.symm h)
-      _         ≡ toAgree a • toAgree a := .symm (CMRA.pcore_op_left rfl)
+end Agree
 
-@[simp, rocq_alias to_agree_included_L]
-theorem Agree.toAgree_included_L [OFE.Leibniz α] {a b : α} :
-    toAgree a ≼ toAgree b ↔ a = b := by simp
+/-! ## `toAgree` -/
 
-@[rocq_alias agree_core_id]
-instance (a : α) : CMRA.CoreId (toAgree a) where
-  core_id := by simp [CMRA.pcore]
+@[rocq_alias to_agree]
+def toAgree (a : α) : Agree α := Agree.mk (Agree.Raw.toAgree a)
+
+theorem toAgree_def {a : α} : toAgree a = Agree.mk (Agree.Raw.toAgree a) := rfl
+
+@[rocq_alias to_agree_ne]
+instance instNonExpansive_toAgree : OFE.NonExpansive (@toAgree α _) where
+  ne n x₁ x₂ heq := by constructor <;> simp_all [Agree.Raw.toAgree]
+
+#rocq_ignore to_agree_proper "Derivable from instNonExpansive_toAgree with NonExpansive.eqv"
+
+@[rocq_alias to_agree_injN]
+theorem Agree.toAgree_injN {a b : α} : toAgree a ≡{n}≡ toAgree b → a ≡{n}≡ b :=
+  Raw.toAgree_injN
+
+@[rocq_alias to_agree_inj]
+theorem Agree.toAgree_inj {a b : α} : toAgree a ≡ toAgree b → a ≡ b := by
+  simp only [OFE.equiv_dist]
+  exact fun heq n => toAgree_injN (heq n)
+
+@[simp] theorem Agree.toAgree_validN {a : α} : ✓{n} toAgree a := Raw.toAgree_validN (a := a) (n := n)
+
+@[simp] theorem Agree.toAgree_valid {a : α} : ✓ toAgree a :=
+  fun m => Agree.toAgree_validN (a := a) (n := m)
+
+@[rocq_alias to_agree_uninjN]
+theorem Agree.toAgree_uninjN {x : Agree α} : ✓{n} x → ∃ a, toAgree a ≡{n}≡ x := by
+  induction x with | _ x => exact fun h => Raw.toAgree_uninjN h
+
+@[rocq_alias to_agree_uninj]
+theorem Agree.toAgree_uninj {x : Agree α} : ✓ x → ∃ a, toAgree a ≡ x := by
+  induction x with | _ x => exact fun h => (Raw.toAgree_uninj h).imp fun _ h n => h n
+
+instance toAgree.ne : OFE.NonExpansive (toAgree : α → Agree α) := instNonExpansive_toAgree
+
+theorem toAgree.inj {a1 a2 : α} {n} (H : toAgree a1 ≡{n}≡ toAgree a2) : a1 ≡{n}≡ a2 :=
+  Agree.toAgree_injN H
+
+namespace Agree
 
 @[rocq_alias agree_cancelable]
 instance {x : Agree α} : CMRA.Cancelable x where
@@ -385,8 +534,34 @@ instance {x : Agree α} : CMRA.Cancelable x where
       _ ≡{n}≡ toAgree c := OFE.NonExpansive.ne heq₃
       _ ≡{n}≡ z := hc
 
+@[rocq_alias agree_core_id]
+instance (a : α) : CMRA.CoreId (toAgree a) where
+  core_id := by simp [CMRA.pcore]
+
+@[simp, rocq_alias to_agree_includedN]
+theorem toAgree_includedN {a b : α} : toAgree a ≼{n} toAgree b ↔ a ≡{n}≡ b := by
+  constructor <;> intro h
+  · exact toAgree_injN (valid_includedN trivial h)
+  · exists toAgree a
+    calc
+      toAgree b ≡{n}≡ toAgree a := OFE.NonExpansive.ne h.symm
+      _         ≡{n}≡ toAgree a • toAgree a := .symm (idemp n)
+
+@[simp, rocq_alias to_agree_included]
+theorem toAgree_included {a b : α} : toAgree a ≼ toAgree b ↔ a ≡ b := by
+  constructor <;> intro h
+  · exact toAgree_inj (valid_included (fun _ => trivial) h)
+  · exists toAgree a
+    calc
+      toAgree b ≡ toAgree a := OFE.NonExpansive.eqv (OFE.Equiv.symm h)
+      _         ≡ toAgree a • toAgree a := .symm (CMRA.pcore_op_left rfl)
+
+@[simp, rocq_alias to_agree_included_L]
+theorem toAgree_included_L [OFE.Leibniz α] {a b : α} :
+    toAgree a ≼ toAgree b ↔ a = b := by simp
+
 @[rocq_alias to_agree_op_validN]
-theorem Agree.toAgree_op_validN_iff_dist {a b : α} :
+theorem toAgree_op_validN_iff_dist {a b : α} :
     ✓{n} (toAgree a • toAgree b) ↔ a ≡{n}≡ b := by
   constructor <;> intro h
   · exact toAgree_injN (op_invN h)
@@ -396,13 +571,15 @@ theorem Agree.toAgree_op_validN_iff_dist {a b : α} :
       _ ≡{n}≡ toAgree a := idemp n
     exact this.symm.validN.mp trivial
 
-set_option synthInstance.checkSynthOrder false in
-instance {x : Agree α} : IsOp io1 x io2 x io3 x where
-  is_op := Agree.idemp.symm
-
 @[rocq_alias to_agree_op_valid]
-theorem Agree.toAgree_op_valid_iff_equiv {a : α} : ✓ (toAgree a • toAgree b) ↔ a ≡ b := by
+theorem toAgree_op_valid_iff_equiv {a : α} : ✓ (toAgree a • toAgree b) ↔ a ≡ b := by
   simp [OFE.equiv_dist, CMRA.valid_iff_validN, toAgree_op_validN_iff_dist]
+
+@[rocq_alias to_agree_discrete]
+instance toAgree.is_discrete {a : α} [OFE.DiscreteE a] : OFE.DiscreteE (toAgree a) where
+  discrete {y} h := by induction y with | _ y => exact fun n => Raw.toAgree_discrete h n
+
+end Agree
 
 @[rocq_alias to_agree_op_valid_L]
 theorem toAgree_op_valid_iff_eq [OFE.Leibniz α] {a : α} :
@@ -410,28 +587,29 @@ theorem toAgree_op_valid_iff_eq [OFE.Leibniz α] {a : α} :
 
 #rocq_ignore to_agree_op_inv_L "Use toAgree_op_valid_iff_eq"
 
-end agree
+end quotient
 
-@[rocq_alias agree_map]
-def Agree.map' {α β} (f : α → β) (a : Agree α) : Agree β := ⟨a.car.map f, by simp⟩
+/-! ## Functoriality -/
 
 section agree_map
 
-variable {α β} [OFE α] [OFE β] {f : α → β} [hne : OFE.NonExpansive f]
+variable {α β γ : Type _} [OFE α] [OFE β] [OFE γ] {f : α → β} [hne : OFE.NonExpansive f]
+
+open Agree (Raw)
+
+@[rocq_alias agree_map]
+def Agree.map' (f : α → β) [OFE.NonExpansive f] : Agree α → Agree β :=
+  Quotient.lift (fun a => Agree.mk (Raw.map' f a))
+    (fun _ _ h => Agree.sound fun n => Raw.instNonExpansiveMap'.ne (h n))
+
+@[simp] theorem Agree.map'_mk (f : α → β) [OFE.NonExpansive f] {x : Raw α} :
+    Agree.map' f (Agree.mk x) = Agree.mk (Raw.map' f x) := rfl
 
 @[rocq_alias agree_map_ne]
 instance instNonExpansive_AgreeMap' : OFE.NonExpansive (Agree.map' f) where
-  ne := by
-    intro n x₁ x₂ h
-    simp only [Agree.map', Agree.dist_def, Agree.dist, List.mem_map, forall_exists_index, and_imp,
-      forall_apply_eq_imp_iff₂]  at h ⊢
-    constructor
-    · intro a ha
-      obtain ⟨b, hb, heq⟩ := h.1 a ha
-      exact ⟨f b, ⟨b, hb, rfl⟩, OFE.NonExpansive.ne heq⟩
-    · intro a ha
-      obtain ⟨b, hb, heq⟩ := h.2 a ha
-      exact ⟨f b, ⟨b, hb, rfl⟩, OFE.NonExpansive.ne heq⟩
+  ne n x y h := by
+    induction x with | _ x => induction y with | _ y =>
+    exact Raw.instNonExpansiveMap'.ne (Agree.dist_mk.mp h)
 
 #rocq_ignore agree_map_proper "Derivable from instNonExpansive_AgreeMap' with NonExpansive.eqv"
 
@@ -439,75 +617,88 @@ variable (f) in
 @[rocq_alias agree_map_morphism]
 def Agree.map : (Agree α) -C> (Agree β) where
   f := map' f
-  ne := inferInstance
+  ne := instNonExpansive_AgreeMap'
   validN {n x} hval := by
-    simp [validN_def, map', validN_iff] at hval ⊢
-    intro a ha b hb
-    exact OFE.NonExpansive.ne (hval a ha b hb)
+    induction x with | _ x => exact Raw.map'_validN hval
   pcore x := .rfl
-  op x y n := by
-    simp only [dist, map', op_def, op, List.map_append, List.mem_append, List.mem_map]
-    constructor <;>
-    · intro a ha
-      obtain ⟨b, hb, rfl⟩ | ⟨b, hb, rfl⟩ := ha
-      · exact ⟨f b, .inl ⟨_, hb, rfl⟩, .rfl⟩
-      · exact ⟨f b, .inr ⟨_, hb, rfl⟩, .rfl⟩
+  op x y := by
+    induction x with | _ x => induction y with | _ y =>
+    show mk (Raw.map' f (Raw.op x y)) ≡ mk (Raw.op (Raw.map' f x) (Raw.map' f y))
+    exact .of_eq (congrArg mk Raw.map'_op)
+
+@[simp] theorem Agree.map_mk (f : α → β) [OFE.NonExpansive f] (x : Raw α) :
+    Agree.map f (mk x) = mk (Raw.map' f x) := rfl
+
+@[simp] theorem Agree.map'_id (x : Agree α) : Agree.map' id x = x := by
+  induction x with | _ x => rw [map'_mk]; exact congrArg mk (Raw.ext (by simp [Raw.map'_car]))
+
+theorem Agree.map'_compose {f : α → β} {g : β → γ}
+    [OFE.NonExpansive f] [OFE.NonExpansive g] [OFE.NonExpansive (g ∘ f)] (x : Agree α) :
+    Agree.map' (g ∘ f) x = Agree.map' g (Agree.map' f x) := by
+  induction x with | _ x =>
+  rw [map'_mk, map'_mk, map'_mk]
+  exact congrArg mk (Raw.ext (by simp [Raw.map'_car, List.map_map]))
 
 @[rocq_alias agreeO_map]
 abbrev Agree.map_hom : (Agree α) -n> (Agree β) := CMRA.Hom.toHom (Agree.map f)
 
 @[rocq_alias agreeO_map_ne]
-theorem Agree.map_ne [OFE.NonExpansive g] (heq : ∀ a, f a ≡{n}≡ g a) :
-    map f x ≡{n}≡ map g x := by
-  simp only [map, map']
-  constructor <;> simp only [List.mem_map] <;> rintro _ ⟨a, ha, rfl⟩
+theorem Agree.map_ne {f g : α → β} [OFE.NonExpansive f] [OFE.NonExpansive g] {x : Agree α}
+    (heq : ∀ a, f a ≡{n}≡ g a) : map f x ≡{n}≡ map g x := by
+  induction x with | _ x =>
+  rw [map_mk, map_mk]
+  refine dist_mk.mpr ⟨?_, ?_⟩ <;> simp only [Raw.map'_car, List.mem_map] <;> rintro _ ⟨a, ha, rfl⟩
   · exact ⟨g a, ⟨a, ha, rfl⟩, heq a⟩
   · exact ⟨f a, ⟨a, ha, rfl⟩, heq a⟩
 
 @[rocq_alias agree_map_ext]
-theorem Agree.agree_map_ext [OFE.NonExpansive g] (H : ∀ a, f a ≡ g a) :
-    map f x ≡ map g x :=
+theorem Agree.agree_map_ext {f g : α → β} [OFE.NonExpansive f] [OFE.NonExpansive g] {x : Agree α}
+    (H : ∀ a, f a ≡ g a) : map f x ≡ map g x :=
   OFE.equiv_dist.mpr fun _ => map_ne (H · |>.dist)
 
 @[rocq_alias agree_map_id]
 theorem Agree.map_id (x : Agree α) : Agree.map id x = x := by
-  simp only [map, map', List.map_id_fun, id_eq]
+  induction x with | _ x => rw [map_mk]; exact congrArg mk (Raw.ext (by simp [Raw.map'_car]))
 
 @[rocq_alias agree_map_compose]
-theorem Agree.map_compose [OFE γ] (f : α -n> β) (g : β -n> γ) (x : Agree α) :
+theorem Agree.map_compose (f : α -n> β) (g : β -n> γ) (x : Agree α) :
     Agree.map (g.comp f) x = Agree.map g (Agree.map f x) := by
-  simp only [map, OFE.Hom.comp, map', List.map_map]
+  induction x with | _ x =>
+  rw [map_mk, map_mk, map_mk]
+  exact congrArg mk (Raw.ext (by simp [Raw.map'_car, OFE.Hom.comp, List.map_map]))
 
-theorem toAgree.incN {a b : α} {n} : toAgree a ≼{n} toAgree b ↔ a ≡{n}≡ b := by
-  refine ⟨?_, fun H => (CMRA.incN_iff_right <| toAgree.ne.ne H).mp <| CMRA.incN_refl _⟩
-  intro H
-  apply toAgree.inj
-  exact Agree.valid_includedN trivial H
+theorem toAgree.incN {a b : α} {n} : toAgree a ≼{n} toAgree b ↔ a ≡{n}≡ b :=
+  Agree.toAgree_includedN
 
 @[rocq_alias agree_map_to_agree]
-theorem Agree.map_toAgree {x : α} : Agree.map f (toAgree x) = toAgree (f x) := rfl
+theorem Agree.map_toAgree {x : α} : Agree.map f (toAgree x) = toAgree (f x) := by
+  show Agree.map f (mk (Raw.toAgree x)) = mk (Raw.toAgree (f x))
+  rw [map_mk]; exact congrArg mk (Raw.ext rfl)
 
 end agree_map
 
 section agree_rfunctor
 
 @[rocq_alias agreeRF]
-abbrev AgreeRF (F : COFE.OFunctorPre) : COFE.OFunctorPre :=
+abbrev AgreeRF (F : COFE.OFunctorPre) [COFE.OFunctor F] : COFE.OFunctorPre :=
   fun A B _ _ => Agree (F A B)
 
 instance {F} [COFE.OFunctor F] : RFunctor (AgreeRF F) where
   map f g := Agree.map (COFE.OFunctor.map f g)
   map_ne.ne _ _ _ Hx _ _ Hy _ := Agree.map_ne <| COFE.OFunctor.map_ne.ne Hx Hy
   map_id x := by
-    conv=> right; rw [<- (Agree.map_id x)]
+    conv => right; rw [← (Agree.map_id x)]
     exact (Agree.map_id x) ▸ Agree.agree_map_ext COFE.OFunctor.map_id
   map_comp f g f' g' x := by
-    rw [<- Agree.map_compose]
+    rw [← Agree.map_compose]
     apply Agree.agree_map_ext
     apply COFE.OFunctor.map_comp
 
 @[rocq_alias agreeRF_contractive]
 instance {F} [COFE.OFunctorContractive F] : RFunctorContractive (AgreeRF F) where
   map_contractive.1 H _ := Agree.map_ne (COFE.OFunctorContractive.map_contractive.1 H)
+
+instance {F} [COFE.OFunctor F] : Leibniz.LeibnizPreservingOFunctor (AgreeRF F) where
+  preserves_leibniz := Agree.instLeibniz
 
 end agree_rfunctor

--- a/Iris/Iris/Algebra/Agree.lean
+++ b/Iris/Iris/Algebra/Agree.lean
@@ -56,7 +56,7 @@ def map' (f : α → β) (a : Raw α) : Raw β := ⟨a.car.map f, by simp⟩
 @[simp] theorem map'_car {f : α → β} {x : Raw α} : (map' f x).car = x.car.map f := rfl
 
 def op (x y : Raw α) : Raw α :=
-  ⟨x.car ++ y.car, by apply List.append_ne_nil_of_left_ne_nil; exact x.not_nil⟩
+  ⟨x.car ++ y.car, List.append_ne_nil_of_left_ne_nil x.not_nil _⟩
 
 theorem map'_op {f : α → β} {x y : Raw α} : map' f (op x y) = op (map' f x) (map' f y) := by
   apply ext; simp [op, map']
@@ -212,13 +212,13 @@ variable [OFE β] {f : α → β}
 instance instNonExpansiveMap' [OFE.NonExpansive f] : OFE.NonExpansive (map' f) where
   ne := by
     intro n x₁ x₂ h
-    simp only [map', dist_def, dist, List.mem_map, forall_exists_index, and_imp,
-      forall_apply_eq_imp_iff₂] at h ⊢
-    constructor
-    · intro a ha
+    refine ⟨?_, ?_⟩
+    · simp only [map', List.mem_map, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
+      intro a ha
       obtain ⟨b, hb, heq⟩ := h.1 a ha
       exact ⟨f b, ⟨b, hb, rfl⟩, OFE.NonExpansive.ne heq⟩
-    · intro a ha
+    · simp only [map', List.mem_map, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
+      intro a ha
       obtain ⟨b, hb, heq⟩ := h.2 a ha
       exact ⟨f b, ⟨b, hb, rfl⟩, OFE.NonExpansive.ne heq⟩
 
@@ -310,33 +310,31 @@ def op : Agree α → Agree α → Agree α :=
 @[simp] theorem op_mk {x y : Raw α} : op (mk x) (mk y) = mk (Raw.op x y) := rfl
 
 @[rocq_alias agree_comm]
-theorem op_comm {x y : Agree α} : op x y ≡ op y x := by
-  induction x with | _ x => induction y with | _ y => exact Raw.op_comm
+theorem op_comm {x y : Agree α} : op x y ≡ op y x :=
+  x.ind fun _ => y.ind fun _ => Raw.op_comm
 
 theorem op_commN {x y : Agree α} : op x y ≡{n}≡ op y x := op_comm n
 
 @[rocq_alias agree_assoc]
-theorem op_assoc {x y z : Agree α} : op x (op y z) ≡ op (op x y) z := by
-  induction x with | _ x => induction y with | _ y => induction z with | _ z => exact Raw.op_assoc
+theorem op_assoc {x y z : Agree α} : op x (op y z) ≡ op (op x y) z :=
+  x.ind fun _ => y.ind fun _ => z.ind fun _ => Raw.op_assoc
 
-theorem op_idemp {x : Agree α} : op x x ≡ x := by
-  induction x with | _ x => exact Raw.idemp
+theorem op_idemp {x : Agree α} : op x x ≡ x :=
+  x.ind fun _ => Raw.idemp
 
 @[rocq_alias agree_validN_ne]
-theorem validN_ne {x y : Agree α} : x ≡{n}≡ y → validN n x → validN n y := by
-  induction x with | _ x => induction y with | _ y => exact Raw.validN_ne
+theorem validN_ne {x y : Agree α} : x ≡{n}≡ y → validN n x → validN n y :=
+  x.ind fun _ => y.ind fun _ => Raw.validN_ne
 
-theorem validN_succ {x : Agree α} : validN (n + 1) x → validN n x := by
-  induction x with | _ x => exact Raw.validN_succ
+theorem validN_succ {x : Agree α} : validN (n + 1) x → validN n x :=
+  x.ind fun _ => Raw.validN_succ
 
-theorem validN_op_left {x y : Agree α} : validN n (op x y) → validN n x := by
-  induction x with | _ x => induction y with | _ y => exact Raw.validN_op_left
+theorem validN_op_left {x y : Agree α} : validN n (op x y) → validN n x :=
+  x.ind fun _ => y.ind fun _ => Raw.validN_op_left
 
 @[rocq_alias agree_op_ne']
-theorem op_ne {x : Agree α} : OFE.NonExpansive (op x) := by
-  refine ⟨fun {n} y₁ y₂ h => ?_⟩
-  induction x with | _ x =>
-  induction y₁ with | _ y₁ => induction y₂ with | _ y₂ => exact Raw.op_ne.ne (dist_mk.mp h)
+theorem op_ne {x : Agree α} : OFE.NonExpansive (op x) :=
+  ⟨fun {_} y₁ y₂ => x.ind fun _ => y₁.ind fun _ => y₂.ind fun _ h => Raw.op_ne.ne (dist_mk.mp h)⟩
 
 @[rocq_alias agree_op_ne]
 theorem op_ne₂ : OFE.NonExpansive₂ (op (α := α)) := by
@@ -344,12 +342,12 @@ theorem op_ne₂ : OFE.NonExpansive₂ (op (α := α)) := by
   exact op_ne.ne hy |>.trans (op_comm n) |>.trans (op_ne.ne hx) |>.trans (op_comm n)
 
 @[rocq_alias agree_op_invN]
-theorem op_invN {x y : Agree α} : validN n (op x y) → x ≡{n}≡ y := by
-  induction x with | _ x => induction y with | _ y => exact Raw.op_invN
+theorem op_invN {x y : Agree α} : validN n (op x y) → x ≡{n}≡ y :=
+  x.ind fun _ => y.ind fun _ => Raw.op_invN
 
 @[rocq_alias agree_op_inv]
-theorem op_inv {x y : Agree α} : valid (op x y) → x ≡ y := by
-  induction x with | _ x => induction y with | _ y => exact Raw.op_inv
+theorem op_inv {x y : Agree α} : valid (op x y) → x ≡ y :=
+  x.ind fun _ => y.ind fun _ => Raw.op_inv
 
 @[rocq_alias agree_cmra_mixin]
 instance instCMRA : CMRA (Agree α) where
@@ -360,7 +358,7 @@ instance instCMRA : CMRA (Agree α) where
   op_ne := op_ne
   pcore_ne := by simp
   validN_ne := validN_ne
-  valid_iff_validN := fun {x} => by induction x with | _ x => exact .rfl
+  valid_iff_validN := fun {x} => x.ind fun _ => .rfl
   validN_succ := validN_succ
   assoc := op_assoc
   comm := op_comm
@@ -368,8 +366,7 @@ instance instCMRA : CMRA (Agree α) where
   pcore_idem := fun {x cx} h => by obtain rfl := Option.some.inj h; exact .rfl
   pcore_op_mono := fun {x cx} h y => by obtain rfl := Option.some.inj h; exact ⟨y, .rfl⟩
   validN_op_left := validN_op_left
-  extend := by
-    intro n x y₁ y₂ hval heq₁
+  extend {n x y₁ y₂ hval heq₁} := by
     have heq₂ := op_invN (validN_ne heq₁ hval)
     have heq₃ : op y₁ y₂ ≡{n}≡ y₁ := op_ne.ne heq₂.symm |>.trans (op_idemp n)
     exact ⟨x, x, op_idemp.symm, heq₁.trans heq₃, heq₁.trans heq₃ |>.trans heq₂⟩
@@ -401,19 +398,18 @@ theorem idemp {x : Agree α} : x • x ≡ x := op_idemp
 
 @[rocq_alias agree_cmra_discrete]
 instance instCMRADiscrete [OFE.Discrete α] : CMRA.Discrete (Agree α) where
-  discrete_0 {x y} h := by induction x with | _ x => induction y with | _ y => exact Raw.discrete_0 h
-  discrete_valid {x} h := by induction x with | _ x => exact Raw.discrete_valid h
+  discrete_0 {x y} := x.ind fun _ => y.ind fun _ => Raw.discrete_0
+  discrete_valid {x} := x.ind fun _ => Raw.discrete_valid
 
 instance instDiscrete [OFE.Discrete α] : OFE.Discrete (Agree α) where
-  discrete_0 {x y} h := by induction x with | _ x => induction y with | _ y => exact Raw.discrete_0 h
+  discrete_0 {x y} := x.ind fun _ => y.ind fun _ => Raw.discrete_0
 
 @[rocq_alias agree_includedN]
 theorem includedN {x y : Agree α} : x ≼{n} y ↔ y ≡{n}≡ y • x := by
   refine ⟨fun ⟨z, h⟩ => ?_, fun h => ⟨y, h.trans op_commN⟩⟩
-  have hid := idemp (x := x) |>.symm
   calc
     y ≡{n}≡ x • z := h
-    _ ≡{n}≡ (x • x) • z := .op_l (hid n)
+    _ ≡{n}≡ (x • x) • z := .op_l (idemp.symm n)
     _ ≡{n}≡ x • (x • z) := CMRA.op_assocN.symm
     _ ≡{n}≡ x • y := h.symm.op_r
     _ ≡{n}≡ y • x := op_commN
@@ -425,19 +421,17 @@ theorem included {x y : Agree α} : x ≼ y ↔ y ≡ y • x :=
 @[rocq_alias agree_valid_includedN]
 theorem valid_includedN {x y : Agree α} : ✓{n} y → x ≼{n} y → x ≡{n}≡ y := by
   intro hval ⟨z, heq⟩
-  have : ✓{n} (x • z) := heq.validN.mp hval
   calc
     x ≡{n}≡ x • x := .symm (idemp _)
-    _ ≡{n}≡ x • z := (op_invN this).op_r
+    _ ≡{n}≡ x • z := (op_invN <| heq.validN.mp hval).op_r
     _ ≡{n}≡ y := heq.symm
 
 @[rocq_alias agree_valid_included]
 theorem valid_included {x y : Agree α} : ✓ y → x ≼ y → x ≡ y := by
   intro hval ⟨z, heq⟩
-  have heq' : x ≡ z := op_inv <| (CMRA.valid_iff heq).mp hval
   calc
     x ≡ x • x := idemp.symm
-    _ ≡ x • z := .op_r heq'
+    _ ≡ x • z := .op_r <| op_inv <| (CMRA.valid_iff heq).mp hval
     _ ≡ y := heq.symm
 
 set_option synthInstance.checkSynthOrder false in
@@ -474,12 +468,12 @@ theorem Agree.toAgree_inj {a b : α} : toAgree a ≡ toAgree b → a ≡ b := by
   fun m => Agree.toAgree_validN (a := a) (n := m)
 
 @[rocq_alias to_agree_uninjN]
-theorem Agree.toAgree_uninjN {x : Agree α} : ✓{n} x → ∃ a, toAgree a ≡{n}≡ x := by
-  induction x with | _ x => exact fun h => Raw.toAgree_uninjN h
+theorem Agree.toAgree_uninjN {x : Agree α} : ✓{n} x → ∃ a, toAgree a ≡{n}≡ x :=
+  x.ind fun _ h => Raw.toAgree_uninjN h
 
 @[rocq_alias to_agree_uninj]
-theorem Agree.toAgree_uninj {x : Agree α} : ✓ x → ∃ a, toAgree a ≡ x := by
-  induction x with | _ x => exact fun h => (Raw.toAgree_uninj h).imp fun _ h n => h n
+theorem Agree.toAgree_uninj {x : Agree α} : ✓ x → ∃ a, toAgree a ≡ x :=
+  x.ind fun _ h => (Raw.toAgree_uninj h).imp fun _ h n => h n
 
 instance toAgree.ne : OFE.NonExpansive (toAgree : α → Agree α) := instNonExpansive_toAgree
 
@@ -490,25 +484,8 @@ namespace Agree
 
 @[rocq_alias agree_cancelable]
 instance {x : Agree α} : CMRA.Cancelable x where
-  cancelableN {n y z} hval heq := by
-    obtain ⟨a, ha⟩ := Agree.toAgree_uninjN (CMRA.validN_op_left hval)
-    obtain ⟨b, hb⟩ := Agree.toAgree_uninjN (CMRA.validN_op_right hval)
-    have hval' : ✓{n} x • z := (OFE.Dist.validN heq).mp hval
-    have : ✓{n} z := CMRA.validN_op_right hval'
-    obtain ⟨c, hc⟩ := Agree.toAgree_uninjN this
-    have heq₁ : a ≡{n}≡ b := Agree.toAgree_injN <| calc
-      toAgree a ≡{n}≡ x         := ha
-      _         ≡{n}≡ y         := Agree.op_invN hval
-      _         ≡{n}≡ toAgree b := hb.symm
-    have heq₂ : a ≡{n}≡ c := Agree.toAgree_injN <| calc
-      toAgree a ≡{n}≡ x         := ha
-      _         ≡{n}≡ z         := Agree.op_invN hval'
-      _         ≡{n}≡ toAgree c := hc.symm
-    have heq₃ : b ≡{n}≡ c := heq₁.symm.trans heq₂
-    calc
-      y ≡{n}≡ toAgree b := hb.symm
-      _ ≡{n}≡ toAgree c := OFE.NonExpansive.ne heq₃
-      _ ≡{n}≡ z := hc
+  cancelableN hval heq :=
+    (Agree.op_invN hval).symm.trans (Agree.op_invN ((OFE.Dist.validN heq).mp hval))
 
 @[rocq_alias agree_core_id]
 instance (a : α) : CMRA.CoreId (toAgree a) where
@@ -541,11 +518,10 @@ theorem toAgree_op_validN_iff_dist {a b : α} :
     ✓{n} (toAgree a • toAgree b) ↔ a ≡{n}≡ b := by
   constructor <;> intro h
   · exact toAgree_injN (op_invN h)
-  · have : toAgree a ≡{n}≡ toAgree b := OFE.NonExpansive.ne h
-    have : toAgree a • toAgree b ≡{n}≡ toAgree a := calc
-      toAgree a • toAgree b ≡{n}≡ toAgree a • toAgree a := this.symm.op_r
+  · have heqv : toAgree a • toAgree b ≡{n}≡ toAgree a := calc
+      toAgree a • toAgree b ≡{n}≡ toAgree a • toAgree a := (OFE.NonExpansive.ne h).symm.op_r
       _ ≡{n}≡ toAgree a := idemp n
-    exact this.symm.validN.mp trivial
+    exact heqv.symm.validN.mp trivial
 
 @[rocq_alias to_agree_op_valid]
 theorem toAgree_op_valid_iff_equiv {a : α} : ✓ (toAgree a • toAgree b) ↔ a ≡ b := by
@@ -553,7 +529,7 @@ theorem toAgree_op_valid_iff_equiv {a : α} : ✓ (toAgree a • toAgree b) ↔ 
 
 @[rocq_alias to_agree_discrete]
 instance toAgree.is_discrete {a : α} [OFE.DiscreteE a] : OFE.DiscreteE (toAgree a) where
-  discrete {y} h := by induction y with | _ y => exact fun n => Raw.toAgree_discrete h n
+  discrete {y} := y.ind fun _ h n => Raw.toAgree_discrete h n
 
 end Agree
 
@@ -583,9 +559,7 @@ def Agree.map' (f : α → β) [OFE.NonExpansive f] : Agree α → Agree β :=
 
 @[rocq_alias agree_map_ne]
 instance instNonExpansive_AgreeMap' : OFE.NonExpansive (Agree.map' f) where
-  ne n x y h := by
-    induction x with | _ x => induction y with | _ y =>
-    exact Raw.instNonExpansiveMap'.ne (Agree.dist_mk.mp h)
+  ne _ x y := x.ind fun _ => y.ind fun _ h => Raw.instNonExpansiveMap'.ne (Agree.dist_mk.mp h)
 
 #rocq_ignore agree_map_proper "Derivable from instNonExpansive_AgreeMap' with NonExpansive.eqv"
 
@@ -594,26 +568,20 @@ variable (f) in
 def Agree.map : (Agree α) -C> (Agree β) where
   f := map' f
   ne := instNonExpansive_AgreeMap'
-  validN {n x} hval := by
-    induction x with | _ x => exact Raw.map'_validN hval
-  pcore x := .rfl
-  op x y := by
-    induction x with | _ x => induction y with | _ y =>
-    show mk (Raw.map' f (Raw.op x y)) ≡ mk (Raw.op (Raw.map' f x) (Raw.map' f y))
-    exact .of_eq (congrArg mk Raw.map'_op)
+  validN {_n x} := x.ind fun _ => Raw.map'_validN
+  pcore _ := .rfl
+  op x y := x.ind fun _ => y.ind fun _ => .of_eq (congrArg mk Raw.map'_op)
 
 @[simp] theorem Agree.map_mk (f : α → β) [OFE.NonExpansive f] (x : Raw α) :
     Agree.map f (mk x) = mk (Raw.map' f x) := rfl
 
-@[simp] theorem Agree.map'_id (x : Agree α) : Agree.map' id x = x := by
-  induction x with | _ x => rw [map'_mk]; exact congrArg mk (Raw.ext (by simp [Raw.map'_car]))
+@[simp] theorem Agree.map'_id (x : Agree α) : Agree.map' id x = x :=
+  x.ind fun _ => congrArg mk (Raw.ext (by simp [Raw.map'_car]))
 
 theorem Agree.map'_compose {f : α → β} {g : β → γ}
     [OFE.NonExpansive f] [OFE.NonExpansive g] [OFE.NonExpansive (g ∘ f)] (x : Agree α) :
-    Agree.map' (g ∘ f) x = Agree.map' g (Agree.map' f x) := by
-  induction x with | _ x =>
-  rw [map'_mk, map'_mk, map'_mk]
-  exact congrArg mk (Raw.ext (by simp [Raw.map'_car, List.map_map]))
+    Agree.map' (g ∘ f) x = Agree.map' g (Agree.map' f x) :=
+  x.ind fun _ => congrArg mk (Raw.ext (by simp [Raw.map'_car, List.map_map]))
 
 @[rocq_alias agreeO_map]
 abbrev Agree.map_hom : (Agree α) -n> (Agree β) := CMRA.Hom.toHom (Agree.map f)
@@ -633,23 +601,20 @@ theorem Agree.agree_map_ext {f g : α → β} [OFE.NonExpansive f] [OFE.NonExpan
   OFE.equiv_dist.mpr fun _ => map_ne (H · |>.dist)
 
 @[rocq_alias agree_map_id]
-theorem Agree.map_id (x : Agree α) : Agree.map id x = x := by
-  induction x with | _ x => rw [map_mk]; exact congrArg mk (Raw.ext (by simp [Raw.map'_car]))
+theorem Agree.map_id (x : Agree α) : Agree.map id x = x :=
+  x.ind fun _ => congrArg mk (Raw.ext (by simp [Raw.map'_car]))
 
 @[rocq_alias agree_map_compose]
 theorem Agree.map_compose (f : α -n> β) (g : β -n> γ) (x : Agree α) :
-    Agree.map (g.comp f) x = Agree.map g (Agree.map f x) := by
-  induction x with | _ x =>
-  rw [map_mk, map_mk, map_mk]
-  exact congrArg mk (Raw.ext (by simp [Raw.map'_car, OFE.Hom.comp, List.map_map]))
+    Agree.map (g.comp f) x = Agree.map g (Agree.map f x) :=
+  x.ind fun _ => congrArg mk (Raw.ext (by simp [Raw.map'_car, OFE.Hom.comp, List.map_map]))
 
 theorem toAgree.incN {a b : α} {n} : toAgree a ≼{n} toAgree b ↔ a ≡{n}≡ b :=
   Agree.toAgree_includedN
 
 @[rocq_alias agree_map_to_agree]
-theorem Agree.map_toAgree {x : α} : Agree.map f (toAgree x) = toAgree (f x) := by
-  show Agree.map f (mk (Raw.toAgree x)) = mk (Raw.toAgree (f x))
-  rw [map_mk]; exact congrArg mk (Raw.ext rfl)
+theorem Agree.map_toAgree {x : α} : Agree.map f (toAgree x) = toAgree (f x) :=
+  congrArg mk (Raw.ext rfl)
 
 end agree_map
 

--- a/Iris/Iris/Algebra/Agree.lean
+++ b/Iris/Iris/Algebra/Agree.lean
@@ -88,11 +88,11 @@ def dist (n : Nat) (x y : Raw α) : Prop :=
 
 theorem dist_equiv : Equivalence (dist (α := α) n) where
   refl := fun ⟨x, h⟩ => by
-    constructor
+    refine ⟨?_, ?_⟩
     · intro a ha; exists a
     · intro b hb; exists b
   symm := fun ⟨h₁, h₂⟩ => by
-    constructor
+    refine ⟨?_, ?_⟩
     · intro a ha
       obtain ⟨b, hb, hd⟩ := h₂ a ha
       exact ⟨b, hb, hd.symm⟩
@@ -100,7 +100,7 @@ theorem dist_equiv : Equivalence (dist (α := α) n) where
       obtain ⟨a, ha, hd⟩ := h₁ b hb
       exact ⟨a, ha, hd.symm⟩
   trans := fun ⟨h₁, h₁'⟩ ⟨h₂, h₂'⟩ => by
-    constructor
+    refine ⟨?_, ?_⟩
     · intro a ha
       obtain ⟨b, hb, hd₁⟩ := h₁ a ha
       obtain ⟨c, hc, hd₂⟩ := h₂ b hb
@@ -116,7 +116,7 @@ instance instOFE : OFE (Raw α) where
   dist_eqv := dist_equiv
   equiv_dist := by simp
   dist_lt {n x y m} := fun ⟨h₁, h₂⟩ hlt => by
-    constructor
+    refine ⟨?_, ?_⟩
     · intro a ha
       obtain ⟨b, hb, hd⟩ := h₁ a ha
       exact ⟨b, hb, OFE.Dist.lt hd hlt⟩
@@ -155,16 +155,16 @@ def valid (x : Raw α) : Prop := ∀ n, x.validN n
 
 theorem op_comm {x y : Raw α} : op x y ≡ op y x := by
   intro n; simp_all only [dist, op, List.mem_append]
-  constructor <;> exact fun _ ha => ⟨_, ha.symm, .rfl⟩
+  refine ⟨?_, ?_⟩ <;> exact fun _ ha => ⟨_, ha.symm, .rfl⟩
 
 theorem op_commN {x y : Raw α} : op x y ≡{n}≡ op y x := op_comm n
 
 theorem op_assoc {x y z : Raw α} : op x (op y z) ≡ op (op x y) z := by
   intro n; simp_all only [dist, op, List.mem_append, List.append_assoc]
-  constructor <;> (intro a ha; exists a)
+  refine ⟨?_, ?_⟩ <;> (intro a ha; exists a)
 
 theorem idemp {x : Raw α} : op x x ≡ x := by
-  intro n; constructor <;> (intro a ha; exists a; simp_all [op])
+  intro n; refine ⟨?_, ?_⟩ <;> (intro a ha; exists a; simp_all [op])
 
 theorem validN_ne {x y : Raw α} : x ≡{n}≡ y → x.validN n → y.validN n := by
   simp only [OFE.Dist, dist, validN_iff, and_imp]
@@ -183,8 +183,9 @@ theorem validN_op_left {x y : Raw α} : (op x y).validN n → x.validN n := by
   exact fun h a ha b hb => h _ (.inl ha) _ (.inl hb)
 
 theorem op_ne {x : Raw α} : OFE.NonExpansive (op x) := by
-  constructor; simp only [OFE.Dist, dist, op, List.mem_append, and_imp]
-  intro n y₁ y₂ heq₁ heq₂; constructor
+  refine ⟨?_⟩
+  simp only [OFE.Dist, dist, op, List.mem_append, and_imp]
+  intro n y₁ y₂ heq₁ heq₂; refine ⟨?_, ?_⟩
   · rintro a (hx | hy)
     · exists a; simp [hx]
     · obtain ⟨b, hb, heq⟩ := heq₁ _ hy
@@ -195,13 +196,12 @@ theorem op_ne {x : Raw α} : OFE.NonExpansive (op x) := by
       exists b; simp_all
 
 theorem op_ne₂ : OFE.NonExpansive₂ (op (α := α)) := by
-  constructor
-  intro n x₁ x₂ hx y₁ y₂ hy
+  refine ⟨fun n x₁ x₂ hx y₁ y₂ hy => ?_⟩
   exact op_ne.ne hy |>.trans (op_comm n) |>.trans (op_ne.ne hx) |>.trans (op_comm n)
 
 theorem op_invN {x y : Raw α} : (op x y).validN n → x ≡{n}≡ y := by
   simp only [op, validN_iff, List.mem_append, OFE.Dist, dist]
-  intro h; constructor
+  intro h; refine ⟨?_, ?_⟩
   · intro a ha
     obtain ⟨b, hb⟩ := mem y
     exists b; simp_all
@@ -224,7 +224,7 @@ theorem toAgree_uninjN {x : Raw α} : x.validN n → ∃ a, dist n (toAgree a) x
   rw [validN_iff]
   obtain ⟨a, ha⟩ := mem x
   intro h; exists a
-  constructor <;> intros
+  refine ⟨?_, ?_⟩ <;> intros
   · exists a; simp_all [toAgree]
   · simp_all [toAgree]
 
@@ -232,7 +232,7 @@ theorem toAgree_uninj {x : Raw α} : x.valid → ∃ a, ∀ n, dist n (toAgree a
   simp only [valid, validN_iff]
   obtain ⟨a, ha⟩ := mem x
   intro h; exists a; intro n
-  constructor <;> intros
+  refine ⟨?_, ?_⟩ <;> intros
   · exists a; simp_all [toAgree]
   · simp_all [toAgree]
 
@@ -539,7 +539,7 @@ variable [OFE α]
 
 @[rocq_alias to_agree_ne]
 instance instNonExpansive_toAgree : OFE.NonExpansive (@toAgree α) where
-  ne n x₁ x₂ heq := by constructor <;> simp_all [Agree.Raw.toAgree]
+  ne n x₁ x₂ heq := by refine ⟨?_, ?_⟩ <;> simp_all [Agree.Raw.toAgree]
 
 #rocq_ignore to_agree_proper "Derivable from instNonExpansive_toAgree with NonExpansive.eqv"
 
@@ -583,7 +583,7 @@ instance (a : α) : CMRA.CoreId (toAgree a) where
 
 @[simp, rocq_alias to_agree_includedN]
 theorem toAgree_includedN {a b : α} : toAgree a ≼{n} toAgree b ↔ a ≡{n}≡ b := by
-  constructor <;> intro h
+  refine ⟨?_, ?_⟩ <;> intro h
   · exact toAgree_injN (valid_includedN trivial h)
   · exists toAgree a
     calc
@@ -592,7 +592,7 @@ theorem toAgree_includedN {a b : α} : toAgree a ≼{n} toAgree b ↔ a ≡{n}�
 
 @[simp, rocq_alias to_agree_included]
 theorem toAgree_included {a b : α} : toAgree a ≼ toAgree b ↔ a ≡ b := by
-  constructor <;> intro h
+  refine ⟨?_, ?_⟩ <;> intro h
   · exact toAgree_inj (valid_included (fun _ => trivial) h)
   · exists toAgree a
     calc
@@ -606,7 +606,7 @@ theorem toAgree_included_L [OFE.Leibniz α] {a b : α} :
 @[rocq_alias to_agree_op_validN]
 theorem toAgree_op_validN_iff_dist {a b : α} :
     ✓{n} (toAgree a • toAgree b) ↔ a ≡{n}≡ b := by
-  constructor <;> intro h
+  refine ⟨?_, ?_⟩ <;> intro h
   · exact toAgree_injN (op_invN h)
   · have heqv : toAgree a • toAgree b ≡{n}≡ toAgree a := calc
       toAgree a • toAgree b ≡{n}≡ toAgree a • toAgree a := (OFE.NonExpansive.ne h).symm.op_r
@@ -679,12 +679,11 @@ abbrev Agree.map_hom : (Agree α) -n> (Agree β) := CMRA.Hom.toHom (Agree.map f)
 
 @[rocq_alias agreeO_map_ne]
 theorem Agree.map_ne {f g : α → β} [OFE.NonExpansive f] [OFE.NonExpansive g] {x : Agree α}
-    (heq : ∀ a, f a ≡{n}≡ g a) : map f x ≡{n}≡ map g x := by
-  induction x with | _ x =>
-  rw [map_mk, map_mk]
-  refine dist_mk.mpr ⟨?_, ?_⟩ <;> simp only [Raw.map'_car, List.mem_map] <;> rintro _ ⟨a, ha, rfl⟩
-  · exact ⟨g a, ⟨a, ha, rfl⟩, heq a⟩
-  · exact ⟨f a, ⟨a, ha, rfl⟩, heq a⟩
+    (heq : ∀ a, f a ≡{n}≡ g a) : map f x ≡{n}≡ map g x :=
+  x.ind fun _ => by
+    refine dist_mk.mpr ⟨?_, ?_⟩ <;> simp only [Raw.map'_car, List.mem_map] <;> rintro _ ⟨a, ha, rfl⟩
+    · exact ⟨g a, ⟨a, ha, rfl⟩, heq a⟩
+    · exact ⟨f a, ⟨a, ha, rfl⟩, heq a⟩
 
 @[rocq_alias agree_map_ext]
 theorem Agree.agree_map_ext {f g : α → β} [OFE.NonExpansive f] [OFE.NonExpansive g] {x : Agree α}

--- a/Iris/Iris/Algebra/Agree.lean
+++ b/Iris/Iris/Algebra/Agree.lean
@@ -17,34 +17,28 @@ namespace Iris
 /-!
 # The agreement camera
 
-The agreement construction is built in two layers. The raw representation `Agree.Raw α` is a
-nonempty list of elements of `α`, together with the step-indexed relation `Agree.Raw.dist` that
-identifies two such lists when they have the same elements up to `≡{n}≡` (essentially, the old definition).
-
-The interface type `Agree α` is the quotient of `Agree.Raw α` by the relation
-`fun x y => ∀ n, Agree.Raw.dist n x y` (which is exactly the OFE equivalence). Quotienting by the
-OFE equivalence makes `≡` coincide with `=`, so `Agree α` is `OFE.Leibniz` by construction.
+`Agree.Raw α` is a nonempty list over `α`. `Agree α` is
+`Agree.Raw α` quotiented by having the same
+elements (i.e., a finite nonempty set).
+When `α` is an OFE, `Agree α` carries the Hausdorff distance.
 -/
 
 /-! ## The raw representation -/
 
 section Raw
 
-variable {α : Type u} {β : Type v}
+variable {α : Type u}
 
-structure Agree.Raw (α : Type u) where
+@[ext]
+structure Agree.Raw α where
   car : List α
   not_nil : car ≠ []
 attribute [simp] Agree.Raw.not_nil
 
 namespace Agree.Raw
 
-@[ext] theorem ext {x y : Raw α} (h : x.car = y.car) : x = y := by
-  cases x; cases y; cases h; rfl
-
 def toAgree (a : α) : Raw α := ⟨[a], by simp⟩
 
-@[rocq_alias elem_of_agree]
 theorem mem (x : Raw α) : ∃ a, a ∈ x.car := by
   rcases x with ⟨as, h⟩
   rcases as
@@ -59,11 +53,35 @@ def op (x y : Raw α) : Raw α :=
   ⟨x.car ++ y.car, List.append_ne_nil_of_left_ne_nil x.not_nil _⟩
 
 theorem map'_op {f : α → β} {x y : Raw α} : map' f (op x y) = op (map' f x) (map' f y) := by
-  apply ext; simp [op, map']
+  ext; simp [op, map']
+
+def SameElems (x y : Raw α) : Prop :=
+  (∀ a ∈ x.car, a ∈ y.car) ∧ (∀ b ∈ y.car, b ∈ x.car)
+
+theorem sameElems_equivalence : Equivalence (SameElems (α := α)) where
+  refl _ := ⟨fun _ h => h, fun _ h => h⟩
+  symm h := ⟨h.2, h.1⟩
+  trans h₁ h₂ := ⟨fun _ ha => h₂.1 _ (h₁.1 _ ha), fun _ hc => h₁.2 _ (h₂.2 _ hc)⟩
+
+instance instSetoid : Setoid (Raw α) := ⟨SameElems, sameElems_equivalence⟩
+
+theorem sameElems_def {x y : Raw α} : x ≈ y ↔ SameElems x y := .rfl
+
+theorem op_sameElems {a b c d : Raw α} (h₁ : SameElems a c) (h₂ : SameElems b d) :
+    SameElems (op a b) (op c d) := by
+  refine ⟨fun x hx => ?_, fun x hx => ?_⟩ <;> simp only [op, List.mem_append] at hx ⊢
+  · exact hx.imp (h₁.1 x) (h₂.1 x)
+  · exact hx.imp (h₁.2 x) (h₂.2 x)
+
+theorem map'_sameElems {f : α → β} {x y : Raw α} (h : SameElems x y) :
+    SameElems (map' f x) (map' f y) := by
+  refine ⟨fun a ha => ?_, fun a ha => ?_⟩ <;>
+  · simp only [map'_car, List.mem_map] at ha ⊢
+    obtain ⟨b, hb, rfl⟩ := ha
+    exact ⟨b, by first | exact h.1 _ hb | exact h.2 _ hb, rfl⟩
 
 variable [OFE α]
 
-@[rocq_alias agree_dist]
 def dist (n : Nat) (x y : Raw α) : Prop :=
   (∀ a ∈ x.car, ∃ b ∈ y.car, a ≡{n}≡ b) ∧
   (∀ b ∈ y.car, ∃ a ∈ x.car, a ≡{n}≡ b)
@@ -112,15 +130,26 @@ theorem dist_lt {x y : Raw α} (h : dist n x y) (hlt : m < n) : dist m x y :=
 theorem equiv_def {x y : Raw α} : x ≡ y ↔ ∀ n, dist n x y := .rfl
 theorem dist_def {x y : Raw α} : x ≡{n}≡ y ↔ dist n x y := .rfl
 
+theorem dist_congr {a b c d : Raw α} (hac : SameElems a c) (hbd : SameElems b d) :
+    dist n a b ↔ dist n c d :=
+  have imp {a b c d : Raw α} (hac : SameElems a c) (hbd : SameElems b d) : dist n a b → dist n c d :=
+    fun h => ⟨fun x hx => (h.1 x (hac.2 x hx)).imp fun _ p => ⟨hbd.1 _ p.1, p.2⟩,
+              fun y hy => (h.2 y (hbd.2 y hy)).imp fun _ p => ⟨hac.1 _ p.1, p.2⟩⟩
+  ⟨imp hac hbd, imp (sameElems_equivalence.symm hac) (sameElems_equivalence.symm hbd)⟩
+
 def validN (n : Nat) (x : Raw α) : Prop :=
   match x.car with
   | [_] => True
   | _ => ∀ a ∈ x.car, ∀ b ∈ x.car, a ≡{n}≡ b
 
-@[rocq_alias agree_validN_def]
 theorem validN_iff {x : Raw α} :
     x.validN n ↔ ∀ a ∈ x.car, ∀ b ∈ x.car, a ≡{n}≡ b := by
   rcases x with ⟨⟨⟩ | ⟨a, ⟨⟩| _⟩, _⟩ <;> simp_all [validN, OFE.Dist.rfl]
+
+theorem validN_congr {x y : Raw α} (h : SameElems x y) : validN n x ↔ validN n y := by
+  simp only [validN_iff]
+  exact ⟨fun hv a ha b hb => hv a (h.2 a ha) b (h.2 b hb),
+         fun hv a ha b hb => hv a (h.1 a ha) b (h.1 b hb)⟩
 
 def valid (x : Raw α) : Prop := ∀ n, x.validN n
 
@@ -247,6 +276,29 @@ theorem toAgree_discrete {a : α} [Ha : OFE.DiscreteE a] {y : Raw α}
     rw [show x = a from by simpa [toAgree] using hx] at hd
     exact ⟨a, by simp [toAgree], (Ha.discrete hd).dist⟩
 
+theorem exists_forall_dist {a : α} {l : List α}
+    (h : ∀ n, ∃ b ∈ l, a ≡{n}≡ b) : ∃ b ∈ l, ∀ n, a ≡{n}≡ b := by
+  induction l with
+  | nil => simpa using h 0
+  | cons c l ih =>
+    by_cases hc : ∀ n, a ≡{n}≡ c
+    · exact ⟨c, List.mem_cons_self, hc⟩
+    · obtain ⟨n₀, hn₀⟩ := Classical.not_forall.mp hc
+      have hl : ∀ n, ∃ b ∈ l, a ≡{n}≡ b := fun n => by
+        obtain ⟨b, hb, hd⟩ := h (max n n₀)
+        rcases List.mem_cons.mp hb with rfl | hb'
+        · exact absurd (hd.le (Nat.le_max_right n n₀)) hn₀
+        · exact ⟨b, hb', hd.le (Nat.le_max_left n n₀)⟩
+      obtain ⟨b, hb, hd⟩ := ih hl
+      exact ⟨b, List.mem_cons_of_mem _ hb, hd⟩
+
+theorem sameElems_of_dist [OFE.Leibniz α] {x y : Raw α} (h : ∀ n, dist n x y) : SameElems x y :=
+  have key : ∀ {x y : Raw α}, (∀ n, dist n x y) → ∀ a ∈ x.car, a ∈ y.car := by
+    intro x y h a ha
+    obtain ⟨b, hb, hd⟩ := exists_forall_dist (fun n => (h n).1 a ha)
+    exact OFE.Leibniz.eq_of_eqv (OFE.equiv_dist.mpr hd) ▸ hb
+  ⟨key h, key (fun n => Raw.dist_equiv.symm (h n))⟩
+
 end Agree.Raw
 
 end Raw
@@ -256,64 +308,94 @@ section Quotient
 open OFE
 open Agree (Raw)
 
-variable {α : Type u} {β : Type v} [OFE α] [OFE β]
+variable {α : Type u}
 
-instance instRawSetoid : Setoid (Raw α) :=
-  QuotientO Raw.dist fun {_} => Raw.dist_equiv
-
-/--
-EXPERIMENT: Leibniz Agree.
-https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/Evaluating.20a.20specialization.20to.20Leibnize.20OFE.27s/with/606745235
-
-Note that the Rocq version of Agree does not require that the agreement type be an OFE. The
-typeclass addition here is trivial: if your [α] type was _not_ an OFE then you should instanstiate
-it with the trivial one. If your type already has a _different_ OFE, and you want agreement
-over the equality relation rather than your OFE equivalence, you should introduce a wrapper type
-with the trivial OFE.
---/
 @[rocq_alias agree]
-def Agree (α : Type u) [OFE α] : Type u := Quotient (instRawSetoid (α := α))
+def Agree (α : Type u) : Type u := Quotient (Raw.instSetoid (α := α))
 
 namespace Agree
 
-def mk (x : Raw α) : Agree α := mkQuotient.mk (heqv := Raw.dist_equiv) x
+def mk (x : Raw α) : Agree α := Quotient.mk _ x
 
 @[elab_as_elim, induction_eliminator]
 theorem ind {motive : Agree α → Prop} (mk : ∀ x : Raw α, motive (Agree.mk x)) (x : Agree α) :
-    motive x := mkQuotient.ind mk x
+    motive x := Quotient.ind mk x
 
-theorem sound {x y : Raw α} (h : ∀ n, Raw.dist n x y) : mk x = mk y := mkQuotient.sound h
+theorem sound {x y : Raw α} (h : Raw.SameElems x y) : mk x = mk y := Quotient.sound h
 
-theorem validN_resp {n} {x y : Raw α} (h : x ≈ y) : Raw.validN n x = Raw.validN n y :=
-  propext ⟨Raw.validN_ne (h n), Raw.validN_ne (Raw.dist_equiv.symm (h n))⟩
+theorem exact {x y : Raw α} (h : mk x = mk y) : Raw.SameElems x y := Quotient.exact h
 
-theorem valid_resp {x y : Raw α} (h : x ≈ y) : Raw.valid x = Raw.valid y := by
-  simp only [Raw.valid, validN_resp h]
+theorem mk_eq {x y : Raw α} : mk x = mk y ↔ Raw.SameElems x y := ⟨exact, sound⟩
+
+def lift {γ : Sort w} (f : Raw α → γ) (resp : ∀ x y, Raw.SameElems x y → f x = f y) :
+    Agree α → γ := Quotient.lift f resp
+
+def lift₂ {γ : Sort w} (f : Raw α → Raw α → γ)
+    (resp : ∀ a b c d, Raw.SameElems a c → Raw.SameElems b d → f a b = f c d) :
+    Agree α → Agree α → γ := Quotient.lift₂ f resp
+
+@[simp] theorem lift_mk {γ : Sort w} (f : Raw α → γ) (resp) (x : Raw α) :
+    lift f resp (mk x) = f x := rfl
+@[simp] theorem lift₂_mk {γ : Sort w} (f) (resp) (x y : Raw α) :
+    lift₂ (γ := γ) f resp (mk x) (mk y) = f x y := rfl
+
+def op : Agree α → Agree α → Agree α :=
+  lift₂ (fun x y => mk (Raw.op x y))
+    (fun _ _ _ _ hac hbd => sound (Raw.op_sameElems hac hbd))
+
+@[simp] theorem op_mk {x y : Raw α} : op (mk x) (mk y) = mk (Raw.op x y) := rfl
+
+instance : Membership α (Agree α) where
+  mem x a := lift (a ∈ ·.car) (fun _ _ h => propext ⟨(h.1 a ·), (h.2 a ·)⟩) x
+
+@[simp] theorem mem_mk {a : α} {x : Raw α} : a ∈ mk x ↔ a ∈ x.car := .rfl
+
+@[rocq_alias elem_of_agree]
+theorem mem_of_agree (x : Agree α) : ∃ a, a ∈ x := x.ind fun r => Raw.mem r
+
+end Agree
+
+namespace Agree
+
+variable [OFE α] [OFE β]
+
+@[rocq_alias agree_dist]
+def dist (n : Nat) : Agree α → Agree α → Prop :=
+  lift₂ (Raw.dist n) (fun _ _ _ _ hac hbd => propext (Raw.dist_congr hac hbd))
 
 @[rocq_alias agree_ofe_mixin]
-instance instOFE : OFE (Agree α) :=
-  OFE.mkQuotient Raw.dist Raw.dist_equiv Raw.dist_lt
+instance instOFE : OFE (Agree α) where
+  Dist := dist
+  Equiv x y := ∀ n, dist n x y
+  dist_eqv := by
+    refine ⟨Quotient.ind fun a => Raw.dist_equiv.refl a, fun {x y} h => ?_, fun {x y z} h₁ h₂ => ?_⟩
+    · induction x, y using Quotient.ind₂ with | _ a b => exact Raw.dist_equiv.symm h
+    · induction x, y using Quotient.ind₂ with | _ a b =>
+        induction z using Quotient.ind with | _ c => exact Raw.dist_equiv.trans h₁ h₂
+  equiv_dist := Iff.rfl
+  dist_lt := fun {n x y m} h hlt => by
+    induction x, y using Quotient.ind₂ with | _ a b => exact Raw.dist_lt h hlt
 
 #rocq_ignore agreeO "Use Agree with a typeclass instance instead."
 #rocq_ignore agree_equiv "Defined in Agree OFE instance."
 
-instance instLeibniz : OFE.Leibniz (Agree α) :=
-  OFE.mkQuotient_leibniz Raw.dist Raw.dist_equiv Raw.dist_lt
+instance instLeibniz [OFE.Leibniz α] : OFE.Leibniz (Agree α) where
+  eq_of_eqv {x y} := Quotient.inductionOn₂ x y fun _ _ h => sound (Raw.sameElems_of_dist h)
 
 def validN (n : Nat) : Agree α → Prop :=
-  mkQuotient.lift (heqv := Raw.dist_equiv) (Raw.validN n) (fun _ _ h => validN_resp h)
+  lift (Raw.validN n) (fun _ _ h => propext (Raw.validN_congr h))
+
+@[rocq_alias agree_validN_def]
+theorem validN_iff {x : Agree α} : validN n x ↔ ∀ a ∈ x, ∀ b ∈ x, a ≡{n}≡ b :=
+  x.ind fun _ => Raw.validN_iff
 
 def valid : Agree α → Prop :=
-  mkQuotient.lift (heqv := Raw.dist_equiv) Raw.valid (fun _ _ h => valid_resp h)
-
-def op : Agree α → Agree α → Agree α :=
-  mkQuotient.lift₂ (heqv := Raw.dist_equiv) (fun x y => mk (Raw.op x y))
-    (fun _ _ _ _ hx hy => sound fun n => Raw.op_ne₂.ne (hx n) (hy n))
+  lift Raw.valid fun _ _ h => propext
+    ⟨fun hv m => (Raw.validN_congr h).mp (hv m), fun hv m => (Raw.validN_congr h).mpr (hv m)⟩
 
 @[simp] theorem dist_mk {n} {x y : Raw α} : mk x ≡{n}≡ mk y ↔ Raw.dist n x y := .rfl
 @[simp] theorem validN_mk {n} {x : Raw α} : validN n (mk x) ↔ x.validN n := .rfl
 @[simp] theorem valid_mk {x : Raw α} : valid (mk x) ↔ x.valid := .rfl
-@[simp] theorem op_mk {x y : Raw α} : op (mk x) (mk y) = mk (Raw.op x y) := rfl
 
 @[rocq_alias agree_comm]
 theorem op_comm {x y : Agree α} : op x y ≡ op y x :=
@@ -446,15 +528,17 @@ instance {x : Agree α} : IsOp io1 x io2 x io3 x where
 
 end Agree
 
-/-! ## `toAgree` -/
-
 @[rocq_alias to_agree]
 def toAgree (a : α) : Agree α := Agree.mk (Agree.Raw.toAgree a)
 
 theorem toAgree_def {a : α} : toAgree a = Agree.mk (Agree.Raw.toAgree a) := rfl
 
+section
+
+variable [OFE α]
+
 @[rocq_alias to_agree_ne]
-instance instNonExpansive_toAgree : OFE.NonExpansive (@toAgree α _) where
+instance instNonExpansive_toAgree : OFE.NonExpansive (@toAgree α) where
   ne n x₁ x₂ heq := by constructor <;> simp_all [Agree.Raw.toAgree]
 
 #rocq_ignore to_agree_proper "Derivable from instNonExpansive_toAgree with NonExpansive.eqv"
@@ -545,23 +629,32 @@ theorem toAgree_op_valid_iff_eq [OFE.Leibniz α] {a : α} :
 
 #rocq_ignore to_agree_op_inv_L "Use toAgree_op_valid_iff_eq"
 
+end
+
 end Quotient
 
 /-! ## Functoriality -/
 
 section agree_map
 
-variable {α β γ : Type _} [OFE α] [OFE β] [OFE γ] {f : α → β} [hne : OFE.NonExpansive f]
-
 open Agree (Raw)
 
 @[rocq_alias agree_map]
-def Agree.map' (f : α → β) [OFE.NonExpansive f] : Agree α → Agree β :=
-  OFE.mkQuotient.map (heqv := Raw.dist_equiv) (heqv' := Raw.dist_equiv) (Raw.map' f)
-    (fun _ _ _ h => Raw.instNonExpansiveMap'.ne h)
+def Agree.map' (f : α → β) : Agree α → Agree β :=
+  Agree.lift (fun x => Agree.mk (Raw.map' f x))
+    (fun _ _ h => Agree.sound (Raw.map'_sameElems h))
 
-@[simp] theorem Agree.map'_mk (f : α → β) [OFE.NonExpansive f] {x : Raw α} :
+@[simp] theorem Agree.map'_mk (f : α → β) {x : Raw α} :
     Agree.map' f (Agree.mk x) = Agree.mk (Raw.map' f x) := rfl
+
+@[simp] theorem Agree.map'_id (x : Agree α) : Agree.map' id x = x :=
+  x.ind fun _ => congrArg mk (Raw.ext (by simp [Raw.map'_car]))
+
+theorem Agree.map'_compose {f : α → β} {g : β → γ} (x : Agree α) :
+    Agree.map' (g ∘ f) x = Agree.map' g (Agree.map' f x) :=
+  x.ind fun _ => congrArg mk (Raw.ext (by simp [Raw.map'_car, List.map_map]))
+
+variable {α β γ : Type _} [OFE α] [OFE β] [OFE γ] {f : α → β} [hne : OFE.NonExpansive f]
 
 @[rocq_alias agree_map_ne]
 instance instNonExpansive_AgreeMap' : OFE.NonExpansive (Agree.map' f) where
@@ -580,14 +673,6 @@ def Agree.map : (Agree α) -C> (Agree β) where
 
 @[simp] theorem Agree.map_mk (f : α → β) [OFE.NonExpansive f] (x : Raw α) :
     Agree.map f (mk x) = mk (Raw.map' f x) := rfl
-
-@[simp] theorem Agree.map'_id (x : Agree α) : Agree.map' id x = x :=
-  x.ind fun _ => congrArg mk (Raw.ext (by simp [Raw.map'_car]))
-
-theorem Agree.map'_compose {f : α → β} {g : β → γ}
-    [OFE.NonExpansive f] [OFE.NonExpansive g] [OFE.NonExpansive (g ∘ f)] (x : Agree α) :
-    Agree.map' (g ∘ f) x = Agree.map' g (Agree.map' f x) :=
-  x.ind fun _ => congrArg mk (Raw.ext (by simp [Raw.map'_car, List.map_map]))
 
 @[rocq_alias agreeO_map]
 abbrev Agree.map_hom : (Agree α) -n> (Agree β) := CMRA.Hom.toHom (Agree.map f)
@@ -615,9 +700,6 @@ theorem Agree.map_compose (f : α -n> β) (g : β -n> γ) (x : Agree α) :
     Agree.map (g.comp f) x = Agree.map g (Agree.map f x) :=
   x.ind fun _ => congrArg mk (Raw.ext (by simp [Raw.map'_car, OFE.Hom.comp, List.map_map]))
 
-theorem toAgree.incN {a b : α} {n} : toAgree a ≼{n} toAgree b ↔ a ≡{n}≡ b :=
-  Agree.toAgree_includedN
-
 @[rocq_alias agree_map_to_agree]
 theorem Agree.map_toAgree {x : α} : Agree.map f (toAgree x) = toAgree (f x) :=
   congrArg mk (Raw.ext rfl)
@@ -627,7 +709,7 @@ end agree_map
 section agree_rfunctor
 
 @[rocq_alias agreeRF]
-abbrev AgreeRF (F : COFE.OFunctorPre) [COFE.OFunctor F] : COFE.OFunctorPre :=
+abbrev AgreeRF (F : COFE.OFunctorPre) : COFE.OFunctorPre :=
   fun A B _ _ => Agree (F A B)
 
 instance {F} [COFE.OFunctor F] : RFunctor (AgreeRF F) where
@@ -645,7 +727,8 @@ instance {F} [COFE.OFunctor F] : RFunctor (AgreeRF F) where
 instance {F} [COFE.OFunctorContractive F] : RFunctorContractive (AgreeRF F) where
   map_contractive.1 H _ := Agree.map_ne (COFE.OFunctorContractive.map_contractive.1 H)
 
-instance {F} [COFE.OFunctor F] : Leibniz.LeibnizPreservingOFunctor (AgreeRF F) where
+instance {F} [COFE.OFunctor F] [Leibniz.LeibnizPreservingOFunctor F] :
+    Leibniz.LeibnizPreservingOFunctor (AgreeRF F) where
   preserves_leibniz := Agree.instLeibniz
 
 end agree_rfunctor

--- a/Iris/Iris/Algebra/Agree.lean
+++ b/Iris/Iris/Algebra/Agree.lean
@@ -259,12 +259,8 @@ variable {α : Type u} {β : Type v} [OFE α] [OFE β]
 
 open Agree (Raw)
 
-instance Agree.Raw.instSetoid : Setoid (Raw α) where
-  r x y := ∀ n, Raw.dist n x y
-  iseqv :=
-    ⟨fun _ _ => Raw.dist_equiv.refl _,
-     fun h n => Raw.dist_equiv.symm (h n),
-     fun h₁ h₂ n => Raw.dist_equiv.trans (h₁ n) (h₂ n)⟩
+instance Agree.Raw.instSetoid : Setoid (Raw α) :=
+  OFE.distSetoid Raw.dist fun _ => Raw.dist_equiv
 
 @[rocq_alias agree]
 def Agree (α : Type u) [OFE α] : Type u := Quotient (Agree.Raw.instSetoid (α := α))
@@ -279,20 +275,21 @@ theorem ind {motive : Agree α → Prop} (mk : ∀ x : Raw α, motive (Agree.mk 
 
 theorem sound {x y : Raw α} (h : ∀ n, Raw.dist n x y) : mk x = mk y := Quotient.sound h
 
-theorem dist_resp {n} {x x' y y' : Raw α} (hx : x ≈ x') (hy : y ≈ y') :
-    Raw.dist n x y = Raw.dist n x' y' := by
-  refine propext ⟨fun h => ?_, fun h => ?_⟩
-  · exact Raw.dist_equiv.trans (Raw.dist_equiv.trans (Raw.dist_equiv.symm (hx n)) h) (hy n)
-  · exact Raw.dist_equiv.trans (Raw.dist_equiv.trans (hx n) h) (Raw.dist_equiv.symm (hy n))
-
 theorem validN_resp {n} {x y : Raw α} (h : x ≈ y) : Raw.validN n x = Raw.validN n y :=
   propext ⟨Raw.validN_ne (h n), Raw.validN_ne (Raw.dist_equiv.symm (h n))⟩
 
 theorem valid_resp {x y : Raw α} (h : x ≈ y) : Raw.valid x = Raw.valid y := by
   simp only [Raw.valid, validN_resp h]
 
-def dist (n : Nat) : Agree α → Agree α → Prop :=
-  Quotient.lift₂ (Raw.dist n) (fun _ _ _ _ hx hy => dist_resp hx hy)
+@[rocq_alias agree_ofe_mixin]
+instance instOFE : OFE (Agree α) :=
+  OFE.mkLeibniz Raw.dist (fun _ => Raw.dist_equiv) (fun h hlt => Raw.dist_lt h hlt)
+
+#rocq_ignore agreeO "Use Agree with a typeclass instance instead."
+#rocq_ignore agree_equiv "Defined in Agree OFE instance."
+
+instance instLeibniz : OFE.Leibniz (Agree α) :=
+  OFE.mkLeibniz_leibniz Raw.dist (fun _ => Raw.dist_equiv) (fun h hlt => Raw.dist_lt h hlt)
 
 def validN (n : Nat) : Agree α → Prop := Quotient.lift (Raw.validN n) (fun _ _ h => validN_resp h)
 
@@ -302,36 +299,10 @@ def op : Agree α → Agree α → Agree α :=
   Quotient.lift₂ (fun x y => mk (Raw.op x y))
     (fun _ _ _ _ hx hy => sound fun n => Raw.op_ne₂.ne (hx n) (hy n))
 
-@[simp] theorem dist_mk {n} {x y : Raw α} : dist n (mk x) (mk y) ↔ Raw.dist n x y := .rfl
+@[simp] theorem dist_mk {n} {x y : Raw α} : mk x ≡{n}≡ mk y ↔ Raw.dist n x y := .rfl
 @[simp] theorem validN_mk {n} {x : Raw α} : validN n (mk x) ↔ x.validN n := .rfl
 @[simp] theorem valid_mk {x : Raw α} : valid (mk x) ↔ x.valid := .rfl
 @[simp] theorem op_mk {x y : Raw α} : op (mk x) (mk y) = mk (Raw.op x y) := rfl
-
-theorem dist_equiv : Equivalence (dist (α := α) n) where
-  refl x := by induction x with | _ x => exact Raw.dist_equiv.refl x
-  symm {x y} h := by induction x with | _ x => induction y with | _ y => exact Raw.dist_equiv.symm h
-  trans {x y z} h₁ h₂ := by
-    induction x with | _ x => induction y with | _ y => induction z with | _ z =>
-    exact Raw.dist_equiv.trans h₁ h₂
-
-@[rocq_alias agree_ofe_mixin]
-instance instOFE : OFE (Agree α) where
-  Equiv x y := ∀ n, dist n x y
-  Dist := dist
-  dist_eqv := dist_equiv
-  equiv_dist := Iff.rfl
-  dist_lt {n x y m} h hlt := by
-    induction x with | _ x => induction y with | _ y => exact Raw.dist_lt h hlt
-
-#rocq_ignore agreeO "Use Agree with a typeclass instance instead."
-#rocq_ignore agree_equiv "Defined in Agree OFE instance."
-
-theorem equiv_def {x y : Agree α} : x ≡ y ↔ ∀ n, dist n x y := .rfl
-theorem dist_def {x y : Agree α} : x ≡{n}≡ y ↔ dist n x y := .rfl
-
-instance instLeibniz : OFE.Leibniz (Agree α) where
-  eq_of_eqv {x y} h := by
-    induction x with | _ x => induction y with | _ y => exact sound fun n => h n
 
 @[rocq_alias agree_comm]
 theorem op_comm {x y : Agree α} : op x y ≡ op y x := by

--- a/Iris/Iris/Algebra/Auth.lean
+++ b/Iris/Iris/Algebra/Auth.lean
@@ -74,6 +74,7 @@ variable [UCMRA A]
 instance : OFE (Auth A) := View.instOFE
 instance : CMRA (Auth A) := View.instCMRA
 instance : UCMRA (Auth A) := View.instUCMRA
+instance instLeibniz [Leibniz A] : Leibniz (Auth A) := View.instLeibniz
 
 #rocq_ignore authO "Use the Auth type and View.instOFE typeclass"
 #rocq_ignore authR "Use the Auth type and View.instCMRA typeclass"

--- a/Iris/Iris/Algebra/Lib/DFracAgree.lean
+++ b/Iris/Iris/Algebra/Lib/DFracAgree.lean
@@ -101,7 +101,7 @@ theorem includedN {d₁ d₂ : DFrac} {a₁ a₂ : A} :
     exact ⟨(inc_iff_incN (α := DFrac) n).mpr ⟨zd, hd⟩, Agree.toAgree_includedN.mp ⟨za, ha⟩⟩
   · rintro ⟨hdinc, ha⟩
     obtain ⟨zd, hd⟩ := (inc_iff_incN (α := DFrac) n).mp hdinc
-    exact ⟨(zd, toAgree a₁), hd, (NonExpansive.ne ha.symm).trans (Equiv.dist Agree.idemp.symm)⟩
+    exact ⟨(zd, toAgree a₁), hd, (toAgree.ne.ne ha.symm).trans (Equiv.dist Agree.idemp.symm)⟩
 
 @[rocq_alias dfrac_agree_update_2]
 theorem update₂ {d₁ d₂ : DFrac} {a₁ a₂ a' : A} (hd : d₁ • d₂ = .own 1) :

--- a/Iris/Iris/Algebra/Lib/DFracAgree.lean
+++ b/Iris/Iris/Algebra/Lib/DFracAgree.lean
@@ -30,6 +30,8 @@ def mk [OFE A] (d : DFrac) (a : A) : DFracAgreeR A := (d, toAgree a)
 
 variable {A : Type _} [OFE A]
 
+instance instLeibniz : Leibniz (DFracAgreeR A) := inferInstance
+
 @[rocq_alias to_dfrac_agree_ne]
 instance mk_ne {d : DFrac} : NonExpansive (mk d : A → DFracAgreeR A) where
   ne _ _ _ h := ⟨.rfl, NonExpansive.ne (f := toAgree) h⟩

--- a/Iris/Iris/Algebra/Lib/DFracAgree.lean
+++ b/Iris/Iris/Algebra/Lib/DFracAgree.lean
@@ -30,7 +30,7 @@ def mk [OFE A] (d : DFrac) (a : A) : DFracAgreeR A := (d, toAgree a)
 
 variable {A : Type _} [OFE A]
 
-instance instLeibniz : Leibniz (DFracAgreeR A) := inferInstance
+instance instLeibniz [Leibniz A] : Leibniz (DFracAgreeR A) := inferInstance
 
 @[rocq_alias to_dfrac_agree_ne]
 instance mk_ne {d : DFrac} : NonExpansive (mk d : A → DFracAgreeR A) where

--- a/Iris/Iris/Algebra/Lib/ExclAuth.lean
+++ b/Iris/Iris/Algebra/Lib/ExclAuth.lean
@@ -31,6 +31,8 @@ public abbrev ExclAuthR := Auth (Option (Excl A))
 @[rocq_alias excl_authUR]
 public abbrev ExclAuthUR := Auth (Option (Excl A))
 
+instance instLeibniz [Leibniz A] : Leibniz (ExclAuthR (A := A)) := inferInstance
+
 @[rocq_alias excl_auth_auth]
 public abbrev auth (a : A) : ExclAuthR (A := A) := ● (some (excl a))
 

--- a/Iris/Iris/Algebra/Lib/FracAuth.lean
+++ b/Iris/Iris/Algebra/Lib/FracAuth.lean
@@ -30,6 +30,8 @@ namespace FracAuth
 
 variable [CMRA A]
 
+instance instLeibniz [Leibniz A] : Leibniz (FracAuth (A := A)) := inferInstance
+
 @[rocq_alias frac_auth_auth]
 public abbrev auth (dq : DFrac) (a : A) : FracAuth (A := A) := Auth.auth dq (some (1, a))
 

--- a/Iris/Iris/Algebra/OFE.lean
+++ b/Iris/Iris/Algebra/OFE.lean
@@ -250,46 +250,96 @@ export OFE.Leibniz (leibniz)
 
 /-- The setoid on `X` identifying points that agree at every step index:
 `x ≈ y ↔ ∀ n, dist n x y`. -/
-def distSetoid {X : Type u} (dist : Nat → X → X → Prop) (heqv : ∀ n, Equivalence (dist n)) :
+@[reducible]
+def QuotientO {X : Type u} (dist : Nat → X → X → Prop) (heqv : ∀ {n}, Equivalence (dist n)) :
     Setoid X where
   r x y := ∀ n, dist n x y
   iseqv :=
-    ⟨fun _ _ => (heqv _).refl _,
-     fun h n => (heqv _).symm (h n),
-     fun h₁ h₂ n => (heqv _).trans (h₁ n) (h₂ n)⟩
+    ⟨fun _ _ => heqv.refl _,
+     fun h n => heqv.symm (h n),
+     fun h₁ h₂ n => heqv.trans (h₁ n) (h₂ n)⟩
 
-/-- Build a `Leibniz` OFE from a step-indexed distance `dist` satisfying the OFE distance axioms
+/--
+EXPERIMENT: Explicit use of quotients to force quotiented (by Equiv) OFE to be Leibniz by quotienting by propositional equality.
+https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/Evaluating.20a.20specialization.20to.20Leibnize.20OFE.27s/with/606745235
+
+Build a `Leibniz` OFE from a step-indexed distance `dist` satisfying the OFE distance axioms
 by quotienting the carrier `X` by the OFE equivalence `fun x y => ∀ n, dist n x y`. -/
-@[reducible] def mkLeibniz {X : Type u} (dist : Nat → X → X → Prop) (heqv : ∀ n, Equivalence (dist n))
+@[reducible] def mkQuotient {X : Type u} (dist : Nat → X → X → Prop) (heqv : ∀ {n}, Equivalence (dist n))
     (hlt : ∀ {n m : Nat} {x y : X}, dist n x y → m < n → dist m x y) :
-    OFE (Quotient (distSetoid dist heqv)) :=
-  let D : Nat → Quotient (distSetoid dist heqv) → Quotient (distSetoid dist heqv) → Prop :=
+    OFE (Quotient (QuotientO dist heqv)) :=
+  letI D : Nat → Quotient (QuotientO dist heqv) → Quotient (QuotientO dist heqv) → Prop :=
     fun n => Quotient.lift₂ (dist n) fun _ _ _ _ hac hbd => propext
-      ⟨fun h => (heqv n).trans ((heqv n).trans ((heqv n).symm (hac n)) h) (hbd n),
-       fun h => (heqv n).trans ((heqv n).trans (hac n) h) ((heqv n).symm (hbd n))⟩
+      ⟨fun h => heqv.trans (heqv.trans (heqv.symm (hac n)) h) (hbd n),
+       fun h => heqv.trans (heqv.trans (hac n) h) (heqv.symm (hbd n))⟩
   { Dist := D
     Equiv x y := ∀ n, D n x y
     dist_eqv := by
       refine ⟨fun x => ?_, fun {x y} h => ?_, fun {x y z} h₁ h₂ => ?_⟩
-      · induction x using Quotient.ind with | _ a => exact (heqv _).refl a
+      · induction x using Quotient.ind with | _ a => exact heqv.refl a
       · induction x using Quotient.ind with | _ a =>
-        induction y using Quotient.ind with | _ b => exact (heqv _).symm h
+        induction y using Quotient.ind with | _ b => exact heqv.symm h
       · induction x using Quotient.ind with | _ a =>
         induction y using Quotient.ind with | _ b =>
-        induction z using Quotient.ind with | _ c => exact (heqv _).trans h₁ h₂
-    equiv_dist := Iff.rfl
+        induction z using Quotient.ind with | _ c => exact heqv.trans h₁ h₂
+    equiv_dist := .rfl
     dist_lt := fun {n x y m} h hlt' => by
       induction x using Quotient.ind with | _ a =>
       induction y using Quotient.ind with | _ b => exact hlt h hlt' }
 
-theorem mkLeibniz_leibniz {X : Type u} (dist : Nat → X → X → Prop)
-    (heqv : ∀ n, Equivalence (dist n))
+theorem mkQuotient_leibniz {X : Type u} (dist : Nat → X → X → Prop)
+    (heqv : ∀ {n}, Equivalence (dist n))
     (hlt : ∀ {n m : Nat} {x y : X}, dist n x y → m < n → dist m x y) :
-    @Leibniz _ (mkLeibniz dist heqv hlt) :=
-  letI := mkLeibniz dist heqv hlt
+    @Leibniz _ (mkQuotient dist heqv hlt) :=
+  letI := mkQuotient dist heqv hlt
   { eq_of_eqv := fun {x y} h => by
       induction x using Quotient.ind with | _ a =>
       induction y using Quotient.ind with | _ b => exact Quotient.sound h }
+
+namespace mkQuotient
+
+variable {X : Type u} {dist : Nat → X → X → Prop} {heqv : ∀ {n}, Equivalence (dist n)}
+
+@[reducible] def mk (x : X) : Quotient (QuotientO dist heqv) := Quotient.mk _ x
+
+@[elab_as_elim] theorem ind {motive : Quotient (QuotientO dist heqv) → Prop}
+    (h : ∀ x : X, motive (mk x)) (q : Quotient (QuotientO dist heqv)) : motive q :=
+  Quotient.ind h q
+
+theorem sound {x y : X} (h : ∀ n, dist n x y) :
+    (mk x : Quotient (QuotientO dist heqv)) = mk y := Quotient.sound h
+
+theorem mk_eq {x y : X} :
+    (mk x : Quotient (QuotientO dist heqv)) = mk y ↔ ∀ n, dist n x y :=
+  ⟨Quotient.exact, sound⟩
+
+@[reducible] def lift {β : Sort v} (f : X → β)
+    (resp : ∀ x y, (∀ n, dist n x y) → f x = f y) :
+    Quotient (QuotientO dist heqv) → β := Quotient.lift f resp
+
+@[simp] theorem lift_mk {β : Sort v} (f : X → β) (resp) (x : X) :
+    lift (dist := dist) (heqv := heqv) f resp (mk x) = f x := rfl
+
+@[reducible] def lift₂ {β : Sort v} (f : X → X → β)
+    (resp : ∀ a b c d, (∀ n, dist n a c) → (∀ n, dist n b d) → f a b = f c d) :
+    Quotient (QuotientO dist heqv) → Quotient (QuotientO dist heqv) → β := Quotient.lift₂ f resp
+
+@[simp] theorem lift₂_mk {β : Sort v} (f : X → X → β) (resp) (x y : X) :
+    lift₂ (dist := dist) (heqv := heqv) f resp (mk x) (mk y) = f x y := rfl
+
+@[reducible] def map {X' : Type u'} {dist' : Nat → X' → X' → Prop} {heqv' : ∀ {n}, Equivalence (dist' n)}
+    (f : X → X') (hf : ∀ n x y, dist n x y → dist' n (f x) (f y)) :
+    Quotient (QuotientO dist heqv) → Quotient (QuotientO dist' heqv') :=
+  Quotient.lift (fun x => mk (f x)) (fun _ _ h => Quotient.sound fun n => hf n _ _ (h n))
+
+@[simp] theorem map_mk {X' : Type u'} {dist' : Nat → X' → X' → Prop}
+    {heqv' : ∀ {n}, Equivalence (dist' n)} (f : X → X') (hf) (x : X) :
+    map (dist := dist) (heqv := heqv) (dist' := dist') (heqv' := heqv') f hf (mk x) = mk (f x) := rfl
+
+theorem dist_mk {hlt : ∀ {n m : Nat} {x y : X}, dist n x y → m < n → dist m x y}
+    {n} {x y : X} : (mkQuotient dist heqv hlt).Dist n (mk x) (mk y) ↔ dist n x y := Iff.rfl
+
+end mkQuotient
 
 /-- A morphism between OFEs, written `α -n> β`, is defined to be a function that is
 non-expansive. -/

--- a/Iris/Iris/Algebra/OFE.lean
+++ b/Iris/Iris/Algebra/OFE.lean
@@ -260,12 +260,14 @@ def QuotientO {X : Type u} (dist : Nat → X → X → Prop) (heqv : ∀ {n}, Eq
      fun h₁ h₂ n => heqv.trans (h₁ n) (h₂ n)⟩
 
 /--
-EXPERIMENT: Explicit use of quotients to force quotiented (by Equiv) OFE to be Leibniz by quotienting by propositional equality.
+EXPERIMENT: Explicit use of quotients to force quotiented (by Equiv) OFE to be Leibniz by
+quotienting by propositional equality.
 https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/Evaluating.20a.20specialization.20to.20Leibnize.20OFE.27s/with/606745235
 
 Build a `Leibniz` OFE from a step-indexed distance `dist` satisfying the OFE distance axioms
 by quotienting the carrier `X` by the OFE equivalence `fun x y => ∀ n, dist n x y`. -/
-@[reducible] def mkQuotient {X : Type u} (dist : Nat → X → X → Prop) (heqv : ∀ {n}, Equivalence (dist n))
+@[reducible] def mkQuotient {X : Type u} (dist : Nat → X → X → Prop)
+    (heqv : ∀ {n}, Equivalence (dist n))
     (hlt : ∀ {n m : Nat} {x y : X}, dist n x y → m < n → dist m x y) :
     OFE (Quotient (QuotientO dist heqv)) :=
   letI D : Nat → Quotient (QuotientO dist heqv) → Quotient (QuotientO dist heqv) → Prop :=
@@ -275,17 +277,13 @@ by quotienting the carrier `X` by the OFE equivalence `fun x y => ∀ n, dist n 
   { Dist := D
     Equiv x y := ∀ n, D n x y
     dist_eqv := by
-      refine ⟨fun x => ?_, fun {x y} h => ?_, fun {x y z} h₁ h₂ => ?_⟩
-      · induction x using Quotient.ind with | _ a => exact heqv.refl a
-      · induction x using Quotient.ind with | _ a =>
-        induction y using Quotient.ind with | _ b => exact heqv.symm h
-      · induction x using Quotient.ind with | _ a =>
-        induction y using Quotient.ind with | _ b =>
-        induction z using Quotient.ind with | _ c => exact heqv.trans h₁ h₂
+      refine ⟨Quotient.ind fun a => heqv.refl a, fun {x y} h => ?_, fun {x y z} h₁ h₂ => ?_⟩
+      · induction x, y using Quotient.ind₂ with | _ a b => exact heqv.symm h
+      · induction x, y using Quotient.ind₂ with | _ a b =>
+          induction z using Quotient.ind with | _ c => exact heqv.trans h₁ h₂
     equiv_dist := .rfl
     dist_lt := fun {n x y m} h hlt' => by
-      induction x using Quotient.ind with | _ a =>
-      induction y using Quotient.ind with | _ b => exact hlt h hlt' }
+      induction x, y using Quotient.ind₂ with | _ a b => exact hlt h hlt' }
 
 theorem mkQuotient_leibniz {X : Type u} (dist : Nat → X → X → Prop)
     (heqv : ∀ {n}, Equivalence (dist n))
@@ -293,8 +291,7 @@ theorem mkQuotient_leibniz {X : Type u} (dist : Nat → X → X → Prop)
     @Leibniz _ (mkQuotient dist heqv hlt) :=
   letI := mkQuotient dist heqv hlt
   { eq_of_eqv := fun {x y} h => by
-      induction x using Quotient.ind with | _ a =>
-      induction y using Quotient.ind with | _ b => exact Quotient.sound h }
+      induction x, y using Quotient.ind₂ with | _ a b => exact Quotient.sound h }
 
 namespace mkQuotient
 

--- a/Iris/Iris/Algebra/OFE.lean
+++ b/Iris/Iris/Algebra/OFE.lean
@@ -248,6 +248,49 @@ theorem Equiv.to_eq {α} [OFE α] [Leibniz α] {x y : α} (h : x ≡ y) : x = y 
   ⟨eq_of_eqv, .of_eq⟩
 export OFE.Leibniz (leibniz)
 
+/-- The setoid on `X` identifying points that agree at every step index:
+`x ≈ y ↔ ∀ n, dist n x y`. -/
+def distSetoid {X : Type u} (dist : Nat → X → X → Prop) (heqv : ∀ n, Equivalence (dist n)) :
+    Setoid X where
+  r x y := ∀ n, dist n x y
+  iseqv :=
+    ⟨fun _ _ => (heqv _).refl _,
+     fun h n => (heqv _).symm (h n),
+     fun h₁ h₂ n => (heqv _).trans (h₁ n) (h₂ n)⟩
+
+/-- Build a `Leibniz` OFE from a step-indexed distance `dist` satisfying the OFE distance axioms
+by quotienting the carrier `X` by the OFE equivalence `fun x y => ∀ n, dist n x y`. -/
+@[reducible] def mkLeibniz {X : Type u} (dist : Nat → X → X → Prop) (heqv : ∀ n, Equivalence (dist n))
+    (hlt : ∀ {n m : Nat} {x y : X}, dist n x y → m < n → dist m x y) :
+    OFE (Quotient (distSetoid dist heqv)) :=
+  let D : Nat → Quotient (distSetoid dist heqv) → Quotient (distSetoid dist heqv) → Prop :=
+    fun n => Quotient.lift₂ (dist n) fun _ _ _ _ hac hbd => propext
+      ⟨fun h => (heqv n).trans ((heqv n).trans ((heqv n).symm (hac n)) h) (hbd n),
+       fun h => (heqv n).trans ((heqv n).trans (hac n) h) ((heqv n).symm (hbd n))⟩
+  { Dist := D
+    Equiv x y := ∀ n, D n x y
+    dist_eqv := by
+      refine ⟨fun x => ?_, fun {x y} h => ?_, fun {x y z} h₁ h₂ => ?_⟩
+      · induction x using Quotient.ind with | _ a => exact (heqv _).refl a
+      · induction x using Quotient.ind with | _ a =>
+        induction y using Quotient.ind with | _ b => exact (heqv _).symm h
+      · induction x using Quotient.ind with | _ a =>
+        induction y using Quotient.ind with | _ b =>
+        induction z using Quotient.ind with | _ c => exact (heqv _).trans h₁ h₂
+    equiv_dist := Iff.rfl
+    dist_lt := fun {n x y m} h hlt' => by
+      induction x using Quotient.ind with | _ a =>
+      induction y using Quotient.ind with | _ b => exact hlt h hlt' }
+
+theorem mkLeibniz_leibniz {X : Type u} (dist : Nat → X → X → Prop)
+    (heqv : ∀ n, Equivalence (dist n))
+    (hlt : ∀ {n m : Nat} {x y : X}, dist n x y → m < n → dist m x y) :
+    @Leibniz _ (mkLeibniz dist heqv hlt) :=
+  letI := mkLeibniz dist heqv hlt
+  { eq_of_eqv := fun {x y} h => by
+      induction x using Quotient.ind with | _ a =>
+      induction y using Quotient.ind with | _ b => exact Quotient.sound h }
+
 /-- A morphism between OFEs, written `α -n> β`, is defined to be a function that is
 non-expansive. -/
 @[ext, rocq_alias ofe_mor] structure Hom (α β : Type _) [OFE α] [OFE β] where

--- a/Iris/Iris/Algebra/View.lean
+++ b/Iris/Iris/Algebra/View.lean
@@ -46,16 +46,16 @@ theorem iff_of_equiv (Ha : a1 ≡ a2) (Hb : b1 ≡ b2) : R n a1 b1 ↔ R n a2 b2
 end ViewRel
 
 @[rocq_alias view]
-structure View {A B : Type _} (R : ViewRel A B) where
+structure View {A B : Type _} [OFE A] (R : ViewRel A B) where
   auth : Option ((DFrac) × Agree A)
   frag : B
 
 @[rocq_alias view_auth]
-abbrev View.Auth [UCMRA B] {R : ViewRel A B} (dq : DFrac) (a : A) : View R :=
+abbrev View.Auth [OFE A] [UCMRA B] {R : ViewRel A B} (dq : DFrac) (a : A) : View R :=
   ⟨some (dq, toAgree a), UCMRA.unit⟩
 
 @[rocq_alias view_frag]
-abbrev View.Frag {R : ViewRel A B} (b : B) : View R := ⟨none, b⟩
+abbrev View.Frag [OFE A] {R : ViewRel A B} (b : B) : View R := ⟨none, b⟩
 
 notation "●V{" dq "} " a => View.Auth dq a
 notation "●V " a => View.Auth (DFrac.own 1) a
@@ -806,30 +806,33 @@ end Updates
 section ViewMap
 
 @[rocq_alias view_map]
-def map {R : ViewRel A B} (R' : ViewRel A' B') (f : A → A') (g : B → B') (v : View R) : View R' where
+def map [OFE A] [OFE A'] {R : ViewRel A B} (R' : ViewRel A' B') (f : A → A') [OFE.NonExpansive f]
+    (g : B → B') (v : View R) : View R' where
   auth := match v.auth with | none => none | some (fr, a) => (fr, a.map' f)
   frag := g v.frag
 
 @[rocq_alias view_map_id]
-theorem map_id {R : ViewRel A B} (v : View R) : View.map R id id v = v := by
+theorem map_id [OFE A] {R : ViewRel A B} (v : View R) : View.map R id id v = v := by
   rcases v with ⟨a, b⟩
-  cases a <;> simp [View.map, Agree.map']
+  cases a <;> simp [View.map, Agree.map'_id]
 
 @[rocq_alias view_map_compose]
-theorem map_compose {R : ViewRel A B} {R' : ViewRel A' B'} {R'' : ViewRel A'' B''}
-    f g (f' : A' → A'') (g' : B' → B'') (v : View R) :
+theorem map_compose [OFE A] [OFE A'] [OFE A''] {R : ViewRel A B} {R' : ViewRel A' B'}
+    {R'' : ViewRel A'' B''} (f : A → A') (g : B → B') (f' : A' → A'') (g' : B' → B'')
+    [OFE.NonExpansive f] [OFE.NonExpansive f'] [OFE.NonExpansive (f' ∘ f)] (v : View R) :
     View.map R'' (f' ∘ f) (g' ∘ g) v = View.map R'' f' g' (View.map R' f g v) := by
   rcases v with ⟨a, b⟩
-  cases a <;> simp [View.map, Agree.map']
+  cases a <;> simp [View.map, Agree.map'_compose]
 
 section mapO
 
 variable [OFE A] [OFE B] [OFE A'] [OFE B'] {R : ViewRel A B} {R' : ViewRel A' B'}
 
 theorem map_compose' [OFE A''] [OFE B''] {R'' : ViewRel A'' B''}
-    f g (f' : A' -n> A'') (g' : B' -n> B'') (v : View R) :
-    View.map R'' (f'.comp f) (g'.comp g) v = View.map R'' f' g' (View.map R' f g v) :=
-  map_compose f.f g.f f'.f g'.f v
+    (f : A -n> A') (g : B -n> B') (f' : A' -n> A'') (g' : B' -n> B'') (v : View R) :
+    View.map R'' (f'.comp f) (g'.comp g) v = View.map R'' f' g' (View.map R' f g v) := by
+  haveI : OFE.NonExpansive (f'.f ∘ f.f) := f'.ne.comp f.ne
+  exact map_compose f.f g.f f'.f g'.f v
 
 omit [OFE B] in
 @[rocq_alias view_map_ext]
@@ -896,7 +899,7 @@ def mapC [OFE A] [UCMRA B] [OFE A'] [UCMRA B']
   op x y := by
     constructor <;> simp [CMRA.Hom.op, CMRA.op, map]
     cases x.auth <;> cases y.auth <;> simp [Prod.op]
-    exact ⟨rfl, (Agree.map _).op _ _⟩
+    exact OFE.eq_of_eqv ((Agree.map f.f).op _ _)
 
 end ViewMap
 

--- a/Iris/Iris/Algebra/View.lean
+++ b/Iris/Iris/Algebra/View.lean
@@ -46,16 +46,16 @@ theorem iff_of_equiv (Ha : a1 ≡ a2) (Hb : b1 ≡ b2) : R n a1 b1 ↔ R n a2 b2
 end ViewRel
 
 @[rocq_alias view]
-structure View {A B : Type _} [OFE A] (R : ViewRel A B) where
+structure View {A B : Type _} (R : ViewRel A B) where
   auth : Option ((DFrac) × Agree A)
   frag : B
 
 @[rocq_alias view_auth]
-abbrev View.Auth [OFE A] [UCMRA B] {R : ViewRel A B} (dq : DFrac) (a : A) : View R :=
+abbrev View.Auth [UCMRA B] {R : ViewRel A B} (dq : DFrac) (a : A) : View R :=
   ⟨some (dq, toAgree a), UCMRA.unit⟩
 
 @[rocq_alias view_frag]
-abbrev View.Frag [OFE A] {R : ViewRel A B} (b : B) : View R := ⟨none, b⟩
+abbrev View.Frag {R : ViewRel A B} (b : B) : View R := ⟨none, b⟩
 
 notation "●V{" dq "} " a => View.Auth dq a
 notation "●V " a => View.Auth (DFrac.own 1) a
@@ -107,7 +107,7 @@ theorem discrete {ag : Option ((DFrac) × Agree A)} (Ha : DiscreteE ag) (Hb : Di
 instance [Discrete A] [Discrete B] : Discrete (View R) where
   discrete_0 H := ⟨discrete_0 H.1, discrete_0 H.2⟩
 
-instance instLeibniz [Leibniz B] : Leibniz (View R) where
+instance instLeibniz [Leibniz A] [Leibniz B] : Leibniz (View R) where
   eq_of_eqv {x y} h := by
     cases x; cases y
     simp only [View.mk.injEq]
@@ -493,7 +493,7 @@ theorem auth_incN_auth_op_frag_iff : (●V{dq1} a1 : View R) ≼{n} ((●V{dq2} 
   · simp only [Auth, Frag, CMRA.IncludedN, CMRA.op]
     rintro ⟨(_|⟨dqf, af⟩),⟨⟨x1, x2⟩, y⟩⟩
     · exact ⟨.inr x1.symm, toAgree.inj x2.symm⟩
-    · exact ⟨.inl ⟨dqf, x1⟩, toAgree.incN.mp ⟨af, x2⟩⟩
+    · exact ⟨.inl ⟨dqf, x1⟩, Agree.toAgree_includedN.mp ⟨af, x2⟩⟩
   · rcases H with ⟨(⟨z, HRz⟩| HRa2), HRb⟩
     · calc (●V{dq1} a1 : View R)
              ≼{n} ((●V{dq1} a1) • ((◯V b) • ●V{z} a1)) := by exists ((◯V b) • ●V{z} a1)
@@ -783,7 +783,7 @@ theorem auth_alloc (Hup : ∀ n bf, R n a bf → R n a (b • bf)) :
     refine ⟨Hv, ?_⟩
     exists a0
     refine ⟨Hag, ?_⟩
-    have Heq  := toAgree.incN.mp ⟨ag, Hag.symm⟩
+    have Heq  := Agree.toAgree_includedN.mp ⟨ag, Hag.symm⟩
     have HR' := IsViewRel.mono Hrel Heq.symm (CMRA.incN_op_right n UCMRA.unit bf) n.le_refl
     apply IsViewRel.mono (Hup _ _ HR') Heq ?_ n.le_refl
     apply Iris.OFE.Dist.to_incN
@@ -812,20 +812,19 @@ end Updates
 section ViewMap
 
 @[rocq_alias view_map]
-def map [OFE A] [OFE A'] {R : ViewRel A B} (R' : ViewRel A' B') (f : A → A') [OFE.NonExpansive f]
+def map {R : ViewRel A B} (R' : ViewRel A' B') (f : A → A')
     (g : B → B') (v : View R) : View R' where
   auth := match v.auth with | none => none | some (fr, a) => (fr, a.map' f)
   frag := g v.frag
 
 @[rocq_alias view_map_id]
-theorem map_id [OFE A] {R : ViewRel A B} (v : View R) : View.map R id id v = v := by
+theorem map_id {R : ViewRel A B} (v : View R) : View.map R id id v = v := by
   rcases v with ⟨a, b⟩
   cases a <;> simp [View.map, Agree.map'_id]
 
 @[rocq_alias view_map_compose]
-theorem map_compose [OFE A] [OFE A'] [OFE A''] {R : ViewRel A B} {R' : ViewRel A' B'}
-    {R'' : ViewRel A'' B''} (f : A → A') (g : B → B') (f' : A' → A'') (g' : B' → B'')
-    [OFE.NonExpansive f] [OFE.NonExpansive f'] [OFE.NonExpansive (f' ∘ f)] (v : View R) :
+theorem map_compose {R : ViewRel A B} {R' : ViewRel A' B'} {R'' : ViewRel A'' B''}
+    f g (f' : A' → A'') (g' : B' → B'') (v : View R) :
     View.map R'' (f' ∘ f) (g' ∘ g) v = View.map R'' f' g' (View.map R' f g v) := by
   rcases v with ⟨a, b⟩
   cases a <;> simp [View.map, Agree.map'_compose]
@@ -835,7 +834,7 @@ section mapO
 variable [OFE A] [OFE B] [OFE A'] [OFE B'] {R : ViewRel A B} {R' : ViewRel A' B'}
 
 theorem map_compose' [OFE A''] [OFE B''] {R'' : ViewRel A'' B''}
-    (f : A -n> A') (g : B -n> B') (f' : A' -n> A'') (g' : B' -n> B'') (v : View R) :
+    f g (f' : A' -n> A'') (g' : B' -n> B'') (v : View R) :
     View.map R'' (f'.comp f) (g'.comp g) v = View.map R'' f' g' (View.map R' f g v) := by
   haveI : OFE.NonExpansive (f'.f ∘ f.f) := f'.ne.comp f.ne
   exact map_compose f.f g.f f'.f g'.f v
@@ -905,7 +904,7 @@ def mapC [OFE A] [UCMRA B] [OFE A'] [UCMRA B']
   op x y := by
     constructor <;> simp [CMRA.Hom.op, CMRA.op, map]
     cases x.auth <;> cases y.auth <;> simp [Prod.op]
-    exact OFE.eq_of_eqv ((Agree.map f.f).op _ _)
+    exact ⟨.rfl, (Agree.map f.f).op _ _⟩
 
 end ViewMap
 

--- a/Iris/Iris/Algebra/View.lean
+++ b/Iris/Iris/Algebra/View.lean
@@ -107,6 +107,12 @@ theorem discrete {ag : Option ((DFrac) × Agree A)} (Ha : DiscreteE ag) (Hb : Di
 instance [Discrete A] [Discrete B] : Discrete (View R) where
   discrete_0 H := ⟨discrete_0 H.1, discrete_0 H.2⟩
 
+instance instLeibniz [Leibniz B] : Leibniz (View R) where
+  eq_of_eqv {x y} h := by
+    cases x; cases y
+    simp only [View.mk.injEq]
+    exact ⟨eq_of_eqv h.1, eq_of_eqv h.2⟩
+
 -- view_auth_dist_inj
 theorem auth_inj_frac [UCMRA B] {q1 q2 : DFrac} {a1 a2 : A} {n} (H : (●V{q1} a1 : View R) ≡{n}≡ ●V{q2} a2) :
     q1 = q2 := H.1.1

--- a/Iris/Iris/Algebra/View.lean
+++ b/Iris/Iris/Algebra/View.lean
@@ -835,9 +835,8 @@ variable [OFE A] [OFE B] [OFE A'] [OFE B'] {R : ViewRel A B} {R' : ViewRel A' B'
 
 theorem map_compose' [OFE A''] [OFE B''] {R'' : ViewRel A'' B''}
     f g (f' : A' -n> A'') (g' : B' -n> B'') (v : View R) :
-    View.map R'' (f'.comp f) (g'.comp g) v = View.map R'' f' g' (View.map R' f g v) := by
-  haveI : OFE.NonExpansive (f'.f ∘ f.f) := f'.ne.comp f.ne
-  exact map_compose f.f g.f f'.f g'.f v
+    View.map R'' (f'.comp f) (g'.comp g) v = View.map R'' f' g' (View.map R' f g v) :=
+    map_compose f.f g.f f'.f g'.f v
 
 omit [OFE B] in
 @[rocq_alias view_map_ext]

--- a/Iris/Iris/BI/Algebra.lean
+++ b/Iris/Iris/BI/Algebra.lean
@@ -135,7 +135,7 @@ theorem agree_op_invI (x y : Agree A) : internalCmraValid (x • y) ⊢@{PROP} i
 theorem toAgree_validI (a : A) :
     ⊢@{PROP} internalCmraValid (toAgree a) := by
   refine internalCmraValid_intro fun n => ?_
-  simp [validN, toAgree]
+  simp
 
 @[rocq_alias to_agree_op_validI]
 theorem toAgree_op_validI (a b : A) :

--- a/Iris/Iris/Examples/Resources.lean
+++ b/Iris/Iris/Examples/Resources.lean
@@ -37,7 +37,7 @@ section const_agree
 abbrev γ : GType := 1
 
 @[simp]
-def MyAg (S : String) : (Option (Agree (LeibnizO String))) := some ⟨[⟨S⟩], by simp⟩
+def MyAg (S : String) : (Option (Agree (LeibnizO String))) := some (toAgree ⟨S⟩)
 
 theorem MyR_always_invalid (S₁ S₂ : String) (Hne : S₁ ≠ S₂) (n : Nat) : ¬✓{n} MyAg S₁ • MyAg S₂ := by
   simp only [CMRA.ValidN, CMRA.op, MyAg, optionValidN, optionOp]


### PR DESCRIPTION
## Description

POC: OFE constructor that takes:
- Carrier: `X: Type _`;
- Distance: `dist: Nat \to X \to X \to Prop`, satisfying old distance axioms.

And returns a OFE that has `X/\sim` carrier, where `x \sim y \iff \forall n. dist n x y` and lifted distance. 
It trivially satisfies old `equiv_dist` axiom, and is Leibniz. 
Tested it on agreement, and it was relatively fast to fix downstream problems (~10 lines in total). 

## Updated summary
Made Agree a Leibniz OFE, on Agree A, equiv is now just =.

There is a generic construction in OFE.lean (QuotientO + mkQuotient, plus a little mk/lift/map wrapper API), then a Leibniz version of Agree on top of it. Agree API is the same, except that now it requires its type argument to be OFE even for the definition.
Once Agree is Leibniz, a bunch of cameras built on it are too, so I added the instances: View, Auth, and the lib ones (DFracAgree, ExclAuth, FracAuth). Plus two tiny fixes where the refactor changed how Agree values get constructed.
The only non-Leibniz (or Leibniz-preserving) OFEs/CMRAs are related to maps, and I'll do them in a separate PR shortly. 
