### PR TITLE
Extensional maps

### DIFF
--- a/Iris/Iris/Algebra/BigOp.lean
+++ b/Iris/Iris/Algebra/BigOp.lean
@@ -313,9 +313,9 @@ theorem bigOpM_insert_eqv (Φ : K → V → M) {m : M' V} {i : K} (x : V) (hi : 
 
 @[rocq_alias big_opM_delete]
 theorem bigOpM_delete_eqv (Φ : K → V → M) {m : M' V} {i : K} {x : V} (hi : get? m i = some x) :
-    ([^ op map] k ↦ v ∈ m, Φ k v) ≡ op (Φ i x) ([^ op map] k ↦ v ∈ delete m i, Φ k v) :=
-  (bigOpM_eqv_of_perm Φ (equiv_iff_eq.mpr (insert_delete_cancel hi).symm)).trans
-    (bigOpM_insert_eqv Φ _ (get?_delete_eq rfl))
+    ([^ op map] k ↦ v ∈ m, Φ k v) ≡ op (Φ i x) ([^ op map] k ↦ v ∈ delete m i, Φ k v) := by
+  rw [congrArg (bigOpM op fun k v => Φ k v) (insert_delete_cancel hi).symm]
+  exact bigOpM_insert_eqv Φ _ (get?_delete_eq rfl)
 
 open Classical in
 @[rocq_alias big_opM_gen_proper_2]
@@ -431,8 +431,7 @@ theorem bigOpM_filterMap_eqv (Φ : K → V → M) (m : M' V) (hinj : Function.In
 theorem bigOpM_insert_delete_eqv (Φ : K → V → M) (m : M' V) (i : K) (x : V) :
     ([^ op map] k ↦ v ∈ insert m i x, Φ k v) ≡
     op (Φ i x) ([^ op map] k ↦ v ∈ delete m i, Φ k v) :=
-  (bigOpM_eqv_of_perm _ (equiv_iff_eq.mpr insert_delete.symm)).trans
-    (bigOpM_insert_eqv _ _ (get?_delete_eq rfl))
+  insert_delete (M := M').symm ▸ (bigOpM_insert_eqv _ _ (get?_delete_eq rfl))
 
 @[rocq_alias big_opM_insert_override]
 theorem bigOpM_insert_override_eqv {Φ : K → A → M} {m : M' A}
@@ -474,13 +473,13 @@ theorem toList_union_perm [DecidableEq K] {m1 m2 : M' V} (hdisj : m1 ##ₘ m2) :
     · exact (fun h => absurd (toList_get.mp h2) (by simp [h]))
   · rw [List.mem_append]
     refine ⟨fun h => ?_, fun h => ?_⟩
-    · have hg : get? (PartialMap.union m1 m2) k = some v := toList_get.mp h
+    · have hg : get? (m1 ∪ m2) k = some v := toList_get.mp h
       rw [get?_union] at hg
       cases hm1 : get? m1 k <;> simp_all [Option.orElse]
       · exact .inr (toList_get.mpr hg)
       · exact .inl (toList_get.mpr hm1)
     · refine toList_get.mpr ?_
-      show get? (PartialMap.union m1 m2) k = some v
+      show get? (m1 ∪ m2) k = some v
       rw [get?_union]
       rcases h with h | h
       · simp [toList_get.mp h, Option.orElse]

--- a/Iris/Iris/Algebra/BigOp.lean
+++ b/Iris/Iris/Algebra/BigOp.lean
@@ -314,7 +314,7 @@ theorem bigOpM_insert_eqv (Φ : K → V → M) {m : M' V} {i : K} (x : V) (hi : 
 @[rocq_alias big_opM_delete]
 theorem bigOpM_delete_eqv (Φ : K → V → M) {m : M' V} {i : K} {x : V} (hi : get? m i = some x) :
     ([^ op map] k ↦ v ∈ m, Φ k v) ≡ op (Φ i x) ([^ op map] k ↦ v ∈ delete m i, Φ k v) :=
-  (bigOpM_eqv_of_perm Φ (insert_delete_cancel hi · |>.symm)).trans
+  (bigOpM_eqv_of_perm Φ (equiv_iff_eq.mpr (insert_delete_cancel hi).symm)).trans
     (bigOpM_insert_eqv Φ _ (get?_delete_eq rfl))
 
 open Classical in
@@ -333,15 +333,11 @@ theorem bigOpM_gen_proper_2 {A : Type _} {B : Type _} {R : M → M → Prop}
     R ([^ op map] k ↦ x ∈ m1', Φ k x) ([^ op map] k ↦ x ∈ m2', Ψ k x)
   suffices h : P m1 from h m2 hdom hf
   apply LawfulFiniteMap.induction_on (P := P)
-  · intro m₁ m₂ heq hP m2' hdom' hf'
-    refine hR_eqv.trans (hR_sub (bigOpM_eqv_of_perm Φ heq).symm) ?_
-    exact hP m2' (fun k => heq k ▸ hdom' k) (hf' <| (heq _) ▸ ·)
   · show P (∅ : M' A)
     intro m2' hdom' _
     rw [bigOpM_empty]
-    refine hR_sub <| (bigOpM_eqv_of_perm Ψ ?_).trans (.of_eq (bigOpM_empty Ψ)) |>.symm
-    refine eq_empty_iff.mpr fun k => ?_
-    simpa [show get? (∅ : M' A) k = none from get?_empty k] using hdom' k
+    refine hR_sub <| (bigOpM_eqv_of_perm Ψ fun k => ?_).trans (.of_eq (bigOpM_empty Ψ)) |>.symm
+    simpa [get?_empty] using hdom' k
   · intro k x1 m1' hm1'k IH m2' hdom' hf'
     obtain ⟨x2, hm2k⟩ := Option.isSome_iff_exists.mp <| by
       simpa [get?_insert_eq (k := k) rfl] using (hdom' k).symm
@@ -435,7 +431,7 @@ theorem bigOpM_filterMap_eqv (Φ : K → V → M) (m : M' V) (hinj : Function.In
 theorem bigOpM_insert_delete_eqv (Φ : K → V → M) (m : M' V) (i : K) (x : V) :
     ([^ op map] k ↦ v ∈ insert m i x, Φ k v) ≡
     op (Φ i x) ([^ op map] k ↦ v ∈ delete m i, Φ k v) :=
-  (bigOpM_eqv_of_perm _ (insert_delete · |>.symm)).trans
+  (bigOpM_eqv_of_perm _ (equiv_iff_eq.mpr insert_delete.symm)).trans
     (bigOpM_insert_eqv _ _ (get?_delete_eq rfl))
 
 @[rocq_alias big_opM_insert_override]
@@ -551,13 +547,13 @@ theorem bigOpM_hom  [ι : MonoidHomomorphism op₁ op₂ unit₁ unit₂ R h] (f
 
 @[rocq_alias big_opM_commute1]
 theorem bigOpM_weak_hom [DecidableEq K] [ι : WeakMonoidHomomorphism op₁ op₂ unit₁ unit₂ R h]
-    (f : K → A → M₁) (m : M' A) (Hne : ¬ m ≡ₘ ∅) :
+    (f : K → A → M₁) (m : M' A) (Hne : ¬ m = ∅) :
     R (h ([^op₁ map] k↦x ∈ m, f k x)) ([^op₂ map] k↦x ∈ m, h (f k x)) := by
   refine bigOpL_hom_weak (H := ι) _ ?_
   refine fun Hk => Hne ?_
-  refine .trans LawfulFiniteMap.ofList_toList.symm ?_
-  rw [show (LawfulFiniteMap.toList m) = [] from List.nil_eq.mpr Hk |>.symm]
-  exact .trans (congrFun rfl) (congrFun rfl )
+  rw [← LawfulFiniteMap.ofList_toList (m := m),
+      show (LawfulFiniteMap.toList m) = [] from List.nil_eq.mpr Hk |>.symm]
+  rfl
 
 #rocq_ignore big_opM_ne' "Use bigOpM_dist"
 #rocq_ignore big_opM_proper' "Use bigOpM_eqv"

--- a/Iris/Iris/Algebra/Heap.lean
+++ b/Iris/Iris/Algebra/Heap.lean
@@ -72,9 +72,9 @@ instance Heap.instCOFE [LawfulPartialMap M K] [COFE V] : COFE (M V) where
 instance instDiscreteHeap [PartialMap M K] [OFE V] [Discrete V] : Discrete (M V) where
   discrete_0 h k := Discrete.discrete_0 (h k)
 
-instance instLeibnizHeap [ExtensionalPartialMap M K] [OFE V] [Leibniz V] : Leibniz (M V) where
+instance instLeibnizHeap [LawfulPartialMap M K] [OFE V] [Leibniz V] : Leibniz (M V) where
   eq_of_eqv h :=
-    ExtensionalPartialMap.equiv_iff_eq.mp (fun i => Leibniz.eq_of_eqv (h i))
+    LawfulPartialMap.equiv_iff_eq.mp (fun i => Leibniz.eq_of_eqv (h i))
 
 instance instDiscreteESingleton [LawfulPartialMap M K] [DecidableEq K] [OFE V] {v : V}
     [ha : DiscreteE v] {k : K} : DiscreteE (PartialMap.singleton (M := M) k v) where

--- a/Iris/Iris/Algebra/HeapView.lean
+++ b/Iris/Iris/Algebra/HeapView.lean
@@ -152,9 +152,9 @@ theorem auth_dfrac_op_eqv : Auth (dp • dq) m1 ≡ Auth dp m1 • Auth dq m1 :=
 /-- An `Auth` inclusion follows from a pointwise map equivalence on the underlying heap.
 This is the workhorse for proofs that rewrite the authoritative map along identities like
 `PartialMap.map_insert`, `map_delete`, or `map_union`. -/
-theorem auth_inc_of_pmap_eqv (dq : DFrac) (h : PartialMap.equiv m1 m2) :
+theorem auth_inc_of_pmap_eqv (dq : DFrac) (h : m1 = m2) :
     Auth (H := H) dq m1 ≼ Auth dq m2 :=
-  CMRA.inc_of_inc_of_eqv .rfl (OFE.NonExpansive.eqv (PartialMap.eqv_of_Equiv h))
+  CMRA.inc_of_inc_of_eqv .rfl (OFE.NonExpansive.eqv (OFE.Equiv.of_eq h))
 
 theorem dist_of_validN_auth_op : ✓{n} Auth dp m1 • Auth dq m2 → m1 ≡{n}≡ m2 :=
   dist_of_validN_auth
@@ -592,12 +592,6 @@ theorem update_big_delete (m m' : H V) :
   Auth (.own one) m • (bigOpM (M := HeapView K V H) op (fun k v => Frag k (.own one) v) m') ~~>
   Auth (.own one) (m \ m') := by
   induction m' using LawfulFiniteMap.induction_on with
-  | hequiv m₁ m₂ heq hP =>
-    refine Update.equiv_left (CMRA.op_right_eqv _ (BigOpM.bigOpM_eqv_of_perm _ heq)) ?_
-    refine .trans hP ?_
-    refine Update.equiv_left ?_ .id
-    refine OFE.NonExpansive.eqv ?_
-    exact eqv_of_Equiv (fun j => by simp [get?_difference, heq j])
   | hemp =>
     rw [bigOpM_frag_empty]
     refine Update.equiv_left CMRA.comm ?_
@@ -623,13 +617,6 @@ theorem update_big_replace (m m0 m1 : H V)
   Auth (.own one) (m1 ∪ m) • (bigOpM (M := HeapView K V H) op (fun k v => Frag k (.own one) v) m1) := by
   revert m1 Hdom
   induction m0 using LawfulFiniteMap.induction_on with
-  | hequiv m₁ m₂ heq hP =>
-    intro m1 Hdom Hall
-    refine Update.equiv_left (CMRA.op_right_eqv _ (BigOpM.bigOpM_eqv_of_perm _ heq)) ?_
-    refine .trans (hP m1 ?_ Hall) ?_
-    · exact Hdom ▸ funext (fun j => congrArg (· = true) (congrArg Option.isSome (heq j)))
-    refine Update.equiv_left ?_ .id
-    exact .rfl
   | hemp =>
     intro m1 Hdom Hall
     rw [bigOpM_frag_empty]
@@ -688,22 +675,6 @@ theorem update_big_alloc (m1 m2 : H V) dq
     Auth (.own one) (m2 ∪ m1)
     • bigOpM (M := HeapView K V H) op (fun k v => Frag k dq v) m2 := by
     induction m2 using LawfulFiniteMap.induction_on generalizing m1 with
-    | hequiv m₁ m₂ heq hP =>
-      have Hall' : all (fun k v => ✓ v) m₁ := by
-        intro k v hk; exact Hall k v (heq k ▸ hk)
-      have Hdisj' : m₁ ##ₘ m1 := by
-        intro k ⟨hs1, hs2⟩; exact Hdisj k ⟨heq k ▸ hs1, hs2⟩
-      have IH := hP m1 Hdisj' Hall'
-      refine IH.trans ?_
-      refine Update.included ?_
-      refine inc_of_inc_of_eqv .rfl ?_
-      refine CMRA.op_eqv ?_ ?_
-      · refine OFE.NonExpansive.eqv ?_
-        intro i
-        exact .of_eq (by
-          change get? (PartialMap.union m₂ m1) i = get? (PartialMap.union m₁ m1) i;
-          simp [PartialMap.union, get?_merge, heq i])
-      · exact BigOpM.bigOpM_eqv_of_perm _ heq.symm
     | hemp =>
       rw [bigOpM_frag_empty]
       refine Update.included ?_
@@ -711,9 +682,7 @@ theorem update_big_alloc (m1 m2 : H V) dq
       refine CMRA.comm.trans ?_
       refine UCMRA.unit_left_id.trans ?_
       refine OFE.NonExpansive.eqv ?_
-      exact eqv_of_Equiv (fun k => by
-        change get? (PartialMap.union ∅ m1) k = get? m1 k;
-        simp [PartialMap.union, get?_merge, get?_empty])
+      exact OFE.Equiv.of_eq union_empty_left
     | hins k v m2 Hm2 IH =>
       have Hall' : all (fun k v => ✓ v) m2 := by exact all_of_all_insert _ Hm2 Hall
       have Hdisj' : m2 ##ₘ m1 := by
@@ -732,7 +701,7 @@ theorem update_big_alloc (m1 m2 : H V) dq
       refine Update.op ?_ ?_
       · refine Update.equiv_left ?_ .id
         refine OFE.NonExpansive.eqv ?_
-        exact eqv_of_Equiv (PartialMap.equiv.symm _ _ union_insert_left)
+        exact OFE.Equiv.of_eq union_insert_left.symm
       · refine Update.equiv_left ?_ .id
         exact BigOpM.bigOpM_insert_eqv _ _ Hm2
 

--- a/Iris/Iris/Algebra/HeapView.lean
+++ b/Iris/Iris/Algebra/HeapView.lean
@@ -149,12 +149,12 @@ variable {dp dq : DFrac} {n : Nat} {m1 m2 : H V} {k : K} {v1 v2 : V}
 theorem auth_dfrac_op_eqv : Auth (dp • dq) m1 ≡ Auth dp m1 • Auth dq m1 :=
   View.auth_op_auth_eqv
 
-/-- An `Auth` inclusion follows from a pointwise map equivalence on the underlying heap.
+/-- An `Auth` inclusion follows from a map equality on the underlying heap.
 This is the workhorse for proofs that rewrite the authoritative map along identities like
 `PartialMap.map_insert`, `map_delete`, or `map_union`. -/
-theorem auth_inc_of_pmap_eqv (dq : DFrac) (h : PartialMap.equiv m1 m2) :
-    Auth (H := H) dq m1 ≼ Auth dq m2 :=
-  CMRA.inc_of_inc_of_eqv .rfl (OFE.NonExpansive.eqv (OFE.Equiv.of_eq (equiv_iff_eq.mp h)))
+theorem auth_inc_of_map_eq (dq : DFrac) (h : m1 = m2) :
+    Auth dq m1 ≼ Auth dq m2 :=
+  CMRA.inc_of_inc_of_eqv .rfl (OFE.NonExpansive.eqv (OFE.Equiv.of_eq h))
 
 theorem dist_of_validN_auth_op : ✓{n} Auth dp m1 • Auth dq m2 → m1 ≡{n}≡ m2 :=
   dist_of_validN_auth
@@ -622,17 +622,16 @@ theorem update_big_replace (m m0 m1 : H V)
     rw [bigOpM_frag_empty]
     refine Update.equiv_left CMRA.comm ?_
     refine Update.equiv_left UCMRA.unit_left_id.symm ?_
-    have Heq : equiv m1 ∅ := by
-      intro j; have h := congrFun Hdom j; simp [dom, get?_empty] at h; exact h.trans (get?_empty j).symm
-    refine Update.equiv_right (CMRA.op_right_eqv _ (BigOpM.bigOpM_eqv_of_perm _ Heq.symm)) ?_
+    have Heq : m1 = ∅ := by
+      apply equiv_iff_eq.mp; intro j; have h := congrFun Hdom.symm j
+      simp [dom, get?_empty] at h; simp [get?_empty, h]
+    refine Heq.symm ▸ Update.equiv_right (CMRA.op_right_eqv _ .rfl) ?_
     simp only [BigOpM.bigOpM_empty]
     refine Update.equiv_right CMRA.comm ?_
     refine Update.equiv_right UCMRA.unit_left_id.symm ?_
     refine Update.equiv_left ?_ .id
     refine OFE.NonExpansive.eqv ?_
-    exact eqv_of_Equiv (fun j => by
-      have h : get? m1 j = none := (Heq j).trans (get?_empty j);
-      change get? (PartialMap.union m1 m) j = get? m j; simp [PartialMap.union, get?_merge, h])
+    rw [union_empty_left]
   | hins k v m2 Hm2 IH =>
     intro m1 Hdom Hall
     refine Update.equiv_left (CMRA.op_right_eqv _ (BigOpM.bigOpM_insert_eqv _ _ Hm2).symm) ?_
@@ -662,9 +661,7 @@ theorem update_big_replace (m m0 m1 : H V)
           cases get? m k <;> rfl
         · rw [get?_insert_ne hjk]; simp [PartialMap.union, get?_merge, get?_delete_ne hjk])
     · refine .trans ?_ (BigOpM.bigOpM_insert_eqv _ _ ?_)
-      · refine BigOpM.bigOpM_eqv_of_perm _ ?_
-        intro j; by_cases hjk : k = j; subst hjk; rw [get?_insert_eq rfl]; exact Hin
-        rw [get?_insert_ne hjk, get?_delete_ne hjk]
+      · exact ((insert_delete_cancel Hin).symm ▸ .rfl)
       · exact get?_delete_eq rfl
 
 -- TODO: golf
@@ -681,8 +678,8 @@ theorem update_big_alloc (m1 m2 : H V) dq
       refine inc_of_inc_of_eqv .rfl ?_
       refine CMRA.comm.trans ?_
       refine UCMRA.unit_left_id.trans ?_
-      refine OFE.NonExpansive.eqv ?_
-      exact OFE.Equiv.of_eq union_empty_left
+      rw [union_empty_left]
+      rfl
     | hins k v m2 Hm2 IH =>
       have Hall' : all (fun k v => ✓ v) m2 := by exact all_of_all_insert _ Hm2 Hall
       have Hdisj' : m2 ##ₘ m1 := by
@@ -691,7 +688,6 @@ theorem update_big_alloc (m1 m2 : H V) dq
       have IH := IH m1 Hdisj' Hall'
       refine IH.trans ?_
       have Hms : get? (m2 ∪ m1) k = none := by
-        change get? (PartialMap.union m2 m1) k = none
         rw [get?_union_none]
         exact ⟨Hm2, Option.not_isSome_iff_eq_none.mp (fun h => Hdisj k ⟨by simp [get?_insert_eq rfl], h⟩)⟩
       have Hv := all_insert_of_all _ Hall
@@ -700,8 +696,8 @@ theorem update_big_alloc (m1 m2 : H V) dq
       refine (Update.equiv_left CMRA.assoc ?_)
       refine Update.op ?_ ?_
       · refine Update.equiv_left ?_ .id
-        refine OFE.NonExpansive.eqv ?_
-        exact OFE.Equiv.of_eq union_insert_left.symm
+        rw [← union_insert_left]
+        rfl
       · refine Update.equiv_left ?_ .id
         exact BigOpM.bigOpM_insert_eqv _ _ Hm2
 

--- a/Iris/Iris/Algebra/HeapView.lean
+++ b/Iris/Iris/Algebra/HeapView.lean
@@ -152,9 +152,9 @@ theorem auth_dfrac_op_eqv : Auth (dp • dq) m1 ≡ Auth dp m1 • Auth dq m1 :=
 /-- An `Auth` inclusion follows from a pointwise map equivalence on the underlying heap.
 This is the workhorse for proofs that rewrite the authoritative map along identities like
 `PartialMap.map_insert`, `map_delete`, or `map_union`. -/
-theorem auth_inc_of_pmap_eqv (dq : DFrac) (h : m1 = m2) :
+theorem auth_inc_of_pmap_eqv (dq : DFrac) (h : PartialMap.equiv m1 m2) :
     Auth (H := H) dq m1 ≼ Auth dq m2 :=
-  CMRA.inc_of_inc_of_eqv .rfl (OFE.NonExpansive.eqv (OFE.Equiv.of_eq h))
+  CMRA.inc_of_inc_of_eqv .rfl (OFE.NonExpansive.eqv (OFE.Equiv.of_eq (equiv_iff_eq.mp h)))
 
 theorem dist_of_validN_auth_op : ✓{n} Auth dp m1 • Auth dq m2 → m1 ≡{n}≡ m2 :=
   dist_of_validN_auth

--- a/Iris/Iris/BI/BigOp/BigSepMap.lean
+++ b/Iris/Iris/BI/BigOp/BigSepMap.lean
@@ -44,7 +44,7 @@ theorem bigSepM_eqv_of_perm {Φ : K → V → PROP} {m₁ m₂ : M V} (h : m₁ 
 /-- A `bigSepM` over the empty map is `emp`. -/
 theorem bigSepM_eqv_empty {Φ : K → V → PROP} {m : M V} (h : m = ∅) :
     ([∗map] k ↦ v ∈ m, Φ k v) ⊣⊢ emp := by
-  rw [h]; exact bigSepM_empty
+  simp [h]
 
 @[rocq_alias big_sepM_singleton]
 theorem bigSepM_singleton {Φ : K → V → PROP} {i : K} {x : V} :
@@ -438,8 +438,7 @@ theorem bigSepM_union [DecidableEq K] {Φ : K → V → PROP} {m₁ m₂ : M V} 
 theorem bigSepM_subseteq [DecidableEq K] {Φ : K → V → PROP} {m₁ m₂ : M V}
     [∀ k v, Affine (Φ k v)] (h : m₂ ⊆ m₁) :
     ([∗map] k ↦ x ∈ m₁, Φ k x) ⊢ [∗map] k ↦ x ∈ m₂, Φ k x :=
-  (equiv_iff.mp <| bigOpM_eqv_of_perm Φ <| equiv_iff_eq.mpr <| union_difference_cancel h).2.trans <|
-  (bigSepM_union disjoint_difference_right).1.trans sep_elim_left
+  union_difference_cancel h ▸ (bigSepM_union disjoint_difference_right).1.trans sep_elim_left
 
 -- FIXME: Refactor for readability
 @[rocq_alias big_sepM_lookup_acc_impl]

--- a/Iris/Iris/BI/BigOp/BigSepMap.lean
+++ b/Iris/Iris/BI/BigOp/BigSepMap.lean
@@ -41,10 +41,10 @@ theorem bigSepM_eqv_of_perm {Φ : K → V → PROP} {m₁ m₂ : M V} (h : m₁ 
     ([∗map] k ↦ v ∈ m₁, Φ k v) ⊣⊢ ([∗map] k ↦ v ∈ m₂, Φ k v) :=
   equiv_iff.mp (bigOpM_eqv_of_perm _ h)
 
-/-- A `bigSepM` over a map equivalent to the empty map is `emp`. -/
-theorem bigSepM_eqv_empty {Φ : K → V → PROP} {m : M V} (h : m ≡ₘ ∅) :
-    ([∗map] k ↦ v ∈ m, Φ k v) ⊣⊢ emp :=
-  (bigSepM_eqv_of_perm h).trans bigSepM_empty
+/-- A `bigSepM` over the empty map is `emp`. -/
+theorem bigSepM_eqv_empty {Φ : K → V → PROP} {m : M V} (h : m = ∅) :
+    ([∗map] k ↦ v ∈ m, Φ k v) ⊣⊢ emp := by
+  rw [h]; exact bigSepM_empty
 
 @[rocq_alias big_sepM_singleton]
 theorem bigSepM_singleton {Φ : K → V → PROP} {i : K} {x : V} :
@@ -438,7 +438,7 @@ theorem bigSepM_union [DecidableEq K] {Φ : K → V → PROP} {m₁ m₂ : M V} 
 theorem bigSepM_subseteq [DecidableEq K] {Φ : K → V → PROP} {m₁ m₂ : M V}
     [∀ k v, Affine (Φ k v)] (h : m₂ ⊆ m₁) :
     ([∗map] k ↦ x ∈ m₁, Φ k x) ⊢ [∗map] k ↦ x ∈ m₂, Φ k x :=
-  (equiv_iff.mp <| bigOpM_eqv_of_perm Φ <| union_difference_cancel h).2.trans <|
+  (equiv_iff.mp <| bigOpM_eqv_of_perm Φ <| equiv_iff_eq.mpr <| union_difference_cancel h).2.trans <|
   (bigSepM_union disjoint_difference_right).1.trans sep_elim_left
 
 -- FIXME: Refactor for readability
@@ -499,19 +499,7 @@ theorem bigSepM_impl_strong [DecidableEq K] {M₂ : Type _ → Type _} {V₂ : T
     ⊢ ([∗map] k ↦ y ∈ m₂, Ψ k y) ∗
       [∗map] k ↦ x ∈ filter (fun k _ => (get? m₂ k).isNone) m₁, Φ k x
   suffices P m₂ from this m₁
-  refine LawfulFiniteMap.induction_on (fun _ _ heq IH m₁ => ?hequiv) ?hemp ?hind m₂
-  case hequiv =>
-    refine (sep_mono_right ?_).trans <| (IH m₁).trans ?_
-    · refine intuitionistically_mono ?_
-      refine forall_mono fun k => ?_
-      refine forall_mono fun y => ?_
-      refine wand_mono_right ?_
-      refine imp_intro_swap ?_
-      refine pure_elim_left ?_
-      refine fun hget => pure_imp_elim (heq k ▸ hget)
-    refine sep_mono (equiv_iff.mp <| bigOpM_eqv_of_perm Ψ heq).1 ?_
-    refine (equiv_iff.mp <| bigOpM_eqv_of_perm Φ ?_).1
-    exact fun k => by cases get? m₁ k <;> simp [get?_filter, heq k]
+  refine LawfulFiniteMap.induction_on ?hemp ?hind m₂
   case hemp =>
     refine fun m₁ => ?_
     refine (sep_mono_right Affine.affine).trans ?_

--- a/Iris/Iris/BI/Lib/GenHeap.lean
+++ b/Iris/Iris/BI/Lib/GenHeap.lean
@@ -353,8 +353,8 @@ section updateLemmas
 
 /-- The state interpretation transports along a pointwise equivalence of
 the value heap. -/
-theorem genHeapInterp_eqv {σ₁ σ₂ : H V} (h : σ₁ = σ₂) :
-    genHeapInterp (GF := GF) σ₁ ⊢ genHeapInterp σ₂ := h ▸ .rfl
+theorem genHeapInterp_eqv {σ₁ σ₂ : H V} (h : σ₁ ≡ₘ σ₂) :
+    genHeapInterp (GF := GF) σ₁ ⊢ genHeapInterp σ₂ := equiv_iff_eq.mp h ▸ .rfl
 
 @[rocq_alias gen_heap_alloc]
 theorem genHeap_alloc [DecidableEq L] {σ : H V} {l : L} {v : V} (Hσl : get? σ l = .none) :
@@ -392,7 +392,7 @@ theorem genHeap_alloc_big [DecidableEq L] (σ' σ : H V) (Hdisj : σ' ##ₘ σ) 
     iintro Hσ
     imodintro
     isplitl [Hσ]
-    · iapply genHeapInterp_eqv LawfulPartialMap.union_empty_left.symm $$ Hσ
+    · iapply genHeapInterp_eqv (equiv_iff_eq.mpr LawfulPartialMap.union_empty_left.symm) $$ Hσ
     isplit <;> (iapply BigSepM.bigSepM_empty; itrivial)
   | hins l v σ'' Hl IH =>
     intro σ Hdisj
@@ -404,7 +404,7 @@ theorem genHeap_alloc_big [DecidableEq L] (σ' σ : H V) (Hdisj : σ' ##ₘ σ) 
     imod genHeap_alloc Hunion_l $$ Hint with ⟨Hint', Hl_pts, Hl_tok⟩
     imodintro
     isplitl [Hint']
-    · iapply genHeapInterp_eqv LawfulPartialMap.union_insert_left $$ Hint'
+    · iapply genHeapInterp_eqv (equiv_iff_eq.mpr LawfulPartialMap.union_insert_left) $$ Hint'
     isplitl [Hl_pts Hpts]
     · iapply (BigSepM.bigSepM_insert Hl) $$ [$Hpts $Hl_pts]
     iapply (BigSepM.bigSepM_insert (Φ := fun l _ => iprop(metaToken l ⊤)) Hl) $$ [$Hl_tok $Htok]
@@ -471,7 +471,7 @@ theorem genHeap_init_names [DecidableEq L] [genHeapPreS L V GF H] (σ : H V) :
   imodintro
   iexists γh, γm
   iframe Hpts Htok
-  iapply genHeapInterp_eqv LawfulPartialMap.union_empty_right $$ Hinterp
+  iapply genHeapInterp_eqv (equiv_iff_eq.mpr LawfulPartialMap.union_empty_right) $$ Hinterp
 
 /-- Initialize `genHeapGS` from a `genHeapPreS`, hiding the freshly allocated
 ghost names. -/

--- a/Iris/Iris/BI/Lib/GenHeap.lean
+++ b/Iris/Iris/BI/Lib/GenHeap.lean
@@ -353,16 +353,8 @@ section updateLemmas
 
 /-- The state interpretation transports along a pointwise equivalence of
 the value heap. -/
-theorem genHeapInterp_eqv {σ₁ σ₂ : H V} (h : σ₁ ≡ₘ σ₂) :
-    genHeapInterp (GF := GF) σ₁ ⊢ genHeapInterp σ₂ := by
-  unfold genHeapInterp
-  iintro ⟨%m, %Hdom, Hh, Hm⟩
-  iexists m
-  isplitr
-  · ipureintro
-    exact fun k hk => by unfold dom; rw [← h k]; exact Hdom k hk
-  iframe Hm
-  apply iOwn_mono (HeapView.auth_inc_of_pmap_eqv _ (LawfulPartialMap.map_equiv h.symm))
+theorem genHeapInterp_eqv {σ₁ σ₂ : H V} (h : σ₁ = σ₂) :
+    genHeapInterp (GF := GF) σ₁ ⊢ genHeapInterp σ₂ := h ▸ .rfl
 
 @[rocq_alias gen_heap_alloc]
 theorem genHeap_alloc [DecidableEq L] {σ : H V} {l : L} {v : V} (Hσl : get? σ l = .none) :
@@ -395,19 +387,6 @@ theorem genHeap_alloc_big [DecidableEq L] (σ' σ : H V) (Hdisj : σ' ##ₘ σ) 
         ([∗map] l↦_v ∈ σ', metaToken l ⊤)) := by
   revert σ Hdisj
   induction σ' using LawfulFiniteMap.induction_on with
-  | hequiv σ₁ σ₂ heqv IH =>
-    intro σ Hdisj
-    have Hdisj₁ : σ₁ ##ₘ σ := fun k ⟨h1, h2⟩ => Hdisj k ⟨by rw [← heqv k]; exact h1, h2⟩
-    have hUnion : (σ₁ ∪ σ) ≡ₘ (σ₂ ∪ σ) :=
-      LawfulPartialMap.union_equiv heqv Std.PartialMap.equiv.refl
-    iintro Hσ
-    imod IH σ Hdisj₁ $$ Hσ with ⟨Hint, Hpts, Htok⟩
-    imodintro
-    isplitl [Hint]
-    · iapply genHeapInterp_eqv hUnion $$ Hint
-    isplitl [Hpts]
-    · iapply (BigSepM.bigSepM_eqv_of_perm (Φ := fun l v => iprop(l ↦ v)) heqv) $$ Hpts
-    iapply (BigSepM.bigSepM_eqv_of_perm (Φ := fun l _ => iprop(metaToken l ⊤)) heqv) $$ Htok
   | hemp =>
     intro σ _
     iintro Hσ

--- a/Iris/Iris/BI/Plainly.lean
+++ b/Iris/Iris/BI/Plainly.lean
@@ -688,13 +688,6 @@ instance bigSepM_plain {K} [DecidableEq K] {M A} [ι : LawfulFiniteMap M K] (Φ 
     Plain ([∗map] k↦x ∈ m, Φ k x) where
   plain := by
     induction m using Iris.Std.LawfulFiniteMap.induction_on
-    case hequiv m₁ m₂ m₁m₂ H =>
-      have h : iprop([∗map] k ↦ x ∈ m₁, Φ k x) ≡ [∗map] k ↦ x ∈ m₂, Φ k x :=
-          Algebra.BigOpM.bigOpM_eqv_of_perm (M' := M) _ m₁m₂
-      calc iprop([∗map] k ↦ x ∈ m₂, Φ k x)
-        _ ⊣⊢ [∗map] k ↦ x ∈ m₁, Φ k x := BI.equiv_iff.1 h |>.symm
-        _  ⊢ ■ [∗map] k ↦ x ∈ m₁, Φ k x := H
-        _ ⊣⊢ ■ [∗map] k ↦ x ∈ m₂, Φ k x := .ofMono plainly_mono <| BI.equiv_iff.1 h
     case hemp =>
       simp only [Algebra.BigOpM.bigOpM_empty, plain]
     case hins k v m get?_m_k IH=>

--- a/Iris/Iris/Examples/IProp.lean
+++ b/Iris/Iris/Examples/IProp.lean
@@ -53,7 +53,7 @@ open HeapView One DFrac Agree LeibnizO
 
 /- Define an OFunctor for the heap. Fractions are concretely `Qp`. -/
 abbrev F1 : OFunctorPre :=
-  constOF <| HeapView Nat (Agree (LeibnizO String)) Iris.Std.AssocList
+  constOF <| HeapView Nat (Agree (LeibnizO String)) (Std.ExtTreeMap Nat · compare)
 
 /- Our OFunctor is present in the global list of OFunctors. -/
 variable {GF} [ElemG GF F1]

--- a/Iris/Iris/Instances/IProp/Instance.lean
+++ b/Iris/Iris/Instances/IProp/Instance.lean
@@ -843,9 +843,9 @@ theorem bigOpL_iOwn {B : Type _} (γ : GName) (f : Nat → B → F.ap (IProp GF)
 @[rocq_alias big_opM_own]
 theorem bigOpM_iOwn {K : Type _} {M : Type _ → Type _} {B : Type _} [LawfulFiniteMap M K]
     [DecidableEq K] (γ : GName) (g : K → B → F.ap (IProp GF)) (m : M B) :
-    ¬ m = (∅ : M B) →
+    ¬ m ≡ₘ (∅ : M B) →
     iOwn γ ([^ CMRA.op map] k ↦ x ∈ m, g k x) ⊣⊢ [∗map] k ↦ x ∈ m, iOwn γ (g k x) :=
-  BigOpM.bigOpM_weak_hom g m
+  fun h => BigOpM.bigOpM_weak_hom g m (fun he => h (equiv_iff_eq.mpr he))
 
 @[rocq_alias big_opS_own]
 theorem bigOpS_iOwn {B : Type _} {S : Type _} [LawfulFiniteSet S B] (γ : GName)

--- a/Iris/Iris/Instances/IProp/Instance.lean
+++ b/Iris/Iris/Instances/IProp/Instance.lean
@@ -843,7 +843,7 @@ theorem bigOpL_iOwn {B : Type _} (γ : GName) (f : Nat → B → F.ap (IProp GF)
 @[rocq_alias big_opM_own]
 theorem bigOpM_iOwn {K : Type _} {M : Type _ → Type _} {B : Type _} [LawfulFiniteMap M K]
     [DecidableEq K] (γ : GName) (g : K → B → F.ap (IProp GF)) (m : M B) :
-    ¬ m ≡ₘ (∅ : M B) →
+    ¬ m = (∅ : M B) →
     iOwn γ ([^ CMRA.op map] k ↦ x ∈ m, g k x) ⊣⊢ [∗map] k ↦ x ∈ m, iOwn γ (g k x) :=
   BigOpM.bigOpM_weak_hom g m
 

--- a/Iris/Iris/Instances/IProp/Instance.lean
+++ b/Iris/Iris/Instances/IProp/Instance.lean
@@ -843,9 +843,9 @@ theorem bigOpL_iOwn {B : Type _} (γ : GName) (f : Nat → B → F.ap (IProp GF)
 @[rocq_alias big_opM_own]
 theorem bigOpM_iOwn {K : Type _} {M : Type _ → Type _} {B : Type _} [LawfulFiniteMap M K]
     [DecidableEq K] (γ : GName) (g : K → B → F.ap (IProp GF)) (m : M B) :
-    ¬ m ≡ₘ (∅ : M B) →
+    ¬ m = (∅ : M B) →
     iOwn γ ([^ CMRA.op map] k ↦ x ∈ m, g k x) ⊣⊢ [∗map] k ↦ x ∈ m, iOwn γ (g k x) :=
-  fun h => BigOpM.bigOpM_weak_hom g m (fun he => h (equiv_iff_eq.mpr he))
+  fun h => BigOpM.bigOpM_weak_hom g m (fun he => h he)
 
 @[rocq_alias big_opS_own]
 theorem bigOpS_iOwn {B : Type _} {S : Type _} [LawfulFiniteSet S B] (γ : GName)

--- a/Iris/Iris/Instances/Lib/Boxes.lean
+++ b/Iris/Iris/Instances/Lib/Boxes.lean
@@ -271,7 +271,7 @@ theorem slice_insert_full {M : Type _ → Type _} [LawfulFiniteMap M SliceName]
   iframe %Hfresh Hslice
   imod slice_fill HE (get?_insert_eq rfl) $$ [$Hslice $HQ $Hbox] with Hbox
   imodintro
-  simp only [box, (bigSepM_eqv_of_perm LawfulPartialMap.insert_insert_same).to_eq]
+  simp only [box, LawfulPartialMap.insert_insert_same]
   itrivial
 
 @[rocq_alias slice_delete_full]

--- a/Iris/Iris/Instances/Lib/GhostMap.lean
+++ b/Iris/Iris/Instances/Lib/GhostMap.lean
@@ -100,7 +100,7 @@ theorem ghost_map_elems_unseal [DecidableEq K] γ (m : H V) dq :
     simp only [BigOpM.bigOpM_empty]
     iapply iOwn_unit (γ := γ) (ε := unit)
   · imodintro
-    iapply bigOpM_iOwn _ _ _ h
+    iapply bigOpM_iOwn _ _ _ (mt equiv_iff_eq.mp h)
     unfold ghost_map_elem
     iexact H
 
@@ -356,7 +356,7 @@ theorem ghost_map_insert {γ} {m : H V} (k : K) (v : V) (Heq : get? m k = .none)
   icases H with ⟨H, $⟩
   imodintro
   iapply iOwn_mono $$ H
-  exact auth_inc_of_pmap_eqv _ map_insert
+  exact auth_inc_of_pmap_eqv _ (equiv_iff_eq.mpr map_insert)
 
 @[rocq_alias ghost_map_insert_persist]
 theorem ghost_map_insert_persist {γ} {m : H V} (k : K) (v : V) (Heq : get? m k = .none) :
@@ -373,7 +373,7 @@ theorem ghost_map_delete {γ} {m : H V} (k : K) (v : V) :
   icombine H1 H2 as G
   imod iOwn_update (update_one_delete (k := k) (v1 := toAgree (⟨v⟩ : LeibnizO V))) $$ G with G
   iapply iOwn_mono $$ G
-  exact auth_inc_of_pmap_eqv _ map_delete
+  exact auth_inc_of_pmap_eqv _ (equiv_iff_eq.mpr map_delete)
 
 @[rocq_alias ghost_map_update]
 theorem ghost_map_update {γ} {m : H V} {k : K} {v : V} (w : V) :
@@ -384,7 +384,7 @@ theorem ghost_map_update {γ} {m : H V} {k : K} {v : V} (w : V) :
   imodintro
   unfold ghost_map_auth
   iapply iOwn_mono $$ aux
-  exact auth_inc_of_pmap_eqv _ (map_equiv insert_delete.symm)
+  exact auth_inc_of_pmap_eqv _ (equiv_iff_eq.mpr (map_equiv insert_delete.symm))
 
 /-! ### Big-op versions of the above lemmas -/
 
@@ -407,9 +407,9 @@ theorem ghost_map_insert_big [DecidableEq K] {γ m} (m' : H V) (Hdisj : m' ##ₘ
     isplitl [H]
     · iapply iOwn_mono $$ H
       exact auth_inc_of_pmap_eqv _
-        (map_equiv ((union_equiv h rfl).trans union_empty_left))
+        (equiv_iff_eq.mpr (map_equiv ((union_equiv h rfl).trans union_empty_left)))
     · iapply (BigSepM.bigSepM_eqv_empty h).mpr; itrivial
-  · rw [←(bigOpM_iOwn γ _ _ h).to_eq, ←iOwn_op.to_eq]
+  · rw [←(bigOpM_iOwn γ _ _ (mt equiv_iff_eq.mp h)).to_eq, ←iOwn_op.to_eq]
     imod iOwn_update (E := GhostMapG.elem) (update_big_alloc _
         (Std.PartialMap.map (fun x ↦ toAgree ⟨x⟩) m') (DFrac.own 1)
         (disjoint_map Hdisj) DFrac.valid_own_one
@@ -418,7 +418,7 @@ theorem ghost_map_insert_big [DecidableEq K] {γ m} (m' : H V) (Hdisj : m' ##ₘ
     imodintro
     isplitl [H1]
     · iapply iOwn_mono $$ H1
-      exact auth_inc_of_pmap_eqv _ map_union
+      exact auth_inc_of_pmap_eqv _ (equiv_iff_eq.mpr map_union)
     · iapply iOwn_mono $$ H2
       exact inc_of_inc_of_eqv .rfl (BigOpM.bigOpM_map_eqv _ _ _).symm
 
@@ -456,11 +456,11 @@ theorem ghost_map_update_big [DecidableEq K] {γ m} (m0 m1 : H V) (Heq : dom m0 
     · unfold ghost_map_auth
       iapply iOwn_mono $$ H1
       exact auth_inc_of_pmap_eqv _
-        (map_equiv ((union_equiv h rfl).trans union_empty_left))
+        (equiv_iff_eq.mpr (map_equiv ((union_equiv h rfl).trans union_empty_left)))
     · iapply (BigSepM.bigSepM_eqv_empty h).mpr; itrivial
   · unfold ghost_map_elem ghost_map_auth
     icombine H1 H2 as H
-    rw [←(bigOpM_iOwn γ _ _ h).to_eq, ←iOwn_op.to_eq]
+    rw [←(bigOpM_iOwn γ _ _ (mt equiv_iff_eq.mp h)).to_eq, ←iOwn_op.to_eq]
     iapply iOwn_update $$ H
     refine Update.equiv_left (CMRA.op_right_eqv _ (BigOpM.bigOpM_map_eqv _ _ m0)) ?_
     have Heq' : dom (Std.PartialMap.map (fun x : V => toAgree (LeibnizO.mk x)) m0) =

--- a/Iris/Iris/Instances/Lib/GhostMap.lean
+++ b/Iris/Iris/Instances/Lib/GhostMap.lean
@@ -100,7 +100,7 @@ theorem ghost_map_elems_unseal [DecidableEq K] γ (m : H V) dq :
     simp only [BigOpM.bigOpM_empty]
     iapply iOwn_unit (γ := γ) (ε := unit)
   · imodintro
-    iapply bigOpM_iOwn _ _ _ (mt equiv_iff_eq.mp h)
+    iapply bigOpM_iOwn _ _ _ h
     unfold ghost_map_elem
     iexact H
 
@@ -356,7 +356,7 @@ theorem ghost_map_insert {γ} {m : H V} (k : K) (v : V) (Heq : get? m k = .none)
   icases H with ⟨H, $⟩
   imodintro
   iapply iOwn_mono $$ H
-  exact auth_inc_of_pmap_eqv _ (equiv_iff_eq.mpr map_insert)
+  exact auth_inc_of_map_eq _ map_insert
 
 @[rocq_alias ghost_map_insert_persist]
 theorem ghost_map_insert_persist {γ} {m : H V} (k : K) (v : V) (Heq : get? m k = .none) :
@@ -373,7 +373,7 @@ theorem ghost_map_delete {γ} {m : H V} (k : K) (v : V) :
   icombine H1 H2 as G
   imod iOwn_update (update_one_delete (k := k) (v1 := toAgree (⟨v⟩ : LeibnizO V))) $$ G with G
   iapply iOwn_mono $$ G
-  exact auth_inc_of_pmap_eqv _ (equiv_iff_eq.mpr map_delete)
+  exact auth_inc_of_map_eq _ map_delete
 
 @[rocq_alias ghost_map_update]
 theorem ghost_map_update {γ} {m : H V} {k : K} {v : V} (w : V) :
@@ -384,7 +384,7 @@ theorem ghost_map_update {γ} {m : H V} {k : K} {v : V} (w : V) :
   imodintro
   unfold ghost_map_auth
   iapply iOwn_mono $$ aux
-  exact auth_inc_of_pmap_eqv _ (equiv_iff_eq.mpr (map_equiv insert_delete.symm))
+  exact auth_inc_of_map_eq _ (map_equiv insert_delete.symm)
 
 /-! ### Big-op versions of the above lemmas -/
 
@@ -406,10 +406,9 @@ theorem ghost_map_insert_big [DecidableEq K] {γ m} (m' : H V) (Hdisj : m' ##ₘ
   · imodintro
     isplitl [H]
     · iapply iOwn_mono $$ H
-      exact auth_inc_of_pmap_eqv _
-        (equiv_iff_eq.mpr (map_equiv ((union_equiv h rfl).trans union_empty_left)))
+      exact auth_inc_of_map_eq _ (map_equiv ((union_equiv h rfl).trans union_empty_left))
     · iapply (BigSepM.bigSepM_eqv_empty h).mpr; itrivial
-  · rw [←(bigOpM_iOwn γ _ _ (mt equiv_iff_eq.mp h)).to_eq, ←iOwn_op.to_eq]
+  · rw [←(bigOpM_iOwn γ _ _ h).to_eq, ←iOwn_op.to_eq]
     imod iOwn_update (E := GhostMapG.elem) (update_big_alloc _
         (Std.PartialMap.map (fun x ↦ toAgree ⟨x⟩) m') (DFrac.own 1)
         (disjoint_map Hdisj) DFrac.valid_own_one
@@ -418,7 +417,7 @@ theorem ghost_map_insert_big [DecidableEq K] {γ m} (m' : H V) (Hdisj : m' ##ₘ
     imodintro
     isplitl [H1]
     · iapply iOwn_mono $$ H1
-      exact auth_inc_of_pmap_eqv _ (equiv_iff_eq.mpr map_union)
+      exact auth_inc_of_map_eq _ map_union
     · iapply iOwn_mono $$ H2
       exact inc_of_inc_of_eqv .rfl (BigOpM.bigOpM_map_eqv _ _ _).symm
 
@@ -455,12 +454,11 @@ theorem ghost_map_update_big [DecidableEq K] {γ m} (m0 m1 : H V) (Heq : dom m0 
     isplitl [H1]
     · unfold ghost_map_auth
       iapply iOwn_mono $$ H1
-      exact auth_inc_of_pmap_eqv _
-        (equiv_iff_eq.mpr (map_equiv ((union_equiv h rfl).trans union_empty_left)))
+      exact auth_inc_of_map_eq _ (map_equiv ((union_equiv h rfl).trans union_empty_left))
     · iapply (BigSepM.bigSepM_eqv_empty h).mpr; itrivial
   · unfold ghost_map_elem ghost_map_auth
     icombine H1 H2 as H
-    rw [←(bigOpM_iOwn γ _ _ (mt equiv_iff_eq.mp h)).to_eq, ←iOwn_op.to_eq]
+    rw [←(bigOpM_iOwn γ _ _ h).to_eq, ←iOwn_op.to_eq]
     iapply iOwn_update $$ H
     refine Update.equiv_left (CMRA.op_right_eqv _ (BigOpM.bigOpM_map_eqv _ _ m0)) ?_
     have Heq' : dom (Std.PartialMap.map (fun x : V => toAgree (LeibnizO.mk x)) m0) =

--- a/Iris/Iris/Instances/Lib/GhostMap.lean
+++ b/Iris/Iris/Instances/Lib/GhostMap.lean
@@ -95,8 +95,8 @@ theorem ghost_map_elems_unseal [DecidableEq K] γ (m : H V) dq :
     iOwn (GF := GF) (E := GhostMapG.elem) γ ([^ op map] k ↦ v ∈ m,
       Frag k dq (toAgree (⟨v⟩: LeibnizO V))) := by
   iintro H
-  by_cases h : m ≡ₘ ∅
-  · iapply OFE.NonExpansive.eqv <| OFE.NonExpansive.eqv (BigOpM.bigOpM_eqv_of_perm _ h)
+  by_cases h : m = ∅
+  · subst h
     simp only [BigOpM.bigOpM_empty]
     iapply iOwn_unit (γ := γ) (ε := unit)
   · imodintro
@@ -215,7 +215,7 @@ theorem ghost_map_alloc_strong [DecidableEq K] (P : GName → Prop) (m : H V) :
         (disjoint_empty_right _) DFrac.valid_own_one
         (all_map fun _ _ => Agree.toAgree_valid))
     refine CMRA.op_eqv ?_ (BigOpM.bigOpM_map_eqv _ _ _)
-    exact OFE.NonExpansive.eqv (PartialMap.eqv_of_Equiv union_empty_right)
+    exact OFE.NonExpansive.eqv (OFE.Equiv.of_eq union_empty_right)
 
 @[rocq_alias ghost_map_alloc_strong_empty]
 theorem ghost_map_alloc_strong_empty [DecidableEq K] (P : GName → Prop)
@@ -277,13 +277,13 @@ theorem ghost_map_auth_valid γ (dq : DFrac) (m : H V) :
 
 @[rocq_alias ghost_map_auth_valid_2]
 theorem ghost_map_auth_valid_2 {γ} {dq1 dq2 : DFrac} {m1 m2 : H V} :
-    ⊢@{IProp GF} (γ ↪●MAP{dq1} m1) -∗ (γ ↪●MAP{dq2} m2) -∗ ⌜✓ (dq1 • dq2) ∧ m1 ≡ₘ m2⌝ := by
+    ⊢@{IProp GF} (γ ↪●MAP{dq1} m1) -∗ (γ ↪●MAP{dq2} m2) -∗ ⌜✓ (dq1 • dq2) ∧ m1 = m2⌝ := by
   unfold ghost_map_auth
   iintro H1 H2
   icombine H1 H2 gives %G
   ipureintro
   have ⟨h₁, h₂⟩ := auth_op_auth_valid_iff.mp G
-  refine ⟨h₁, fun k => ?_⟩
+  refine ⟨h₁, equiv_iff_eq.mp fun k => ?_⟩
   have h := h₂ k
   simp only [get?_map, Option.map] at h
   cases h₁ : get? m1 k <;> cases h₂ : get? m2 k <;>
@@ -292,7 +292,7 @@ theorem ghost_map_auth_valid_2 {γ} {dq1 dq2 : DFrac} {m1 m2 : H V} :
 
 @[rocq_alias ghost_map_auth_agree]
 theorem ghost_map_auth_agree γ (dq1 dq2 : DFrac) (m1 m2 : H V) :
-    ⊢@{IProp GF} (γ ↪●MAP{dq1} m1) -∗ (γ ↪●MAP{dq2} m2) -∗ ⌜m1 ≡ₘ m2⌝ := by
+    ⊢@{IProp GF} (γ ↪●MAP{dq1} m1) -∗ (γ ↪●MAP{dq2} m2) -∗ ⌜m1 = m2⌝ := by
   iintro H₁ H₂
   ihave ⟨_, $⟩ := ghost_map_auth_valid_2 $$ H₁ H₂
 
@@ -384,9 +384,7 @@ theorem ghost_map_update {γ} {m : H V} {k : K} {v : V} (w : V) :
   imodintro
   unfold ghost_map_auth
   iapply iOwn_mono $$ aux
-  refine auth_inc_of_pmap_eqv _ ?_
-  intro i
-  rw [get?_map, get?_map, insert_delete i]
+  exact auth_inc_of_pmap_eqv _ (map_equiv insert_delete.symm)
 
 /-! ### Big-op versions of the above lemmas -/
 
@@ -404,11 +402,12 @@ theorem ghost_map_insert_big [DecidableEq K] {γ m} (m' : H V) (Hdisj : m' ##ₘ
   ⊢@{IProp GF} (γ ↪●MAP m) ==∗ (γ ↪●MAP (m' ∪ m)) ∗ [∗map] k ↦ v ∈ m', γ ↪◯MAP[k] v := by
   unfold ghost_map_auth ghost_map_elem
   iintro H
-  by_cases h : m' ≡ₘ ∅
+  by_cases h : m' = ∅
   · imodintro
     isplitl [H]
     · iapply iOwn_mono $$ H
-      exact auth_inc_of_pmap_eqv _ (map_equiv ((union_equiv h .refl).trans union_empty_left))
+      exact auth_inc_of_pmap_eqv _
+        (map_equiv ((union_equiv h rfl).trans union_empty_left))
     · iapply (BigSepM.bigSepM_eqv_empty h).mpr; itrivial
   · rw [←(bigOpM_iOwn γ _ _ h).to_eq, ←iOwn_op.to_eq]
     imod iOwn_update (E := GhostMapG.elem) (update_big_alloc _
@@ -443,7 +442,7 @@ theorem ghost_map_delete_big [DecidableEq K] {γ m} (m0 : H V) :
   refine Update.equiv_left (CMRA.op_right_eqv _ (BigOpM.bigOpM_map_eqv _ _ m0)) ?_
   refine (update_big_delete _ _).trans ?_
   refine Update.equiv_right ?_ .id
-  exact OFE.NonExpansive.eqv (PartialMap.eqv_of_Equiv map_difference_map)
+  exact OFE.NonExpansive.eqv (OFE.Equiv.of_eq map_difference_map)
 
 @[rocq_alias ghost_map_update_big]
 theorem ghost_map_update_big [DecidableEq K] {γ m} (m0 m1 : H V) (Heq : dom m0 = dom m1) :
@@ -451,12 +450,13 @@ theorem ghost_map_update_big [DecidableEq K] {γ m} (m0 m1 : H V) (Heq : dom m0 
     (γ ↪●MAP (m1 ∪ m)) ∗ [∗map] k ↦ v ∈ m1, γ ↪◯MAP[k] v := by
   iintro H1 H2
   imod ghost_map_elems_unseal $$ H2 with H2
-  by_cases h : m1 ≡ₘ ∅
+  by_cases h : m1 = ∅
   · imodintro
     isplitl [H1]
     · unfold ghost_map_auth
       iapply iOwn_mono $$ H1
-      exact auth_inc_of_pmap_eqv _ (map_equiv ((union_equiv h .refl).trans union_empty_left))
+      exact auth_inc_of_pmap_eqv _
+        (map_equiv ((union_equiv h rfl).trans union_empty_left))
     · iapply (BigSepM.bigSepM_eqv_empty h).mpr; itrivial
   · unfold ghost_map_elem ghost_map_auth
     icombine H1 H2 as H
@@ -470,7 +470,7 @@ theorem ghost_map_update_big [DecidableEq K] {γ m} (m0 m1 : H V) (Heq : dom m0 
       (all_map fun _ _ => Agree.toAgree_valid)).trans ?_
     refine Update.equiv_right ?_ .id
     refine CMRA.op_eqv ?_ (BigOpM.bigOpM_map_eqv _ _ _)
-    exact OFE.NonExpansive.eqv (PartialMap.eqv_of_Equiv map_union.symm)
+    exact OFE.NonExpansive.eqv (OFE.Equiv.of_eq map_union.symm)
 
 end lemmas
 

--- a/Iris/Iris/Instances/Lib/WSat.lean
+++ b/Iris/Iris/Instances/Lib/WSat.lean
@@ -297,9 +297,7 @@ theorem ownI_alloc [W : WsatGS GF] (φ : Pos → Prop) (P : IProp GF)
     · suffices Hi : insert (liftInv I) j (toAgree (invariant_unfold P)) = liftInv (insert I j P) by
         rw [Hi]
         iexact Hown
-      refine ExtensionalPartialMap.equiv_iff_eq.mp fun k => ?_
-      simp only [get?_insert, get?_map, Option.map_map]
-      by_cases h : j = k <;> simp [h]
+      simp only [liftInv, map_insert]
     · iapply bigSepM_insert (x := P) Hget $$ [Hmap HProp HD]
       isplitl [HProp HD]
       · rw [HEQ]
@@ -340,9 +338,7 @@ theorem ownI_alloc_open [W : WsatGS GF] (φ : Pos → Prop) (P : IProp GF)
     · suffices Hi : Std.insert (liftInv I) j (toAgree (invariant_unfold P)) = liftInv (Std.insert I j P) by
         rw [Hi]
         iexact Hown
-      refine ExtensionalPartialMap.equiv_iff_eq.mp fun k => ?_
-      simp only [get?_insert, get?_map, Option.map_map]
-      by_cases h : j = k <;> simp [h]
+      simp only [liftInv, map_insert]
     · iapply bigSepM_insert (x := P) Hget $$ [Hmap HE]
       isplitl [HE]
       · iright; iassumption
@@ -371,8 +367,7 @@ theorem wsat_alloc [WP : WsatGpreS GF] :
     isplitl
     · iclear Hd
       have H : liftInv (∅ : InvMap (IProp GF)) = ∅ := by
-        refine ExtensionalPartialMap.equiv_iff_eq.mp fun _ => ?_
-        simp [get?_map, get?_empty]
+        simp only [liftInv, map_empty]
       rw [invMap, H]
       iassumption
     · iapply bigSepM_empty

--- a/Iris/Iris/Std/HeapInstances.lean
+++ b/Iris/Iris/Std/HeapInstances.lean
@@ -57,8 +57,6 @@ instance : LawfulPartialMap (K → Option ·) K where
   get?_delete_ne := by simp [get?, delete]; grind
   get?_bindAlter := by simp [get?, bindAlter]
   get?_merge {_ _ _ _ _} := by simp [get?, merge]; split <;> simp_all
-
-instance : ExtensionalPartialMap (K → Option ·) K where
   equiv_iff_eq := ⟨funext, congrFun⟩
 
 end FunPartialMap
@@ -83,160 +81,6 @@ instance instClassicalUnboundedHeap [InfiniteType K] : UnboundedHeap (K → Opti
     grind
 
 end ClassicalAllocHeap
-
-section AssociationLists
-
-/-- An association list represented as a sequence of set and remove operations. -/
-inductive AssocList (V : Type _)
-  | empty : AssocList V
-  | set : Nat → V → AssocList V → AssocList V
-  | remove : Nat → AssocList V → AssocList V
-
-open AssocList
-
-/-- Look up a value in an association list. -/
-@[simp]
-def AssocList.lookup (f : AssocList V) (k : Nat) : Option V :=
-  match f with
-  | .empty => none
-  | .set n v' rest => if n = k then some v' else rest.lookup k
-  | .remove n rest => if n = k then none else rest.lookup k
-
-/-- Update an association list by setting or removing a key. -/
-@[simp]
-def AssocList.update (f : AssocList V) (k : Nat) (v : Option V) : AssocList V :=
-  match v with
-  | some v' => f.set k v'
-  | none => f.remove k
-
-/-- Map a function over the values in an association list. -/
-@[simp]
-def AssocList.map (f : Nat → V → Option V') (g : AssocList V) : AssocList V' :=
-  match g with
-  | .empty => .empty
-  | .set n v rest =>
-      match (f n v) with
-      | .some r => .set n r (rest.map f)
-      | .none => .remove n (rest.map f)
-  | .remove n rest => .remove n (rest.map f)
-
-/-- Find a fresh key that is not present in the association list. -/
-@[simp]
-def AssocList.fresh (f : AssocList V) : Nat :=
-  match f with
-  | .empty => 0
-  | .set n _ rest => max (n + 1) rest.fresh
-  | .remove n rest => max (n + 1) rest.fresh
-
-/-- Construct an association list from a function on naturals less than N. -/
-@[simp]
-def AssocList.construct (f : Nat → Option V) (N : Nat) : AssocList V :=
-  match N with
-  | .zero => .empty
-  | .succ N' =>
-      match (f N') with
-      | some v => .set N' v (AssocList.construct f N')
-      | none => (AssocList.construct f N')
-
-/-- The specification function for `construct`: returns f n for n < N, none otherwise. -/
-@[simp]
-def AssocList.construct_spec (f : Nat → Option V) (N : Nat) : Nat → (Option V) :=
-  fun n => if n < N then f n else none
-
-/-- Updating an association list and then looking up is equivalent to the functional set. -/
-theorem AssocList.lookup_update (f : AssocList V) :
-    (f.update k v).lookup = fset (f.lookup) k v := by
-  funext k'
-  cases f <;> cases v <;> simp [fset]
-
-/-- Keys greater than or equal to `fresh` are not present in the association list. -/
-theorem AssocList.fresh_lookup_ge (f : AssocList V) n :
-    f.fresh ≤ n → f.lookup n = none := by
-  induction f <;> simp
-  case set => split <;> grind
-  case remove => grind
-
-/-- The lookup function of a constructed association list matches its specification. -/
-theorem AssocList.construct_get (f : Nat → Option V) (N : Nat) :
-    lookup (construct f N) = construct_spec f N := by
-  funext k
-  rcases Nat.lt_or_ge k N with hl | hg
-  · induction N <;> simp
-    rename_i N' IH
-    split <;> rename_i h
-    · simp only [lookup]; split
-      · simp_all
-      · rw [IH (by omega)]; simp; omega
-    · rw [if_pos hl]
-      if h : k < N' then
-        simp [IH h]; omega
-      else
-        have : k = N' := by omega
-        simp_all
-        clear this h
-        suffices ∀ N'', N' ≤ N'' → (construct f N').lookup N'' = none by grind
-        induction N' <;> simp
-        rename_i n' _
-        cases f n' <;> simp <;> grind
-  · simp; rw [if_neg (by omega)]
-    induction N <;> simp
-    split
-    · simp [lookup]; grind
-    · grind
-
-/-- Lift a binary operation to `Option`, treating `none` as an identity element. -/
-abbrev op_lift (op : V → V → V) (v1 v2 : Option V) : Option V :=
-  match v1, v2 with
-  | some v1, some v2 => some (op v1 v2)
-  | some v1, none => some v1
-  | none, some v2 => some v2
-  | none, none => none
-
-/-- PartialMap instance for AssocList. -/
-instance AssocList.instPartialMapAssocList : Iris.Std.PartialMap AssocList Nat where
-  get? f k := f.lookup k
-  insert f k v := f.update k (some v)
-  delete f k := f.update k none
-  empty := .empty
-  bindAlter f m := m.map f
-  merge op t1 t2 :=
-    construct (fun n => op_lift (op n) (t1.lookup n) (t2.lookup n)) (max t1.fresh t2.fresh)
-
-instance AssocList.instLawfulPartialMapAssocList : Iris.Std.LawfulPartialMap AssocList Nat where
-  get?_empty := by simp [get?, EmptyCollection.emptyCollection, Std.empty]
-  get?_insert_eq := by simp [get?, insert]; grind
-  get?_insert_ne := by simp [get?, insert]; grind
-  get?_delete_eq := by simp [get?, delete]
-  get?_delete_ne := by simp [get?, delete]; grind
-  get?_bindAlter {_ _ n t f} := by
-    induction t with
-    | empty => simp_all [get?, bindAlter, AssocList.map]
-    | set n' v' t' IH =>
-      simp_all [get?, bindAlter]
-      cases h1 : f n' v' <;> simp <;> split <;> rename_i h2 <;> simp_all
-    | remove n' t' IH =>
-      simp_all [get?, bindAlter]
-      split <;> simp [Option.bind]
-  get?_merge := by
-    intro _ op t1 t2 k
-    simp [PartialMap.get?, merge, construct_get, Option.merge, op_lift]
-    split
-    · rename_i h
-      cases t1.lookup k <;> cases t2.lookup k <;> simp_all
-    · rename_i h
-      rw [fresh_lookup_ge _ _ (by omega : t1.fresh ≤ k)]
-      rw [fresh_lookup_ge _ _ (by omega : t2.fresh ≤ k)]
-
-instance instAllocHeapAssocList : Iris.Std.Heap AssocList Nat where
-  notFull _ := True
-  fresh {_ f} _ := f.fresh
-  get?_fresh {_ f _} := fresh_lookup_ge f f.fresh (f.fresh.le_refl)
-
-instance instUnboundedHeapAssocList : Iris.Std.UnboundedHeap AssocList Nat where
-  notFull_empty := by simp [notFull]
-  notFull_insert_fresh {t v h} := by simp [notFull]
-
-end AssociationLists
 
 end Iris.Std
 
@@ -276,15 +120,6 @@ open Option Std.DTreeMap.Internal.Impl List TransCmp OrientedCmp LawfulEqCmp Ord
 open Iris.Std
 
 variable {K V : Type _} [Ord K] [TransOrd K] [LawfulEqOrd K]
-
-/-- TreeMap forms a Store with Option values. -/
-instance instStoreTreeMap : PartialMap (TreeMap K · compare) K where
-  get? t k := t[k]?
-  insert t k v := t.alter k (fun _ => some v)
-  delete t k := t.alter k (fun _ => none)
-  empty := ∅
-  bindAlter f t := t.filterMap f
-  merge op t1 t2 := t1.mergeWith op t2
 
 private theorem get?_foldl_alter_impl_sigma {l : List ((_ : K) × V)}
     (hinit : init.WF) (hl : l.Pairwise (fun x y => ¬ (compare x.1 y.1).isEq)) :
@@ -386,41 +221,6 @@ theorem getElem?_mergeWith' {t₁ t₂ : TreeMap K V compare} {f : K → V → V
     simp [← hval, hfind]
     simp [eq_of_compare hkv_cmp]
 
-instance : LawfulPartialMap (TreeMap K · compare) K where
-  get?_empty := by simp [Iris.Std.get?]
-  get?_insert_eq := by simp [Iris.Std.get?, Iris.Std.insert]; grind
-  get?_insert_ne := by simp [Iris.Std.get?, Iris.Std.insert]; grind
-  get?_delete_eq := by simp [Iris.Std.get?, Iris.Std.delete]
-  get?_delete_ne := by simp [Iris.Std.get?, Iris.Std.delete]; grind
-  get?_bindAlter := by simp [Iris.Std.get?, Iris.Std.bindAlter]
-  get?_merge := getElem?_mergeWith'
-
-instance : FiniteMap (TreeMap K · compare) K where
-  toList t := t.toList
-
-instance : LawfulFiniteMap (TreeMap K · compare) K where
-  toList_empty := rfl
-  toList_noDupKeys := by
-    intro V m
-    have h' : List.Pairwise (fun a b => ¬compare a b = eq) (m.toList.map (·.1)) := by
-      refine List.pairwise_map.mpr ?_
-      refine (distinct_keys_toList (t := m)).imp ?_
-      intro _ _ hab
-      exact hab
-    refine h'.imp ?_
-    intro a b hab
-    rw [compare_eq_iff_eq] at hab
-    exact hab
-  toList_get := by
-    intro V m k v
-    constructor
-    · intro h
-      exact getElem?_eq_some_iff_exists_compare_eq_eq_and_mem_toList.mpr ⟨k, compare_self, h⟩
-    · intro h
-      obtain ⟨_, hcmp, hmem⟩ := getElem?_eq_some_iff_exists_compare_eq_eq_and_mem_toList.mp h
-      rw [compare_eq_iff_eq.mp hcmp]
-      exact hmem
-
 end HeapInstance
 
 end Std.TreeMap
@@ -468,6 +268,7 @@ instance : LawfulPartialMap (ExtTreeMap K · compare) K where
   get?_delete_ne := by simp [Iris.Std.get?, Iris.Std.delete]; grind
   get?_bindAlter := by simp [Iris.Std.get?, Iris.Std.bindAlter]
   get?_merge := getElem?_mergeWith'
+  equiv_iff_eq {V m₁ m₂} := by rw [ExtTreeMap.ext_getElem?_iff]; rfl
 
 instance : FiniteMap (ExtTreeMap K · compare) K where
   toList t := t.toList
@@ -479,9 +280,6 @@ instance : LawfulFiniteMap (ExtTreeMap K · compare) K where
       refine h.imp (· <| LawfulEqOrd.compare_eq_iff_eq.mpr ·)
     exact List.pairwise_map.mpr distinct_keys_toList
   toList_get {_ m _ _} := m.mem_toList_iff_getElem?_eq_some
-
-instance : ExtensionalPartialMap (ExtTreeMap K · compare) K where
-  equiv_iff_eq {V m₁ m₂} := by rw [ExtTreeMap.ext_getElem?_iff]; rfl
 
 end HeapInstance
 

--- a/Iris/Iris/Std/PartialMap.lean
+++ b/Iris/Iris/Std/PartialMap.lean
@@ -643,10 +643,10 @@ theorem disjoint_difference_right {m₁ m₂ : M V} :
   cases h_in_diff
 
 theorem union_difference_cancel {m₁ m₂ : M V} (h : m₂ ⊆ m₁) :
-    union m₂ (m₁ \ m₂) = m₁ := by
+    m₂ ∪ (m₁ \ m₂) = m₁ := by
   apply equiv_iff_eq.mp
   intro k
-  simp only [PartialMap.union, get?_merge, get?_difference]
+  simp only [Union.union, PartialMap.union, get?_merge, get?_difference]
   cases hm2 : get? m₂ k with
   | none =>
     cases get? m₁ k <;> simp [Option.merge]
@@ -655,39 +655,40 @@ theorem union_difference_cancel {m₁ m₂ : M V} (h : m₂ ⊆ m₁) :
     exact (h k v hm2).symm
 
 theorem get?_union {m₁ m₂ : M V} {k : K} :
-    get? (union m₁ m₂) k = (get? m₁ k).orElse (fun _ => get? m₂ k) := by
-  simp only [PartialMap.union, get?_merge]
+    get? (m₁ ∪ m₂) k = (get? m₁ k).orElse (fun _ => get? m₂ k) := by
+  simp only [Union.union, PartialMap.union, get?_merge]
   cases get? m₁ k <;> cases get? m₂ k <;> simp [Option.merge, Option.orElse]
 
 theorem get?_union_none {m₁ m₂ : M V} {i : K} :
-    get? (union m₁ m₂) i = none ↔ get? m₁ i = none ∧ get? m₂ i = none := by
+    get? (m₁ ∪ m₂) i = none ↔ get? m₁ i = none ∧ get? m₂ i = none := by
   rw [get?_union]
   cases h1 : get? m₁ i <;> cases h2 : get? m₂ i <;> simp [Option.orElse]
 
 theorem union_equiv {m₁ m₁' m₂ m₂' : M V}
-    (h₁ : m₁ = m₁') (h₂ : m₂ = m₂') : union m₁ m₂ = union m₁' m₂' := by
+    (h₁ : m₁ = m₁') (h₂ : m₂ = m₂') : m₁ ∪ m₂ = m₁' ∪ m₂' := by
   rw [h₁, h₂]
 
-theorem union_empty_right {m : M V} : union m (∅ : M V) = m := by
+theorem union_empty_right {m : M V} : m ∪ (∅ : M V) = m := by
   apply equiv_iff_eq.mp
   intro k
   rw [get?_union, get?_empty]
   cases get? m k <;> rfl
 
-theorem union_empty_left {m : M V} : union (∅ : M V) m = m := by
+theorem union_empty_left {m : M V} : (∅ : M V) ∪ m = m := by
   apply equiv_iff_eq.mp
   intro k
   rw [get?_union, get?_empty]
   rfl
 
 theorem union_insert_left {m₁ m₂ : M V} {i : K} {x : V} :
-    insert (union m₁ m₂) i x = union (insert m₁ i x) m₂ := by
+    insert (m₁ ∪ m₂) i x = insert m₁ i x ∪ m₂ := by
   apply equiv_iff_eq.mp
   intro k
   by_cases hik : i = k
   · subst hik
-    cases h : get? m₂ i <;> simp [get?_insert_eq rfl, PartialMap.union, get?_merge, Option.merge, h]
-  · simp [get?_insert_ne hik, PartialMap.union, get?_merge]
+    cases h : get? m₂ i <;>
+      simp [get?_insert_eq rfl, Union.union, PartialMap.union, get?_merge, Option.merge, h]
+  · simp [get?_insert_ne hik, Union.union, PartialMap.union, get?_merge]
 
 theorem get?_map {f : V → V'} {m : M V} {k : K} :
     get? (PartialMap.map f m) k = (get? m k).map f := by

--- a/Iris/Iris/Std/PartialMap.lean
+++ b/Iris/Iris/Std/PartialMap.lean
@@ -219,11 +219,8 @@ end PartialMap
 /-- An association list has no duplicate keys -/
 def NoDupKeys (L : List (K × A)) : Prop := L.map (·.1) |>.Nodup
 
-class ExtensionalPartialMap (M : Type _ → Type _) (K : outParam (Type _))
-    extends PartialMap M K where
-  equiv_iff_eq {m₁ m₂ : M V} : PartialMap.equiv m₁ m₂ ↔ m₁ = m₂
-
-/-- Laws that a partial map implementation must satisfy. -/
+/-- Laws that a partial map implementation must satisfy. Includes extensionality
+(`equiv_iff_eq`): pointwise-equivalent maps are equal. -/
 class LawfulPartialMap (M : Type _ → Type _) (K : outParam (Type _))
     extends PartialMap M K where
   get?_empty k : get? (∅ : M V) k = none
@@ -235,8 +232,10 @@ class LawfulPartialMap (M : Type _ → Type _) (K : outParam (Type _))
       get? (bindAlter f m) k = (get? m k).bind (f k)
   get?_merge :
       get? (merge op m₁ m₂) k = Option.merge (op k) (get? m₁ k) (get? m₂ k)
+  /-- Pointwise-equivalent maps are equal (extensionality). -/
+  equiv_iff_eq {m₁ m₂ : M V} : PartialMap.equiv m₁ m₂ ↔ m₁ = m₂
 export LawfulPartialMap (get?_empty get?_insert_eq get?_insert_ne get?_delete_eq
-  get?_delete_ne get?_bindAlter get?_merge)
+  get?_delete_ne get?_bindAlter get?_merge equiv_iff_eq)
 
 class LawfulFiniteMap (M : Type _ → Type _) (K : outParam (Type _))
     extends LawfulPartialMap M K, FiniteMap M K where
@@ -340,31 +339,36 @@ theorem get?_delete_none_iff [DecidableEq K] {m : M V} {i j : K} :
   rw [get?_delete]; split <;> simp_all
 
 theorem insert_delete_cancel {m : M V} {i : K} {v : V} (h : get? m i = some v) :
-    insert (delete m i) i v ≡ₘ m := by
+    insert (delete m i) i v = m := by
+  apply equiv_iff_eq.mp
   intros j
   by_cases hij : i = j
   · rw [get?_insert_eq hij, ← h, hij]
   · rw [get?_insert_ne hij, get?_delete_ne hij]
 
 theorem delete_insert_cancel {m : M V} {i : K} {x : V} (h : get? m i = none) :
-    delete (insert m i x) i ≡ₘ m := by
+    delete (insert m i x) i = m := by
+  apply equiv_iff_eq.mp
   intro j
   by_cases hij : i = j
   · rw [get?_delete_eq hij, ← h, hij]
   · rw [get?_delete_ne hij, get?_insert_ne hij]
 
-theorem eq_empty_iff {m : M V} : (m ≡ₘ ∅) ↔ ∀ k, get? m k = none :=
-  ⟨fun h k => (h k) ▸ get?_empty k, fun h k => (h k) ▸ (get?_empty k).symm⟩
+theorem eq_empty_iff {m : M V} : (m = ∅) ↔ ∀ k, get? m k = none := by
+  rw [← equiv_iff_eq]
+  exact ⟨fun h k => (h k) ▸ get?_empty k, fun h k => (h k) ▸ (get?_empty k).symm⟩
 
 theorem delete_delete {m : M V} {i : K} :
-    delete (delete m i) i ≡ₘ delete m i := by
+    delete (delete m i) i = delete m i := by
+  apply equiv_iff_eq.mp
   intro j
   by_cases h : i = j
   · rw [get?_delete_eq h, get?_delete_eq h]
   · rw [get?_delete_ne h]
 
 theorem delete_delete_comm {m : M V} {i j : K} :
-    delete (delete m i) j ≡ₘ delete (delete m j) i := by
+    delete (delete m i) j = delete (delete m j) i := by
+  apply equiv_iff_eq.mp
   intro k
   by_cases hik : i = k <;> by_cases hjk : j = k
   · rw [get?_delete_eq hik, get?_delete_eq hjk]
@@ -373,21 +377,24 @@ theorem delete_delete_comm {m : M V} {i j : K} :
   · rw [get?_delete_ne hik, get?_delete_ne hjk, get?_delete_ne hik, get?_delete_ne hjk]
 
 theorem insert_insert_same {m : M V} {i : K} {x y : V} :
-    insert (insert m i x) i y ≡ₘ insert m i y := by
+    insert (insert m i x) i y = insert m i y := by
+  apply equiv_iff_eq.mp
   intro j
   by_cases h : i = j
   · rw [get?_insert_eq h, get?_insert_eq h]
   · rw [get?_insert_ne h, get?_insert_ne h, get?_insert_ne h]
 
 theorem insert_delete {m : M V} {i : K} {x : V} :
-    insert (delete m i) i x ≡ₘ insert m i x := by
+    insert (delete m i) i x = insert m i x := by
+  apply equiv_iff_eq.mp
   intro j
   by_cases h : i = j
   · rw [get?_insert_eq h, get?_insert_eq h]
   · rw [get?_insert_ne h, get?_delete_ne h, get?_insert_ne h]
 
 theorem insert_insert_comm {m : M V} {i j : K} {x y : V} (h : i ≠ j) :
-    insert (insert m i x) j y ≡ₘ insert (insert m j y) i x := by
+    insert (insert m i x) j y = insert (insert m j y) i x := by
+  apply equiv_iff_eq.mp
   intro k
   by_cases hik : i = k <;> by_cases hjk : j = k
   · rw [hik, hjk] at h; exact False.elim (h rfl)
@@ -396,7 +403,8 @@ theorem insert_insert_comm {m : M V} {i j : K} {x y : V} (h : i ≠ j) :
   · rw [get?_insert_ne hjk, get?_insert_ne hik, get?_insert_ne hik, get?_insert_ne hjk]
 
 theorem delete_insert_of_ne {m : M V} {i j : K} {x : V} (h : i ≠ j) :
-    delete (insert m i x) j ≡ₘ insert (delete m j) i x := by
+    delete (insert m i x) j = insert (delete m j) i x := by
+  apply equiv_iff_eq.mp
   intro k
   by_cases hik : i = k <;> by_cases hjk : j = k
   · rw [hik, hjk] at h; exact False.elim (h rfl)
@@ -404,28 +412,31 @@ theorem delete_insert_of_ne {m : M V} {i j : K} {x : V} (h : i ≠ j) :
   · rw [get?_insert_ne hik, get?_delete_eq hjk, get?_delete_eq hjk]
   · rw [get?_delete_ne hjk, get?_insert_ne hik, get?_insert_ne hik, get?_delete_ne hjk]
 
-theorem delete_empty {i : K} : delete (∅ : M V) i ≡ₘ ∅ := by
+theorem delete_empty {i : K} : delete (∅ : M V) i = ∅ := by
+  apply equiv_iff_eq.mp
   intro j
   by_cases h : i = j
   · rw [get?_delete_eq h, get?_empty]
   · rw [get?_delete_ne h, get?_empty]
 
-theorem delete_of_get? {m : M V} {i : K} (h : get? m i = none) : delete m i ≡ₘ m := by
+theorem delete_of_get? {m : M V} {i : K} (h : get? m i = none) : delete m i = m := by
+  apply equiv_iff_eq.mp
   intro j
   by_cases hij : i = j
   · rw [get?_delete_eq hij, ← h, hij]
   · rw [get?_delete_ne hij]
 
 theorem insert_get? {m : M V} {i : K} {x : V} (h : get? m i = some x) :
-    insert m i x ≡ₘ m := by
+    insert m i x = m := by
+  apply equiv_iff_eq.mp
   intro j
   by_cases hij : i = j
   · rw [get?_insert_eq hij, ← h, hij]
   · rw [get?_insert_ne hij]
 
-theorem insert_ne_empty {m : M V} {i : K} {x : V} : ¬(insert m i x ≡ₘ ∅) := by
+theorem insert_ne_empty {m : M V} {i : K} {x : V} : ¬(insert m i x = ∅) := by
   intro h
-  have : get? (insert m i x) i = none := (h i) ▸ get?_empty i
+  have : get? (insert m i x) i = none := by rw [h]; exact get?_empty i
   rw [get?_insert_eq rfl] at this
   cases this
 
@@ -464,16 +475,18 @@ theorem insert_subset_insert {m₁ m₂ : M V} {i : K} {x : V} (h : m₁ ⊆ m�
   · rw [get?_insert_ne hik] at hk ⊢
     exact h k v hk
 
-theorem singleton_ne_empty {i : K} {x : V} : ¬({[i := x]} ≡ₘ (∅ : M V)) := insert_ne_empty
+theorem singleton_ne_empty {i : K} {x : V} : ¬({[i := x]} = (∅ : M V)) := insert_ne_empty
 
-theorem delete_singleton_eq {i : K} {x : V} : delete ({[i := x]} : M V) i ≡ₘ ∅ := by
+theorem delete_singleton_eq {i : K} {x : V} : delete ({[i := x]} : M V) i = ∅ := by
+  apply equiv_iff_eq.mp
   intro j
   by_cases h : i = j
   · rw [get?_delete_eq h, get?_empty]
   · rw [get?_delete_ne h, get?_singleton_ne h, get?_empty]
 
 theorem delete_singleton_ne {i j : K} {x : V} (h : i ≠ j) :
-    delete ({[j := x]} : M V) i ≡ₘ {[j := x]} := by
+    delete ({[j := x]} : M V) i = {[j := x]} := by
+  apply equiv_iff_eq.mp
   intro k
   by_cases hik : i = k
   · rw [get?_delete_eq hik, get?_singleton_ne (hik ▸ h.symm)]
@@ -630,7 +643,8 @@ theorem disjoint_difference_right {m₁ m₂ : M V} :
   cases h_in_diff
 
 theorem union_difference_cancel {m₁ m₂ : M V} (h : m₂ ⊆ m₁) :
-    union m₂ (m₁ \ m₂) ≡ₘ m₁ := by
+    union m₂ (m₁ \ m₂) = m₁ := by
+  apply equiv_iff_eq.mp
   intro k
   simp only [PartialMap.union, get?_merge, get?_difference]
   cases hm2 : get? m₂ k with
@@ -651,22 +665,24 @@ theorem get?_union_none {m₁ m₂ : M V} {i : K} :
   cases h1 : get? m₁ i <;> cases h2 : get? m₂ i <;> simp [Option.orElse]
 
 theorem union_equiv {m₁ m₁' m₂ m₂' : M V}
-    (h₁ : m₁ ≡ₘ m₁') (h₂ : m₂ ≡ₘ m₂') : union m₁ m₂ ≡ₘ union m₁' m₂' := by
-  intro k
-  rw [get?_union, get?_union, h₁ k, h₂ k]
+    (h₁ : m₁ = m₁') (h₂ : m₂ = m₂') : union m₁ m₂ = union m₁' m₂' := by
+  rw [h₁, h₂]
 
-theorem union_empty_right {m : M V} : union m (∅ : M V) ≡ₘ m := by
+theorem union_empty_right {m : M V} : union m (∅ : M V) = m := by
+  apply equiv_iff_eq.mp
   intro k
   rw [get?_union, get?_empty]
   cases get? m k <;> rfl
 
-theorem union_empty_left {m : M V} : union (∅ : M V) m ≡ₘ m := by
+theorem union_empty_left {m : M V} : union (∅ : M V) m = m := by
+  apply equiv_iff_eq.mp
   intro k
   rw [get?_union, get?_empty]
   rfl
 
 theorem union_insert_left {m₁ m₂ : M V} {i : K} {x : V} :
-    insert (union m₁ m₂) i x ≡ₘ union (insert m₁ i x) m₂ := by
+    insert (union m₁ m₂) i x = union (insert m₁ i x) m₂ := by
+  apply equiv_iff_eq.mp
   intro k
   by_cases hik : i = k
   · subst hik
@@ -679,35 +695,39 @@ theorem get?_map {f : V → V'} {m : M V} {k : K} :
   cases get? m k <;> simp
 
 theorem map_id {m : M V} :
-    PartialMap.map id m ≡ₘ m := by
+    PartialMap.map id m = m := by
+  apply equiv_iff_eq.mp
   intro k
   rw [get?_map]
   cases get? m k <;> simp
 
-theorem map_empty {f : V → V'} : PartialMap.map f (∅ : M V) ≡ₘ (∅ : M V') := by
+theorem map_empty {f : V → V'} : PartialMap.map f (∅ : M V) = (∅ : M V') := by
+  apply equiv_iff_eq.mp
   intro k
   rw [get?_map, get?_empty, get?_empty]
   rfl
 
-theorem map_equiv {f : V → V'} {m₁ m₂ : M V} (h : m₁ ≡ₘ m₂) :
-    PartialMap.map f m₁ ≡ₘ PartialMap.map f m₂ := by
-  intro k
-  rw [get?_map, get?_map, h k]
+theorem map_equiv {f : V → V'} {m₁ m₂ : M V} (h : m₁ = m₂) :
+    PartialMap.map f m₁ = PartialMap.map f m₂ := by
+  rw [h]
 
 theorem map_insert {f : V → V'} {m : M V} {k : K} {v : V} :
-    PartialMap.map f (insert m k v) ≡ₘ insert (PartialMap.map f m) k (f v) := by
+    PartialMap.map f (insert m k v) = insert (PartialMap.map f m) k (f v) := by
+  apply equiv_iff_eq.mp
   intro i
   by_cases h : k = i <;>
     simp [h, get?_map, get?_insert_eq, get?_insert_ne]
 
 theorem map_delete {f : V → V'} {m : M V} {k : K} :
-    PartialMap.map f (delete m k) ≡ₘ delete (PartialMap.map f m) k := by
+    PartialMap.map f (delete m k) = delete (PartialMap.map f m) k := by
+  apply equiv_iff_eq.mp
   intro i
   by_cases h : k = i <;>
     simp [h, get?_map, get?_delete_eq, get?_delete_ne]
 
 theorem map_union {f : V → V'} {m₁ m₂ : M V} :
-    PartialMap.map f (m₁ ∪ m₂) ≡ₘ (PartialMap.map f m₁ ∪ PartialMap.map f m₂) := by
+    PartialMap.map f (m₁ ∪ m₂) = (PartialMap.map f m₁ ∪ PartialMap.map f m₂) := by
+  apply equiv_iff_eq.mp
   intro k
   simp only [get?_map, Union.union, PartialMap.union, get?_merge]
   cases get? m₁ k <;> cases get? m₂ k <;> simp [Option.merge]
@@ -726,7 +746,8 @@ theorem disjoint_map {f g : V → V'} {m₁ m₂ : M V}
 The conclusion uses `map` on both sides so the right-hand side type-checks. -/
 theorem map_difference_map {f : V → V'} {g : V → V'}
     {m₁ m₂ : M V} :
-    (PartialMap.map f m₁ \ PartialMap.map g m₂) ≡ₘ PartialMap.map f (m₁ \ m₂) := by
+    (PartialMap.map f m₁ \ PartialMap.map g m₂) = PartialMap.map f (m₁ \ m₂) := by
+  apply equiv_iff_eq.mp
   intro k
   simp only [get?_map, get?_difference, Option.isSome_map]
   split <;> simp
@@ -750,22 +771,25 @@ theorem get?_zip {m₁ : M V} {m₂ : M V'} {k : K} :
   cases h1 : get? m₁ k <;> cases h2 : get? m₂ k <;> simp [Option.bind]
 
 theorem map_zipWith_right {f : V → V' → V''} {g : V''' → V'} {m₁ : M V} {m₂ : M V'''} :
-    PartialMap.map (fun (v, w) => f v (g w)) (zip m₁ m₂) ≡ₘ
+    PartialMap.map (fun (v, w) => f v (g w)) (zip m₁ m₂) =
       zipWith f m₁ (PartialMap.map g m₂) := by
+  apply equiv_iff_eq.mp
   intro k
   simp [get?_map, get?_zip, get?_zipWith]
   cases get? m₁ k <;> cases get? m₂ k <;> simp [Option.bind, Option.map]
 
 theorem map_zipWith_left {f : V → V' → V''} {g : V''' → V} {m₁ : M V'''} {m₂ : M V'} :
-    PartialMap.map (fun (w, v) => f (g w) v) (zip m₁ m₂) ≡ₘ
+    PartialMap.map (fun (w, v) => f (g w) v) (zip m₁ m₂) =
       zipWith f (PartialMap.map g m₁) m₂ := by
+  apply equiv_iff_eq.mp
   intro k
   simp [get?_map, get?_zip, get?_zipWith]
   cases get? m₁ k <;> cases get? m₂ k <;> simp [Option.bind, Option.map]
 
 theorem zipWith_insert {f : V → V' → V''} {m₁ : M V} {m₂ : M V'} {k : K} {v : V} {v' : V'} :
-    zipWith f (insert m₁ k v) (insert m₂ k v') ≡ₘ
+    zipWith f (insert m₁ k v) (insert m₂ k v') =
       insert (zipWith f m₁ m₂) k (f v v') := by
+  apply equiv_iff_eq.mp
   intro k'
   by_cases h : k = k'
   · subst h
@@ -773,7 +797,8 @@ theorem zipWith_insert {f : V → V' → V''} {m₁ : M V} {m₂ : M V'} {k : K}
   · simp [get?_zipWith, get?_insert_ne h]
 
 theorem zipWith_delete {f : V → V' → V''} {m₁ : M V} {m₂ : M V'} {k : K} :
-    zipWith f (delete m₁ k) (delete m₂ k) ≡ₘ delete (zipWith f m₁ m₂) k := by
+    zipWith f (delete m₁ k) (delete m₂ k) = delete (zipWith f m₁ m₂) k := by
+  apply equiv_iff_eq.mp
   intro k'
   by_cases h : k = k'
   · subst h
@@ -782,23 +807,25 @@ theorem zipWith_delete {f : V → V' → V''} {m₁ : M V} {m₂ : M V'} {k : K}
 
 theorem zipWith_comm {f : V → V' → V''} {m₁ : M V} {m₂ : M V'} :
     (∀ v v', f v v' = f v v') →
-    zipWith f m₁ m₂ ≡ₘ zipWith f m₁ m₂ := by
-  intro _; intro _; rfl
+    zipWith f m₁ m₂ = zipWith f m₁ m₂ :=
+  fun _ => rfl
 
 -- -- FIXME: universe issue
 -- theorem zip_comm {m₁ : M V} {m₂ : M V'} :
---     PartialMap.map Prod.swap (zip m₁ m₂) ≡ₘ zip m₂ m₁ := by
+--     PartialMap.map Prod.swap (zip m₁ m₂) = zip m₂ m₁ := by
 --   sorry
 
 theorem zip_map {f : V → V'} {g : V → V''} {m : M V} :
-    zip (PartialMap.map f m) (PartialMap.map g m) ≡ₘ
+    zip (PartialMap.map f m) (PartialMap.map g m) =
       PartialMap.map (fun v => (f v, g v)) m := by
+  apply equiv_iff_eq.mp
   intro k
   simp [zip, get?_map, zipWith, get?_bindAlter]
   cases get? m k <;> simp [Option.bind, Option.map]
 
 theorem zip_fst_snd {m : M (V × V')} :
-    zip (PartialMap.map Prod.fst m) (PartialMap.map Prod.snd m) ≡ₘ m := by
+    zip (PartialMap.map Prod.fst m) (PartialMap.map Prod.snd m) = m := by
+  apply equiv_iff_eq.mp
   intro k
   simp [zip, zipWith, get?_map, get?_bindAlter]
   cases h : get? m k <;> simp [Option.bind, Option.map]
@@ -810,24 +837,26 @@ theorem isSome_zipWith {f : V → V' → V''} {m₁ : M V} {m₂ : M V'} {k : K}
   cases h1 : get? m₁ k <;> cases h2 : get? m₂ k <;> simp
 
 theorem zip_empty_left {m : M V'} :
-    zip (∅ : M V) m ≡ₘ ∅ := by
+    zip (∅ : M V) m = ∅ := by
+  apply equiv_iff_eq.mp
   intro k
   simp only [zip, zipWith, get?_bindAlter, get?_empty, Option.bind]
 
 theorem zip_empty_right {m : M V} :
-    zip m (∅ : M V') ≡ₘ ∅ := by
+    zip m (∅ : M V') = ∅ := by
+  apply equiv_iff_eq.mp
   intro k
   simp only [zip, zipWith, get?_bindAlter, get?_empty, Option.bind]
   cases h : get? m k <;> simp
 
 -- -- FIXME: universe issue
 -- theorem zip_insert {m₁ : M V} {m₂ : M V'} {k : K} {v : V} {v' : V'} :
---     zip (insert m₁ k v) (insert m₂ k v') ≡ₘ insert (zip m₁ m₂) k (v, v') := by
+--     zip (insert m₁ k v) (insert m₂ k v') = insert (zip m₁ m₂) k (v, v') := by
 --   sorry
 
 -- FIXME: universe issue
 -- theorem zip_delete {m₁ : M V} {m₂ : M V'} {k : K} :
---     zip (delete m₁ k) (delete m₂ k) ≡ₘ delete (zip m₁ m₂) k := by
+--     zip (delete m₁ k) (delete m₂ k) = delete (zip m₁ m₂) k := by
 --   sorry
 
 theorem isSome_zip {m₁ : M V} {m₂ : M V'} {k : K} :
@@ -925,7 +954,8 @@ theorem nodup_toList {m : M V} : (toList m).Nodup :=
   NoDupKeys_noDup toList_noDupKeys
 
 theorem ofList_toList [DecidableEq K] {m : M V} :
-    PartialMap.equiv (ofList (toList m)) m := by
+    ofList (toList m) = m := by
+  apply equiv_iff_eq.mp
   intro k
   rcases h : get? m k with _|v
   · refine get?_ofList_none ?_ toList_noDupKeys
@@ -934,11 +964,10 @@ theorem ofList_toList [DecidableEq K] {m : M V} :
   · exact get?_ofList_some (toList_get.mpr h) toList_noDupKeys
 
 theorem induction_on [DecidableEq K] {P : M V → Prop}
-    (hequiv : ∀ m₁ m₂, PartialMap.equiv m₁ m₂ → P m₁ → P m₂)
     (hemp : P ∅)
     (hins : ∀ i x m, get? m i = none → P m → P (PartialMap.insert m i x))
     (m : M V) : P m := by
-  apply hequiv _ _ ofList_toList
+  rw [← ofList_toList (m := m)]
   suffices ∀ l, NoDupKeys l → P (ofList l) from this _ toList_noDupKeys
   intro l hnd
   induction l with
@@ -1054,15 +1083,15 @@ theorem mem_ofList [DecidableEq K] {l : List (K × V)} {i : K} {x : V}
 
 theorem ofList_injective [DecidableEq K] {l₁ l₂ : List (K × V)}
     (hnodup1 : (l₁.map Prod.fst).Nodup) (hnodup2 : (l₂.map Prod.fst).Nodup) :
-    PartialMap.equiv (ofList l₁ : M V) (ofList l₂) → l₁.Perm l₂ := by
+    (ofList l₁ : M V) = ofList l₂ → l₁.Perm l₂ := by
   intro He
   refine (List.perm_ext_iff_of_nodup (NoDupKeys_noDup hnodup1) (NoDupKeys_noDup hnodup2)).mpr ?_
   refine fun ⟨k, v⟩ => ⟨fun H => ?_, fun H => ?_⟩
   · apply mem_of_mem_ofList (M := M)
-    rw [← He k]
+    rw [← He]
     exact get?_ofList_some H (List.nodup_iff_pairwise_ne.mpr hnodup1)
   · apply mem_of_mem_ofList (M := M)
-    rw [He k]
+    rw [He]
     exact get?_ofList_some H (List.nodup_iff_pairwise_ne.mpr hnodup2)
 
 theorem toList_insert_delete {m : M V} {k : K} {v : V} :


### PR DESCRIPTION
## Description

Beyond what quotient PR did, this PR is mostly the extensional maps preps before moving to equality for OFEs:

- Made partial maps extensional by default. Folded the old `ExtensionalPartialMap` class into `LawfulPartialMap` (it now carries `equiv_iff_eq`), so pointwise-equivalent maps are just equal. As a result ~40 map lemmas (`insert_delete`, `union_*`, `map_*`, `zip_*`, etc) now conclude `=` instead of `≡ₘ`, and a lot of downstream proofs collapse to `rw`/`subst`.
- Dropped the `≡ₘ` case from map induction. Induction_on no longer needs the `hequiv` obligation, which deleted that case everywhere maps are inducted (BigOp, BigSepMap, Plainly, GenHeap, HeapView).
- Removed now dead map implementations. The whole `AssocList` type (can restore with `PartialMap` instance) and the plain `TreeMap` instances are gone, the only instances of `LawfulPartialMap` are functions and `ExtTreeMap`.

Added `Leibniz` instances for dependent functions, `GenMap`, `ReservationMap`, and `HeapView`. With that, all constructions in the project should be Leibniz/Leibniz-preserving. 

There is some simplification (~230 lines), but the `≡` that is introduced on BI level cuts short the gain from it.  

Builds on top of #485 
