### PR TITLE
feat: OFunctor defined on COFEs

### DIFF
--- a/Iris/Iris/Algebra/CMRA.lean
+++ b/Iris/Iris/Algebra/CMRA.lean
@@ -1119,20 +1119,20 @@ section rFunctor
 class RFunctor (F : COFE.OFunctorPre) where
   -- EXPERIMENT: Replacing COFE in this definition with OFE
   -- https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/OFunctor.20definition
-  -- cofe [COFE α] [COFE β] : CMRA (F α β)
-  [cmra [OFE α] [OFE β] : CMRA (F α β)]
-  map [OFE α₁] [OFE α₂] [OFE β₁] [OFE β₂] :
+  -- UPD.: Reverted after more discussion
+  [cmra [COFE α] [COFE β] : CMRA (F α β)]
+  map [COFE α₁] [COFE α₂] [COFE β₁] [COFE β₂] :
     (α₂ -n> α₁) → (β₁ -n> β₂) → F α₁ β₁ -C> F α₂ β₂
-  map_ne [OFE α₁] [OFE α₂] [OFE β₁] [OFE β₂] :
+  map_ne [COFE α₁] [COFE α₂] [COFE β₁] [COFE β₂] :
     NonExpansive₂ (@map α₁ α₂ β₁ β₂ _ _ _ _)
-  map_id [OFE α] [OFE β] (x : F α β) : map (@Hom.id α _) (@Hom.id β _) x ≡ x
-  map_comp [OFE α₁] [OFE α₂] [OFE α₃] [OFE β₁] [OFE β₂] [OFE β₃]
+  map_id [COFE α] [COFE β] (x : F α β) : map (@Hom.id α _) (@Hom.id β _) x ≡ x
+  map_comp [COFE α₁] [COFE α₂] [COFE α₃] [COFE β₁] [COFE β₂] [COFE β₃]
     (f : α₂ -n> α₁) (g : α₃ -n> α₂) (f' : β₁ -n> β₂) (g' : β₂ -n> β₃) (x : F α₁ β₁) :
     map (f.comp g) (g'.comp f') x ≡ map g g' (map f f' x)
 
 @[rocq_alias rFunctorContractive]
 class RFunctorContractive (F : COFE.OFunctorPre) extends (RFunctor F) where
-  map_contractive [OFE α₁] [OFE α₂] [OFE β₁] [OFE β₂] :
+  map_contractive [COFE α₁] [COFE α₂] [COFE β₁] [COFE β₂] :
     Contractive (Function.uncurry (@map α₁ α₂ β₁ β₂ _ _ _ _))
 
 attribute [reducible, instance] RFunctor.cmra
@@ -1140,7 +1140,7 @@ attribute [reducible, instance] RFunctor.cmra
 
 @[rocq_alias rFunctor_to_oFunctor]
 instance RFunctor.toOFunctor [R : RFunctor F] : COFE.OFunctor F where
-  cofe       := RFunctor.cmra.toOFE
+  ofe        := RFunctor.cmra.toOFE
   map a b    := (RFunctor.map a b).toHom
   map_ne.ne  := RFunctor.map_ne.ne
   map_id     := RFunctor.map_id
@@ -1160,19 +1160,19 @@ class URFunctor (F : COFE.OFunctorPre) where
   -- EXPERIMENT: Replacing COFE in this definition with OFE
   -- https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/OFunctor.20definition
   -- cofe [COFE α] [COFE β] : UCMRA (F α β)
-  [cmra [OFE α] [OFE β] : UCMRA (F α β)]
-  map [OFE α₁] [OFE α₂] [OFE β₁] [OFE β₂] :
+  [cmra [COFE α] [COFE β] : UCMRA (F α β)]
+  map [COFE α₁] [COFE α₂] [COFE β₁] [COFE β₂] :
     (α₂ -n> α₁) → (β₁ -n> β₂) → F α₁ β₁ -C> F α₂ β₂
-  map_ne [OFE α₁] [OFE α₂] [OFE β₁] [OFE β₂] :
+  map_ne [COFE α₁] [COFE α₂] [COFE β₁] [COFE β₂] :
     NonExpansive₂ (@map α₁ α₂ β₁ β₂ _ _ _ _)
