### PR TITLE
Fix broken link to proofmode.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ Currently, Iris-Lean has support for
 - `IProp`, the standard model of Iris
 - A selection of the Iris resources, including invariants, later credits, and many more.
 
-MoSeL (in contrast to the older IPM) supports different separation logics as well. For more details on the proofmode, see [proofmode.md](proofmode.md).
+MoSeL (in contrast to the older IPM) supports different separation logics as well. For more details on the proofmode, see [proofmode.md](Iris/proofmode.md).
 
 More details about the status of our port can be found on our [tracking site](https://leanprover-community.github.io/iris-lean/). 
 


### PR DESCRIPTION
## Description
Fixed a broken link in the main README.md

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [ ] I have added my name to the `authors` section of any appropriate files
It's just a documentation change, so I don't think this needs attribution.