-  map_id [OFE α] [OFE β] (x : F α β) : map (@Hom.id α _) (@Hom.id β _) x ≡ x
-  map_comp [OFE α₁] [OFE α₂] [OFE α₃] [OFE β₁] [OFE β₂] [OFE β₃]
+  map_id [COFE α] [COFE β] (x : F α β) : map (@Hom.id α _) (@Hom.id β _) x ≡ x
+  map_comp [COFE α₁] [COFE α₂] [COFE α₃] [COFE β₁] [COFE β₂] [COFE β₃]
     (f : α₂ -n> α₁) (g : α₃ -n> α₂) (f' : β₁ -n> β₂) (g' : β₂ -n> β₃) (x : F α₁ β₁) :
     map (f.comp g) (g'.comp f') x ≡ map g g' (map f f' x)
 
 @[rocq_alias urFunctorContractive]
 class URFunctorContractive (F : COFE.OFunctorPre) extends URFunctor F where
-  map_contractive [OFE α₁] [OFE α₂] [OFE β₁] [OFE β₂] :
+  map_contractive [COFE α₁] [COFE α₂] [COFE β₁] [COFE β₂] :
     Contractive (Function.uncurry (@map α₁ α₂ β₁ β₂ _ _ _ _))
 
 attribute [reducible, instance] URFunctor.cmra
@@ -1196,25 +1196,27 @@ section Id
 
 @[rocq_alias constRF]
 instance COFE.OFunctor.constOF_RFunctor [CMRA B] : RFunctor (constOF B) where
-  map f g := ⟨map f g, by simp [map], by simp [map], by simp [map]⟩
-  map_ne.ne := map_ne.ne
-  map_id := map_id
-  map_comp := map_comp
+  cmra := inferInstance
+  map _ _ := (CMRA.Hom.id : B -C> B)
+  map_ne.ne _ _ _ _ _ _ _ := .rfl
+  map_id _ := .rfl
+  map_comp _ _ _ _ _ := .rfl
 
 @[rocq_alias constRF_contractive]
 instance OFunctor.constOF_RFunctorContractive [CMRA B] :
     RFunctorContractive (constOF B) where
-  map_contractive.1 := by simp [Function.uncurry, RFunctor.map, COFE.OFunctor.map]
+  map_contractive.1 := fun _ => .rfl
 
 instance COFE.OFunctor.constOF_URFunctor [UCMRA B] : URFunctor (constOF B) where
-  map f g := ⟨map f g, by simp [map], by simp [map], by simp [map]⟩
-  map_ne.ne := map_ne.ne
-  map_id := map_id
-  map_comp := map_comp
+  cmra := inferInstance
+  map _ _ := (CMRA.Hom.id : B -C> B)
+  map_ne.ne _ _ _ _ _ _ _ := .rfl
+  map_id _ := .rfl
+  map_comp _ _ _ _ _ := .rfl
 
 instance OFunctor.constOF_URFunctorContractive [UCMRA B] :
     URFunctorContractive (constOF B) where
-  map_contractive.1 := by simp [Function.uncurry, URFunctor.map, COFE.OFunctor.map]
+  map_contractive.1 _ := .rfl
 
 end Id
 

--- a/Iris/Iris/Algebra/CMRA.lean
+++ b/Iris/Iris/Algebra/CMRA.lean
@@ -1117,9 +1117,6 @@ section rFunctor
 
 @[rocq_alias rFunctor]
 class RFunctor (F : COFE.OFunctorPre) where
-  -- EXPERIMENT: Replacing COFE in this definition with OFE
-  -- https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/OFunctor.20definition
-  -- UPD.: Reverted after more discussion
   [cmra [COFE α] [COFE β] : CMRA (F α β)]
   map [COFE α₁] [COFE α₂] [COFE β₁] [COFE β₂] :
     (α₂ -n> α₁) → (β₁ -n> β₂) → F α₁ β₁ -C> F α₂ β₂
@@ -1157,9 +1154,6 @@ section urFunctor
 
 @[rocq_alias urFunctor]
 class URFunctor (F : COFE.OFunctorPre) where
-  -- EXPERIMENT: Replacing COFE in this definition with OFE
-  -- https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/OFunctor.20definition
-  -- cofe [COFE α] [COFE β] : UCMRA (F α β)
   [cmra [COFE α] [COFE β] : UCMRA (F α β)]
   map [COFE α₁] [COFE α₂] [COFE β₁] [COFE β₂] :
     (α₂ -n> α₁) → (β₁ -n> β₂) → F α₁ β₁ -C> F α₂ β₂

--- a/Iris/Iris/Algebra/COFESolver.lean
+++ b/Iris/Iris/Algebra/COFESolver.lean
@@ -15,7 +15,7 @@ meta import Iris.Std.RocqPorting
 namespace Iris.COFE.OFunctor
 open OFE
 
-variable {F : ∀ α β [OFE α] [OFE β], Type u} [OFunctorContractive F]
+variable {F : ∀ α β [COFE α] [COFE β], Type u} [OFunctorContractive F]
 variable [∀ α [COFE α], IsCOFE (F α α)]
 variable [inh : Inhabited (F (ULift Unit) (ULift Unit))]
 

--- a/Iris/Iris/Algebra/GenMap.lean
+++ b/Iris/Iris/Algebra/GenMap.lean
@@ -328,7 +328,7 @@ abbrev GenMap.lift [OFE α] [OFE β] (f : α -n> β) : GenMap α -n> GenMap β w
 
 instance instOFunctor_GenMapOF (F : OFunctorPre) [OFunctor F] :
     OFunctor (GenMapOF F) where
-  cofe {A B _ _} := instOFE_GenMap (F A B)
+  ofe {A B _ _} := instOFE_GenMap (F A B)
   map f₁ f₂ := GenMap.lift <| OFunctor.map (F := F) f₁ f₂
   map_ne.ne {n x1 x2} Hx {y1 y2} Hy k γ := by
     simp only [OFE.Dist, Option.Forall₂, Option.map]

--- a/Iris/Iris/Algebra/Heap.lean
+++ b/Iris/Iris/Algebra/Heap.lean
@@ -637,7 +637,7 @@ abbrev PartialMapOF (F : COFE.OFunctorPre) : COFE.OFunctorPre :=
   fun A B _ _ => H (F A B)
 
 instance {F} [COFE.OFunctor F] : COFE.OFunctor (PartialMapOF H F) where
-  cofe := inferInstance
+  ofe := inferInstance
   map f g := mapO H (COFE.OFunctor.map f g)
   map_ne {_} _ _ _ _ _ _ _ := by
     constructor

--- a/Iris/Iris/Algebra/HeapView.lean
+++ b/Iris/Iris/Algebra/HeapView.lean
@@ -496,7 +496,7 @@ section heapViewFunctor
 
 open Iris.Std PartialMap
 
-theorem heapR_map_eq [OFE A] [OFE B] [OFE A'] [OFE B'] [RFunctor T] (f : A' -n> A) (g : B -n> B')
+theorem heapR_map_eq [COFE A] [COFE B] [COFE A'] [COFE B'] [RFunctor T] (f : A' -n> A) (g : B -n> B')
     (n : Nat) (m : H (T A B)) (mv : H (DFrac × T A B)) :
     HeapR K (T A B) H n m mv →
     HeapR K (T A' B') H n

--- a/Iris/Iris/Algebra/OFE.lean
+++ b/Iris/Iris/Algebra/OFE.lean
@@ -1093,7 +1093,7 @@ instance {P : α → Type _} [∀ x, OFE (P x)] [∀ x, IsCOFE (P x)] : IsCOFE (
     exact hequiv
 #rocq_ignore sigT_compl "Local Compl definition; folded into Lean's IsCOFE instance."
 
-abbrev OFunctorPre := ∀ α β [OFE α] [OFE β], Type _
+abbrev OFunctorPre := ∀ α β [COFE α] [COFE β], Type _
 #rocq_ignore oFunctor_apply "Definition for application of an `oFunctor`; subsumed by `OFunctorPre` in Lean."
 
 @[rocq_alias oFunctor]
@@ -1101,22 +1101,23 @@ class OFunctor (F : OFunctorPre) where
   -- EXPERIMENT: Replacing COFE in this definition with OFE
   -- https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/OFunctor.20definition
   -- cofe [COFE α] [COFE β] : OFE (F α β)
-  cofe [OFE α] [OFE β] : OFE (F α β)
-  map [OFE α₁] [OFE α₂] [OFE β₁] [OFE β₂] :
+  -- UPD.: Reverted after more discussion
+  ofe [COFE α] [COFE β] : OFE (F α β)
+  map [COFE α₁] [COFE α₂] [COFE β₁] [COFE β₂] :
     (α₂ -n> α₁) → (β₁ -n> β₂) → F α₁ β₁ -n> F α₂ β₂
-  map_ne [OFE α₁] [OFE α₂] [OFE β₁] [OFE β₂] :
+  map_ne [COFE α₁] [COFE α₂] [COFE β₁] [COFE β₂] :
     NonExpansive₂ (@map α₁ α₂ β₁ β₂ _ _ _ _)
-  map_id [OFE α] [OFE β] (x : F α β) : map (@Hom.id α _) (@Hom.id β _) x ≡ x
-  map_comp [OFE α₁] [OFE α₂] [OFE α₃] [OFE β₁] [OFE β₂] [OFE β₃]
+  map_id [COFE α] [COFE β] (x : F α β) : map (@Hom.id α _) (@Hom.id β _) x ≡ x
+  map_comp [COFE α₁] [COFE α₂] [COFE α₃] [COFE β₁] [COFE β₂] [COFE β₃]
     (f : α₂ -n> α₁) (g : α₃ -n> α₂) (f' : β₁ -n> β₂) (g' : β₂ -n> β₃) (x : F α₁ β₁) :
     map (f.comp g) (g'.comp f') x ≡ map g g' (map f f' x)
 
 @[rocq_alias oFunctorContractive]
 class OFunctorContractive (F : OFunctorPre) extends OFunctor F where
-  map_contractive [OFE α₁] [OFE α₂] [OFE β₁] [OFE β₂] :
+  map_contractive [COFE α₁] [COFE α₂] [COFE β₁] [COFE β₂] :
     Contractive (Function.uncurry (@map α₁ α₂ β₁ β₂ _ _ _ _))
 
-attribute [reducible, instance] OFunctor.cofe
+attribute [reducible, instance] OFunctor.ofe
 
 end COFE
 
@@ -1152,7 +1153,7 @@ abbrev DiscreteFunOF {C : Type _} (F : C → OFunctorPre) : OFunctorPre :=
 @[rocq_alias discrete_funOF]
 instance oFunctor_discreteFunOF {C} (F : C → OFunctorPre) [∀ c, OFunctor (F c)] :
     OFunctor (DiscreteFunOF F) where
-  cofe := _
+  ofe := _
   map f₁ f₂ := mapCodHom fun _ => OFunctor.map f₁ f₂
   map_ne.ne _ _ _ Hx _ _ Hy _ _ := OFunctor.map_ne.ne Hx Hy ..
   map_id _ _ := OFunctor.map_id ..
@@ -1227,7 +1228,7 @@ variable (F : OFunctorPre)
 
 @[rocq_alias optionOF]
 instance oFunctorOption [OFunctor F] : OFunctor (OptionOF F) where
-  cofe := _
+  ofe := _
   map f g := optionMap (OFunctor.map f g)
   map_ne.ne _ _ _ Hx _ _ Hy z := by
     cases z <;> simp [optionMap, Dist, Option.Forall₂]
@@ -1287,7 +1288,7 @@ abbrev ProdOF (F1 F2 : OFunctorPre) : OFunctorPre := fun A B => (F1 A B) × (F2 
 open OFunctor in
 @[rocq_alias prodOF]
 instance instOFunctorProdOF [OFunctor F1] [OFunctor F2] : OFunctor (ProdOF F1 F2) where
-  cofe := inferInstance
+  ofe := inferInstance
   map f g := Prod.mapO (map f g) (map f g)
   map_ne.ne _ _ _ Hx _ _ Hy _ := ⟨map_ne.ne Hx Hy _, map_ne.ne Hx Hy _⟩
   map_id _ := ⟨map_id _, map_id _⟩
@@ -1343,7 +1344,7 @@ abbrev SumOF (F1 F2 : OFunctorPre) : OFunctorPre := fun A B => (F1 A B) ⊕ (F2 
 open OFunctor in
 @[rocq_alias sumOF]
 instance instOFunctorSumOF [OFunctor F1] [OFunctor F2] : OFunctor (SumOF F1 F2) where
-  cofe := inferInstance
+  ofe := inferInstance
   map f g := Sum.mapO (map f g) (map f g)
   map_ne.ne _ _ _ Hx _ _ Hy x := match x with
     | .inl _ => dist_inl (map_ne.ne Hx Hy _)
@@ -1381,7 +1382,7 @@ abbrev SigmaOF (F : A → OFunctorPre) : OFunctorPre :=
 open OFunctor in
 @[rocq_alias sigTOF]
 instance instOFunctorSigmaOF {F : A → OFunctorPre} [∀ a, OFunctor (F a)] : OFunctor (SigmaOF F) where
-  cofe := inferInstance
+  ofe := inferInstance
   map f g := Sigma.mapO (fun _ => map f g)
   map_ne.ne _ _ _ Hx _ _ Hy := NonExpansive.ne (fun _ => map_ne.ne Hx Hy)
   map_id _ _ := ⟨rfl, (map_id _).dist⟩
@@ -1402,15 +1403,15 @@ open COFE
 abbrev constOF (B : Type) : OFunctorPre := fun _ _ _ _ => B
 
 @[rocq_alias constOF]
-instance oFunctorConstOF [OFE B] : OFunctor (constOF B) where
-  cofe := _
+instance oFunctorConstOF [COFE B] : OFunctor (constOF B) where
+  ofe := _
   map _ _ := ⟨id, id_ne⟩
   map_ne := by intros; constructor; simp
   map_id := by simp
   map_comp := by simp
 
 @[rocq_alias constOF_contractive]
-instance OFunctor.constOF_contractive [OFE B] : OFunctorContractive (constOF B) where
+instance OFunctor.constOF_contractive [COFE B] : OFunctorContractive (constOF B) where
   map_contractive.1 := by simp [OFunctor.map]
 
 end constOF
@@ -1419,12 +1420,12 @@ section IdOF
 
 open COFE
 
-abbrev IdOF : OFunctorPre := fun (_ : Type _) (B : Type _) (_ : OFE _) (_ : OFE B) => B
+abbrev IdOF : OFunctorPre := fun (_ : Type _) (B : Type _) (_ : COFE _) (_ : COFE B) => B
 
 open OFunctor in
 @[rocq_alias idOF]
 instance : OFunctor IdOF where
-  cofe := inferInstance
+  ofe := inferInstance
   map _ g := g
   map_ne.ne _ _ _ _ _ _ Hy := Hy
   map_id _ := .rfl
@@ -1452,12 +1453,12 @@ instance instNonExpansive₂HomMap :
     (NonExpansive.ne (f := y₁) (NonExpansive.ne (f := f) (Hx g))).trans (Hy _)
 
 abbrev HomOF (F1 F2 : OFunctorPre) [OFunctor F1] [OFunctor F2] : OFunctorPre :=
-  fun (A : Type _) (B : Type _) (_ : OFE A) (_ : OFE B) => @F1 B A _ _ -n> @F2 A B _ _
+  fun (A : Type _) (B : Type _) (_ : COFE A) (_ : COFE B) => @F1 B A _ _ -n> @F2 A B _ _
 
 open OFunctor in
 @[rocq_alias ofe_morOF]
 instance instOFunctorHomOF [OFunctor F1] [OFunctor F2] : OFunctor (HomOF F1 F2) where
-  cofe := inferInstance
+  ofe := inferInstance
   map f g := Hom.map (map (F := F1) g f) (map (F := F2) f g)
   map_ne.ne _ _ _ Hf _ _ Hg := NonExpansive₂.ne (map_ne.ne Hg Hf) (map_ne.ne Hf Hg)
   map_id {_ _ _ _ _} _ := (map_id _).trans (NonExpansive.eqv (map_id _))
@@ -1781,7 +1782,7 @@ variable (F : OFunctorPre)
 
 @[rocq_alias laterOF]
 instance instOFunctorLater [OFunctor F] : OFunctor (LaterOF F) where
-  cofe := _
+  ofe := _
   map f g := laterMap (OFunctor.map f g)
   map_ne.ne _ _ _ Hx _ _ Hy _ _ := (OFunctor.map_ne.ne Hx Hy _).lt
   map_id _ := OFunctor.map_id _
@@ -1800,10 +1801,10 @@ open COFE
 -- EXPERIMENT: Threading of Leibniz property through the recursive domain equation solver
 -- https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/Bi-entailment.20and.20generalized.20rewriting/with/565019365
 class LeibnizPreservingOFunctor (F : OFunctorPre) [OFunctor F] where
-  preserves_leibniz [OFE α] [OFE β] [Leibniz α] [Leibniz β] : Leibniz (F α β)
+  preserves_leibniz [COFE α] [COFE β] [Leibniz α] [Leibniz β] : Leibniz (F α β)
 
 instance LeibnizPreservingOFunctor.out {F : OFunctorPre} [OFunctor F] [LeibnizPreservingOFunctor F]
-    [OFE α] [OFE β] [Leibniz α] [Leibniz β] : Leibniz (F α β) where
+    [COFE α] [COFE β] [Leibniz α] [Leibniz β] : Leibniz (F α β) where
   eq_of_eqv {x y} hequiv := by
     haveI := LeibnizPreservingOFunctor.preserves_leibniz (F := F) (α := α) (β := β)
     exact eq_of_eqv hequiv
@@ -1813,7 +1814,7 @@ instance instLeibnizPreservingOFunctorLaterOF [OFunctor F] [LeibnizPreservingOFu
   preserves_leibniz :=
     ⟨fun {x y} hequiv => match x, y with | ⟨_⟩, ⟨_⟩ => Later.next.inj (eq_of_eqv hequiv)⟩
 
-instance instLeibnizPreservingOFunctorConstOF [OFE T] [Leibniz T] :
+instance instLeibnizPreservingOFunctorConstOF [COFE T] [Leibniz T] :
     LeibnizPreservingOFunctor (constOF T) where
   preserves_leibniz := ⟨fun hequiv => by simp only [leibniz] at hequiv; exact hequiv⟩
 

--- a/Iris/Iris/Algebra/OFE.lean
+++ b/Iris/Iris/Algebra/OFE.lean
@@ -1098,10 +1098,6 @@ abbrev OFunctorPre := ∀ α β [COFE α] [COFE β], Type _
 
 @[rocq_alias oFunctor]
 class OFunctor (F : OFunctorPre) where
-  -- EXPERIMENT: Replacing COFE in this definition with OFE
-  -- https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/OFunctor.20definition
-  -- cofe [COFE α] [COFE β] : OFE (F α β)
-  -- UPD.: Reverted after more discussion
   ofe [COFE α] [COFE β] : OFE (F α β)
   map [COFE α₁] [COFE α₂] [COFE β₁] [COFE β₂] :
     (α₂ -n> α₁) → (β₁ -n> β₂) → F α₁ β₁ -n> F α₂ β₂

--- a/Iris/Iris/Algebra/UPred.lean
+++ b/Iris/Iris/Algebra/UPred.lean
@@ -131,7 +131,7 @@ def uPred_map [UCMRA α] [UCMRA β] (f : β -C> α) : UPred α -n> UPred β := b
 
 @[rocq_alias uPredOF]
 instance [URFunctor F] : COFE.OFunctor (UPredOF F) where
-  cofe := inferInstance
+  ofe := inferInstance
   map f g := uPred_map (URFunctor.map (F := F) g f)
   map_ne.ne _ _ _ Hx _ _ Hy _ _ z2 Hn _ := by
     simp only [uPred_map]

--- a/Iris/Iris/Instances/IProp/Instance.lean
+++ b/Iris/Iris/Instances/IProp/Instance.lean
@@ -21,20 +21,20 @@ open COFE Std CMRA
 theorem IProp.ext {P Q : IProp GF} : P ⊣⊢ Q → P = Q := OFE.Leibniz.eq_of_eqv ∘ BI.equiv_iff.mpr
 
 /-- Apply an OFunctor at a fixed type -/
-abbrev COFE.OFunctorPre.ap (F : OFunctorPre) (T : Type _) [OFE T] :=
+abbrev COFE.OFunctorPre.ap (F : OFunctorPre) (T : Type _) [COFE T] :=
   F T T
 
 /-- Apply a list of OFunctors at a fixed type and index -/
-abbrev BundledGFunctors.api (FF : BundledGFunctors) (τ : GType) (T : Type _) [OFE T] :=
+abbrev BundledGFunctors.api (FF : BundledGFunctors) (τ : GType) (T : Type _) [COFE T] :=
   FF τ |>.fst |>.ap T
 
 /-- Transport an OFunctorPre application along equality of the OFunctorPre.  -/
-def transpAp {F1 F2 : OFunctorPre} (H : F1 = F2) {T} [OFE T] : F1.ap T = F2.ap T :=
+def transpAp {F1 F2 : OFunctorPre} (H : F1 = F2) {T} [COFE T] : F1.ap T = F2.ap T :=
   congrArg (OFunctorPre.ap · T) H
 
 section TranspAp
 
-variable [RF₁ : RFunctorContractive F₁] [RF₂ : RFunctorContractive F₂] [OFE T]
+variable [RF₁ : RFunctorContractive F₁] [RF₂ : RFunctorContractive F₂] [COFE T]
 
 theorem OFE.transpAp_eqv_mp (h_fun : F₁ = F₂) (h_inst : HEq RF₁ RF₂) {x y : F₁.ap T} (H : x ≡{n}≡ y) :
     (transpAp h_fun).mp x ≡{n}≡ (transpAp h_fun).mp y := by
@@ -80,23 +80,23 @@ def ElemG.transpMap (E : ElemG GF F) T [OFE T] : (GF E.τ).fst = F :=
 def ElemG.transpClass (E : ElemG GF F) T [OFE T] : (GF E.τ).snd ≍ I :=
   Sigma.mk.inj E.transp |>.2
 
-def ElemG.bundle (E : ElemG GF F) [OFE T] : F.ap T → GF.api E.τ T :=
+def ElemG.bundle (E : ElemG GF F) [COFE T] : F.ap T → GF.api E.τ T :=
   transpAp (E.transpMap T) |>.mpr
 
-def ElemG.unbundle (E : ElemG GF F) [OFE T] : GF.api E.τ T → F.ap T :=
+def ElemG.unbundle (E : ElemG GF F) [COFE T] : GF.api E.τ T → F.ap T :=
   transpAp (E.transpMap T) |>.mp
 
-theorem ElemG.bundle_unbundle (E : ElemG GF F) [OFE T] (x : GF.api E.τ T) :
+theorem ElemG.bundle_unbundle (E : ElemG GF F) [COFE T] (x : GF.api E.τ T) :
     E.bundle (E.unbundle x) ≡ x := by simp [bundle, unbundle]
 
-theorem ElemG.unbundle_bundle (E : ElemG GF F) [OFE T] (x : F.ap T) :
+theorem ElemG.unbundle_bundle (E : ElemG GF F) [COFE T] (x : F.ap T) :
     E.unbundle (E.bundle x) ≡ x := by simp [bundle, unbundle]
 
-instance ElemG.bundle.ne {E : ElemG GF F} [OFE T] :
+instance ElemG.bundle.ne {E : ElemG GF F} [COFE T] :
     OFE.NonExpansive (E.bundle (T := T)) where
   ne {_ _ _} := OFE.transpAp_eqv_mp (E.transpMap T).symm (E.transpClass T).symm
 
-instance ElemG.unbundle.ne {E : ElemG GF F} [OFE T] :
+instance ElemG.unbundle.ne {E : ElemG GF F} [COFE T] :
     OFE.NonExpansive (E.unbundle (T := T)) where
   ne {_ _ _} H := OFE.transpAp_eqv_mp (E.transpMap T) (E.transpClass T) H
 


### PR DESCRIPTION
## Description

`OFunctor` now takes `COFE` inputs but only promises an `OFE` output (OFE.lean). 
`OFunctorPre` is re-indexed with `[COFE a]` `[COFE b]` (was `OFE`), and the old `cofe` field becomes `ofe`. 
The requirement that the result is a `COFE` is still in COFESolver.lean file.

Fixes the problem encountered in 
https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/OFunctor.20definition/with/607339808

The problematic snippet then becomes:
```
import Iris.Algebra.COFESolver

open Iris Iris.COFE OFE

namespace TraceMWE

abbrev TraceF (V : Type _) [OFE V] : OFunctorPre :=
  SumOF (constOF V) (LaterOF IdOF)

instance (V : Type _) [OFE V] : Inhabited (TraceF V (ULift Unit) (ULift Unit)) :=
  ⟨.inr (Later.next default)⟩

abbrev Trace (V : Type _) [COFE V] : Type _ := OFunctor.Fix (TraceF V)

example (V : Type _) [COFE V] : Type _ := Trace V

section Functoriality
open OFunctor

@[simp] theorem laterMap_apply {A B : Type _} [OFE A] [OFE B] (t : A -n> B) (x : Later A) :
    laterMap t x = Later.next (t x.car) := rfl

theorem laterMap_id {A : Type _} [OFE A] : laterMap (Hom.id : A -n> A) = Hom.id := rfl

theorem laterMap_comp {A B C : Type _} [OFE A] [OFE B] [OFE C] (g : B -n> C) (f : A -n> B) :
    laterMap (g.comp f) = (laterMap g).comp (laterMap f) := rfl

theorem laterMap_ne {A B : Type _} [OFE A] [OFE B] {n} {t t' : A -n> B} (h : t ≡{n}≡ t') :
    laterMap t ≡{n}≡ laterMap t' := fun x _ hm => (h x.car).lt hm

theorem laterMap_contractive {A B : Type _} [OFE A] [OFE B] {n} {t t' : A -n> B}
    (h : DistLater n t t') : laterMap t ≡{n}≡ laterMap t' := fun x m hm => h m hm x.car

variable {V₁ V₂ V₃ : Type _} [COFE V₁] [COFE V₂] [COFE V₃]

def traceMapBody (h : V₁ -n> V₂) (t : Trace V₁ -n> Trace V₂) : Trace V₁ -n> Trace V₂ :=
  Fix.fold.comp (Hom.comp ⟨Sum.map h (laterMap t), inferInstance⟩ Fix.unfold)

theorem traceMapBody_contractive (h : V₁ -n> V₂) : Contractive (traceMapBody h) where
  distLater_dist {n t t'} H := by
    have hlt : laterMap t ≡{n}≡ laterMap t' := laterMap_contractive H
    intro x
    refine Fix.fold.ne.1 ?_
    show Sum.map h (laterMap t) (Fix.unfold x) ≡{n}≡ Sum.map h (laterMap t') (Fix.unfold x)
    rcases Fix.unfold x with a | b
    · exact .rfl
    · exact hlt b

def traceMap (h : V₁ -n> V₂) : Trace V₁ -n> Trace V₂ :=
  haveI : Contractive (traceMapBody h) := traceMapBody_contractive h
  ContractiveHom.fixpoint (Function.toContractiveHom (traceMapBody h))

theorem traceMap_unfold (h : V₁ -n> V₂) : traceMap h ≡ traceMapBody h (traceMap h) := by
  haveI : Contractive (traceMapBody h) := traceMapBody_contractive h
  exact fixpoint_unfold (Function.toContractiveHom (traceMapBody h))

theorem traceMap_id : traceMap (Hom.id : V₁ -n> V₁) ≡ Hom.id := by
  haveI : Contractive (traceMapBody (Hom.id : V₁ -n> V₁)) := traceMapBody_contractive _
  refine (fixpoint_unique (f := Function.toContractiveHom (traceMapBody Hom.id)) ?_).symm
  intro x
  refine (Fix.fold_unfold x).symm.trans (NonExpansive.eqv ?_)
  show Fix.unfold x ≡ Sum.map Hom.id (laterMap Hom.id) (Fix.unfold x)
  rcases Fix.unfold x with a | b <;> exact .rfl

theorem traceMap_comp (g : V₂ -n> V₃) (f : V₁ -n> V₂) :
    traceMap (g.comp f) ≡ (traceMap g).comp (traceMap f) := by
  haveI : Contractive (traceMapBody (g.comp f)) := traceMapBody_contractive _
  refine (fixpoint_unique (f := Function.toContractiveHom (traceMapBody (g.comp f))) ?_).symm
  intro x
  have e₂ : Fix.unfold (traceMap f x) ≡ Sum.map f (laterMap (traceMap f)) (Fix.unfold x) :=
    (NonExpansive.eqv (traceMap_unfold f x)).trans (Fix.unfold_fold _)
  refine (traceMap_unfold g (traceMap f x)).trans (NonExpansive.eqv (f := Fix.fold) ?_)
  refine (NonExpansive.eqv (f := Sum.map g (laterMap (traceMap g))) e₂).trans ?_
  show Sum.map g (laterMap (traceMap g)) (Sum.map f (laterMap (traceMap f)) (Fix.unfold x))
      ≡ Sum.map (g.comp f) (laterMap ((traceMap g).comp (traceMap f))) (Fix.unfold x)
  rcases Fix.unfold x with a | b <;> exact .rfl

theorem traceMap_ne {n} {h h' : V₁ -n> V₂} (e : h ≡{n}≡ h') : traceMap h ≡{n}≡ traceMap h' := by
  haveI : Contractive (traceMapBody h) := traceMapBody_contractive h
  haveI : Contractive (traceMapBody h') := traceMapBody_contractive h'
  refine NonExpansive.ne (f := ContractiveHom.fixpoint) ?_
  intro T x
  refine Fix.fold.ne.1 ?_
  show Sum.map h (laterMap T) (Fix.unfold x) ≡{n}≡ Sum.map h' (laterMap T) (Fix.unfold x)
  rcases Fix.unfold x with a | b
  · exact e a
  · exact .rfl

end Functoriality

open OFunctor in
abbrev TraceLaterOF : OFunctorPre := fun _ β _ _ => Trace (Later β)

open OFunctor in
instance : OFunctor TraceLaterOF where
  ofe := inferInstance
  map _ g := traceMap (laterMap g)
  map_ne := ⟨fun _ _ _ _ _ _ hg => traceMap_ne (laterMap_ne hg)⟩
  map_id x := traceMap_id x
  map_comp _ _ f' g' x := traceMap_comp (laterMap g') (laterMap f') x

open OFunctor OFunctorContractive in
instance : OFunctorContractive TraceLaterOF where
  map_contractive.1 {_} _ _ h :=
    traceMap_ne (laterMap_contractive fun m hm => (h m hm).2)

open OFunctor in
abbrev DSig : OFunctorPre := HomOF (LaterOF IdOF) TraceLaterOF

instance : OFunctorContractive DSig := inferInstance

abbrev D : Type _ := OFunctor.Fix DSig

open OFunctor in
def D.iso : OFE.Iso D (Later D -n> Trace (Later D)) := by
  refine ⟨Fix.unfold (F := DSig), Fix.fold (F := DSig), ?_, ?_⟩
  · intro x; exact Fix.unfold_fold (F := DSig) x
  · intro x; exact Fix.fold_unfold (F := DSig) x

end TraceMWE
```