### PR TITLE
feat: rm setoids (step 1)

### DIFF
--- a/Iris/Iris/Algebra/Agree.lean
+++ b/Iris/Iris/Algebra/Agree.lean
@@ -110,25 +110,15 @@ theorem dist_equiv : Equivalence (dist (α := α) n) where
       obtain ⟨a, ha, hd₂⟩ := h₁' b hb
       exact ⟨a, ha, hd₂.trans hd₁⟩
 
-instance instOFE : OFE (Raw α) where
-  Equiv x y := ∀ n, dist n x y
-  Dist := dist
-  dist_eqv := dist_equiv
-  equiv_dist := by simp
-  dist_lt {n x y m} := fun ⟨h₁, h₂⟩ hlt => by
-    refine ⟨?_, ?_⟩
-    · intro a ha
-      obtain ⟨b, hb, hd⟩ := h₁ a ha
-      exact ⟨b, hb, OFE.Dist.lt hd hlt⟩
-    · intro b hb
-      obtain ⟨a, ha, hd⟩ := h₂ b hb
-      exact ⟨a, ha, OFE.Dist.lt hd hlt⟩
-
-theorem dist_lt {x y : Raw α} (h : dist n x y) (hlt : m < n) : dist m x y :=
-  instOFE.dist_lt h hlt
-
-theorem equiv_def {x y : Raw α} : x ≡ y ↔ ∀ n, dist n x y := .rfl
-theorem dist_def {x y : Raw α} : x ≡{n}≡ y ↔ dist n x y := .rfl
+theorem dist_lt {x y : Raw α} (h : dist n x y) (hlt : m < n) : dist m x y := by
+  obtain ⟨h₁, h₂⟩ := h
+  refine ⟨?_, ?_⟩
+  · intro a ha
+    obtain ⟨b, hb, hd⟩ := h₁ a ha
+    exact ⟨b, hb, OFE.Dist.lt hd hlt⟩
+  · intro b hb
+    obtain ⟨a, ha, hd⟩ := h₂ b hb
+    exact ⟨a, ha, OFE.Dist.lt hd hlt⟩
 
 theorem dist_congr {a b c d : Raw α} (hac : SameElems a c) (hbd : SameElems b d) :
     dist n a b ↔ dist n c d :=
@@ -153,21 +143,21 @@ theorem validN_congr {x y : Raw α} (h : SameElems x y) : validN n x ↔ validN 
 
 def valid (x : Raw α) : Prop := ∀ n, x.validN n
 
-theorem op_comm {x y : Raw α} : op x y ≡ op y x := by
+theorem op_comm {x y : Raw α} : ∀ n, dist n (op x y) (op y x) := by
   intro n; simp_all only [dist, op, List.mem_append]
   refine ⟨?_, ?_⟩ <;> exact fun _ ha => ⟨_, ha.symm, .rfl⟩
 
-theorem op_commN {x y : Raw α} : op x y ≡{n}≡ op y x := op_comm n
+theorem op_commN {x y : Raw α} : dist n (op x y) (op y x) := op_comm n
 
-theorem op_assoc {x y z : Raw α} : op x (op y z) ≡ op (op x y) z := by
+theorem op_assoc {x y z : Raw α} : ∀ n, dist n (op x (op y z)) (op (op x y) z) := by
   intro n; simp_all only [dist, op, List.mem_append, List.append_assoc]
   refine ⟨?_, ?_⟩ <;> (intro a ha; exists a)
 
-theorem idemp {x : Raw α} : op x x ≡ x := by
+theorem idemp {x : Raw α} : ∀ n, dist n (op x x) x := by
   intro n; refine ⟨?_, ?_⟩ <;> (intro a ha; exists a; simp_all [op])
 
-theorem validN_ne {x y : Raw α} : x ≡{n}≡ y → x.validN n → y.validN n := by
-  simp only [OFE.Dist, dist, validN_iff, and_imp]
+theorem validN_ne {x y : Raw α} : dist n x y → x.validN n → y.validN n := by
+  simp only [dist, validN_iff, and_imp]
   intro h₁ h₂ hn a ha b hb
   have ⟨a', ha', ha'a⟩ := h₂ _ ha
   have ⟨b', hb', hb'b⟩ := h₂ _ hb
@@ -182,10 +172,10 @@ theorem validN_op_left {x y : Raw α} : (op x y).validN n → x.validN n := by
   simp only [op, validN_iff, List.mem_append]
   exact fun h a ha b hb => h _ (.inl ha) _ (.inl hb)
 
-theorem op_ne {x : Raw α} : OFE.NonExpansive (op x) := by
-  refine ⟨?_⟩
-  simp only [OFE.Dist, dist, op, List.mem_append, and_imp]
-  intro n y₁ y₂ heq₁ heq₂; refine ⟨?_, ?_⟩
+theorem op_ne {x y₁ y₂ : Raw α} (h : dist n y₁ y₂) : dist n (op x y₁) (op x y₂) := by
+  obtain ⟨heq₁, heq₂⟩ := h
+  simp only [dist, op, List.mem_append]
+  refine ⟨?_, ?_⟩
   · rintro a (hx | hy)
     · exists a; simp [hx]
     · obtain ⟨b, hb, heq⟩ := heq₁ _ hy
@@ -195,12 +185,13 @@ theorem op_ne {x : Raw α} : OFE.NonExpansive (op x) := by
     · obtain ⟨b, hb, heq⟩ := heq₂ _ hy
       exists b; simp_all
 
-theorem op_ne₂ : OFE.NonExpansive₂ (op (α := α)) := by
-  refine ⟨fun n x₁ x₂ hx y₁ y₂ hy => ?_⟩
-  exact op_ne.ne hy |>.trans (op_comm n) |>.trans (op_ne.ne hx) |>.trans (op_comm n)
+theorem op_ne₂ {x₁ x₂ y₁ y₂ : Raw α} (hx : dist n x₁ x₂) (hy : dist n y₁ y₂) :
+    dist n (op x₁ y₁) (op x₂ y₂) :=
+  dist_equiv.trans (op_ne hy) <| dist_equiv.trans (op_comm n) <|
+    dist_equiv.trans (op_ne hx) (op_comm n)
 
-theorem op_invN {x y : Raw α} : (op x y).validN n → x ≡{n}≡ y := by
-  simp only [op, validN_iff, List.mem_append, OFE.Dist, dist]
+theorem op_invN {x y : Raw α} : (op x y).validN n → dist n x y := by
+  simp only [op, validN_iff, List.mem_append, dist]
   intro h; refine ⟨?_, ?_⟩
   · intro a ha
     obtain ⟨b, hb⟩ := mem y
@@ -209,8 +200,8 @@ theorem op_invN {x y : Raw α} : (op x y).validN n → x ≡{n}≡ y := by
     obtain ⟨b, hb⟩ := mem x
     exists b; simp_all
 
-theorem op_inv {x y : Raw α} : (op x y).valid → x ≡ y := by
-  simp only [valid, equiv_def]
+theorem op_inv {x y : Raw α} : (op x y).valid → ∀ n, dist n x y := by
+  simp only [valid]
   intro h n
   exact op_invN (h n)
 
@@ -238,18 +229,17 @@ theorem toAgree_uninj {x : Raw α} : x.valid → ∃ a, ∀ n, dist n (toAgree a
 
 variable [OFE β] {f : α → β}
 
-instance instNonExpansiveMap' [OFE.NonExpansive f] : OFE.NonExpansive (map' f) where
-  ne := by
-    intro n x₁ x₂ h
-    refine ⟨?_, ?_⟩
-    · simp only [map', List.mem_map, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
-      intro a ha
-      obtain ⟨b, hb, heq⟩ := h.1 a ha
-      exact ⟨f b, ⟨b, hb, rfl⟩, OFE.NonExpansive.ne heq⟩
-    · simp only [map', List.mem_map, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
-      intro a ha
-      obtain ⟨b, hb, heq⟩ := h.2 a ha
-      exact ⟨f b, ⟨b, hb, rfl⟩, OFE.NonExpansive.ne heq⟩
+theorem map'_ne [OFE.NonExpansive f] {x₁ x₂ : Raw α} (h : dist n x₁ x₂) :
+    dist n (map' f x₁) (map' f x₂) := by
+  refine ⟨?_, ?_⟩
+  · simp only [map', List.mem_map, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
+    intro a ha
+    obtain ⟨b, hb, heq⟩ := h.1 a ha
+    exact ⟨f b, ⟨b, hb, rfl⟩, OFE.NonExpansive.ne heq⟩
+  · simp only [map', List.mem_map, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
+    intro a ha
+    obtain ⟨b, hb, heq⟩ := h.2 a ha
+    exact ⟨f b, ⟨b, hb, rfl⟩, OFE.NonExpansive.ne heq⟩
 
 theorem map'_validN [OFE.NonExpansive f] {x : Raw α} (h : x.validN n) : (map' f x).validN n := by
   rw [validN_iff] at h ⊢
@@ -292,11 +282,11 @@ theorem exists_forall_dist {a : α} {l : List α}
       obtain ⟨b, hb, hd⟩ := ih hl
       exact ⟨b, List.mem_cons_of_mem _ hb, hd⟩
 
-theorem sameElems_of_dist [OFE.Leibniz α] {x y : Raw α} (h : ∀ n, dist n x y) : SameElems x y :=
+theorem sameElems_of_dist {x y : Raw α} (h : ∀ n, dist n x y) : SameElems x y :=
   have key : ∀ {x y : Raw α}, (∀ n, dist n x y) → ∀ a ∈ x.car, a ∈ y.car := by
     intro x y h a ha
     obtain ⟨b, hb, hd⟩ := exists_forall_dist (fun n => (h n).1 a ha)
-    exact OFE.Leibniz.eq_of_eqv (OFE.equiv_dist.mpr hd) ▸ hb
+    exact OFE.Equiv.to_eq (OFE.equiv_dist.mpr hd) ▸ hb
   ⟨key h, key (fun n => Raw.dist_equiv.symm (h n))⟩
 
 end Agree.Raw
@@ -366,21 +356,21 @@ def dist (n : Nat) : Agree α → Agree α → Prop :=
 @[rocq_alias agree_ofe_mixin]
 instance instOFE : OFE (Agree α) where
   Dist := dist
-  Equiv x y := ∀ n, dist n x y
   dist_eqv := by
     refine ⟨Quotient.ind fun a => Raw.dist_equiv.refl a, fun {x y} h => ?_, fun {x y z} h₁ h₂ => ?_⟩
     · induction x, y using Quotient.ind₂ with | _ a b => exact Raw.dist_equiv.symm h
     · induction x, y using Quotient.ind₂ with | _ a b =>
         induction z using Quotient.ind with | _ c => exact Raw.dist_equiv.trans h₁ h₂
-  equiv_dist := Iff.rfl
+  eq_dist {x y} := by
+    induction x, y using Quotient.ind₂ with | _ a b =>
+      refine ⟨fun h n => ?_, fun h => sound (Raw.sameElems_of_dist h)⟩
+      exact (Raw.dist_congr (Raw.sameElems_equivalence.refl a) (Agree.exact h)).mp
+        (Raw.dist_equiv.refl a)
   dist_lt := fun {n x y m} h hlt => by
     induction x, y using Quotient.ind₂ with | _ a b => exact Raw.dist_lt h hlt
 
 #rocq_ignore agreeO "Use Agree with a typeclass instance instead."
 #rocq_ignore agree_equiv "Defined in Agree OFE instance."
-
-instance instLeibniz [OFE.Leibniz α] : OFE.Leibniz (Agree α) where
-  eq_of_eqv {x y} := Quotient.inductionOn₂ x y fun _ _ h => sound (Raw.sameElems_of_dist h)
 
 def validN (n : Nat) : Agree α → Prop :=
   lift (Raw.validN n) (fun _ _ h => propext (Raw.validN_congr h))
@@ -422,7 +412,7 @@ theorem validN_op_left {x y : Agree α} : validN n (op x y) → validN n x :=
 
 @[rocq_alias agree_op_ne']
 theorem op_ne {x : Agree α} : OFE.NonExpansive (op x) :=
-  ⟨fun {_} y₁ y₂ => x.ind fun _ => y₁.ind fun _ => y₂.ind fun _ h => Raw.op_ne.ne (dist_mk.mp h)⟩
+  ⟨fun {_} y₁ y₂ => x.ind fun _ => y₁.ind fun _ => y₂.ind fun _ h => Raw.op_ne (dist_mk.mp h)⟩
 
 @[rocq_alias agree_op_ne]
 theorem op_ne₂ : OFE.NonExpansive₂ (op (α := α)) := by
@@ -600,8 +590,9 @@ theorem toAgree_included {a b : α} : toAgree a ≼ toAgree b ↔ a ≡ b := by
       _         ≡ toAgree a • toAgree a := .symm (CMRA.pcore_op_left rfl)
 
 @[simp, rocq_alias to_agree_included_L]
-theorem toAgree_included_L [OFE.Leibniz α] {a b : α} :
-    toAgree a ≼ toAgree b ↔ a = b := by simp
+theorem toAgree_included_L {a b : α} :
+    toAgree a ≼ toAgree b ↔ a = b := by
+  rw [toAgree_included]; exact ⟨OFE.Equiv.to_eq, OFE.Equiv.of_eq⟩
 
 @[rocq_alias to_agree_op_validN]
 theorem toAgree_op_validN_iff_dist {a b : α} :
@@ -624,8 +615,9 @@ instance toAgree.is_discrete {a : α} [OFE.DiscreteE a] : OFE.DiscreteE (toAgree
 end Agree
 
 @[rocq_alias to_agree_op_valid_L]
-theorem toAgree_op_valid_iff_eq [OFE.Leibniz α] {a : α} :
-    ✓ (toAgree a • toAgree b) ↔ a = b := by simp_all [Agree.toAgree_op_valid_iff_equiv]
+theorem toAgree_op_valid_iff_eq {a : α} :
+    ✓ (toAgree a • toAgree b) ↔ a = b := by
+  rw [Agree.toAgree_op_valid_iff_equiv]; exact ⟨OFE.Equiv.to_eq, OFE.Equiv.of_eq⟩
 
 #rocq_ignore to_agree_op_inv_L "Use toAgree_op_valid_iff_eq"
 
@@ -658,7 +650,7 @@ variable {α β γ : Type _} [OFE α] [OFE β] [OFE γ] {f : α → β} [hne : O
 
 @[rocq_alias agree_map_ne]
 instance instNonExpansive_AgreeMap' : OFE.NonExpansive (Agree.map' f) where
-  ne _ x y := x.ind fun _ => y.ind fun _ h => Raw.instNonExpansiveMap'.ne (Agree.dist_mk.mp h)
+  ne _ x y := x.ind fun _ => y.ind fun _ h => Raw.map'_ne (Agree.dist_mk.mp h)
 
 #rocq_ignore agree_map_proper "Derivable from instNonExpansive_AgreeMap' with NonExpansive.eqv"
 
@@ -725,9 +717,5 @@ instance {F} [COFE.OFunctor F] : RFunctor (AgreeRF F) where
 @[rocq_alias agreeRF_contractive]
 instance {F} [COFE.OFunctorContractive F] : RFunctorContractive (AgreeRF F) where
   map_contractive.1 H _ := Agree.map_ne (COFE.OFunctorContractive.map_contractive.1 H)
-
-instance {F} [COFE.OFunctor F] [Leibniz.LeibnizPreservingOFunctor F] :
-    Leibniz.LeibnizPreservingOFunctor (AgreeRF F) where
-  preserves_leibniz := Agree.instLeibniz
 
 end agree_rfunctor

--- a/Iris/Iris/Algebra/Auth.lean
+++ b/Iris/Iris/Algebra/Auth.lean
@@ -74,7 +74,6 @@ variable [UCMRA A]
 instance : OFE (Auth A) := View.instOFE
 instance : CMRA (Auth A) := View.instCMRA
 instance : UCMRA (Auth A) := View.instUCMRA
-instance instLeibniz [Leibniz A] : Leibniz (Auth A) := View.instLeibniz
 
 #rocq_ignore authO "Use the Auth type and View.instOFE typeclass"
 #rocq_ignore authR "Use the Auth type and View.instCMRA typeclass"
@@ -114,7 +113,7 @@ nonrec theorem auth_dist_inj {n : Nat} {dq1 dq2 : DFrac} {a1 a2 : A}
 
 @[rocq_alias auth_auth_inj]
 theorem auth_inj {dq1 dq2 : DFrac} {a1 a2 : A} (h : (●{dq1} a1) ≡ ●{dq2} a2) :
-    dq1 = dq2 ∧ a1 ≡ a2 := ⟨h.1.1, equiv_dist.mpr fun _ => dist_of_auth_dist h.dist⟩
+    dq1 = dq2 ∧ a1 ≡ a2 := ⟨auth_inj_frac (h 0), equiv_dist.mpr fun _ => dist_of_auth_dist h.dist⟩
 
 @[rocq_alias auth_frag_dist_inj]
 theorem frag_dist_inj {n : Nat} {b1 b2 : A} (h : (◯ b1 : Auth A) ≡{n}≡ ◯ b2) : b1 ≡{n}≡ b2 :=
@@ -143,7 +142,7 @@ set_option synthInstance.checkSynthOrder false in
 instance {dq dq1 dq2 : DFrac} [h : IsOp io1 dq io2 dq1 io3 dq2] :
     IsOp io1 (●{dq} a : Auth A) io2 (●{dq1} a) io3 (●{dq2} a) where
   is_op := by
-    rw [h.is_op]
+    rw [h.is_op.to_eq]
     apply auth_dfrac_op
 
 @[rocq_alias auth_frag_op]
@@ -184,7 +183,7 @@ nonrec instance {a : A} {b : A} [CoreId b] :
 @[rocq_alias auth_frag_is_op]
 instance {a b1 b2 : A} [h : IsOp io1 a io2 b1 io3 b2] :
     IsOp io1 (◯ a : Auth A) io2 (◯ b1) io3 (◯ b2) where
-  is_op := ⟨⟨⟩, h.is_op⟩
+  is_op := NonExpansive₂.eqv .rfl h.is_op
 
 -- TODO: auth_frag_sep_homomorphism
 
@@ -208,7 +207,7 @@ theorem auth_dfrac_op_inv {dq1 dq2 : DFrac} {a b : A}
   eqv_of_valid_auth h
 
 @[rocq_alias auth_auth_dfrac_op_inv_L]
-theorem auth_dfrac_op_inv_L [Leibniz A] {dq1 dq2 : DFrac} {a b : A}
+theorem auth_dfrac_op_inv_L {dq1 dq2 : DFrac} {a b : A}
     (h : ✓ ((●{dq1} a) • ●{dq2} b)) : a = b :=
   (auth_dfrac_op_inv h).to_eq
 

--- a/Iris/Iris/Algebra/BigOp.lean
+++ b/Iris/Iris/Algebra/BigOp.lean
@@ -105,7 +105,7 @@ theorem bigOpL_append_eqv (Φ : Nat → A → M) (l₁ l₂ : List A) :
     op ([^ op list] k ↦ x ∈ l₁, Φ k x) ([^ op list] k ↦ x ∈ l₂, Φ (k + l₁.length) x) :=
   match l₁ with
   | .nil => op_left_id.symm
-  | .cons _ _ => op_congr_right (bigOpL_append_eqv ..) |>.trans op_assoc.symm
+  | .cons _ _ => op_congr_right (bigOpL_append_eqv _ _ _) |>.trans op_assoc.symm
 
 @[rocq_alias big_opL_snoc]
 theorem bigOpL_snoc_eqv (Φ : Nat → A → M) (l : List A) (a : A) :
@@ -124,7 +124,7 @@ theorem bigOpL_op_eqv (Φ Ψ : Nat → A → M) (l : List A) :
     op ([^ op list] k ↦ x ∈ l, Φ k x) ([^ op list] k ↦ x ∈ l, Ψ k x) :=
   match l with
   | .nil => op_left_id.symm
-  | .cons _ _ => op_congr_right (bigOpL_op_eqv ..) |>.trans op_op_op_comm
+  | .cons _ _ => op_congr_right (bigOpL_op_eqv _ _ _) |>.trans op_op_op_comm
 
 @[rocq_alias big_opL_fmap]
 theorem bigOpL_map_eqv {B : Type _} (h : A → B) (Φ : Nat → B → M) (l : List A) :
@@ -180,7 +180,7 @@ theorem bigOpL_flatMap_eqv {B : Type v} (h : A → List B) (Φ : B → M) (l : L
     ([^ op list] x ∈ l.flatMap h, Φ x) ≡ ([^ op list] x ∈ l, [^ op list] y ∈ h x, Φ y) :=
   match l with
   | .nil => .rfl
-  | .cons _ _ => (bigOpL_append_eqv ..).trans (op_congr_right <| bigOpL_flatMap_eqv ..)
+  | .cons _ _ => (bigOpL_append_eqv _ _ _).trans (op_congr_right <| bigOpL_flatMap_eqv _ _ _)
 
 @[rocq_alias big_opL_gen_proper_2]
 theorem bigOpL_gen_proper_2 {B : Type v} (R : M → M → Prop) {Φ : Nat → A → M}
@@ -272,7 +272,7 @@ theorem bigOpL_hom [H : MonoidHomomorphism op₁ op₂ unit₁ unit₂ R f] (Φ 
     R (f ([^ op₁ list] k ↦ x ∈ l, Φ k x)) ([^ op₂ list] k ↦ x ∈ l, f (Φ k x)) :=
   match l with
   | .nil => H.map_unit
-  | .cons _ _ => H.rel_trans H.map_op <| H.op_proper H.rel_refl <| (bigOpL_hom (H := H) ..)
+  | .cons _ _ => H.rel_trans H.map_op <| H.op_proper H.rel_refl <| (bigOpL_hom (H := H) _ _)
 
 /-- Weak monoid homomorphisms distribute over non-empty big ops. -/
 @[rocq_alias big_opL_commute1]
@@ -416,14 +416,14 @@ theorem bigOpM_const_unit_eqv [DecidableEq K] (m : M' V) :
 @[rocq_alias big_opM_fmap]
 theorem bigOpM_map_eqv (h : V → B) (Φ : K → B → M) (m : M' V) :
     ([^ op map] k ↦ x ∈ PartialMap.map h m, Φ k x) ≡ ([^ op map] k ↦ v ∈ m, Φ k (h v)) :=
-  bigOpL_eqv_of_perm _ LawfulFiniteMap.toList_map |>.trans (bigOpL_map_eqv ..)
+  bigOpL_eqv_of_perm _ LawfulFiniteMap.toList_map |>.trans (bigOpL_map_eqv _ _ _)
 
 @[rocq_alias big_opM_omap]
 theorem bigOpM_filterMap_eqv (Φ : K → V → M) (m : M' V) (hinj : Function.Injective h) :
     ([^ op map] k ↦ x ∈ PartialMap.filterMap h m, Φ k x) ≡
     ([^ op map] k ↦ v ∈ m, (h v).elim unit (Φ k)) := by
   refine (bigOpL_eqv_of_perm _ (LawfulFiniteMap.toList_filterMap hinj)).trans ?_
-  refine (bigOpL_filterMap_eqv ..).trans ?_
+  refine (bigOpL_filterMap_eqv _ _ _).trans ?_
   refine bigOpL_eqv_of_forall_eqv @fun _ ⟨_, v⟩ => ?_
   cases _ : h v <;> simp_all
 
@@ -493,13 +493,13 @@ theorem bigOpM_union_eqv [DecidableEq K] (Φ : K → V → M) (m1 m2 : M' V) (hd
     ([^ op map] k ↦ x ∈ m1 ∪ m2, Φ k x) ≡
     op ([^ op map] k ↦ x ∈ m1, Φ k x) ([^ op map] k ↦ x ∈ m2, Φ k x) :=
   (bigOpL_eqv_of_perm _ (toList_union_perm hdisj)).trans
-    ((bigOpL_append_eqv ..).trans (op_congr_right (bigOpL_eqv_of_forall_eqv .rfl)))
+    ((bigOpL_append_eqv _ _ _).trans (op_congr_right (bigOpL_eqv_of_forall_eqv .rfl)))
 
 @[rocq_alias big_opM_op]
 theorem bigOpM_op_eqv (Φ Ψ : K → V → M) (m : M' V) :
     ([^ op map] k ↦ x ∈ m, op (Φ k x) (Ψ k x)) ≡
     op ([^ op map] k ↦ x ∈ m, Φ k x) ([^ op map] k ↦ x ∈ m, Ψ k x) :=
-  bigOpL_op_eqv ..
+  bigOpL_op_eqv _ _ _
 
 @[rocq_alias big_opM_closed]
 theorem bigOpM_closed {P : M → Prop} {Φ : K → V → M} {m : M' V}
@@ -593,7 +593,7 @@ theorem bigOpS_const_unit (s : S) : ([^ op set] _x ∈ s, unit) ≡ unit := by
 
 @[rocq_alias big_opS_singleton]
 theorem bigOpS_singleton {Φ : A → M} {a : A} : ([^ op set] x ∈ ({a} : S), Φ x) ≡ Φ a := by
-  simpa only [bigOpS, toList_singleton] using (bigOpL_singleton_eqv ..)
+  simpa only [bigOpS, toList_singleton] using (bigOpL_singleton_eqv _ _)
 
 @[rocq_alias big_opS_union]
 theorem bigOpS_union {Φ : A → M} {s₁ s₂ : S} (Hdisj : s₁ ## s₂) :
@@ -629,7 +629,7 @@ theorem bigOpS_eqv {Φ Ψ : A → M} {s : S} (h : ∀ {x}, x ∈ s → Φ x ≡ 
 @[rocq_alias big_opS_op]
 theorem bigOpS_op_eqv {Φ Ψ : A → M} {s : S} :
     ([^ op set] x ∈ s, op (Φ x) (Ψ x)) ≡ op ([^ op set] x ∈ s, Φ x) ([^ op set] x ∈ s, Ψ x) :=
-  (bigOpS_bigOpL ..).trans (bigOpL_op_eqv ..)
+  (bigOpS_bigOpL).trans (bigOpL_op_eqv _ _ _)
 
 @[rocq_alias big_opS_closed]
 theorem bigOpS_closed (P : M → Prop) (Φ : A → M) (s : S)

--- a/Iris/Iris/Algebra/BigOp.lean
+++ b/Iris/Iris/Algebra/BigOp.lean
@@ -272,7 +272,7 @@ theorem bigOpL_hom [H : MonoidHomomorphism op₁ op₂ unit₁ unit₂ R f] (Φ 
     R (f ([^ op₁ list] k ↦ x ∈ l, Φ k x)) ([^ op₂ list] k ↦ x ∈ l, f (Φ k x)) :=
   match l with
   | .nil => H.map_unit
-  | .cons _ _ => H.rel_trans H.map_op <| H.op_proper H.rel_refl <| (bigOpL_hom (H := H) _ _)
+  | .cons _ _ => H.rel_trans H.map_op <| H.op_proper H.rel_refl <| (bigOpL_hom _ _)
 
 /-- Weak monoid homomorphisms distribute over non-empty big ops. -/
 @[rocq_alias big_opL_commute1]

--- a/Iris/Iris/Algebra/BigOp.lean
+++ b/Iris/Iris/Algebra/BigOp.lean
@@ -314,7 +314,7 @@ theorem bigOpM_insert_eqv (Φ : K → V → M) {m : M' V} {i : K} (x : V) (hi : 
 @[rocq_alias big_opM_delete]
 theorem bigOpM_delete_eqv (Φ : K → V → M) {m : M' V} {i : K} {x : V} (hi : get? m i = some x) :
     ([^ op map] k ↦ v ∈ m, Φ k v) ≡ op (Φ i x) ([^ op map] k ↦ v ∈ delete m i, Φ k v) :=
-  (bigOpM_eqv_of_perm Φ (insert_delete_cancel hi · |>.symm)).trans
+  (bigOpM_eqv_of_perm Φ (equiv_iff_eq.mpr (insert_delete_cancel hi).symm)).trans
     (bigOpM_insert_eqv Φ _ (get?_delete_eq rfl))
 
 open Classical in
@@ -333,15 +333,11 @@ theorem bigOpM_gen_proper_2 {A : Type _} {B : Type _} {R : M → M → Prop}
     R ([^ op map] k ↦ x ∈ m1', Φ k x) ([^ op map] k ↦ x ∈ m2', Ψ k x)
   suffices h : P m1 from h m2 hdom hf
   apply LawfulFiniteMap.induction_on (P := P)
-  · intro m₁ m₂ heq hP m2' hdom' hf'
-    refine hR_eqv.trans (hR_sub (bigOpM_eqv_of_perm Φ heq).symm) ?_
-    exact hP m2' (fun k => heq k ▸ hdom' k) (hf' <| (heq _) ▸ ·)
   · show P (∅ : M' A)
     intro m2' hdom' _
     rw [bigOpM_empty]
-    refine hR_sub <| (bigOpM_eqv_of_perm Ψ ?_).trans (.of_eq (bigOpM_empty Ψ)) |>.symm
-    refine eq_empty_iff.mpr fun k => ?_
-    simpa [show get? (∅ : M' A) k = none from get?_empty k] using hdom' k
+    refine hR_sub <| (bigOpM_eqv_of_perm Ψ fun k => ?_).trans (.of_eq (bigOpM_empty Ψ)) |>.symm
+    simpa [get?_empty] using hdom' k
   · intro k x1 m1' hm1'k IH m2' hdom' hf'
     obtain ⟨x2, hm2k⟩ := Option.isSome_iff_exists.mp <| by
       simpa [get?_insert_eq (k := k) rfl] using (hdom' k).symm
@@ -435,7 +431,7 @@ theorem bigOpM_filterMap_eqv (Φ : K → V → M) (m : M' V) (hinj : Function.In
 theorem bigOpM_insert_delete_eqv (Φ : K → V → M) (m : M' V) (i : K) (x : V) :
     ([^ op map] k ↦ v ∈ insert m i x, Φ k v) ≡
     op (Φ i x) ([^ op map] k ↦ v ∈ delete m i, Φ k v) :=
-  (bigOpM_eqv_of_perm _ (insert_delete · |>.symm)).trans
+  (bigOpM_eqv_of_perm _ (equiv_iff_eq.mpr insert_delete.symm)).trans
     (bigOpM_insert_eqv _ _ (get?_delete_eq rfl))
 
 @[rocq_alias big_opM_insert_override]
@@ -551,13 +547,13 @@ theorem bigOpM_hom  [ι : MonoidHomomorphism op₁ op₂ unit₁ unit₂ R h] (f
 
 @[rocq_alias big_opM_commute1]
 theorem bigOpM_weak_hom [DecidableEq K] [ι : WeakMonoidHomomorphism op₁ op₂ unit₁ unit₂ R h]
-    (f : K → A → M₁) (m : M' A) (Hne : ¬ m ≡ₘ ∅) :
+    (f : K → A → M₁) (m : M' A) (Hne : ¬ m = ∅) :
     R (h ([^op₁ map] k↦x ∈ m, f k x)) ([^op₂ map] k↦x ∈ m, h (f k x)) := by
   refine bigOpL_hom_weak (H := ι) _ ?_
   refine fun Hk => Hne ?_
-  refine .trans LawfulFiniteMap.ofList_toList.symm ?_
-  rw [show (LawfulFiniteMap.toList m) = [] from List.nil_eq.mpr Hk |>.symm]
-  exact .trans (congrFun rfl) (congrFun rfl )
+  rw [← LawfulFiniteMap.ofList_toList (m := m),
+      show (LawfulFiniteMap.toList m) = [] from List.nil_eq.mpr Hk |>.symm]
+  rfl
 
 #rocq_ignore big_opM_ne' "Use bigOpM_dist"
 #rocq_ignore big_opM_proper' "Use bigOpM_eqv"

--- a/Iris/Iris/Algebra/CMRA.lean
+++ b/Iris/Iris/Algebra/CMRA.lean
@@ -1355,7 +1355,7 @@ instance cmraOption : CMRA (Option α) where
     rintro (_|x) <;> simp [Equiv]
     rcases H : pcore x with _|y <;> simp
     obtain ⟨z, Hz1, Hz2⟩ := equiv_some (pcore_idem H)
-    simp [Hz1]; exact Hz2
+    simpa only [Hz1]
   pcore_op_mono := by
     rintro (_|x) _ ⟨⟩ y <;> simp
     · exact ⟨_, .rfl⟩

--- a/Iris/Iris/Algebra/CMRA.lean
+++ b/Iris/Iris/Algebra/CMRA.lean
@@ -957,7 +957,6 @@ end ucmra
 
 
 section Leibniz
-variable [Leibniz α]
 
 @[rocq_alias cmra_assoc_L]
 theorem assoc_L {x y z : α} : x • (y • z) = (x • y) • z := assoc.to_eq
@@ -975,7 +974,7 @@ theorem pcore_idem_L {x cx : α} (h : pcore x = some cx) : pcore cx = some cx :=
 
 @[rocq_alias cmra_op_opM_assoc_L]
 theorem op_opM_assoc_L {x y : α} {mz} : (x • y) •? mz = x • (y •? mz) :=
-  (op_opM_assoc ..).to_eq
+  (op_opM_assoc _ _ _).to_eq
 
 @[rocq_alias cmra_pcore_r_L]
 theorem pcore_op_right_L {x cx : α} (h : pcore x = some cx) : x • cx = x :=
@@ -1008,7 +1007,7 @@ theorem core_op_core_L {x : α} [IsTotal α] : core x • core x = core x :=
 @[rocq_alias core_id_total_L]
 theorem coreId_iff_core_eq_self {x : α} [IsTotal α] : CoreId x ↔ core x = x := calc
   CoreId x ↔ core x ≡ x := coreId_iff_core_eqv_self
-  _        ↔ core x = x := leibniz
+  _        ↔ core x = x := ⟨Equiv.to_eq, Equiv.of_eq⟩
 @[rocq_alias core_id_core_L]
 theorem core_eq_self {x : α} [IsTotal α] [c : CoreId x] : core x = x :=
   coreId_iff_core_eq_self.mp c
@@ -1029,13 +1028,11 @@ theorem ucmra_unit_left_id {x : α} : unit • x ≡ x := unit_left_id
 @[rocq_alias ucmra_pcore_unit]
 theorem ucmra_pcore_unit : pcore (unit : α) ≡ some unit := pcore_unit
 
-variable [Leibniz α]
-
 @[rocq_alias ucmra_unit_left_id_L]
-theorem unit_left_id_L {x : α} : unit • x = x := leibniz.mp unit_left_id
+theorem unit_left_id_L {x : α} : unit • x = x := unit_left_id.to_eq
 
 @[rocq_alias ucmra_unit_right_id_L]
-theorem unit_right_id_L {x : α} : x • unit = x := leibniz.mp unit_right_id
+theorem unit_right_id_L {x : α} : x • unit = x := unit_right_id.to_eq
 
 end UCMRA
 
@@ -1057,14 +1054,13 @@ infixr:25 " -C> " => Hom
 instance [CMRA β] : CoeFun (α -C> β) (fun _ => α → β) := ⟨fun F => F.f⟩
 
 instance [CMRA β] : OFE (α -C> β) where
-  Equiv f g := f.toHom ≡ g.toHom
   Dist n f g := f.toHom ≡{n}≡ g.toHom
   dist_eqv := {
     refl _ := dist_eqv.refl _
     symm h := dist_eqv.symm h
     trans h1 h2 := dist_eqv.trans h1 h2
   }
-  equiv_dist := equiv_dist
+  eq_dist {_ _} := Hom.ext_iff.trans eq_dist
   dist_lt := dist_lt
 
 @[rocq_alias cmra_morphism_id]
@@ -1099,11 +1095,11 @@ protected theorem Hom.core [CMRA β] (f : α -C> β) {x : α} : core (f x) ≡ f
 
 @[rocq_alias cmra_morphism_mono]
 protected theorem Hom.mono [CMRA β] (f : α -C> β) {x₁ x₂ : α} : x₁ ≼ x₂ → f x₁ ≼ f x₂
-  | ⟨z, hz⟩ => ⟨f.f z, (f.eqv hz).trans (f.op ..)⟩
+  | ⟨z, hz⟩ => ⟨f.f z, (f.eqv hz).trans (f.op _ _)⟩
 
 @[rocq_alias cmra_morphism_monoN]
 protected theorem Hom.monoN [CMRA β] (f : α -C> β) n {x₁ x₂ : α} : x₁ ≼{n} x₂ → f x₁ ≼{n} f x₂
-  | ⟨z, hz⟩ => ⟨f.f z, (f.ne.ne hz).trans (f.op ..).dist⟩
+  | ⟨z, hz⟩ => ⟨f.f z, (f.ne.ne hz).trans (f.op _ _).dist⟩
 
 @[rocq_alias cmra_morphism_valid]
 protected theorem Hom.valid [CMRA β] (f : α -C> β) {x : α} (H : ✓ x) : ✓ f x :=
@@ -1236,19 +1232,19 @@ instance cmraDiscreteFunO {α : Type _} (β : α → Type _)
   valid_iff_validN {g} := by simpa [valid_iff_validN] using forall_comm
   validN_succ H _ := validN_succ (H _)
   validN_op_left H _ := validN_op_left (H _)
-  assoc _ := assoc
-  comm _ := comm
-  pcore_op_left := by rintro f _ ⟨⟩ x; exact core_op (f x)
-  pcore_idem := by rintro f _ ⟨⟩ x; exact core_idem (f x)
+  assoc _ _ := assoc.dist
+  comm _ _ := comm.dist
+  pcore_op_left := by rintro f _ ⟨⟩ n x; exact (core_op (f x)).dist
+  pcore_idem := by rintro f _ ⟨⟩ n x; exact (core_idem (f x)).dist
   pcore_op_mono := by
     rintro f _ ⟨⟩ g
-    refine ⟨fun x => core (f x • g x), fun x => ?_⟩
+    refine ⟨fun x => core (f x • g x), fun n x => ?_⟩
     have ⟨r, hr⟩ := core_op_mono (f x) (g x)
-    exact hr.trans (hr.op_r.trans <| assoc.trans core_op_core.op_l).symm
+    exact (hr.trans (hr.op_r.trans <| assoc.trans core_op_core.op_l).symm).dist
   extend {n f f1 f2} Hv He := by
     let F x := extend (Hv x) (He x)
     exact ⟨fun x => (F x).1, fun x => (F x).2.1,
-      fun x => (F x).2.2.1, fun x => (F x).2.2.2.1, fun x => (F x).2.2.2.2⟩
+      fun n x => (F x).2.2.1 n, fun x => (F x).2.2.2.1, fun x => (F x).2.2.2.2⟩
 
 #rocq_ignore discrete_fun_unit_instance "Use UCMRA instance"
 #rocq_ignore discrete_fun_ucmra_mixin "Use UCMRA instance"
@@ -1257,8 +1253,8 @@ instance cmraDiscreteFunO {α : Type _} (β : α → Type _)
 instance ucmraDiscreteFunO {α : Type _} (β : α → Type _) [∀ x, UCMRA (β x)] : UCMRA (∀ x, β x) where
   unit _ := unit
   unit_valid _ := unit_valid
-  unit_left_id _ := unit_left_id
-  pcore_unit _ := core_eqv_self _
+  unit_left_id _ _ := unit_left_id.dist
+  pcore_unit _ _ := (core_eqv_self _).dist
 
 end DiscreteFunO
 
@@ -1272,12 +1268,12 @@ instance urFunctorDiscreteFunOF {C} (F : C → COFE.OFunctorPre) [∀ c, URFunct
     validN hv _ := (URFunctor.map f g).validN (hv _)
     pcore x := by
       simp only [CMRA.pcore, Option.map]
-      intro c
-      show (URFunctor.map f g).f (CMRA.core (x c)) ≡ CMRA.core ((URFunctor.map f g).f (x c))
+      intro n c
+      show (URFunctor.map f g).f (CMRA.core (x c)) ≡{n}≡ CMRA.core ((URFunctor.map f g).f (x c))
       have h := (URFunctor.map f g).pcore (x c)
       rw [CMRA.pcore_eq_core (x c), CMRA.pcore_eq_core] at h
-      simpa using h
-    op _ _ _ := (URFunctor.map f g).op _ _
+      simpa using h.dist
+    op _ _ _ _ := ((URFunctor.map f g).op _ _).dist
   }
   map_ne.ne := COFE.OFunctor.map_ne.ne
   map_id := COFE.OFunctor.map_id
@@ -1356,10 +1352,10 @@ instance cmraOption : CMRA (Option α) where
   pcore_op_left {x cx} := by
     rcases x, cx with ⟨_|_, _|_⟩ <;> simp_all [pcore_op_left]
   pcore_idem := by
-    rintro (_|x) <;> simp [Equiv, Option.Forall₂]
+    rintro (_|x) <;> simp [Equiv]
     rcases H : pcore x with _|y <;> simp
     obtain ⟨z, Hz1, Hz2⟩ := equiv_some (pcore_idem H)
-    simp [Hz1, Hz2]
+    simp [Hz1]; exact Hz2
   pcore_op_mono := by
     rintro (_|x) _ ⟨⟩ y <;> simp
     · exact ⟨_, .rfl⟩
@@ -1736,8 +1732,8 @@ instance cmraProd : CMRA (α × β) where
     · exact CMRA.valid_iff_validN.mpr fun n => (h n).right
   validN_succ {x n} := fun ⟨va, vb⟩ => ⟨CMRA.validN_succ va, CMRA.validN_succ vb⟩
   validN_op_left {n x y} := fun ⟨va, vb⟩ => ⟨CMRA.validN_op_left va, CMRA.validN_op_left vb⟩
-  assoc {x y z} := ⟨CMRA.assoc, CMRA.assoc⟩
-  comm {x y} := ⟨CMRA.comm, CMRA.comm⟩
+  assoc {x y z} := equiv_prod_ext CMRA.assoc CMRA.assoc
+  comm {x y} := equiv_prod_ext CMRA.comm CMRA.comm
   pcore_op_left {x cx} h :=
     let ⟨a, ha, ho⟩ := Option.bind_eq_some_iff.mp h
     let ⟨b, hb, hh⟩ := Option.bind_eq_some_iff.mp ho
@@ -1747,7 +1743,7 @@ instance cmraProd : CMRA (α × β) where
     have ⟨cx₂, hcx₂, hcx⟩ := Option.bind_eq_some_iff.mp this
     have ⟨a, ha, ea⟩ := equiv_some (CMRA.pcore_idem hcx₁)
     have ⟨b, hb, eb⟩ := equiv_some (CMRA.pcore_idem hcx₂)
-    have g : (a, b) ≡ (cx₁, cx₂) := ⟨ea, eb⟩
+    have g : (a, b) ≡ (cx₁, cx₂) := equiv_prod_ext ea eb
     rw [Option.some.inj hcx.symm]
     simp [ha, hb, g, pcore]
   pcore_op_mono {x cx} h y := by
@@ -1759,11 +1755,11 @@ instance cmraProd : CMRA (α × β) where
     have ⟨b, hb, eb⟩ := equiv_some hcy₂
     unfold pcore
     rw [Option.some.inj hcx.symm, ha, hb]
-    exists (cy₁, cy₂)
+    exact ⟨(cy₁, cy₂), equiv_prod_ext ea eb⟩
   extend {n x y₁ y₂} := fun ⟨vx₁, vx₂⟩ e =>
     let ⟨z₁, w₁, hx₁, hz₁, hw₁⟩ := CMRA.extend vx₁ (OFE.dist_fst e)
     let ⟨z₂, w₂, hx₂, hz₂, hw₂⟩ := CMRA.extend vx₂ (OFE.dist_snd e)
-    ⟨(z₁, z₂), (w₁, w₂), ⟨hx₁, hx₂⟩, ⟨hz₁, hz₂⟩, ⟨hw₁, hw₂⟩⟩
+    ⟨(z₁, z₂), (w₁, w₂), equiv_prod_ext hx₁ hx₂, ⟨hz₁, hz₂⟩, ⟨hw₁, hw₂⟩⟩
 
 theorem valid_fst {x : α × β} (h : ✓ x) : ✓ x.fst := h.left
 theorem valid_snd {x : α × β} (h : ✓ x) : ✓ x.snd := h.right
@@ -1814,8 +1810,8 @@ def Prod.mapC (f : A -C> A') (g : B -C> B') : A × B -C> A' × B' where
       cases _ : CMRA.pcore (f.f x.fst) <;>
       cases _ : CMRA.pcore (g.f x.snd) <;>
       simp_all
-      exact ⟨Option.equiv_of_some_equiv_some h1, Option.equiv_of_some_equiv_some h2⟩
-  op x y := ⟨CMRA.Hom.op .., CMRA.Hom.op ..⟩
+      exact equiv_prod_ext (Option.equiv_of_some_equiv_some h1) (Option.equiv_of_some_equiv_some h2)
+  op x y := equiv_prod_ext (f.op x.fst y.fst) (g.op x.snd y.snd)
 
 end ProdMor
 
@@ -1828,8 +1824,8 @@ instance instRFunctorProdOF [RFunctor F1] [RFunctor F2] : RFunctor (ProdOF F1 F2
   map f g := Prod.mapC (map f g) (map f g)
   map_ne.ne _ _ _ Hx _ _ Hy _ :=
     Prod.map_ne (fun _ => map_ne.ne Hx Hy _) (fun _ => map_ne.ne Hx Hy _)
-  map_id _ := ⟨map_id _, map_id _⟩
-  map_comp _ _ _ _ _ := ⟨map_comp .., map_comp ..⟩
+  map_id _ := equiv_prod_ext (map_id _) (map_id _)
+  map_comp _ _ _ _ _ := equiv_prod_ext (map_comp _ _ _ _ _) (map_comp _ _ _ _ _)
 
 @[rocq_alias prodRF_contractive]
 instance instRFunctorContractiveProdOF
@@ -1858,7 +1854,7 @@ instance urFunctorOptionOF [RFunctor F] : URFunctor (OptionOF F) where
       rintro (_|x) <;> simp [optionCore, CMRA.pcore, COFE.OFunctor.map, optionMap]
       have := (RFunctor.map f g).pcore x; revert this
       cases CMRA.pcore x <;> cases CMRA.pcore (RFunctor.map f g x)
-        <;> simp [Equiv, Option.Forall₂]
+        <;> simp [Equiv]
     op := by
       rintro (_|x) (_|y) <;> simp [CMRA.op, COFE.OFunctor.map, optionOp, optionMap]
       exact (RFunctor.map f g).op x y

--- a/Iris/Iris/Algebra/COFESolver.lean
+++ b/Iris/Iris/Algebra/COFESolver.lean
@@ -52,12 +52,12 @@ end
 @[rocq_alias solver.gf]
 theorem down_up : ∀ {k} x, down F k (up F k x) ≡ x
   | 0, ⟨()⟩ => .rfl
-  | _+1, _ => (map_comp ..).symm.trans <|
-    (map_ne.eqv down_up down_up _).trans (map_id _)
+  | _+1, x => (map_comp _ _ _ _ _).symm.trans <|
+    Equiv.trans (fun n => map_ne.eqv (fun m y => (down_up y) m) (fun m y => (down_up y) m) n x) (map_id _)
 
 @[rocq_alias solver.fg]
 theorem up_down {k} (x) : up F (k+1) (down F (k+1) x) ≡{k}≡ x := by
-  refine (map_comp ..).dist.symm.trans <| .trans ?_ (map_id _).dist
+  refine (map_comp _ _ _ _ _).dist.symm.trans <| .trans ?_ (map_id _).dist
   open OFunctorContractive in exact match k with
   | 0 => map_contractive.zero (x := (_, _)) (y := (_, _)) _ _
   | k+1 => map_contractive.succ (x := (_, _)) (y := (_, _)) _ ⟨up_down, up_down⟩ _
@@ -72,14 +72,13 @@ instance : CoeFun (Tower F) (fun _ => ∀ k, A F k) := ⟨Tower.val⟩
 
 @[rocq_alias solver.T]
 instance : OFE (Tower F) where
-  Equiv f g := ∀ k, f k ≡ g k
   Dist n f g := ∀ k, f k ≡{n}≡ g k
   dist_eqv := {
     refl _ _ := dist_eqv.refl _
     symm h _ := dist_eqv.symm (h _)
     trans h1 h2 _ := dist_eqv.trans (h1 _) (h2 _)
   }
-  equiv_dist {_ _} := by simp [equiv_dist]; apply forall_comm
+  eq_dist {_ _} := by rw [Tower.ext_iff, funext_iff]; simp only [eq_dist]; exact forall_comm
   dist_lt h1 h2 _ := dist_lt (h1 _) h2
 
 #rocq_ignore solver.tower_equiv "Included in OFE (Tower F) instance"
@@ -118,7 +117,7 @@ def downN {k} : ∀ n, A F (k + n) -n> A F k
 @[rocq_alias solver.ggff]
 theorem downN_upN {k} (x : A F k) : ∀ {i}, downN F i (upN F i x) ≡ x
   | 0 => .rfl
-  | n+1 => ((downN F n).ne.eqv (down_up ..)).trans (downN_upN _)
+  | n+1 => ((downN F n).ne.eqv (down_up _)).trans (downN_upN _)
 
 @[rocq_alias solver.f_tower]
 protected theorem Tower.up (X : Tower F) : up F (k+1) (X (k+1)) ≡{k}≡ X (k+2) :=
@@ -170,7 +169,7 @@ protected def Tower.embed (k) : A F k -n> Tower F := by
   dsimp [embed]; split <;> rename_i h₁
   · split <;> rename_i h₂
     · suffices ∀ a b (e₁ : k+a = i+1) (e₂ : k+b = i),
-        down F i (eqToHom e₁ (upN F a n)) ≡ eqToHom e₂ (upN F b n) from this ..
+        down F i (eqToHom e₁ (upN F a n)) ≡ eqToHom e₂ (upN F b n) from this _ _ _ _
       rintro a _ eq rfl
       rw [Nat.add_assoc, Nat.add_left_cancel_iff] at eq; subst a
       apply down_up
@@ -182,7 +181,7 @@ protected def Tower.embed (k) : A F k -n> Tower F := by
       apply this <;> simp [Nat.add_sub_cancel_left]
   · rw [dif_neg (mt Nat.le_succ_of_le h₁)]
     suffices ∀ k a b (e₁ : k = i+1+a) (e₂ : k = i+b) (n : A F k),
-        down F i (downN F a (eqToHom e₁ n)) ≡ downN F b (eqToHom e₂ n) from this ..
+        down F i (downN F a (eqToHom e₁ n)) ≡ downN F b (eqToHom e₂ n) from this _ _ _ _ _ _
     rintro k a b eq rfl n
     rw [Nat.add_assoc, Nat.add_left_cancel_iff, Nat.add_comm] at eq; subst eq
     show _ ≡ downN F a (down F (i+a) n)
@@ -214,7 +213,7 @@ theorem Tower.embed_up (x : A F k) :
       have {a b} {e₁ : k+1 = k+a} {e₂ : k+b = k+0} :
         downN F a (eqToHom e₁ (up F k x)) ≡{n}≡ eqToHom e₂ (upN F b x) := by
         cases Nat.add_left_cancel e₁; cases Nat.add_left_cancel e₂
-        exact (down_up ..).dist
+        exact (down_up _).dist
       exact this
     · dsimp [Hom.comp]
       suffices ∀ a b (e₁ : k + 1 = i + a) (e₂ : k = i + b),
@@ -249,36 +248,38 @@ def unfoldChain (X : Tower F) : Chain (F (Tower F) (Tower F)) where
     | zero => exact .rfl
     | succ k ih =>
       exact (((map ..).ne.1 X.up).le (Nat.le_add_right ..)).symm.trans <|
-        (map_comp ..).dist.symm.trans <|
+        (map_comp _ _ _ _ _).dist.symm.trans <|
         (map_ne.ne (·.down.dist) (fun Y => (Tower.embed_up Y).dist) _).trans ih
 
 def Tower.iso : OFE.Iso (F (Tower F) (Tower F)) (Tower F) where
   hom.f X := {
     val n := (down F n).comp (map (Tower.embed _) (Tower.proj _)) X
     down {n} := (down ..).ne.eqv <|
-      (map_comp ..).symm.trans (map_ne.eqv Tower.embed_up (·.down) _)
+      (map_comp _ _ _ _ _).symm.trans
+        (fun m => map_ne.eqv (fun m' Y => (Tower.embed_up Y) m') (fun m' Y => Y.down m') m _)
   }
   hom.ne.1 _ _ _ h _ := by dsimp only; exact (Hom.ne _).1 h
   inv.f X := compl (unfoldChain X)
   inv.ne.1 n _ _ h := by
     refine conv_compl.trans <| .trans ?_ conv_compl.symm
     exact (map ..).ne.1 (h (n+1))
-  hom_inv {X} k := equiv_dist.2 fun n => by
+  hom_inv {X} := equiv_dist.2 fun n => by
+    intro k
     refine ((down ..).ne.1 (.trans ?_ (X.downN n).dist)).trans X.down.dist
     refine ((map ..).ne.1 (conv_compl.trans
       ((unfoldChain ..).cauchy (show n ≤ k+n+1 by omega)).symm)).trans ?_
     refine (((map ..).comp _).ne.1 (X.up.le (Nat.le_add_left ..)).symm).trans (Equiv.dist ?_)
-    refine ((map_comp ..).trans <| (map ..).ne.eqv (map_comp ..)).symm.trans ?_
+    refine ((map_comp _ _ _ _ _).trans <| (map ..).ne.eqv (map_comp _ _ _ _ _)).symm.trans ?_
     refine .trans (y := map (upN F n) (downN F n) (X (k+n+1))) ?_ ?_
-    · refine map_ne.eqv (fun Y => ?_) (fun Y => ?_) _
+    · refine fun m => map_ne.eqv (fun m' Y => ?_) (fun m' Y => ?_) m _
       · simp [Hom.comp, Tower.embed, Tower.proj, embed, (by omega : k ≤ k+n+1)]
         have {a e} : down F (k + n) (eqToHom e (upN F a Y)) ≡ upN F n Y := by
           cases Nat.add_left_cancel (k := n+1) e; exact (down_up _)
-        exact this
+        exact this.dist
       · simp [Hom.comp, Tower.embed, Tower.proj, embed, show ¬k+n+1 ≤ k by omega]
         have {a e} : downN F a (eqToHom e (up F (k + n) Y)) ≡ downN F n Y := by
           cases Nat.add_left_cancel (m := n+1) e; exact (downN ..).ne.eqv (down_up _)
-        exact this
+        exact this.dist
     · have e : k+n+1 = k+1+n := by omega
       suffices ∀ x y, eqToHom e x = y → map (upN F n) (downN F n) x ≡ downN F n y by
         apply this; clear this; revert e; generalize k+1+n = a; rintro rfl; rfl
@@ -286,12 +287,12 @@ def Tower.iso : OFE.Iso (F (Tower F) (Tower F)) (Tower F) where
       induction n with
       | zero => exact map_id _
       | succ n ih =>
-        refine (map_comp ..).trans <| (ih (Nat.succ.inj e) _).trans ((downN ..).ne.eqv ?_)
+        refine (map_comp _ _ _ _ _).trans <| (ih (Nat.succ.inj e) _).trans ((downN ..).ne.eqv ?_)
         exact .of_eq (down_eqToHom _).symm
   inv_hom := equiv_dist.2 fun n => by
     refine (conv_compl' n.le_succ).trans ?_
     dsimp [unfoldChain]; rw [down]
-    refine ((map_comp ..).trans <| (map ..).ne.eqv (map_comp ..)).dist.symm.trans ?_
+    refine ((map_comp _ _ _ _ _).trans <| (map ..).ne.eqv (map_comp _ _ _ _ _)).dist.symm.trans ?_
     refine (map_ne.ne (fun Y => ?_) (fun Y => ?_) _).trans (map_id _).dist
     · exact ((Tower.embed _).ne.1 Y.up).trans (Y.embed_self.le (by omega))
     · exact ((Tower.embed _).ne.1 Y.down.dist).trans Y.embed_self
@@ -317,34 +318,5 @@ def Fix.unfold : Fix F -n> F (Fix F) (Fix F) := Fix.iso.inv
 #rocq_ignore solver.unfold_ne "Implicit in the OFE.Iso structure"
 theorem Fix.fold_unfold (X : Fix F) : Fix.fold (Fix.unfold X) ≡ X := Fix.iso.hom_inv
 theorem Fix.unfold_fold (X : F (Fix F) (Fix F)) : Fix.unfold (Fix.fold X) ≡ X := Fix.iso.inv_hom
-
-section leibniz
-
-open Iris.Leibniz
-
-variable [LeibnizPreservingOFunctor F]
-
-instance : Leibniz (A F 0) where
-  eq_of_eqv {x y} _ := match x, y with | ⟨_⟩, ⟨_⟩ => rfl
-
-instance {k : Nat} [Leibniz (A F k)] : Leibniz (A F (k+1)) where
-  eq_of_eqv {_ _} := by
-    simp only [A, A'] at *
-    exact eq_of_eqv (self := LeibnizPreservingOFunctor.out)
-
-@[reducible]
-def LeibnizA (k : Nat) : Leibniz (A F k) :=
-  match k with
-  | 0 => inferInstance
-  | k+1 => haveI := LeibnizA k; inferInstance
-
-instance {k : Nat} : Leibniz (A F k) := LeibnizA k
-
-instance : Leibniz (Tower F) where
-  eq_of_eqv {_ _} H := by ext n; exact eq_of_eqv (H n)
-
-instance : Leibniz (Fix F) := inferInstanceAs (Leibniz (Tower F))
-
-end leibniz
 
 attribute [irreducible] Fix Fix.fold Fix.unfold Fix.iso

--- a/Iris/Iris/Algebra/COFESolver.lean
+++ b/Iris/Iris/Algebra/COFESolver.lean
@@ -78,7 +78,7 @@ instance : OFE (Tower F) where
     symm h _ := dist_eqv.symm (h _)
     trans h1 h2 _ := dist_eqv.trans (h1 _) (h2 _)
   }
-  eq_dist {_ _} := by rw [Tower.ext_iff, funext_iff]; simp only [eq_dist]; exact forall_comm
+  eq_dist {_ _} := by rw [Tower.ext_iff, funext_iff]; simpa only [eq_dist] using forall_comm
   dist_lt h1 h2 _ := dist_lt (h1 _) h2
 
 #rocq_ignore solver.tower_equiv "Included in OFE (Tower F) instance"

--- a/Iris/Iris/Algebra/Csum.lean
+++ b/Iris/Iris/Algebra/Csum.lean
@@ -50,13 +50,10 @@ theorem dist_eqv [OFE α] [OFE β] {n} : Equivalence (Csum.Dist (α := α) (β :
 
 @[rocq_alias csumO]
 instance [OFE α] [OFE β] : OFE (Csum α β) where
-  Equiv := Csum.Equiv
   Dist := Csum.Dist
   dist_eqv := dist_eqv
-  equiv_dist {x y} := by
-    refine ⟨fun h _ => ?_, fun h => ?_⟩
-    · cases x <;> cases y <;> first | exact OFE.Equiv.dist h | trivial
-    · cases x <;> cases y <;> first | exact equiv_dist.mpr h | exact (h 0).elim | trivial
+  eq_dist {x y} := by
+    cases x <;> cases y <;> simp [Csum.Dist] <;> exact eq_dist
   dist_lt {n x y m} hn hlt := by
     cases x <;> cases y <;> first | exact OFE.Dist.lt hn hlt | exact hn.elim | trivial
 
@@ -91,21 +88,28 @@ instance [OFE α] [OFE β] [OFE.Discrete α] [OFE.Discrete β] : OFE.Discrete (C
   discrete_0 {x y} h := by cases x <;> cases y <;>
     first | exact discrete_0 (α := α) h | exact discrete_0 (α := β) h | trivial
 
-@[rocq_alias csum_leibniz]
-instance [OFE α] [OFE β] [OFE.Leibniz α] [OFE.Leibniz β] : OFE.Leibniz (Csum α β) where
-  eq_of_eqv {x y} h := by cases x <;> cases y <;>
-    first | exact congrArg _ (eq_of_eqv h) | exact h.elim | rfl
-
 @[rocq_alias Cinl_discrete]
 instance [OFE α] [OFE β] {a : α} [DiscreteE a] : DiscreteE (inl (β := β) a) where
-  discrete {x} h := by cases x with | inl => exact DiscreteE.discrete (x := a) h | _ => exact h
+  discrete {x} h := by
+    cases x with
+    | inl => exact DiscreteE.discrete (x := a) h
+    | inr => exact h.elim
+    | invalid => exact h.elim
 
 @[rocq_alias Cinr_discrete]
 instance [OFE α] [OFE β] {b : β} [DiscreteE b] : DiscreteE (inr (α := α) b) where
-  discrete {x} h := by cases x with | inr => exact DiscreteE.discrete (x := b) h | _ => exact h
+  discrete {x} h := by
+    cases x with
+    | inl => exact h.elim
+    | inr => exact DiscreteE.discrete (x := b) h
+    | invalid => exact h.elim
 
 instance [OFE α] [OFE β] : DiscreteE (@invalid α β) where
-  discrete {x} h := by cases x <;> exact h
+  discrete {x} h := by
+    cases x with
+    | inl => exact h.elim
+    | inr => exact h.elim
+    | invalid => exact .rfl
 
 /-! ## COFE -/
 
@@ -208,7 +212,7 @@ instance [CMRA α] [CMRA β] : CMRA (Csum α β) where
       obtain ⟨cy, hcy, ecy⟩ := CMRA.pcore_ne hxy hpb
       exact ⟨inr cy, by simp [Csum.pcore, hcy], ecy⟩
     · simp only [Csum.pcore, Option.some.injEq] at hpx
-      exact ⟨invalid, rfl, hpx ▸ trivial⟩
+      exact ⟨invalid, rfl, hpx ▸ .rfl⟩
   validN_ne {n x y} h hv := by
     cases x <;> cases y <;> first | exact CMRA.validN_ne h hv | exact h.elim | trivial
   valid_iff_validN {x} := by cases x <;> simp [CMRA.valid_iff_validN]
@@ -219,7 +223,7 @@ instance [CMRA α] [CMRA β] : CMRA (Csum α β) where
   pcore_op_left {x cx} hpx := by cases x with
     | inl a => obtain ⟨ca, hpa, rfl⟩ := pcore_map_inl_eq hpx; exact CMRA.pcore_op_left hpa
     | inr b => obtain ⟨cb, hpb, rfl⟩ := pcore_map_inr_eq hpx; exact CMRA.pcore_op_left hpb
-    | invalid => simp only [Csum.pcore, Option.some.injEq] at hpx; exact hpx ▸ trivial
+    | invalid => simp only [Csum.pcore, Option.some.injEq] at hpx; exact hpx ▸ .rfl
   pcore_idem {x cx} hpx := by cases x with
     | inl a =>
       obtain ⟨ca, hpa, rfl⟩ := pcore_map_inl_eq hpx
@@ -227,22 +231,22 @@ instance [CMRA α] [CMRA β] : CMRA (Csum α β) where
     | inr b =>
       obtain ⟨cb, hpb, rfl⟩ := pcore_map_inr_eq hpx
       exact Option.map_forall₂ inr (CMRA.pcore_idem hpb)
-    | invalid => simp only [Csum.pcore, Option.some.injEq] at hpx; exact hpx ▸ trivial
+    | invalid => simp only [Csum.pcore, Option.some.injEq] at hpx; exact hpx ▸ .rfl
   pcore_op_mono {x cx} hpx y := by cases x with
     | inl a =>
       obtain ⟨ca, hpa, rfl⟩ := pcore_map_inl_eq hpx; cases y with
       | inl a' =>
         obtain ⟨cy, hcy⟩ := CMRA.pcore_op_mono hpa a'
         exact ⟨inl cy, Option.map_forall₂ inl hcy⟩
-      | _ => exact ⟨invalid, trivial⟩
+      | _ => exact ⟨invalid, .rfl⟩
     | inr b =>
       obtain ⟨cb, hpb, rfl⟩ := pcore_map_inr_eq hpx; cases y with
       | inr b' =>
         obtain ⟨cy, hcy⟩ := CMRA.pcore_op_mono hpb b'
         exact ⟨inr cy, Option.map_forall₂ inr hcy⟩
-      | _ => exact ⟨invalid, trivial⟩
+      | _ => exact ⟨invalid, .rfl⟩
     | invalid =>
-      simp only [Csum.pcore, Option.some.injEq] at hpx; exact hpx ▸ ⟨invalid, trivial⟩
+      simp only [Csum.pcore, Option.some.injEq] at hpx; exact hpx ▸ ⟨invalid, .rfl⟩
   validN_op_left {n x y} h := by
     cases x <;> cases y <;> first | exact CMRA.validN_op_left h | exact h.elim
   extend {n x y₁ y₂} hv he := by
@@ -333,7 +337,7 @@ theorem included [CMRA α] [CMRA β] {x y : Csum α β} :
   · rintro ⟨z, hz⟩; cases x <;> cases z <;> cases y <;>
       first
       | exact Or.inl rfl
-      | exact hz.elim
+      | exact hz.elim | exact (hz 0).elim
       | exact Or.inr (Or.inl ⟨_, _, rfl, rfl, _, hz⟩)
       | exact Or.inr (Or.inr ⟨_, _, rfl, rfl, _, hz⟩)
   · rintro (rfl | ⟨a, a', rfl, rfl, c, hc⟩ | ⟨b, b', rfl, rfl, c, hc⟩)
@@ -345,14 +349,14 @@ theorem included [CMRA α] [CMRA β] {x y : Csum α β} :
 theorem inl_included [CMRA α] [CMRA β] {a a' : α} :
     (inl (β := β) a) ≼ inl a' ↔ a ≼ a' := by
   constructor
-  · rintro ⟨z, hz⟩; cases z <;> first | exact ⟨_, hz⟩ | exact hz.elim
+  · rintro ⟨z, hz⟩; cases z <;> first | exact ⟨_, hz⟩ | exact hz.elim | exact (hz 0).elim
   · rintro ⟨c, hc⟩; exact ⟨inl c, hc⟩
 
 @[rocq_alias Cinr_included]
 theorem inr_included [CMRA α] [CMRA β] {b b' : β} :
     (inr (α := α) b) ≼ inr b' ↔ b ≼ b' := by
   constructor
-  · rintro ⟨z, hz⟩; cases z <;> first | exact ⟨_, hz⟩ | exact hz.elim
+  · rintro ⟨z, hz⟩; cases z <;> first | exact ⟨_, hz⟩ | exact hz.elim | exact (hz 0).elim
   · rintro ⟨c, hc⟩; exact ⟨inr c, hc⟩
 
 @[rocq_alias CsumInvalid_included]
@@ -368,7 +372,7 @@ theorem includedN [CMRA α] [CMRA β] {n} {x y : Csum α β} :
   · rintro ⟨z, hz⟩; cases x <;> cases z <;> cases y <;>
       first
       | exact Or.inl rfl
-      | exact hz.elim
+      | exact hz.elim | exact (hz 0).elim
       | exact Or.inr (Or.inl ⟨_, _, rfl, rfl, _, hz⟩)
       | exact Or.inr (Or.inr ⟨_, _, rfl, rfl, _, hz⟩)
   · rintro (rfl | ⟨a, a', rfl, rfl, c, hc⟩ | ⟨b, b', rfl, rfl, c, hc⟩)
@@ -386,7 +390,7 @@ theorem some_included [CMRA α] [CMRA β] {x y : Csum α β} :
     · cases x <;> cases y <;>
         first
         | exact .inl rfl
-        | exact heq.elim
+        | exact heq.elim | exact (heq 0).elim
         | exact .inr (Or.inl ⟨_, _, rfl, rfl, Option.some_inc_some_iff.mpr (.inl heq)⟩)
         | exact .inr (Or.inr ⟨_, _, rfl, rfl, Option.some_inc_some_iff.mpr (.inl heq)⟩)
     · rcases included.mp hinc with rfl | ⟨a, a', rfl, rfl, ha⟩ | ⟨b, b', rfl, rfl, hb⟩
@@ -408,7 +412,7 @@ theorem some_includedN [CMRA α] [CMRA β] {n} {x y : Csum α β} :
     · cases x <;> cases y <;>
         first
         | exact .inl rfl
-        | exact heq.elim
+        | exact heq.elim | exact (heq 0).elim
         | exact .inr (Or.inl ⟨_, _, rfl, rfl, Option.some_incN_some_iff.mpr (.inl heq)⟩)
         | exact .inr (Or.inr ⟨_, _, rfl, rfl, Option.some_incN_some_iff.mpr (.inl heq)⟩)
     · rcases includedN.mp hinc with rfl | ⟨a, a', rfl, rfl, ha⟩ | ⟨b, b', rfl, rfl, hb⟩

--- a/Iris/Iris/Algebra/Csum.lean
+++ b/Iris/Iris/Algebra/Csum.lean
@@ -53,7 +53,7 @@ instance [OFE α] [OFE β] : OFE (Csum α β) where
   Dist := Csum.Dist
   dist_eqv := dist_eqv
   eq_dist {x y} := by
-    cases x <;> cases y <;> simp [Csum.Dist] <;> exact eq_dist
+    cases x <;> cases y <;> simp [Csum.Dist, eq_dist]
   dist_lt {n x y m} hn hlt := by
     cases x <;> cases y <;> first | exact OFE.Dist.lt hn hlt | exact hn.elim | trivial
 

--- a/Iris/Iris/Algebra/DFrac.lean
+++ b/Iris/Iris/Algebra/DFrac.lean
@@ -79,8 +79,8 @@ instance instCMRADFrac : CMRA DFrac where
   valid_iff_validN := ⟨fun x _ => x, fun x => x 0⟩
   validN_succ := id
   validN_op_left {_} := by rintro ⟨⟩ ⟨⟩ <;> simp [valid, op] <;> grind
-  assoc := by rintro ⟨⟩ ⟨⟩ ⟨⟩ <;> simp [op] <;> exact OFE.Equiv.of_eq (by grind)
-  comm := by rintro ⟨⟩ ⟨⟩ <;> simp [op] <;> exact OFE.Equiv.of_eq (by grind)
+  assoc := by rintro ⟨⟩ ⟨⟩ ⟨⟩ <;> grind [op, OFE.Equiv.of_eq]
+  comm := by rintro ⟨⟩ ⟨⟩ <;> grind [op, OFE.Equiv.of_eq]
   pcore_op_left := by rintro ⟨⟩ ⟨⟩ <;> simp [op, pcore]
   pcore_idem := by rintro ⟨⟩ ⟨⟩ <;> simp [pcore]
   pcore_op_mono := by

--- a/Iris/Iris/Algebra/DFrac.lean
+++ b/Iris/Iris/Algebra/DFrac.lean
@@ -30,9 +30,8 @@ inductive DFrac where
 #rocq_ignore DfracOwn_inj "Not needed"
 #rocq_ignore DfracBoth_inj "Not needed"
 
-@[simp] instance : COFE DFrac := COFE.ofDiscrete _ Eq_Equivalence
-instance : OFE.Leibniz DFrac := ⟨(·)⟩
-instance : OFE.Discrete DFrac := ⟨congrArg id⟩
+@[simp] instance : COFE DFrac := COFE.ofDiscrete _
+instance : OFE.Discrete DFrac := ⟨fun h _ => h⟩
 #rocq_ignore dfracO "Use DFrac type with typeclass inference"
 
 namespace DFrac
@@ -80,8 +79,8 @@ instance instCMRADFrac : CMRA DFrac where
   valid_iff_validN := ⟨fun x _ => x, fun x => x 0⟩
   validN_succ := id
   validN_op_left {_} := by rintro ⟨⟩ ⟨⟩ <;> simp [valid, op] <;> grind
-  assoc := by rintro ⟨⟩ ⟨⟩ ⟨⟩ <;> simp [op] <;> grind
-  comm := by rintro ⟨⟩ ⟨⟩ <;> simp [op] <;> grind
+  assoc := by rintro ⟨⟩ ⟨⟩ ⟨⟩ <;> simp [op] <;> exact OFE.Equiv.of_eq (by grind)
+  comm := by rintro ⟨⟩ ⟨⟩ <;> simp [op] <;> exact OFE.Equiv.of_eq (by grind)
   pcore_op_left := by rintro ⟨⟩ ⟨⟩ <;> simp [op, pcore]
   pcore_idem := by rintro ⟨⟩ ⟨⟩ <;> simp [pcore]
   pcore_op_mono := by
@@ -89,27 +88,7 @@ instance instCMRADFrac : CMRA DFrac where
     · intro z
       exists discard
       rcases z with z|_|z <;> simp [op]
-  extend {_} := by -- x y z} Hx Hxyz := by
-    rintro (x|_|x)
-    · rintro (y|_|y) (z|_|z) Hx Hxyz <;> simp [op] at Hxyz
-      all_goals have Hxyz' := discrete Hxyz <;> simp at Hxyz'
-      exists own y, own z
-    · rintro (y|_|y) (z|_|z) Hx Hxyz <;> simp [op] at Hxyz
-      any_goals have Hxyz' := discrete Hxyz <;> simp at Hxyz'
-      exists discard, discard
-    · rintro (y|_|y) (z|_|z) Hx Hxyz <;> simp [op] at Hxyz
-      any_goals have Hxyz' := discrete Hxyz <;> simp at Hxyz'
-      · exists own x, discard
-        obtain rfl : x = y := Subtype.ext Hxyz'
-        exact ⟨.rfl, .rfl, .rfl⟩
-      · exists own y, ownDiscard z
-      · exists discard, own x
-        obtain rfl : x = z := Subtype.ext Hxyz'
-        exact ⟨.rfl, .rfl, .rfl⟩
-      · exists discard, ownDiscard x
-      · exists ownDiscard y, own z
-      · exists ownDiscard x, discard
-      · exists ownDiscard y, ownDiscard z
+  extend _ Hxyz := ⟨_, _, discrete Hxyz, .rfl, .rfl⟩
 
 @[rocq_alias dfrac_full_exclusive]
 instance own_whole_exclusive : CMRA.Exclusive (α := DFrac) (own 1) where
@@ -138,7 +117,7 @@ instance one_exclusive_right [CMRA V] {v : V} : CMRA.Exclusive (v, own (One.one 
 instance {f : Qp} : CMRA.Cancelable (own f) where
   cancelableN {_} := by
     rintro (a|_|a) (b|_|b) <;> simp [CMRA.ValidN, CMRA.op, op] <;> intro H Hxyz
-    any_goals have Hxyz' := discrete Hxyz <;> simp at Hxyz'
+    any_goals have Hxyz' := (discrete Hxyz).to_eq <;> simp at Hxyz'
     · exact congrArg own (Subtype.ext (by grind))
     · exact absurd Hxyz' (by have := b.2; grind)
     · exact absurd Hxyz' (by have := a.2; grind)
@@ -150,7 +129,7 @@ instance {f : Qp} : CMRA.IdFree (own f) where
     rintro (y|_|y) <;>
       simp [CMRA.ValidN, CMRA.op, op] <;>
       intro H Hxyz <;>
-      any_goals have Hxyz' := discrete Hxyz <;>
+      any_goals have Hxyz' := (discrete Hxyz).to_eq <;>
       simp at Hxyz'
     exact absurd Hxyz' (by have := y.2; grind)
 
@@ -178,7 +157,7 @@ theorem valid_own_op_discard {q : Qp} : ✓ own q • discard ↔ q.val < 1 := b
 instance : CMRA.Discrete DFrac where
   discrete_valid {x} := by simp [CMRA.Valid, CMRA.ValidN]
 
-theorem is_discrete {q : DFrac} : OFE.DiscreteE q := ⟨congrArg id⟩
+theorem is_discrete {q : DFrac} : OFE.DiscreteE q := ⟨fun h _ => h⟩
 
 @[rocq_alias dfrac_discarded_core_id]
 instance : CMRA.CoreId (DFrac.discard) where
@@ -244,12 +223,12 @@ theorem discard_included : (discard : DFrac) ≼ discard := ⟨discard, .rfl⟩
 @[rocq_alias dfrac_own_included]
 theorem own_included {p q : Qp} : own p ≼ own q ↔ ∃ r, q = p + r := by
   refine ⟨fun ⟨z, hz⟩ => ?_, fun ⟨r, hr⟩ => ⟨own r, hr ▸ .rfl⟩⟩
-  rcases z with (r|_|r) <;> simp [CMRA.op, op] at hz
+  rcases z with (r|_|r) <;> replace hz := hz.to_eq <;> simp [CMRA.op, op] at hz
   exact ⟨r, Qp.ext_iff.mpr hz⟩
 
 @[rocq_alias dfrac_is_op]
 instance isOp_dfrac_own {q q1 q2 : Qp} [h : IsOp io1 q io2 q1 io3 q2] :
     IsOp io1 (own q) io2 (own q1) io3 (own q2) where
-  is_op := by rw [h.is_op]; rfl
+  is_op := by rw [h.is_op.to_eq]; rfl
 
 end DFrac

--- a/Iris/Iris/Algebra/Excl.lean
+++ b/Iris/Iris/Algebra/Excl.lean
@@ -52,7 +52,7 @@ instance [OFE α] : OFE (Excl α) where
   Dist := Excl.Dist
   dist_eqv
   eq_dist {x y} := by
-    cases x <;> cases y <;> simp [Excl.Dist] <;> exact eq_dist
+    cases x <;> cases y <;> simp [Excl.Dist, eq_dist]
   dist_lt {n x y m} hn hlt := by
     cases x <;> cases y <;> simp at *
     exact Dist.lt hn hlt
@@ -80,6 +80,8 @@ instance [OFE α] [Discrete α] : Discrete (Excl α) where
     · exact h'.elim
     · exact h'.elim
     · exact .rfl
+
+#rocq_ignore excl_leibniz "Not needed"
 
 @[rocq_alias Excl_discrete]
 instance [OFE α] {a : α} [h : DiscreteE a] : DiscreteE (excl a) where

--- a/Iris/Iris/Algebra/Excl.lean
+++ b/Iris/Iris/Algebra/Excl.lean
@@ -49,17 +49,10 @@ theorem dist_eqv [OFE α] {n} : Equivalence (Excl.Dist (α := α) n) where
 
 @[rocq_alias exclO]
 instance [OFE α] : OFE (Excl α) where
-  Equiv := Excl.Equiv
   Dist := Excl.Dist
   dist_eqv
-  equiv_dist {x y} := by
-    constructor
-    · intro h n
-      cases x <;> cases y <;> simp at *
-      exact Equiv.dist h
-    · intro h
-      cases x <;> cases y <;> simp at *
-      exact equiv_dist.mpr h
+  eq_dist {x y} := by
+    cases x <;> cases y <;> simp [Excl.Dist] <;> exact eq_dist
   dist_lt {n x y m} hn hlt := by
     cases x <;> cases y <;> simp at *
     exact Dist.lt hn hlt
@@ -82,25 +75,25 @@ theorem ne_match [OFE α] {B : Type _} [OFE B]
 @[rocq_alias excl_ofe_discrete]
 instance [OFE α] [Discrete α] : Discrete (Excl α) where
   discrete_0 {x y} h' := by
-    cases x <;> cases y <;> try exact h'
-    exact discrete_0 (α := α) h'
-
-@[rocq_alias excl_leibniz]
-instance [OFE α] [Leibniz α] : Leibniz (Excl α) where
-  eq_of_eqv {x y} h' := by
-    cases x <;> cases y <;> try trivial
-    exact congrArg excl (eq_of_eqv h')
+    cases x <;> cases y
+    · exact discrete_0 (α := α) h'
+    · exact h'.elim
+    · exact h'.elim
+    · exact .rfl
 
 @[rocq_alias Excl_discrete]
 instance [OFE α] {a : α} [h : DiscreteE a] : DiscreteE (excl a) where
   discrete {x} h' := by
     cases x
     · exact h.discrete h'
-    · exact h'
+    · exact h'.elim
 
 @[rocq_alias ExclInvalid_discrete]
 instance [OFE α] : DiscreteE (@invalid α) where
-  discrete {x} h := by cases x <;> exact h
+  discrete {x} h := by
+    cases x
+    · exact h.elim
+    · exact .rfl
 
 /- Adapted from the corresponding definitions for [Option]. -/
 /- This could be simplified if there was an isomorphism lemma for [COFE]s in [OFE.lean]. -/
@@ -163,9 +156,8 @@ instance [OFE α] : CMRA (Excl α) where
 @[rocq_alias excl_included]
 theorem inc_iff [OFE α] {x y : Excl α} : x ≼ y ↔ y = invalid := by
   constructor
-  · intro h
-    rcases h with ⟨z, hz⟩
-    cases x <;> cases y <;> trivial
+  · rintro ⟨z, hz⟩
+    exact hz.to_eq
   · intro h
     exists invalid
     exact Equiv.of_eq h
@@ -173,7 +165,7 @@ theorem inc_iff [OFE α] {x y : Excl α} : x ≼ y ↔ y = invalid := by
 @[rocq_alias excl_includedN]
 theorem incN_iff [OFE α] {x y : Excl α} (n) : x ≼{n} y ↔ y = invalid := by
   constructor
-  · intro ⟨z, hz⟩; cases x <;> cases y <;> trivial
+  · intro ⟨z, hz⟩; cases x <;> cases y <;> first | rfl | exact hz.elim
   · rintro rfl; exists invalid
 
 @[rocq_alias Excl_inj]
@@ -191,7 +183,7 @@ theorem excl_included [OFE α] {a b : α} :
   refine ⟨fun ⟨z, hz⟩ => ?_, fun h => ⟨none, OFE.some_eqv_some.mpr (show excl b ≡ excl a from h.symm)⟩⟩
   rcases z with _|z
   · exact (OFE.some_eqv_some.mp hz : excl b ≡ excl a).symm
-  · exact (OFE.some_eqv_some.mp hz : excl b ≡ invalid).elim
+  · exact ((OFE.some_eqv_some.mp hz : excl b ≡ invalid) 0).elim
 
 @[rocq_alias Excl_includedN]
 theorem excl_includedN [OFE α] {a b : α} {n} :

--- a/Iris/Iris/Algebra/Frac.lean
+++ b/Iris/Iris/Algebra/Frac.lean
@@ -62,30 +62,29 @@ instance instHDivQpQpQp : HDiv Qp Qp Qp where
 def Qp.divide_even (q : Qp) (n : Nat) (hn : 0 < n) : Qp :=
   ⟨q.val / n, Rat.div_pos q.2 (by exact_mod_cast hn)⟩
 
-instance instCOFEQp : COFE Qp := COFE.ofDiscrete _ Eq_Equivalence
-
-instance instLeibnizQp : OFE.Leibniz Qp := ⟨id⟩
+instance instCOFEQp : COFE Qp := COFE.ofDiscrete _
 
 instance instCMRAQp : CMRA Qp where
   pcore _ := none
   op x y := x + y
   ValidN _ x := x.val ≤ 1
   Valid x := x.val ≤ 1
-  op_ne.ne n x1 x2 H := by rw [H]
+  op_ne.ne n x1 x2 H := by rw [(H : x1 = x2)]
   pcore_ne _ H := by rcases H
-  validN_ne H := by rw [H]; exact id
+  validN_ne H := by rw [(H : _ = _)]; exact id
   valid_iff_validN := .symm (forall_const _)
   validN_succ := id
   validN_op_left {n x y} h := by
     show x.val ≤ 1
     have h' : x.val + y.val ≤ 1 := h
     grind
-  assoc := OFE.leibniz.mpr <| Subtype.ext (Rat.add_assoc ..).symm
-  comm := OFE.leibniz.mpr <| Subtype.ext (Rat.add_comm ..)
+  assoc := OFE.Equiv.of_eq <| Subtype.ext (Rat.add_assoc ..).symm
+  comm := OFE.Equiv.of_eq <| Subtype.ext (Rat.add_comm ..)
   pcore_op_left H := by rcases H
   pcore_idem H := by rcases H
   pcore_op_mono H := by rcases H
-  extend {_ x y z} := by rintro H rfl; exists y; exists z
+  extend {_ x y z} := by
+    rintro H He; exact ⟨y, z, fun _ => He, .rfl, .rfl⟩
 
 
 -- TODO: A different solution to having these bridge lemmas might be to internalize
@@ -105,7 +104,8 @@ instance instCMRAQp : CMRA Qp where
 @[simp, grind =] theorem Qp.lt_iff {x y : Qp} : x < y ↔ x.val < y.val := Iff.rfl
 @[simp] theorem Qp.ext_iff {x y : Qp} : x = y ↔ x.val = y.val := Subtype.ext_iff
 @[simp] theorem Qp.dist_iff {n} {x y : Qp} : x ≡{n}≡ y ↔ x.val = y.val := Subtype.ext_iff
-@[simp] theorem Qp.equiv_iff {x y : Qp} : x ≡ y ↔ x.val = y.val := Subtype.ext_iff
+@[simp] theorem Qp.equiv_iff {x y : Qp} : x ≡ y ↔ x.val = y.val :=
+  Iff.trans ⟨OFE.Equiv.to_eq, OFE.Equiv.of_eq⟩ Subtype.ext_iff
 @[simp, rocq_alias frac_valid_1] theorem Qp.valid_one : ✓ (1 : Qp) := by grind
 @[simp, grind =] theorem Qp.half_add_half (q : Qp) : q.half + q.half = q := Subtype.ext (by grind)
 
@@ -130,7 +130,7 @@ theorem Frac.le_of_inc {p q : Qp} (H : p ≼ q) : p ≤ q := by
 
 @[rocq_alias frac_cmra_discrete]
 instance instDiscreteQp : CMRA.Discrete Qp where
-  discrete_0 := id
+  discrete_0 := fun h _ => h
   discrete_valid := id
 
 @[rocq_alias frac_full_exclusive]
@@ -162,4 +162,4 @@ instance (priority := default - 10) (q1 q2 : Qp) :
 set_option synthInstance.checkSynthOrder false in
 @[rocq_alias is_op_frac]
 instance (q : Qp) : IsOp io1 q io2 q.half io3 q.half where
-  is_op := by refine q.ext ?_; grind
+  is_op := by refine OFE.Equiv.of_eq (q.ext ?_); grind

--- a/Iris/Iris/Algebra/GenMap.lean
+++ b/Iris/Iris/Algebra/GenMap.lean
@@ -92,29 +92,34 @@ section OFE
 variable (β : Type _) [OFE β]
 
 instance instOFE_GenMap : OFE (GenMap β) where
-  Equiv := (·.car ≡ ·.car)
   Dist n := (·.car ≡{n}≡ ·.car)
   dist_eqv.refl _ := Dist.of_eq rfl
   dist_eqv.symm := Dist.symm
   dist_eqv.trans := Dist.trans
-  equiv_dist := equiv_dist
+  eq_dist {x y} := by
+    refine ⟨fun h _ => h ▸ .rfl, fun h => ?_⟩
+    obtain ⟨cx, bx⟩ := x; obtain ⟨cy, by'⟩ := y
+    have : cx = cy := eq_dist.mpr h
+    subst this; rfl
   dist_lt := Dist.lt
 end OFE
 
 theorem GenMap.singleton_discreteE {v : β} [OFE β] [DiscreteE v] :
     DiscreteE (GenMap.singleton (β := β) k v) where
-  discrete {y} H γ' := by
+  discrete {y} H := by
+    intro n γ'
     specialize H γ'
     simp only [GenMap.singleton, GenMap.alter, GenMap.empty, Iris.alter] at H ⊢
     split
-    · next heq => simp only [heq, ite_true] at H ⊢; exact Option.some_is_discrete.discrete H
-    · next hne => simp only [hne, ite_false] at H ⊢; exact Option.none_is_discrete.discrete H
+    · next heq => simp only [heq, ite_true] at H ⊢; exact (Option.some_is_discrete.discrete H).dist
+    · next hne => simp only [hne, ite_false] at H ⊢; exact (Option.none_is_discrete.discrete H).dist
 
 theorem GenMap.empty_discreteE [OFE β] : DiscreteE (GenMap.empty (β := β)) where
-  discrete {y} H γ' := by
+  discrete {y} H := by
+    intro n γ'
     specialize H γ'
     simp only [GenMap.empty] at H ⊢
-    exact Option.none_is_discrete.discrete H
+    exact (Option.none_is_discrete.discrete H).dist
 
 @[ext] theorem GenMap.ext {a b : GenMap β} (h : a.car = b.car) : a = b := by
   obtain ⟨ca, ba⟩ := a
@@ -154,7 +159,7 @@ theorem extend_bound {n : Nat} {x : GenMap β}
       x.car k ≡ z₁ • z₂ → z₁ = none ∧ z₂ = none := by
     intro k hk z₁ z₂ hp1
     have _ : none ≡ z₁ • z₂ := (hN k hk) ▸ hp1
-    cases z₁ <;> cases z₂ <;> simp_all [CMRA.op, optionOp, OFE.Equiv, Option.Forall₂]
+    cases z₁ <;> cases z₂ <;> simp_all [CMRA.op, optionOp, OFE.Equiv]
   constructor
   · exact ⟨N, fun k hk => (aux k hk _ _ (CMRA.extend (Hv k) (He k)).2.2.1).1⟩
   · exact ⟨N, fun k hk => (aux k hk _ _ (CMRA.extend (Hv k) (He k)).2.2.1).2⟩
@@ -183,29 +188,29 @@ instance instCMRA_GenMap : CMRA (GenMap β) where
     ⟨fun Hv n => Hv.validN, fun H => valid_iff_validN.mpr (H ·)⟩
   validN_succ {x n} := validN_succ
   validN_op_left {n x y} := validN_op_left
-  assoc {x y z} a := by
+  assoc {x y z} _ a := by
     cases _ : x.car a <;> cases _ : y.car a <;> cases _ : z.car a <;>
-      simp_all [op, OFE.Equiv, Option.Forall₂, optionOp]
-    exact assoc
-  comm {x y} a := by
+      simp_all [op, optionOp]
+    exact assoc.dist
+  comm {x y} _ a := by
     cases _ : x.car a <;> cases _ : y.car a <;>
-      simp_all [op, OFE.Equiv, Option.Forall₂, optionOp]
-    exact comm
+      simp_all [op, optionOp]
+    exact comm.dist
   pcore_op_left {x cx} H := by
     have hcx : cx.car = fun k => CMRA.core (x.car k) := by
       simp [pcore_genmap] at H; exact (congrArg GenMap.car H).symm
-    intro k
+    intro n k
     have H : cx.car k = CMRA.core (x.car k) := congrFun hcx k
     simp only [CMRA.op, optionOp, H]
-    exact core_op (x.car k)
+    exact (core_op (x.car k)).dist
   pcore_idem {x cx} H := by
     have hcx : cx.car = fun k => CMRA.core (x.car k) := by
       simp [pcore_genmap] at H; exact (congrArg GenMap.car H).symm
-    simp only [pcore_genmap, OFE.Equiv, Option.Forall₂]
-    intro k
+    simp only [pcore_genmap, OFE.Equiv]
+    intro n k
     have H : cx.car k = CMRA.core (x.car k) := congrFun hcx k
     simp only [H]
-    exact core_idem (x.car k)
+    exact (core_idem (x.car k)).dist
   pcore_op_mono {x cx} H y := by
     have hcx : cx.car = fun k => CMRA.core (x.car k) := by
       simp [pcore_genmap] at H; exact (congrArg GenMap.car H).symm
@@ -219,12 +224,12 @@ instance instCMRA_GenMap : CMRA (GenMap β) where
       cases hx : x.car k <;> cases hy : y.car k <;> simp_all
       have hcxy : CMRA.core (x.car • y.car) k = none := by
         simp [CMRA.core, CMRA.pcore, optionCore, hx, hy, CMRA.op, optionOp]
-      have hHeqk := Hcy k
+      have hHeqk := Hcy 0 k
       simp only [CMRA.core, CMRA.pcore, optionCore, CMRA.op, optionOp,
         hx, hy, Option.bind] at hHeqk
       cases hcy : cy k <;> simp_all
-    · intro k
-      have hHeqk := Hcy k
+    · intro n k
+      have hHeqk := Hcy n k
       simp [CMRA.core, CMRA.pcore, optionCore, CMRA.op, optionOp] at hHeqk ⊢
       exact hHeqk
   extend {n x y1 y2} := by
@@ -232,16 +237,17 @@ instance instCMRA_GenMap : CMRA (GenMap β) where
     have eb := extend_bound β Hv H
     let F k := CMRA.extend (Hv k) (H k)
     exact ⟨⟨fun k => (F k).1, eb.1⟩, ⟨fun k => (F k).2.1, eb.2⟩,
-      fun k => (F k).2.2.1, fun k => (F k).2.2.2.1, fun k => (F k).2.2.2.2⟩
+      fun _ k => ((F k).2.2.1).dist, fun k => (F k).2.2.2.1, fun k => (F k).2.2.2.2⟩
 
 instance instUCMRA_GenMap : UCMRA (GenMap β) where
   unit := GenMap.empty
   unit_valid _ := trivial
   unit_left_id {x} k := by
     simp only [CMRA.op, optionOp, empty]
-    cases x.car k <;> simp [OFE.Equiv, Option.Forall₂]
-  pcore_unit k := by
-    simp [OFE.Equiv, Option.Forall₂, empty, CMRA.core, CMRA.pcore, optionCore]
+    cases x.car k <;> simp
+  pcore_unit _ := by
+    refine OFE.some_dist_some.mpr fun k => ?_
+    simp [empty, CMRA.core, CMRA.pcore, optionCore]
 
 instance : IsTotal (GenMap β) := unit_total
 
@@ -283,7 +289,7 @@ theorem GenMap.validN_singleton_map_in (x : Nat) (y : β) (n : Nat) :
 theorem GenMap.op_singleton_comm {mf : GenMap β} {x : Nat} (y : β)
     (H_free : IsFree mf.car x) :
     GenMap.singleton x y • mf ≡ mf.alter x (some y) := by
-  intro k
+  intro n k
   simp only [IsFree] at H_free
   by_cases heq : k = x
   · subst heq
@@ -334,10 +340,12 @@ instance instOFunctor_GenMapOF (F : OFunctorPre) [OFunctor F] :
     simp only [OFE.Dist, Option.Forall₂, Option.map]
     cases _ : k.car γ <;> simp
     exact OFunctor.map_ne.ne Hx Hy _
-  map_id {α β _ _} x γ := by
-    simp only [Option.map]; cases _ : x.car γ <;> simp [OFunctor.map_id]
-  map_comp _ _ _ _ x γ := by
-    simp only [Option.map]; cases _ : x.car γ <;> simp [OFunctor.map_comp]
+  map_id {α β _ _} x _ γ := by
+    simp only [Option.map]; cases _ : x.car γ <;> simp
+    exact (OFunctor.map_id _).dist
+  map_comp _ _ _ _ x _ γ := by
+    simp only [Option.map]; cases _ : x.car γ <;> simp
+    exact (OFunctor.map_comp _ _ _ _ _).dist
 
 instance instURFunctor_GenMapOF (F : COFE.OFunctorPre) [RFunctor F] :
     URFunctor (GenMapOF F) where
@@ -353,7 +361,7 @@ instance instURFunctor_GenMapOF (F : COFE.OFunctorPre) [RFunctor F] :
         have hv' := hv z
         simp only [h, CMRA.ValidN, optionValidN] at hv'
         exact Hvalid hv'
-    pcore x γ := by
+    pcore x _ γ := by
       have Hcore := @(URFunctor.map (F := OptionOF F) f g).pcore (x.car γ)
       simp only [CMRA.pcore, optionCore, Option.bind, Option.map, URFunctor.map,
                  OFunctor.map, optionMap, CMRA.core] at Hcore ⊢
@@ -361,12 +369,13 @@ instance instURFunctor_GenMapOF (F : COFE.OFunctorPre) [RFunctor F] :
       | none => simp
       | some v =>
         revert Hcore
-        cases h' : pcore v <;> cases h'' : pcore ((OFunctor.map f g).f v) <;> simp_all
-    op z x γ := by
+        cases h' : pcore v <;> cases h'' : pcore ((OFunctor.map f g).f v) <;>
+          simp_all <;> exact (·.dist)
+    op z x _ γ := by
       have Hop := @(URFunctor.map (F := OptionOF F) f g).op (z.car γ) (x.car γ)
       simp only [Option.map, CMRA.op, optionOp, URFunctor.map] at Hop ⊢
       cases h : z.car γ <;> cases h' : x.car γ <;>
-        simp_all [OFunctor.map, optionMap, OFE.Equiv, Option.Forall₂]
+        simp_all [OFunctor.map, optionMap, OFE.Equiv]
   }
   map_ne.ne := OFunctor.map_ne.ne
   map_id := OFunctor.map_id

--- a/Iris/Iris/Algebra/GenMap.lean
+++ b/Iris/Iris/Algebra/GenMap.lean
@@ -19,7 +19,7 @@ section GenMap
 /-! ## GenMap
 
 The OFE over gmaps is equivalent to a non-dependent discrete function to an `Option` type with a
-`Leibniz` OFE of keys, and a finite number of allocated elements.
+OFE of keys, and a finite number of allocated elements.
 
 In this setting, the CMRA is always unital, and as a consequence the oFunctors do not require
 unitality in order to act as a `URFunctor(Contractive)`.
@@ -190,11 +190,11 @@ instance instCMRA_GenMap : CMRA (GenMap β) where
   validN_op_left {n x y} := validN_op_left
   assoc {x y z} _ a := by
     cases _ : x.car a <;> cases _ : y.car a <;> cases _ : z.car a <;>
-      simp_all [op, optionOp]
+    simp_all [op, optionOp]
     exact assoc.dist
   comm {x y} _ a := by
     cases _ : x.car a <;> cases _ : y.car a <;>
-      simp_all [op, optionOp]
+    simp_all [op, optionOp]
     exact comm.dist
   pcore_op_left {x cx} H := by
     have hcx : cx.car = fun k => CMRA.core (x.car k) := by

--- a/Iris/Iris/Algebra/Heap.lean
+++ b/Iris/Iris/Algebra/Heap.lean
@@ -72,9 +72,9 @@ instance Heap.instCOFE [LawfulPartialMap M K] [COFE V] : COFE (M V) where
 instance instDiscreteHeap [PartialMap M K] [OFE V] [Discrete V] : Discrete (M V) where
   discrete_0 h k := Discrete.discrete_0 (h k)
 
-instance instLeibnizHeap [ExtensionalPartialMap M K] [OFE V] [Leibniz V] : Leibniz (M V) where
+instance instLeibnizHeap [LawfulPartialMap M K] [OFE V] [Leibniz V] : Leibniz (M V) where
   eq_of_eqv h :=
-    ExtensionalPartialMap.equiv_iff_eq.mp (fun i => Leibniz.eq_of_eqv (h i))
+    LawfulPartialMap.equiv_iff_eq.mp (fun i => Leibniz.eq_of_eqv (h i))
 
 instance instDiscreteESingleton [LawfulPartialMap M K] [DecidableEq K] [OFE V] {v : V}
     [ha : DiscreteE v] {k : K} : DiscreteE (PartialMap.singleton (M := M) k v) where

--- a/Iris/Iris/Algebra/Heap.lean
+++ b/Iris/Iris/Algebra/Heap.lean
@@ -20,22 +20,23 @@ open OFE
 
 namespace PartialMap
 
-instance instOFE [PartialMap M K] [OFE V] : OFE (M V) where
-  Equiv s0 s1  := get? s0 ≡ get? s1
+instance instOFE [LawfulPartialMap M K] [OFE V] : OFE (M V) where
   Dist n s0 s1 := get? s0 ≡{n}≡ get? s1
   dist_eqv     := ⟨fun _ => .of_eq rfl, (·.symm), (·.trans ·)⟩
-  equiv_dist   := equiv_dist
+  eq_dist {s0 s1} := by
+    rw [← LawfulPartialMap.equiv_iff_eq]
+    exact ⟨fun h n k => Dist.of_eq (h k), fun h k => Equiv.to_eq fun n => h n k⟩
   dist_lt      := dist_lt
 
-@[simp] def toMap [PartialMap M K] [OFE V] : (M V) -n> (K → Option V) where
+@[simp] def toMap [LawfulPartialMap M K] [OFE V] : (M V) -n> (K → Option V) where
   f x := get? x
   ne.1 {_ _ _} H k := H k
 
-@[simp] def ofMap [PartialMap M K] [R : RepFunMap M K] [OFE V] :  (K → Option V) -n> (M V) where
+@[simp] def ofMap [LawfulPartialMap M K] [R : RepFunMap M K] [OFE V] :  (K → Option V) -n> (M V) where
   f x := of_fun x
   ne.1 {_ _ _} H k := by simp only [get_of_fun, H k]
 
-instance get?_ne [PartialMap M K] [OFE V] (k : K) : NonExpansive (get? · k : M V → Option V) where
+instance get?_ne [LawfulPartialMap M K] [OFE V] (k : K) : NonExpansive (get? · k : M V → Option V) where
   ne {_ _ _} Ht := Ht k
 
 instance [LawfulPartialMap M K] [OFE V] (k : K) : NonExpansive₂ (insert · k · : M V → V → M V) where
@@ -44,19 +45,19 @@ instance [LawfulPartialMap M K] [OFE V] (k : K) : NonExpansive₂ (insert · k �
     · simp [get?_insert_eq h, Ht]
     · simp [get?_insert_ne h, Hv k']
 
-theorem eqv_of_Equiv [OFE V] [PartialMap M K] {t1 t2 : M V} (H : PartialMap.equiv t1 t2) : t1 ≡ t2 :=
-  (.of_eq <| H ·)
+theorem eqv_of_Equiv [OFE V] [LawfulPartialMap M K] {t1 t2 : M V} (H : PartialMap.equiv t1 t2) : t1 ≡ t2 :=
+  fun _ k => Dist.of_eq (H k)
 
 instance [LawfulPartialMap M K] [OFE V] (op : K → V → V → V) [∀ k, NonExpansive₂ (op k)] :
     NonExpansive₂ (merge (M := M) op) where
   ne _ {_ _} Ht {_ _} Hs k := by simp only [get?_merge]; exact NonExpansive₂.ne (Ht k) (Hs k)
 
 /-- Project a chain of stores through its kth coordinate to a chain of values. -/
-def chain [PartialMap M K] [OFE V] (k : K) (c : Chain (M V)) : Chain (Option V) where
+def chain [LawfulPartialMap M K] [OFE V] (k : K) (c : Chain (M V)) : Chain (Option V) where
   chain i := get? (c i) k
   cauchy Hni := c.cauchy Hni k
 
-theorem chain_get [PartialMap M K] [OFE V] (k : K) (c : Chain (M V)) :
+theorem chain_get [LawfulPartialMap M K] [OFE V] (k : K) (c : Chain (M V)) :
     (chain k c) i = get? (c i) k := by simp [chain]
 
 end PartialMap
@@ -69,28 +70,26 @@ instance Heap.instCOFE [LawfulPartialMap M K] [COFE V] : COFE (M V) where
     · simp [← PartialMap.chain_get, chain_none_const (c := PartialMap.chain k c) (n := 0) (H▸rfl)]
     · exact IsCOFE.conv_compl
 
-instance instDiscreteHeap [PartialMap M K] [OFE V] [Discrete V] : Discrete (M V) where
-  discrete_0 h k := Discrete.discrete_0 (h k)
-
-instance instLeibnizHeap [LawfulPartialMap M K] [OFE V] [Leibniz V] : Leibniz (M V) where
-  eq_of_eqv h :=
-    LawfulPartialMap.equiv_iff_eq.mp (fun i => Leibniz.eq_of_eqv (h i))
+instance instDiscreteHeap [LawfulPartialMap M K] [OFE V] [Discrete V] : Discrete (M V) where
+  discrete_0 h _ k := (Discrete.discrete_0 (h k)).dist
 
 instance instDiscreteESingleton [LawfulPartialMap M K] [DecidableEq K] [OFE V] {v : V}
     [ha : DiscreteE v] {k : K} : DiscreteE (PartialMap.singleton (M := M) k v) where
-  discrete {y} h k' := by
+  discrete {y} h := by
+    intro n k'
     by_cases hh : k = k'
     · simp only [LawfulPartialMap.get?_singleton, hh, ↓reduceIte]
-      refine (Option.some_is_discrete.discrete (.trans ?_ (h k')))
+      refine (Option.some_is_discrete.discrete (.trans ?_ (h k'))).dist
       simp [LawfulPartialMap.get?_singleton, hh, ↓reduceIte]
     · simp only [LawfulPartialMap.get?_singleton, hh, ↓reduceIte]
-      refine (Option.none_is_discrete.discrete (.trans ?_ (h k')))
+      refine (Option.none_is_discrete.discrete (.trans ?_ (h k'))).dist
       simp [LawfulPartialMap.get?_singleton, hh, ↓reduceIte]
 
 instance instDiscreteEEmpty [LawfulPartialMap M K] [OFE V] : DiscreteE (∅ : M V) where
-  discrete {y} h k := by
+  discrete {y} h := by
+    intro n k
     simp only [LawfulPartialMap.get?_empty]
-    refine (DiscreteE.discrete (.trans ?_ (h k)))
+    refine (DiscreteE.discrete (.trans ?_ (h k))).dist
     simp [LawfulPartialMap.get?_empty]
 
 theorem singleton_dist [LawfulPartialMap M K] [DecidableEq K] [OFE V] {n : Nat} {x y : V}
@@ -100,10 +99,8 @@ theorem singleton_dist [LawfulPartialMap M K] [DecidableEq K] [OFE V] {n : Nat} 
   split <;> simp [h]
 
 theorem singleton_equiv [LawfulPartialMap M K] [DecidableEq K] [OFE V] {x y : V} (h : x ≡ y) (k : K) :
-    PartialMap.singleton (M := M) k x ≡ PartialMap.singleton k y := by
-  intro k'
-  simp only [LawfulPartialMap.get?_singleton]
-  split <;> simp [h]
+    PartialMap.singleton (M := M) k x ≡ PartialMap.singleton k y :=
+  fun _ => singleton_dist h.dist k
 
 end OFE
 
@@ -149,7 +146,7 @@ theorem lookup_inc {m1 m2 : M V} :
     cases get? m1 i <;> cases get? z i <;> simp
   · obtain ⟨f, Hf⟩ := Classical.axiomOfChoice H
     exists bindAlter (fun k _ => f k) m2
-    refine fun i => (Hf i).trans ?_
+    refine fun n i => ((Hf i).trans ?_).dist
     specialize Hf i; revert Hf
     simp [CMRA.op, optionOp, get?_merge, get?_bindAlter]
     cases get? m2 i <;> cases get? m1 i <;> cases f i <;> simp
@@ -183,31 +180,32 @@ instance instStoreCMRA : CMRA (M V) where
     specialize H k; revert H
     simp only [op, get?_merge, Option.merge]
     cases get? x1 k <;> cases get? x2 k <;> simp [optionOp, CMRA.op]
-  assoc {x y z} k := by
+  assoc {x y z} _ k := by
     simp only [op, get?_merge]
     cases get? x k <;> cases get? y k <;> cases get? z k <;> simp
-    exact assoc
-  comm {x y} k := by
+    exact assoc.dist
+  comm {x y} _ k := by
     simp [op, get?_merge]
     cases get? x k <;> cases get? y k <;> simp
-    exact comm
-  pcore_op_left {x cx} H k := by
+    exact comm.dist
+  pcore_op_left {x cx} H _ k := by
     simp only [← Option.getD_some (a := cx) (b := cx), op, get?_merge]
     cases Hcx : get? cx k <;> cases hx : get? x k <;>
       simp <;>
       simp only [pcore, Option.some.injEq] at H
     · rw [← H, get?_bindAlter, hx] at Hcx
       cases Hcx
-    · apply pcore_op_left
+    · refine (pcore_op_left ?_).dist
       simp [← Hcx, ← H, get?_bindAlter, hx]
   pcore_idem {x cx} H := by
     simp only [pcore, Option.some.injEq] at H
     change (pcore cx |>.getD cx) ≡ cx
-    intro k
-    simp [← H, get?_bindAlter]
+    simp only [pcore, ← H, Option.getD_some]
+    intro n k
+    simp [get?_bindAlter]
     rcases get? x k with (_|v) <;> simp
     cases HY : CMRA.pcore v; simp
-    exact pcore_idem HY
+    exact (pcore_idem HY).dist
   pcore_op_mono := by
     apply pcore_op_mono_of_core_op_mono
     rintro x cx y ⟨z, Hz⟩
@@ -216,13 +214,13 @@ instance instStoreCMRA : CMRA (M V) where
       simp only [pcore, Option.some.injEq, op, exists_eq_left']
       rcases this with ⟨z', Hz'⟩
       exists z'
-      refine .trans Hz' (fun i => ?_)
+      refine .trans Hz' (fun n i => ?_)
       cases get? z' i <;> cases get? x i <;> simp_all
     refine lookup_inc.mpr (fun i => ?_)
     obtain ⟨v', Hv'⟩ : (core (get? x i)) ≼ (core (get? y i))  := by
       apply core_mono
       exists get? z i
-      have Hz := Hz i; revert Hz
+      have Hz := (get?_ne i).eqv Hz; revert Hz
       simp [CMRA.op, optionOp, get?_merge]
       cases get? x i <;> cases get? z i <;> simp_all
     exists v'
@@ -236,9 +234,9 @@ instance instStoreCMRA : CMRA (M V) where
     exists bindAlter (fun k (_ : V) => extendF k |>.fst) y1
     exists bindAlter (fun k (_ : V) => extendF k |>.snd.fst) y2
     simp [op]
-    refine ⟨fun i => ?_, fun i => ?_, fun i => ?_⟩
+    refine ⟨fun _ i => ?_, fun i => ?_, fun i => ?_⟩
     all_goals rcases hF : extendF i with ⟨z1, z2, Hm, Hz1, Hz2⟩
-    · refine Hm.trans ?_
+    · refine Hm.dist.trans ?_
       simp [get?_merge, CMRA.op, optionOp, Option.merge, get?_bindAlter]
       rw [hF]
       cases z1 <;> cases z2 <;> simp_all
@@ -262,8 +260,10 @@ instance instStoreCMRA : CMRA (M V) where
 instance instStoreUCMRA : UCMRA (M V) where
   unit := unit
   unit_valid := by simp [CMRA.Valid, get?_empty]
-  unit_left_id _ := by simp [CMRA.op, get?_merge, get?_empty]
-  pcore_unit _ := by simp [get?_bindAlter, get?_empty]
+  unit_left_id _ k := by simp [CMRA.op, get?_merge, get?_empty]
+  pcore_unit _ := by
+    refine OFE.some_dist_some.mpr fun k => ?_
+    simp [get?_bindAlter, get?_empty]
 
 instance instIsTotalHeap : IsTotal (M V) where
   total _ := Option.isSome_iff_exists.mp rfl
@@ -348,7 +348,7 @@ theorem insert_eq_singleton_op_singleton [IsoFunMap M K] {m : M V} (Hemp : get? 
   IsoFunMap.ext (insert_equiv_singleton_op_singleton Hemp)
 
 theorem core_empty : core (∅ : M V) ≡ ∅ := by
-  intro k
+  intro n k
   simp [core, CMRA.pcore, get?_empty, get?_bindAlter]
 
 open Classical in
@@ -365,9 +365,9 @@ theorem singleton_core_eq [IsoFunMap M K] {i : K} {x : V} {cx} (Hpcore : CMRA.pc
 open Classical in
 theorem singleton_core_eqv {i : K} {x : V} {cx} (Hpcore : CMRA.pcore x ≡ some cx) :
     core (singleton i x : M V) ≡ singleton i cx := by
-  intro k
+  intro n k
   simp [core, CMRA.pcore, get?_singleton, get?_bindAlter]
-  split <;> trivial
+  split <;> first | exact Hpcore.dist | trivial
 
 theorem singleton_core_total [IsTotal V] {i : K} {x : V} :
     equiv (core <| singleton i x : M V) ((singleton i (core x))) :=
@@ -389,17 +389,19 @@ theorem singleton_op_singleton_eq [IsoFunMap M K] {i : K} {x y : V} :
   IsoFunMap.ext singleton_op_singleton
 
 instance {m : M V} [I : ∀ x : V, CoreId x] : CoreId m where
-  core_id i := by
+  core_id _ := by
+    refine OFE.some_dist_some.mpr fun k => ?_
     rw [get?_bindAlter]
-    cases get? m i <;> simp
-    exact core_id
+    cases get? m k <;> simp
+    exact core_id.dist
 
 open Classical in
 instance [CoreId (x : V)] : CoreId (singleton i x : M V) where
-  core_id k := by
+  core_id _ := by
+    refine OFE.some_dist_some.mpr fun k => ?_
     simp [get?_bindAlter, get?_singleton]
     split <;> simp
-    exact core_id
+    exact core_id.dist
 
 open Classical in
 theorem singleton_incN_iff {m : M V} :
@@ -437,7 +439,7 @@ open Classical in
 theorem singleton_inc_iff {m : M V} :
     (singleton i x) ≼ m ↔ ∃ y, (get? m i ≡ some y) ∧ some x ≼ some y := by
   refine ⟨fun ⟨z, Hz⟩ => ?_, fun ⟨y, Hy, z, Hz⟩ => ?_⟩
-  · specialize Hz i; revert Hz
+  · replace Hz := (get?_ne i).eqv Hz; revert Hz
     simp only [CMRA.op, Heap.op, get?_merge, get?_singleton_eq rfl]
     rcases get? z i with (_|v)
     · intro _
@@ -446,22 +448,22 @@ theorem singleton_inc_iff {m : M V} :
       exists v
   · cases z
     · exists (PartialMap.delete m i)
-      intros j
+      intros _ j
       simp [CMRA.op, get?_merge, get?_singleton, get?_delete]
       split
       · rename_i h
         simp
-        refine (h ▸ Hy).trans <| Hz.trans ?_
+        refine ((h ▸ Hy).trans <| Hz.trans ?_).dist
         simp [CMRA.op]
       · simp
     · rename_i z
       exists (PartialMap.insert m i z)
-      intros j
+      intros _ j
       simp [CMRA.op, get?_merge, get?_singleton, get?_insert]
       split
       · rename_i h
         simp
-        refine (h ▸ Hy).trans <| Hz.trans ?_
+        refine ((h ▸ Hy).trans <| Hz.trans ?_).dist
         simp [CMRA.op]
       · simp
 
@@ -560,8 +562,8 @@ theorem inc_dom_inc {m1 m2 : M V} (Hinc : m1 ≼ m2) : Set.Included (dom m1) (do
   revert Hz
   cases get? m1 i <;> cases get? m2 i <;> cases z <;> simp [CMRA.op, optionOp]
 
-nonrec instance [HD : CMRA.Discrete V] [PartialMap M K] : Discrete (M V) where
-  discrete_0 {_ _} H := (OFE.Discrete.discrete_0 <| H ·)
+nonrec instance [HD : CMRA.Discrete V] [LawfulPartialMap M K] : Discrete (M V) where
+  discrete_0 {_ _} H := fun _ k => (OFE.Discrete.discrete_0 (H k)).dist
   discrete_valid {_} := (CMRA.Discrete.discrete_valid <| · ·)
 
 end Heap
@@ -583,8 +585,8 @@ instance [OFE α] [OFE β] {f : α → β} [hne : OFE.NonExpansive f] : OFE.NonE
 
 def map_id [OFE α] (a : H α):
     PartialMap.map H id a ≡ a := by
-  simp [OFE.Equiv, PartialMap.map, get?_bindAlter, Option.bind, Option.Forall₂]
-  intro x
+  intro n x
+  simp [PartialMap.map, get?_bindAlter, Option.bind]
   rcases get? a x <;> simp
 
 def mapO [OFE α] [OFE β] (f : α -n> β) : OFE.Hom (H α) (H β) where
@@ -592,10 +594,10 @@ def mapO [OFE α] [OFE β] (f : α -n> β) : OFE.Hom (H α) (H β) where
   ne := inferInstance
 
 def map_ext [OFE α] [OFE β] {f g : α -> β} (heq : f ≡ g) : map H f m ≡ map H g m := by
-  intro k
+  intro n k
   simp [map, get?_bindAlter, Option.bind]
   cases get? m k <;> simp
-  exact heq _
+  exact heq _ _
 
 def map_ne [OFE α] [OFE β] (f g : α -> β) {heq : f ≡{n}≡ g} : map H f m ≡{n}≡ map H g m := by
   simp [OFE.Dist, Option.Forall₂, map, get?_bindAlter]
@@ -605,7 +607,7 @@ def map_ne [OFE α] [OFE β] (f g : α -> β) {heq : f ≡{n}≡ g} : map H f m 
 
 def map_compose [OFE α] [OFE β] [OFE γ] (f : α -> β) (g : β -> γ) m :
     map H (g.comp f) m ≡ map H g (map H f m) := by
-  intro k
+  intro n k
   simp [map, get?_bindAlter]
   cases get? m k <;> simp
 
@@ -620,18 +622,18 @@ def mapC [CMRA α] [CMRA β] (f : α -C> β) : CMRA.Hom (H α) (H β) where
     cases (get? x k) <;> simp
     apply CMRA.Hom.validN
   pcore m := by
-    intro x
+    intro _ x
     simp [map, get?_bindAlter]
     rcases get? m x with _|v <;> simp
     have h : (CMRA.pcore v).bind (fun a => some (f a)) = (CMRA.pcore v).map f := by
       rw [Option.map_eq_bind]
       rfl
     rw [h]
-    exact CMRA.Hom.pcore f v
-  op m1 m2 n := by
+    exact (CMRA.Hom.pcore f v).dist
+  op m1 m2 _ k := by
     simp [CMRA.op, map, get?_bindAlter, get?_merge, Option.merge]
-    cases get? m1 n <;> cases get? m2 n <;> simp
-    apply CMRA.Hom.op
+    cases get? m1 k <;> cases get? m2 k <;> simp
+    exact (CMRA.Hom.op f _ _).dist
 
 abbrev PartialMapOF (F : COFE.OFunctorPre) : COFE.OFunctorPre :=
   fun A B _ _ => H (F A B)
@@ -647,13 +649,13 @@ instance {F} [COFE.OFunctor F] : COFE.OFunctor (PartialMapOF H F) where
   map_id x := by
     refine .trans ?_ (map_id H x)
     apply map_ext
-    exact (fun _ => COFE.OFunctor.map_id _)
+    exact fun _ a => (COFE.OFunctor.map_id a).dist
   map_comp f g f' g' m := by
     simp [mapO, map]
-    intro x
+    intro n x
     simp [get?_bindAlter]
     cases get? m x <;> simp
-    exact COFE.OFunctor.map_comp f g f' g' _
+    exact (COFE.OFunctor.map_comp f g f' g' _).dist
 
 instance {F} [RFunctor F] : URFunctor (PartialMapOF H F) where
   map f g := mapC H (RFunctor.map f g)
@@ -665,13 +667,13 @@ instance {F} [RFunctor F] : URFunctor (PartialMapOF H F) where
   map_id x := by
     refine .trans ?_ (map_id H x)
     apply map_ext
-    exact (fun _ => RFunctor.map_id _)
+    exact fun _ a => (RFunctor.map_id a).dist
   map_comp f g f' g' m := by
     simp [mapC, map]
-    intro x
+    intro n x
     simp [get?_bindAlter]
     cases get? m x <;> simp
-    exact (RFunctor.map_comp ..)
+    exact (RFunctor.map_comp f g f' g' _).dist
 
 instance {F} [RFunctorContractive F] : URFunctorContractive (PartialMapOF H F) where
   map_contractive.1 H m := by

--- a/Iris/Iris/Algebra/HeapView.lean
+++ b/Iris/Iris/Algebra/HeapView.lean
@@ -152,9 +152,9 @@ theorem auth_dfrac_op_eqv : Auth (dp • dq) m1 ≡ Auth dp m1 • Auth dq m1 :=
 /-- An `Auth` inclusion follows from a pointwise map equivalence on the underlying heap.
 This is the workhorse for proofs that rewrite the authoritative map along identities like
 `PartialMap.map_insert`, `map_delete`, or `map_union`. -/
-theorem auth_inc_of_pmap_eqv (dq : DFrac) (h : PartialMap.equiv m1 m2) :
+theorem auth_inc_of_pmap_eqv (dq : DFrac) (h : m1 = m2) :
     Auth (H := H) dq m1 ≼ Auth dq m2 :=
-  CMRA.inc_of_inc_of_eqv .rfl (OFE.NonExpansive.eqv (PartialMap.eqv_of_Equiv h))
+  CMRA.inc_of_inc_of_eqv .rfl (OFE.NonExpansive.eqv (OFE.Equiv.of_eq h))
 
 theorem dist_of_validN_auth_op : ✓{n} Auth dp m1 • Auth dq m2 → m1 ≡{n}≡ m2 :=
   dist_of_validN_auth
@@ -592,12 +592,6 @@ theorem update_big_delete (m m' : H V) :
   Auth (.own one) m • (bigOpM (M := HeapView K V H) op (fun k v => Frag k (.own one) v) m') ~~>
   Auth (.own one) (m \ m') := by
   induction m' using LawfulFiniteMap.induction_on with
-  | hequiv m₁ m₂ heq hP =>
-    refine Update.equiv_left (CMRA.op_right_eqv _ (BigOpM.bigOpM_eqv_of_perm _ heq)) ?_
-    refine .trans hP ?_
-    refine Update.equiv_left ?_ .id
-    refine OFE.NonExpansive.eqv ?_
-    exact eqv_of_Equiv (fun j => by simp [get?_difference, heq j])
   | hemp =>
     rw [bigOpM_frag_empty]
     refine Update.equiv_left CMRA.comm ?_
@@ -623,13 +617,6 @@ theorem update_big_replace (m m0 m1 : H V)
   Auth (.own one) (m1 ∪ m) • (bigOpM (M := HeapView K V H) op (fun k v => Frag k (.own one) v) m1) := by
   revert m1 Hdom
   induction m0 using LawfulFiniteMap.induction_on with
-  | hequiv m₁ m₂ heq hP =>
-    intro m1 Hdom Hall
-    refine Update.equiv_left (CMRA.op_right_eqv _ (BigOpM.bigOpM_eqv_of_perm _ heq)) ?_
-    refine .trans (hP m1 ?_ Hall) ?_
-    · exact Hdom ▸ funext (fun j => congrArg (· = true) (congrArg Option.isSome (heq j)))
-    refine Update.equiv_left ?_ .id
-    exact .rfl
   | hemp =>
     intro m1 Hdom Hall
     rw [bigOpM_frag_empty]
@@ -688,22 +675,6 @@ theorem update_big_alloc (m1 m2 : H V) dq
     Auth (.own one) (m2 ∪ m1)
     • bigOpM (M := HeapView K V H) op (fun k v => Frag k dq v) m2 := by
     induction m2 using LawfulFiniteMap.induction_on generalizing m1 with
-    | hequiv m₁ m₂ heq hP =>
-      have Hall' : all (fun k v => ✓ v) m₁ := by
-        intro k v hk; exact Hall k v (heq k ▸ hk)
-      have Hdisj' : m₁ ##ₘ m1 := by
-        intro k ⟨hs1, hs2⟩; exact Hdisj k ⟨heq k ▸ hs1, hs2⟩
-      have IH := hP m1 Hdisj' Hall'
-      refine IH.trans ?_
-      refine Update.included ?_
-      refine inc_of_inc_of_eqv .rfl ?_
-      refine CMRA.op_eqv ?_ ?_
-      · refine OFE.NonExpansive.eqv ?_
-        intro i
-        exact .of_eq (by
-          change get? (PartialMap.union m₂ m1) i = get? (PartialMap.union m₁ m1) i;
-          simp [PartialMap.union, get?_merge, heq i])
-      · exact BigOpM.bigOpM_eqv_of_perm _ heq.symm
     | hemp =>
       rw [bigOpM_frag_empty]
       refine Update.included ?_
@@ -711,9 +682,7 @@ theorem update_big_alloc (m1 m2 : H V) dq
       refine CMRA.comm.trans ?_
       refine UCMRA.unit_left_id.trans ?_
       refine OFE.NonExpansive.eqv ?_
-      exact eqv_of_Equiv (fun k => by
-        change get? (PartialMap.union ∅ m1) k = get? m1 k;
-        simp [PartialMap.union, get?_merge, get?_empty])
+      exact OFE.Equiv.of_eq union_empty_left
     | hins k v m2 Hm2 IH =>
       have Hall' : all (fun k v => ✓ v) m2 := by exact all_of_all_insert _ Hm2 Hall
       have Hdisj' : m2 ##ₘ m1 := by
@@ -732,7 +701,7 @@ theorem update_big_alloc (m1 m2 : H V) dq
       refine Update.op ?_ ?_
       · refine Update.equiv_left ?_ .id
         refine OFE.NonExpansive.eqv ?_
-        exact eqv_of_Equiv (PartialMap.equiv.symm _ _ union_insert_left)
+        exact OFE.Equiv.of_eq union_insert_left.symm
       · refine Update.equiv_left ?_ .id
         exact BigOpM.bigOpM_insert_eqv _ _ Hm2
 

--- a/Iris/Iris/Algebra/HeapView.lean
+++ b/Iris/Iris/Algebra/HeapView.lean
@@ -196,7 +196,7 @@ set_option synthInstance.checkSynthOrder false in
 instance
   [hdp : IsOp io1 dp io2 dp1 io3 dp2]
   [hv : IsOp io1 v io2 v1 io3 v2] :
-  IsOp io1 (Frag (H:=H) k dp v) io2 (Frag (H:=H) k dp1 v1) io3 (Frag (H:=H) k dp2 v2) where
+  IsOp io1 (Frag k dp v) io2 (Frag k dp1 v1) io3 (Frag (H := H) k dp2 v2) where
   is_op := by
     rw [hdp.is_op.to_eq]
     exact (NonExpansive.eqv hv.is_op).trans frag_op_eqv
@@ -276,13 +276,12 @@ instance [Hdq : CoreId dq] [Hv1 : CoreId v1] : CoreId (Frag (H := H) k dq v1) wh
   core_id := by
     obtain ⟨H⟩ := Hdq
     simp [CMRA.pcore] at H
-    replace H := H.to_eq
     simp only [CMRA.pcore, View.Pcore, some_eqv_some]
     refine NonExpansive₂.eqv .rfl (singleton_core_eqv ?_)
     simp [CMRA.pcore, Prod.pcore]
     cases h : CMRA.pcore v1
     · exact not_none_eqv_some (h ▸ Hv1.core_id) |>.elim
-    · simp only [Option.bind_some, H]
+    · simp only [Option.bind_some, H.to_eq]
       exact OFE.some_eqv_some.mpr (NonExpansive₂.eqv .rfl (some_eqv_some.mp (h ▸ Hv1.core_id)))
 
 nonrec theorem frag_validN_iff : ✓{n} Frag (H := H) k dq v1 ↔ ✓ dq ∧ ✓{n} v1 :=

--- a/Iris/Iris/Algebra/HeapView.lean
+++ b/Iris/Iris/Algebra/HeapView.lean
@@ -152,9 +152,9 @@ theorem auth_dfrac_op_eqv : Auth (dp • dq) m1 ≡ Auth dp m1 • Auth dq m1 :=
 /-- An `Auth` inclusion follows from a pointwise map equivalence on the underlying heap.
 This is the workhorse for proofs that rewrite the authoritative map along identities like
 `PartialMap.map_insert`, `map_delete`, or `map_union`. -/
-theorem auth_inc_of_pmap_eqv (dq : DFrac) (h : m1 = m2) :
+theorem auth_inc_of_pmap_eqv (dq : DFrac) (h : PartialMap.equiv m1 m2) :
     Auth (H := H) dq m1 ≼ Auth dq m2 :=
-  CMRA.inc_of_inc_of_eqv .rfl (OFE.NonExpansive.eqv (OFE.Equiv.of_eq h))
+  CMRA.inc_of_inc_of_eqv .rfl (OFE.NonExpansive.eqv (OFE.Equiv.of_eq (equiv_iff_eq.mp h)))
 
 theorem dist_of_validN_auth_op : ✓{n} Auth dp m1 • Auth dq m2 → m1 ≡{n}≡ m2 :=
   dist_of_validN_auth

--- a/Iris/Iris/Algebra/HeapView.lean
+++ b/Iris/Iris/Algebra/HeapView.lean
@@ -198,7 +198,7 @@ instance
   [hv : IsOp io1 v io2 v1 io3 v2] :
   IsOp io1 (Frag (H:=H) k dp v) io2 (Frag (H:=H) k dp1 v1) io3 (Frag (H:=H) k dp2 v2) where
   is_op := by
-    rw [eq_of_eqv hdp.is_op]
+    rw [hdp.is_op.to_eq]
     exact (NonExpansive.eqv hv.is_op).trans frag_op_eqv
 
 theorem frag_add_op_eqv {q1 q2 : Qp} :
@@ -256,11 +256,11 @@ theorem auth_op_frag_valid_total_discrete_iff [IsTotal V] [CMRA.Discrete V]
   obtain ⟨v', dq', Hdp, Hl, Hv, Hi⟩ := auth_op_frag_discrete_valid_iff |>.mp H
   refine ⟨v', Hdp, ?_, Hl, Hv.2, ?_⟩
   · rcases Hi with ⟨(_|x), Hx⟩
-    · exact valid_of_eqv Hx.1 Hv.1
-    · exact Option.valid_of_inc_valid Hv.1 ⟨x.fst, Hx.1⟩
+    · exact valid_of_eqv (fun n => (some_eqv_some.mp Hx n).1) Hv.1
+    · exact Option.valid_of_inc_valid Hv.1 ⟨x.fst, fun n => (some_eqv_some.mp Hx n).1⟩
   · rcases Hi with ⟨(_|x), Hx⟩
-    · exact inc_of_inc_of_eqv (inc_refl _) Hx.2.symm
-    · rcases (⟨x.snd, Hx.2⟩ : some v1 ≼ some v') with ⟨(_|z), Hz⟩
+    · exact inc_of_inc_of_eqv (inc_refl _) (OFE.Equiv.symm fun n => (some_eqv_some.mp Hx n).2)
+    · rcases (⟨x.snd, fun n => (some_eqv_some.mp Hx n).2⟩ : some v1 ≼ some v') with ⟨(_|z), Hz⟩
       · exact inc_of_inc_of_eqv (inc_refl _) Hz.symm
       · exists z
 
@@ -276,13 +276,14 @@ instance [Hdq : CoreId dq] [Hv1 : CoreId v1] : CoreId (Frag (H := H) k dq v1) wh
   core_id := by
     obtain ⟨H⟩ := Hdq
     simp [CMRA.pcore] at H
+    replace H := H.to_eq
     simp only [CMRA.pcore, View.Pcore, some_eqv_some]
-    refine NonExpansive₂.eqv trivial (singleton_core_eqv ?_)
+    refine NonExpansive₂.eqv .rfl (singleton_core_eqv ?_)
     simp [CMRA.pcore, Prod.pcore]
     cases h : CMRA.pcore v1
     · exact not_none_eqv_some (h ▸ Hv1.core_id) |>.elim
     · simp only [Option.bind_some, H]
-      exact ⟨rfl, some_eqv_some.mp (h ▸ Hv1.core_id)⟩
+      exact OFE.some_eqv_some.mpr (NonExpansive₂.eqv .rfl (some_eqv_some.mp (h ▸ Hv1.core_id)))
 
 nonrec theorem frag_validN_iff : ✓{n} Frag (H := H) k dq v1 ↔ ✓ dq ∧ ✓{n} v1 :=
   frag_validN_iff.trans <| (HeapR.exists_iff_validN ..).trans singleton_validN_iff
@@ -564,8 +565,8 @@ instance {T} [RFunctor T] : URFunctor (HeapViewURF (H := H) T) where
       refine .trans ?_ (PartialMap.map_compose _ _ _ _)
       apply PartialMap.map_ext
       rw [Prod.map_comp_map]
-      apply (fun _ => Prod.map_ext _ _) <;> simp
-      exact (fun _ => RFunctor.map_comp _ _ _ _)
+      refine OFE.Equiv.of_eq (funext fun p => ?_)
+      exact Prod.ext rfl (RFunctor.map_comp _ _ _ _ p.2).to_eq
 
 instance {T} [RFunctorContractive T] : URFunctorContractive (HeapViewURF (H := H) T) where
   map_contractive.1 H _ := by

--- a/Iris/Iris/Algebra/IsOp.lean
+++ b/Iris/Iris/Algebra/IsOp.lean
@@ -64,14 +64,14 @@ instance isOp_pair [CMRA α] {ioa iob1 iob2 : InOut}
     (a b1 b2 : α) (a' b1' b2' : α)
     [h1 : IsOp ioa a iob1 b1 iob2 b2] [h2 : IsOp ioa a' iob1 b1' iob2 b2'] :
     IsOp ioa (a, a') iob1 (b1, b1') iob2 (b2, b2') where
-  is_op := ⟨h1.is_op, h2.is_op⟩
+  is_op := OFE.equiv_prod_ext h1.is_op h2.is_op
 
 set_option synthInstance.checkSynthOrder false in
 @[rocq_alias is_op_pair_core_id_l]
 instance isOp_pair_core_id_l [CMRA α] [CMRA β] {ioa iob1 iob2 : InOut}
     (a : α) (a' b1' b2' : β) [h1 : CoreId a] [h2 : IsOp ioa a' iob1 b1' iob2 b2'] :
     IsOp ioa (a, a') iob1 (a, b1') iob2 (a, b2') where
-  is_op := ⟨(op_self a).symm, h2.is_op⟩
+  is_op := OFE.equiv_prod_ext (op_self a).symm h2.is_op
 
 set_option synthInstance.checkSynthOrder false in
 @[rocq_alias is_op_pair_core_id_r]
@@ -79,7 +79,7 @@ instance isOpMerge_pair_core_id_r [CMRA α] [CMRA β] {ioa iob1 iob2 : InOut}
     (a b1 b2 : α) (a' : β)
     [h1 : CoreId a'] [h2 : IsOp ioa a iob1 b1 iob2 b2] :
     IsOp ioa (a, a') iob1 (b1, a') iob2 (b2, a') where
-  is_op := ⟨h2.is_op, (op_self a').symm⟩
+  is_op := OFE.equiv_prod_ext h2.is_op (op_self a').symm
 
 @[rocq_alias is_op_Some]
 instance isOp_some [CMRA α] (a b1 b2 : α) {ioa iob1 iob2 : InOut}

--- a/Iris/Iris/Algebra/LeibnizSet.lean
+++ b/Iris/Iris/Algebra/LeibnizSet.lean
@@ -26,12 +26,10 @@ inductive DisjointLeibnizSet (S : Type _) where
   | valid : S → DisjointLeibnizSet S
   | error : DisjointLeibnizSet S
 
-instance : COFE (DisjointLeibnizSet S) := COFE.ofDiscrete _ Eq_Equivalence
+instance : COFE (DisjointLeibnizSet S) := COFE.ofDiscrete _
 
 instance inst_disjointLeibnizSet_DiscreteE {S : Type _} (x : DisjointLeibnizSet S) :
-    DiscreteE x := ⟨id⟩
-
-instance : Leibniz (DisjointLeibnizSet S) := ⟨id⟩
+    DiscreteE x := ⟨fun h _ => h⟩
 
 instance instEmptyCollectionDisjointLeibnizSet [LawfulSet S A] :
     EmptyCollection (DisjointLeibnizSet S) where
@@ -57,8 +55,8 @@ theorem DisjointLeibnizSet.mem_of_eqv [LawfulSet S A] {a b : DisjointLeibnizSet 
     (eqv : a ≡ b) (mx : x ∈ a) : x ∈ b :=
   match a, b with
   | .error, _ => False.elim mx
-  | .valid _, .error => by simp at eqv
-  | .valid _, .valid _ => by simpa [← show _ = _ from eqv]
+  | .valid _, .error => absurd eqv.to_eq (by simp)
+  | .valid _, .valid _ => by simpa [← show _ = _ from eqv.to_eq]
 
 namespace DisjointLeibnizSet
 
@@ -71,15 +69,15 @@ instance : CMRA (DisjointLeibnizSet S) where
     | _, _ => error
   ValidN _ | valid _ => True | _ => False
   Valid | valid _ => True | _ => False
-  op_ne.ne _ _ _ H := by rw [H]
-  pcore_ne {_ _ _ cx} _ H := ⟨cx, H, rfl⟩
-  validN_ne H G := H ▸ G
+  op_ne.ne _ _ _ H := by rw [(H : _ = _)]
+  pcore_ne {_ _ _ cx} _ H := ⟨cx, H, .rfl⟩
+  validN_ne H G := (H : _ = _) ▸ G
   valid_iff_validN := ⟨(fun _ => ·), (· 0)⟩
   validN_succ := id
   validN_op_left {_ x y} := by rcases x <;> rcases y <;> simp
   assoc {x y z} := by
     rcases x with (x|_) <;> rcases y with (y|_) <;> rcases z with (z|_) <;> (try · simp)
-    simp only [leibniz]
+    refine Equiv.of_eq ?_
     by_cases hyz : y ## z <;> by_cases hxy : x ## y <;>
       by_cases hxyzL : x ## y ∪ z <;> by_cases hxyzR : x ∪ y ## z <;>
     all_goals simp only [hyz, hxy, hxyzL, hxyzR, ↓reduceIte, valid.injEq]
@@ -98,22 +96,25 @@ instance : CMRA (DisjointLeibnizSet S) where
       exact hyz h |>.elim
   comm {x y} := by
     rcases x with (x|_) <;> rcases y with (y|_) <;> (try · simp)
+    refine Equiv.of_eq ?_
     by_cases H : x ## y
     · simp [H, disjoint_symm H, union_comm]
-    · simpa [H] using (H <| disjoint_symm ·)
+    · have H' : ¬ y ## x := fun a => H (disjoint_symm a)
+      simp [H, H']
   pcore_op_left {cx x} := by
     rcases x with (x|_) <;> rcases cx with (cx|_) <;> (try · simp)
     rintro ⟨⟩
     simp [disjoint_empty_left]
-  pcore_idem {x cx} := by rcases x with (x|_) <;> rcases cx with (cx|_) <;> simp
+  pcore_idem {x cx} := by
+    rcases x with (x|_) <;> rcases cx with (cx|_) <;> simp <;> rintro rfl <;> rfl
   pcore_op_mono {_ x} := by
     rcases x with (x|_) <;> rintro ⟨⟩ y
     exists (.valid ∅)
     simp [disjoint_empty_left]
-  extend {_ _ y₁ y₂} _ h := ⟨y₁, y₂, ⟨h, rfl, rfl⟩⟩
+  extend {_ _ y₁ y₂} _ h := ⟨y₁, y₂, ⟨fun _ => h, .rfl, .rfl⟩⟩
 
 instance instDiscreteDisjointLeibnizSet : CMRA.Discrete (DisjointLeibnizSet S) where
-  discrete_0 := id
+  discrete_0 := fun h _ => h
   discrete_valid := id
 
 instance instUCMRADisjointLeibnizSet : UCMRA (DisjointLeibnizSet S) where
@@ -146,14 +147,15 @@ theorem included_iff_subset {X Y : S} : valid X ≼ valid Y ↔ X ⊆ Y := by
   refine ⟨?_, ?_⟩
   · rintro ⟨(Z|_), HZ⟩
     · by_cases H : X ## Z
-      · obtain rfl : Y = X ∪ Z := by simp_all [op]
+      · obtain rfl : Y = X ∪ Z := by have := HZ.to_eq; simp_all [op]
         exact fun _ => (mem_union.mpr <| .inl ·)
-      · simp [op, H] at HZ
-    · simp [op] at HZ
+      · exact absurd HZ.to_eq (by simp [op, H])
+    · exact absurd HZ.to_eq (by simp [op])
   · intro Hsub
     exists valid (Y \ X)
     suffices Y = X ∪ Y \ X by
       have H : X ## (Y \ X) := fun _ H => (mem_diff.mp H.2).right H.1
+      refine OFE.Equiv.of_eq ?_
       simpa [op, H]
     ext p; rw [mem_union, mem_diff]
     refine ⟨by grind, (·.casesOn (Hsub _) (·.left))⟩
@@ -186,21 +188,23 @@ theorem not_mem_of_mem_and_valid_op_right {x y : DisjointLeibnizSet S}
 theorem localUpdate_dealloc {X Y : S} : (valid X, valid Y) ~l~> (valid (X \ Y), valid ∅) := by
   refine LocalUpdate.total_valid fun vx vy inc => ?_
   refine (local_update_unital_discrete ..).mpr fun z hx heq => ⟨valid_mapN (fun _ _ => vx) vx, ?_⟩
-  rcases z with (z|_) <;> try · cases heq
-  by_cases Hdisj : Y ## z <;> simp only [Hdisj, ↓reduceIte, op, leibniz] at heq
-  · obtain ⟨rfl⟩ := valid.injEq _ _ ▸ heq
-    simp only [op, leibniz, disjoint_empty_left, ↓reduceIte, union_empty_left, valid.injEq] at ⊢
-    ext i
-    rw [mem_diff, mem_union]
-    specialize (Hdisj i)
-    grind
-  · cases heq
+  rcases z with (z|_)
+  · by_cases Hdisj : Y ## z <;> simp only [Hdisj, ↓reduceIte, op] at heq
+    · obtain rfl := valid.inj heq.to_eq
+      refine Equiv.of_eq ?_
+      simp only [op, disjoint_empty_left, ↓reduceIte, union_empty_left, valid.injEq]
+      ext i
+      rw [mem_diff, mem_union]
+      specialize (Hdisj i)
+      grind
+    · exact absurd heq.to_eq (by simp)
+  · exact absurd heq.to_eq (by simp [op])
 
 theorem localUpdate_dealloc_empty {X Z : S} :
     (valid Z • valid X, valid Z) ~l~> (valid X, valid ∅) := by
   refine LocalUpdate.total_valid fun Hdisj _ _ => ?_
   rw [valid_op_iff_disj] at Hdisj
-  rw [disj_op_union Hdisj]
+  rw [(disj_op_union Hdisj).to_eq]
   have Heq : X = (Z ∪ X) \ Z := by
     ext a; rw [mem_diff, mem_union]
     exact ⟨fun H => ⟨.inr H, (Hdisj a ⟨·, H⟩)⟩, fun H => H.1.casesOn (H.2 · |>.elim) id⟩
@@ -210,7 +214,7 @@ theorem localUpdate_dealloc_empty {X Z : S} :
 theorem localUpdate_op_l {X Y Z : S} :
     (valid Z • valid X, valid Z • valid Y) ~l~> (valid X, valid Y) := by
   suffices (valid Z • valid X, valid Z • valid Y) ~l~> (valid X, unit • valid Y) by
-    rwa [show UCMRA.unit • valid Y ≡ valid Y by apply unit_left_id] at this
+    rwa [(show UCMRA.unit • valid Y ≡ valid Y by apply unit_left_id).to_eq] at this
   exact LocalUpdate.op_frame _ _ _ _ _ localUpdate_dealloc_empty
 
 theorem localUpdate_op_r {X Y Z : S} (Hdisj : Z ## X) :
@@ -221,13 +225,13 @@ theorem localUpdate_union_r_of_disj (X Y Z : S) (Hdisj : Z ## X) :
     (valid X, valid Y) ~l~> (valid (Z ∪ X), valid (Z ∪ Y)) := by
   refine LocalUpdate.total_valid fun vx vy inc => ?_
   have HdisjY : Z ## Y := fun a ⟨Hz, Hy⟩ => Hdisj a ⟨Hz, included_iff_subset.mp inc a Hy⟩
-  rw [←disj_op_union Hdisj, ←disj_op_union HdisjY]
+  rw [←(disj_op_union Hdisj).to_eq, ←(disj_op_union HdisjY).to_eq]
   exact localUpdate_op_r Hdisj
 
 theorem localUpdate_alloc_empty_of_disj (X Z : S) (Hdisj : Z ## X) :
     (valid X, valid ∅) ~l~>
     (valid (Z ∪ X), valid Z) := by
-  rw [show valid Z ≡ valid (Z ∪ ∅) by simp [union_empty_right]]
+  rw [(show valid Z ≡ valid (Z ∪ ∅) by simp [union_empty_right]).to_eq]
   exact localUpdate_union_r_of_disj X ∅ Z Hdisj
 
 theorem alloc_updateP_strong {P : A → Prop} {Q : DisjointLeibnizSet S → Prop} {X : S}
@@ -290,8 +294,7 @@ end DisjointLeibnizSet
 inductive LeibnizSet (S : Type _) where
   | valid (s : S)
 
-instance : COFE (LeibnizSet S) := COFE.ofDiscrete _ Eq_Equivalence
-instance : Leibniz (LeibnizSet S) := ⟨id⟩
+instance : COFE (LeibnizSet S) := COFE.ofDiscrete _
 
 namespace LeibnizSet
 
@@ -302,7 +305,7 @@ instance : CMRA (LeibnizSet S) where
   op | .valid x, valid y => valid (x ∪ y)
   ValidN _ _ := True
   Valid _ := True
-  op_ne.ne _ _ _ H := by rw [H]
+  op_ne.ne _ _ _ H := by rw [(H : _ = _)]
   pcore_ne {_ _ _} _ H1 H2 :=  ⟨_, rfl, .trans (.of_eq <| Option.some.injEq _ _ ▸ H2.symm) H1⟩
   validN_ne _ _ := by simp
   valid_iff_validN := by simp
@@ -313,7 +316,7 @@ instance : CMRA (LeibnizSet S) where
   pcore_op_left {_ _} := by rintro ⟨rfl⟩; simp [union_idem]
   pcore_idem := by simp
   pcore_op_mono {_ _} := by rintro ⟨rfl⟩ y; exists y
-  extend {_ _ _ _} _ := (⟨_, _, ⟨·, rfl, rfl⟩⟩)
+  extend {_ _ _ _} _ h := ⟨_, _, fun _ => h, .rfl, .rfl⟩
 
 instance : UCMRA (LeibnizSet S) where
   unit := valid ∅
@@ -330,7 +333,7 @@ theorem core_equiv (X : LeibnizSet S) : core X ≡ X := by
 theorem included_iff_subset (X Y : S) : valid X ≼ valid Y ↔ X ⊆ Y := by
   simp only [Included, op]
   refine ⟨fun ⟨_, H⟩ => ?_, fun Hsub => ?_⟩
-  · rcases H with ⟨rfl⟩
+  · obtain ⟨rfl⟩ := H.to_eq
     exact fun _ Hp => mem_union.mpr (.inl Hp)
   · exists valid (Y \ X)
     refine .of_eq ?_

--- a/Iris/Iris/Algebra/LeibnizSet.lean
+++ b/Iris/Iris/Algebra/LeibnizSet.lean
@@ -96,17 +96,12 @@ instance : CMRA (DisjointLeibnizSet S) where
       exact hyz h |>.elim
   comm {x y} := by
     rcases x with (x|_) <;> rcases y with (y|_) <;> (try · simp)
-    refine Equiv.of_eq ?_
-    by_cases H : x ## y
-    · simp [H, disjoint_symm H, union_comm]
-    · have H' : ¬ y ## x := fun a => H (disjoint_symm a)
-      simp [H, H']
+    by_cases H : x ## y <;> grind only [Equiv.of_eq, disjoint_symm, union_comm]
   pcore_op_left {cx x} := by
     rcases x with (x|_) <;> rcases cx with (cx|_) <;> (try · simp)
     rintro ⟨⟩
     simp [disjoint_empty_left]
-  pcore_idem {x cx} := by
-    rcases x with (x|_) <;> rcases cx with (cx|_) <;> simp <;> rintro rfl <;> rfl
+  pcore_idem {x cx} := by grind only [Equiv.of_eq]
   pcore_op_mono {_ x} := by
     rcases x with (x|_) <;> rintro ⟨⟩ y
     exists (.valid ∅)
@@ -194,9 +189,7 @@ theorem localUpdate_dealloc {X Y : S} : (valid X, valid Y) ~l~> (valid (X \ Y), 
       refine Equiv.of_eq ?_
       simp only [op, disjoint_empty_left, ↓reduceIte, union_empty_left, valid.injEq]
       ext i
-      rw [mem_diff, mem_union]
-      specialize (Hdisj i)
-      grind
+      grind [Hdisj i, mem_diff, mem_union]
     · exact absurd heq.to_eq (by simp)
   · exact absurd heq.to_eq (by simp [op])
 

--- a/Iris/Iris/Algebra/Lib/DFracAgree.lean
+++ b/Iris/Iris/Algebra/Lib/DFracAgree.lean
@@ -30,8 +30,6 @@ def mk [OFE A] (d : DFrac) (a : A) : DFracAgreeR A := (d, toAgree a)
 
 variable {A : Type _} [OFE A]
 
-instance instLeibniz [Leibniz A] : Leibniz (DFracAgreeR A) := inferInstance
-
 @[rocq_alias to_dfrac_agree_ne]
 instance mk_ne {d : DFrac} : NonExpansive (mk d : A → DFracAgreeR A) where
   ne _ _ _ h := ⟨.rfl, NonExpansive.ne (f := toAgree) h⟩
@@ -43,7 +41,7 @@ instance mk_exclusive {a : A} : Exclusive (mk (.own (1 : Qp)) a) := one_exclusiv
 
 @[rocq_alias to_dfrac_agree_discrete]
 instance mk_discrete {d : DFrac} {a : A} [DiscreteE a] : DiscreteE (mk d a) :=
-  ⟨fun h => ⟨is_discrete.discrete h.1, Agree.toAgree.is_discrete.discrete h.2⟩⟩
+  ⟨fun h n => ⟨(is_discrete.discrete h.1) n, (Agree.toAgree.is_discrete.discrete h.2) n⟩⟩
 
 @[rocq_alias to_dfrac_agree_injN]
 theorem mk_injN {d₁ d₂ : DFrac} {a₁ a₂ : A} (h : mk d₁ a₁ ≡{n}≡ mk d₂ a₂) : d₁ ≡{n}≡ d₂ ∧ a₁ ≡{n}≡ a₂ :=
@@ -51,11 +49,11 @@ theorem mk_injN {d₁ d₂ : DFrac} {a₁ a₂ : A} (h : mk d₁ a₁ ≡{n}≡ 
 
 @[rocq_alias to_dfrac_agree_inj]
 theorem mk_inj {d₁ d₂ : DFrac} {a₁ a₂ : A} (h : mk d₁ a₁ ≡ mk d₂ a₂) : d₁ ≡ d₂ ∧ a₁ ≡ a₂ :=
-  ⟨h.1, Agree.toAgree_inj h.2⟩
+  ⟨fun n => (h n).1, Agree.toAgree_inj fun n => (h n).2⟩
 
 @[rocq_alias dfrac_agree_op]
 theorem mk_op {d₁ d₂ : DFrac} {a : A} : mk (d₁ • d₂) a ≡ mk d₁ a • mk d₂ a :=
-  ⟨Equiv.rfl, Agree.idemp.symm⟩
+  NonExpansive₂.eqv Equiv.rfl Agree.idemp.symm
 
 @[rocq_alias dfrac_agree_op_valid]
 theorem op_valid {d₁ d₂ : DFrac} {a₁ a₂ : A} : ✓ (mk d₁ a₁ • mk d₂ a₂) ↔ ✓ (d₁ • d₂) ∧ a₁ ≡ a₂ := by
@@ -63,10 +61,10 @@ theorem op_valid {d₁ d₂ : DFrac} {a₁ a₂ : A} : ✓ (mk d₁ a₁ • mk 
   exact and_congr_right fun _ => Agree.toAgree_op_valid_iff_equiv
 
 @[rocq_alias dfrac_agree_op_valid_L]
-theorem op_valid_L [Leibniz A] {d₁ d₂ : DFrac} {a₁ a₂ : A} :
+theorem op_valid_L {d₁ d₂ : DFrac} {a₁ a₂ : A} :
     ✓ (mk d₁ a₁ • mk d₂ a₂) ↔ ✓ (d₁ • d₂) ∧ a₁ = a₂ := by
   rw [op_valid]
-  exact and_congr_right fun _ => Leibniz.leibniz
+  exact and_congr_right fun _ => ⟨OFE.Equiv.to_eq, OFE.Equiv.of_eq⟩
 
 @[rocq_alias dfrac_agree_op_validN]
 theorem op_validN {d₁ d₂ : DFrac} {a₁ a₂ : A} :
@@ -81,18 +79,18 @@ theorem included {d₁ d₂ : DFrac} {a₁ a₂ : A} :
     mk d₁ a₁ ≼ mk d₂ a₂ ↔ (d₁ ≼ d₂) ∧ a₁ ≡ a₂ := by
   simp only [mk, Included]
   constructor
-  · rintro ⟨⟨zd, za⟩, hd, ha⟩
-    exact ⟨⟨zd, hd⟩, Agree.toAgree_included.mp ⟨za, ha⟩⟩
+  · rintro ⟨⟨zd, za⟩, H⟩
+    exact ⟨⟨zd, fun n => (H n).1⟩, Agree.toAgree_included.mp ⟨za, fun n => (H n).2⟩⟩
   · rintro ⟨⟨zd, hd⟩, ha⟩
-    refine ⟨(zd, toAgree a₁), hd, ?_⟩
+    refine ⟨(zd, toAgree a₁), NonExpansive₂.eqv hd ?_⟩
     show toAgree a₂ ≡ toAgree a₁ • toAgree a₁
     exact (NonExpansive.eqv ha.symm).trans Agree.idemp.symm
 
 @[rocq_alias dfrac_agree_included_L]
-theorem included_L [Leibniz A] {d₁ d₂ : DFrac} {a₁ a₂ : A} :
+theorem included_L {d₁ d₂ : DFrac} {a₁ a₂ : A} :
     mk d₁ a₁ ≼ mk d₂ a₂ ↔ (d₁ ≼ d₂) ∧ a₁ = a₂ := by
   rw [included]
-  exact and_congr_right fun _ => Leibniz.leibniz
+  exact and_congr_right fun _ => ⟨OFE.Equiv.to_eq, OFE.Equiv.of_eq⟩
 
 @[rocq_alias dfrac_agree_includedN]
 theorem includedN {d₁ d₂ : DFrac} {a₁ a₂ : A} :
@@ -109,7 +107,7 @@ theorem includedN {d₁ d₂ : DFrac} {a₁ a₂ : A} :
 theorem update₂ {d₁ d₂ : DFrac} {a₁ a₂ a' : A} (hd : d₁ • d₂ = .own 1) :
     mk d₁ a₁ • mk d₂ a₂ ~~> mk d₁ a' • mk d₂ a' := by
   have : mk d₁ a₁ • mk d₂ a₂ ≡ (own (1 : Qp), toAgree a₁ • toAgree a₂) :=
-    ⟨hd ▸ Equiv.rfl, Equiv.rfl⟩
+    NonExpansive₂.eqv (OFE.Equiv.of_eq hd) Equiv.rfl
   calc
     _ ≡ (own (1 : Qp), toAgree a₁ • toAgree a₂) := this
     _ ~~> mk d₁ a' • mk d₂ a' :=
@@ -153,7 +151,7 @@ theorem op_valid {q₁ q₂ : Qp} {a₁ a₂ : A} :
     ✓ (mk q₁ a₁ • mk q₂ a₂) ↔ (q₁ + q₂).val ≤ 1 ∧ a₁ ≡ a₂ := DFracAgree.op_valid
 
 @[rocq_alias frac_agree_op_valid_L]
-theorem op_valid_L [Leibniz A] {q₁ q₂ : Qp} {a₁ a₂ : A} :
+theorem op_valid_L {q₁ q₂ : Qp} {a₁ a₂ : A} :
     ✓ (mk q₁ a₁ • mk q₂ a₂) ↔ (q₁ + q₂).val ≤ 1 ∧ a₁ = a₂ := DFracAgree.op_valid_L
 
 @[rocq_alias frac_agree_op_validN]
@@ -166,7 +164,7 @@ theorem included {q₁ q₂ : Qp} {a₁ a₂ : A} :
     mk q₁ a₁ ≼ mk q₂ a₂ ↔ (own q₁ ≼ own q₂) ∧ a₁ ≡ a₂ := DFracAgree.included
 
 @[rocq_alias frac_agree_included_L]
-theorem included_L [Leibniz A] {q₁ q₂ : Qp} {a₁ a₂ : A} :
+theorem included_L {q₁ q₂ : Qp} {a₁ a₂ : A} :
     mk q₁ a₁ ≼ mk q₂ a₂ ↔ (own q₁ ≼ own q₂) ∧ a₁ = a₂ := DFracAgree.included_L
 
 @[rocq_alias frac_agree_includedN]

--- a/Iris/Iris/Algebra/Lib/ExclAuth.lean
+++ b/Iris/Iris/Algebra/Lib/ExclAuth.lean
@@ -31,8 +31,6 @@ public abbrev ExclAuthR := Auth (Option (Excl A))
 @[rocq_alias excl_authUR]
 public abbrev ExclAuthUR := Auth (Option (Excl A))
 
-instance instLeibniz [Leibniz A] : Leibniz (ExclAuthR (A := A)) := inferInstance
-
 @[rocq_alias excl_auth_auth]
 public abbrev auth (a : A) : ExclAuthR (A := A) := ● (some (excl a))
 
@@ -81,7 +79,7 @@ theorem agree {a b : A} (h : ✓ (●E a) • ◯E b) : a ≡ b :=
   equiv_dist.mpr fun _ => agreeN (Valid.validN h)
 
 @[rocq_alias excl_auth_agree_L]
-theorem agree_L [Leibniz A] {a b : A} (h : ✓ (●E a) • ◯E b) : a = b :=
+theorem agree_L {a b : A} (h : ✓ (●E a) • ◯E b) : a = b :=
   (agree h).to_eq
 
 @[rocq_alias excl_auth_auth_op_validN]

--- a/Iris/Iris/Algebra/Lib/FracAuth.lean
+++ b/Iris/Iris/Algebra/Lib/FracAuth.lean
@@ -30,8 +30,6 @@ namespace FracAuth
 
 variable [CMRA A]
 
-instance instLeibniz [Leibniz A] : Leibniz (FracAuth (A := A)) := inferInstance
-
 @[rocq_alias frac_auth_auth]
 public abbrev auth (dq : DFrac) (a : A) : FracAuth (A := A) := Auth.auth dq (some (1, a))
 
@@ -111,7 +109,7 @@ theorem agree {dq : DFrac} {a b : A} (h : ✓ (●F{dq} a) • ◯F b) : a ≡ b
   equiv_dist.mpr fun n => agreeN (valid_iff_validN.mp h n)
 
 @[rocq_alias frac_auth_agree_L]
-theorem agree_L [OFE.Leibniz A] {dq : DFrac} {a b : A} (h : ✓ (●F{dq} a) • ◯F b) : a = b :=
+theorem agree_L {dq : DFrac} {a b : A} (h : ✓ (●F{dq} a) • ◯F b) : a = b :=
   (agree h).to_eq
 
 /-! ## Inclusion -/
@@ -131,8 +129,8 @@ theorem included [CMRA.Discrete A] {dq : DFrac} {a b : A} (h : ✓ (●F{dq} a) 
   rw [both_dfrac_valid_discrete] at h
   obtain ⟨_, ⟨mc, hmc⟩, hv⟩ := h
   match mc with
-  | none => exact ⟨none, hmc.2⟩
-  | some (_, cr) => exact ⟨some cr, hmc.2⟩
+  | none => exact ⟨none, fun n => (hmc n).2⟩
+  | some (_, cr) => exact ⟨some cr, fun n => (hmc n).2⟩
 
 @[rocq_alias frac_auth_includedN_total]
 theorem includedN_total [IsTotal A] {dq : DFrac} {a b : A} (h : ✓{n} (●F{dq} a) • ◯F{q} b) :
@@ -207,7 +205,7 @@ theorem auth_op_validN {a b : A} (h : ✓{n} (●F a : FracAuth) • ●F b) : F
 theorem auth_dfrac_op_valid {dq1 dq2 : DFrac} {a b : A} (h : ✓ (●F{dq1} a) • ●F{dq2} b) :
     ✓ (dq1 • dq2) ∧ a ≡ b := by
   rw [Auth.auth_dfrac_op_valid] at h
-  exact ⟨h.1, h.2.1.2⟩
+  exact ⟨h.1, fun n => ((OFE.some_eqv_some.mp h.2.1) n).2⟩
 
 @[rocq_alias frac_auth_auth_op_valid]
 theorem auth_op_valid {a b : A} (h : ✓ (●F a : FracAuth) • ●F b) : False :=
@@ -233,14 +231,14 @@ theorem frag_op_valid {q1 q2 : Qp} {a b : A} :
 instance isOp_frac_auth {q q1 q2 : Qp} {a1 a2 : A} {a : outParam A}
     [h1 : IsOp io1 q io2 q1 io3 q2] [h2 : IsOp io1 a io2 a1 io3 a2] :
     IsOp io1 (◯F{q} a) io2 (◯F{q1} a1) io3 (◯F{q2} a2) where
-  is_op := ⟨⟨⟩, ⟨h1.is_op, h2.is_op⟩⟩
+  is_op := NonExpansive.eqv (OFE.some_eqv_some.mpr (NonExpansive₂.eqv h1.is_op h2.is_op))
 
 set_option synthInstance.checkSynthOrder false in
 @[rocq_alias frac_auth_is_op_core_id]
 instance isOp_frac_auth_core_id {q q1 q2 : Qp} {a : A}
     [h1 : CoreId a] [h2 : IsOp io1 q io2 q1 io3 q2] :
     IsOp io1 (◯F{q} a) io2 (◯F{q1} a) io3 (◯F{q2} a) where
-  is_op := ⟨⟨⟩, ⟨h2.is_op, (op_self a).symm⟩⟩
+  is_op := NonExpansive.eqv (OFE.some_eqv_some.mpr (NonExpansive₂.eqv h2.is_op (op_self a).symm))
 
 /-! ## Updates -/
 

--- a/Iris/Iris/Algebra/Lib/MonoNat.lean
+++ b/Iris/Iris/Algebra/Lib/MonoNat.lean
@@ -28,9 +28,8 @@ scoped instance : LawfulLeftIdentity (Add.add (α := MaxNat)) (0 : MaxNat) where
   left_id := Nat.zero_max
 scoped instance : Std.IdempotentOp (Add.add (α := MaxNat)) where
   idempotent x := by simp [Add.add]
-scoped instance : COFE MaxNat := COFE.ofDiscrete _ Eq_Equivalence
-scoped instance : OFE.Discrete MaxNat := ⟨congrArg id⟩
-scoped instance : OFE.Leibniz MaxNat := ⟨congrArg id⟩
+scoped instance : COFE MaxNat := COFE.ofDiscrete _
+scoped instance : OFE.Discrete MaxNat := ⟨fun h _ => h⟩
 scoped instance : UCMRA MaxNat := OrdCommMonoidLike.instUCMRAOfLawfulLeftIdentityAddZero
 scoped instance : CMRA.Discrete MaxNat := OrdCommMonoidLike.instDiscrete
 scoped instance : CMRA.CoreId (a : MaxNat) := OrdCommMonoidLike.instCoreId _
@@ -123,7 +122,7 @@ theorem auth_dfrac_op_valid (dq1 dq2 : DFrac) (n1 n2 : MaxNat) :
       CMRA.assoc.trans <| (CMRA.op_left_eqv _ CMRA.comm).trans CMRA.assoc.symm).trans
       CMRA.assoc) h
     have ⟨hdq, heq, _⟩ := Auth.auth_dfrac_op_valid.mp (CMRA.valid_op_left h)
-    exact ⟨hdq, OFE.Leibniz.eq_of_eqv heq⟩
+    exact ⟨hdq, heq.to_eq⟩
   · rintro ⟨hdq, rfl⟩
     refine CMRA.valid_of_eqv ?_ (Auth.both_dfrac_valid_discrete.mpr ⟨hdq, CMRA.inc_refl n1, trivial⟩)
     exact auth_dfrac_op dq1 dq2 n1
@@ -142,10 +141,12 @@ theorem both_dfrac_valid (dq : DFrac) (n m : MaxNat) :
   rw [CMRA.valid_iff CMRA.assoc.symm, ←Auth.frag_op, Auth.both_dfrac_valid_discrete]
   constructor
   · intro ⟨hdq, ⟨k, hk⟩, _⟩; refine ⟨hdq, ?_⟩
-    simp only [CMRA.op, Add.add, OFE.Equiv] at hk
+    replace hk := hk.to_eq
+    simp only [CMRA.op, Add.add] at hk
     grind
   · intro ⟨hdq, hle⟩; refine ⟨hdq, ⟨0, ?_⟩, trivial⟩
-    simp [CMRA.op, Add.add, OFE.Equiv, Nat.max_eq_left hle]
+    refine OFE.Equiv.of_eq ?_
+    simp [CMRA.op, Add.add, Nat.max_eq_left hle]
 
 @[rocq_alias mono_nat_both_valid]
 theorem both_valid (n m : MaxNat) :
@@ -158,7 +159,8 @@ theorem lb_mono (n1 n2 : MaxNat) (h : n1 ≤ n2) :
   (◯MN n1 : MonoNat) ≼ ◯MN n2 := by
   refine Auth.frag_inc_of_inc ?_
   exists n2
-  simp only [CMRA.op, Add.add, OFE.Equiv]
+  refine OFE.Equiv.of_eq ?_
+  simp only [CMRA.op, Add.add]
   grind
 
 @[rocq_alias mono_nat_included]
@@ -190,13 +192,13 @@ set_option synthInstance.checkSynthOrder false in
 instance {dq dq1 dq2 : DFrac} {n : MaxNat}
     [h : IsOp io1 dq io2 dq1 io3 dq2] :
     IsOp io1 (●MN{dq} n) io2 (●MN{dq1} n) io3 (●MN{dq2} n) where
-  is_op := by rw [h.is_op]; apply auth_dfrac_op
+  is_op := by rw [h.is_op.to_eq]; apply auth_dfrac_op
 
 @[rocq_alias mono_nat_lb_max_is_op]
 instance {n n1 n2 : MaxNat}
     [h : IsOp io1 n io2 n1 io3 n2] :
     IsOp io1 (◯MN n : MonoNat) io2 (◯MN n1) io3 (◯MN n2) where
-  is_op := by rw [h.is_op]; .rfl
+  is_op := by rw [h.is_op.to_eq]; exact .rfl
 
 end MonoNat
 

--- a/Iris/Iris/Algebra/LocalUpdates.lean
+++ b/Iris/Iris/Algebra/LocalUpdates.lean
@@ -28,9 +28,9 @@ theorem LocalUpdate.id (x : α × α) : x ~l~> x := fun _ _ vx e => ⟨vx, e⟩
 
 theorem LocalUpdate.equiv_left {x y : α × α} (z : α × α) (h : x ≡ y) : x ~l~> z → y ~l~> z := by
   intro u n mw v e
-  refine u n mw ((OFE.Dist.validN h.1.dist.symm).mp v) ?_
+  refine u n mw ((OFE.Dist.validN (OFE.equiv_fst h).dist.symm).mp v) ?_
   calc
-    x.fst ≡{n}≡ y.fst       := h.1.dist
+    x.fst ≡{n}≡ y.fst       := (OFE.equiv_fst h).dist
     _     ≡{n}≡ y.snd •? mw := e
     _     ≡{n}≡ x.snd •? mw := CMRA.opM_left_dist mw (OFE.equiv_snd h).dist.symm
 
@@ -168,17 +168,17 @@ theorem local_update_unital_discrete [CMRA.Discrete α] (x y x' y' : α) :
 
 @[rocq_alias cancel_local_update_unit]
 theorem cancel_local_update_unit (x y : α) [CMRA.Cancelable x] : (x • y, x) ~l~> (y, CMRA.unit) :=
-  have e : (x • y, x • CMRA.unit) ≡ (x • y, x) := ⟨.rfl, CMRA.unit_right_id⟩
+  have e : (x • y, x • CMRA.unit) ≡ (x • y, x) := OFE.equiv_prod_ext .rfl CMRA.unit_right_id
   .equiv_left _ e (.cancel x y CMRA.unit)
 
 /-- Necessary and sufficient condition for a local update on a unital discrete leibniz CMRA
   with trivial validity predicate -/
-theorem leibniz_discrete_unital_triv_local_update [OFE.Leibniz α] [CMRA.Discrete α]
+theorem leibniz_discrete_unital_triv_local_update [CMRA.Discrete α]
     (Hv : ∀ x : α, ✓ x)
     (H : ∀ {z : α}, x = y • z → x' = y' • z) :
     (x,y) ~l~> (x', y') := by
   refine (local_update_unital_discrete x y x' y').mpr fun _ _ He => ?_
-  refine ⟨Hv _, .of_eq <| H <| OFE.leibniz.mp He⟩
+  refine ⟨Hv _, .of_eq <| H <| He.to_eq⟩
 
 end UCMRA
 

--- a/Iris/Iris/Algebra/LocalUpdates.lean
+++ b/Iris/Iris/Algebra/LocalUpdates.lean
@@ -173,7 +173,7 @@ theorem cancel_local_update_unit (x y : α) [CMRA.Cancelable x] : (x • y, x) ~
 
 /-- Necessary and sufficient condition for a local update on a unital discrete leibniz CMRA
   with trivial validity predicate -/
-theorem leibniz_discrete_unital_triv_local_update [CMRA.Discrete α]
+theorem discrete_unital_triv_local_update [CMRA.Discrete α]
     (Hv : ∀ x : α, ✓ x)
     (H : ∀ {z : α}, x = y • z → x' = y' • z) :
     (x,y) ~l~> (x', y') := by

--- a/Iris/Iris/Algebra/Monoid.lean
+++ b/Iris/Iris/Algebra/Monoid.lean
@@ -97,14 +97,21 @@ class WeakMonoidHomomorphism {M₁ : Type u} {M₂ : Type v} [OFE M₁] [OFE M�
   rel_refl : ∀ {a : M₂}, R a a
   /-- The relation is transitive -/
   rel_trans : ∀ {a b c : M₂}, R a b → R b c → R a c
-  /-- The relation is proper with respect to equivalence -/
-  rel_proper : ∀ {a a' b b' : M₂}, a ≡ a' → b ≡ b' → (R a b ↔ R a' b')
   /-- The operation is proper with respect to R -/
   op_proper : ∀ {a a' b b' : M₂}, R a a' → R b b' → R (op₂ a b) (op₂ a' b')
   /-- The function is non-expansive -/
   map_ne : NonExpansive f
   /-- The homomorphism property -/
   map_op : ∀ {x y}, R (f (op₁ x y)) (op₂ (f x) (f y))
+
+theorem WeakMonoidHomomorphism.rel_proper {M₁ : Type u} {M₂ : Type v}
+  [OFE M₁] [OFE M₂] {a a' b b' : M₂}
+  {op₁ : M₁ → M₁ → M₁} {op₂ : M₂ → M₂ → M₂} {unit₁ : M₁} {unit₂ : M₂}
+  [MonoidOps op₁ unit₁] [MonoidOps op₂ unit₂]
+  {R : M₂ → M₂ → Prop} {f : M₁ → M₂}
+  [WeakMonoidHomomorphism op₁ op₂ unit₁ unit₂ R f] : a ≡ a' → b ≡ b' → (R a b ↔ R a' b') := by
+    intro Heq1 Heq2
+    rw [Heq1.to_eq, Heq2.to_eq]
 
 @[rocq_alias weak_monoid_homomorphism_proper]
 theorem weak_monoid_homomorphism_equiv [ OFE M₁] [OFE M₂]

--- a/Iris/Iris/Algebra/Numbers.lean
+++ b/Iris/Iris/Algebra/Numbers.lean
@@ -40,7 +40,7 @@ namespace CommMonoidLike
 
 open Iris Iris.OFE Add Zero One Associative Commutative LawfulLeftIdentity CMRA
 
-variable [OFE α] [Discrete α] [Leibniz α]
+variable [OFE α] [Discrete α]
 variable [Add α] [Associative (add (α := α))] [Commutative (add (α := α))]
 variable [Zero α] [LawfulLeftIdentity (add (α := α)) zero]
 variable {x y x' y' : α}
@@ -97,7 +97,7 @@ scoped instance : UCMRA α where
 #rocq_ignore Z_unit_instance "Use UCMRA instance"
 
 scoped instance [LeftCancelAdd α] {a : α} : Cancelable a where
-  cancelableN {_ _ _} _ := .of_eq ∘ LeftCancelAdd.cancel_left ∘ eq_of_eqv ∘ discrete
+  cancelableN {_ _ _} _ := .of_eq ∘ LeftCancelAdd.cancel_left ∘ Equiv.to_eq ∘ discrete
 #rocq_ignore nat_cancelable "Use scoped Cancelable instance"
 #rocq_ignore Z_cancelable "Use scoped Cancelable instance"
 
@@ -106,7 +106,7 @@ scoped instance [LeftCancelAdd α] {a : α} : Cancelable a where
 theorem op_eq {x y : α} : x • y = x + y := rfl
 
 theorem included_iff {x y : α} : x ≼ y ↔ ∃ z, y = x + z := by
-  refine ⟨fun ⟨z, hz⟩ => ⟨z, leibniz.mp hz⟩, fun ⟨z, hz⟩ => ⟨z, .of_eq hz⟩⟩
+  refine ⟨fun ⟨z, hz⟩ => ⟨z, hz.to_eq⟩, fun ⟨z, hz⟩ => ⟨z, .of_eq hz⟩⟩
 
 /-- Sufficient condition for a local update on a LeftCancelAdd structure, such as (ℕ, +) -/
 theorem leftCancelAdd_local_update [LeftCancelAdd α] (h : add x y' = add x' y) :
@@ -132,7 +132,7 @@ namespace OrdCommMonoidLike
 
 open Iris Iris.OFE Add Zero One Associative Commutative LawfulLeftIdentity CMRA IdempotentOp
 
-variable [OFE α] [OFE.Discrete α] [Leibniz α]
+variable [OFE α] [OFE.Discrete α]
 variable [Add α] [Associative (add (α := α))] [Commutative (add (α := α))]
 variable [IdempotentOp (add (α := α))]
 variable [Zero α]
@@ -146,7 +146,7 @@ scoped instance : CMRA α where
   op_ne.ne _ _ _ h := by rw [(discrete h).to_eq]
   pcore_ne {_ y _ _} h := by
     rintro ⟨rfl⟩
-    exact ⟨y, congrArg _ <| leibniz.mp (discrete h.symm), .rfl⟩
+    exact ⟨y, congrArg _ <| (discrete h.symm).to_eq, .rfl⟩
   validN_ne _ _ := .intro
   valid_iff_validN := .symm <| forall_const Nat
   validN_succ := (·)
@@ -210,7 +210,7 @@ scoped instance [LawfulLeftIdentity (add (α := α)) zero] : UCMRA α where
 #rocq_ignore max_Z_unit_instance "Use UCMRA instance"
 
 scoped instance [LeftCancelAdd α] {a : α} : Cancelable a where
-  cancelableN {_ _ _} _ := .of_eq ∘ LeftCancelAdd.cancel_left ∘ eq_of_eqv ∘ discrete
+  cancelableN {_ _ _} _ := .of_eq ∘ LeftCancelAdd.cancel_left ∘ Equiv.to_eq ∘ discrete
 
 omit [Zero α] in
 /-- The CMRA operation is `add` (which is `max`/`min` for max_nat/min_nat/max_Z). -/
@@ -226,7 +226,7 @@ namespace PosCommMonoidLike
 
 open Iris Iris.OFE Add Zero One Associative Commutative LawfulLeftIdentity CMRA IdempotentOp
 
-variable [OFE α] [OFE.Discrete α] [Leibniz α]
+variable [OFE α] [OFE.Discrete α]
 variable [Add α] [Associative (add (α := α))] [Commutative (add (α := α))]
 variable [IdempotentOp (add (α := α))]
 
@@ -261,11 +261,11 @@ scoped instance : CMRA.Discrete α where
 #rocq_ignore pos_cmra_discrete "Use Discrete instance"
 
 scoped instance [LeftCancelAdd α] {a : α} : Cancelable a where
-  cancelableN {_ _ _} _ := .of_eq ∘ LeftCancelAdd.cancel_left ∘ eq_of_eqv ∘ discrete
+  cancelableN {_ _ _} _ := .of_eq ∘ LeftCancelAdd.cancel_left ∘ Equiv.to_eq ∘ discrete
 #rocq_ignore pos_cancelable "Use scoped Cancelable instance"
 
 scoped instance [IdentityFree α] {a : α} : CMRA.IdFree a where
-  id_free0_r _ _ h := IdentityFree.id_free (α := α) <| leibniz.mp (discrete h)
+  id_free0_r _ _ h := IdentityFree.id_free (α := α) <| (discrete h).to_eq
 #rocq_ignore pos_id_free "Use scoped IdentityFree instance"
 
 #rocq_ignore pos_op_add "Not needed"

--- a/Iris/Iris/Algebra/Numbers.lean
+++ b/Iris/Iris/Algebra/Numbers.lean
@@ -111,7 +111,7 @@ theorem included_iff {x y : α} : x ≼ y ↔ ∃ z, y = x + z := by
 /-- Sufficient condition for a local update on a LeftCancelAdd structure, such as (ℕ, +) -/
 theorem leftCancelAdd_local_update [LeftCancelAdd α] (h : add x y' = add x' y) :
     (x, y) ~l~> (x', y') := by
-  refine leibniz_discrete_unital_triv_local_update (fun _ => trivial) @fun z hz => ?_
+  refine discrete_unital_triv_local_update (fun _ => trivial) @fun z hz => ?_
   refine LeftCancelAdd.cancel_right (y := y) ?_
   calc
     add x' y = add x y' := h.symm
@@ -226,7 +226,7 @@ namespace PosCommMonoidLike
 
 open Iris Iris.OFE Add Zero One Associative Commutative LawfulLeftIdentity CMRA IdempotentOp
 
-variable [OFE α] [OFE.Discrete α]
+variable [OFE α] [Discrete α]
 variable [Add α] [Associative (add (α := α))] [Commutative (add (α := α))]
 variable [IdempotentOp (add (α := α))]
 
@@ -265,7 +265,7 @@ scoped instance [LeftCancelAdd α] {a : α} : Cancelable a where
 #rocq_ignore pos_cancelable "Use scoped Cancelable instance"
 
 scoped instance [IdentityFree α] {a : α} : CMRA.IdFree a where
-  id_free0_r _ _ h := IdentityFree.id_free (α := α) <| (discrete h).to_eq
+  id_free0_r _ _ h := IdentityFree.id_free <| (discrete h).to_eq
 #rocq_ignore pos_id_free "Use scoped IdentityFree instance"
 
 #rocq_ignore pos_op_add "Not needed"

--- a/Iris/Iris/Algebra/OFE.lean
+++ b/Iris/Iris/Algebra/OFE.lean
@@ -14,11 +14,17 @@ namespace Iris
 /-- Ordered family of equivalences -/
 @[rocq_alias ofe]
 class OFE (α : Type _) where
-  Equiv : α → α → Prop
   Dist : Nat → α → α → Prop
   dist_eqv : Equivalence (Dist n)
-  equiv_dist : Equiv x y ↔ ∀ n, Dist n x y
+  eq_dist : x = y ↔ ∀ n, Dist n x y
   dist_lt : Dist n x y → m < n → Dist m x y
+
+def OFE.Equiv [OFE α] (x y : α) : Prop := (∀ n, OFE.Dist n x y)
+theorem OFE.Equiv.to_eq [OFE α] {x y : α} (h : OFE.Equiv x y) : x = y := OFE.eq_dist.mpr h
+theorem OFE.equiv_dist [OFE α] {x y : α} : OFE.Equiv x y ↔ ∀ n, Dist n x y := .rfl
+
+theorem Eq_Equivalence {α : Type _} : Equivalence (@Eq α) :=
+  ⟨congrFun rfl, (Eq.symm ·), (· ▸ ·)⟩
 
 #rocq_ignore OfeMixin "Use the OFE type class"
 #rocq_ignore ofe_mixin_of' "Not needed"
@@ -181,11 +187,10 @@ instance [OFE α] [OFE β] {x : β} : Contractive (fun _ : α => x) where
 
 /-- The discrete OFE obtained from an equivalence relation `Equiv` -/
 @[reducible, rocq_alias discrete_ofe_mixin]
-def ofDiscrete (Equiv : α → α → Prop) (equiv_eqv : Equivalence Equiv) : OFE α where
-  Equiv := Equiv
-  Dist _ := Equiv
-  dist_eqv := equiv_eqv
-  equiv_dist := (forall_const _).symm
+def ofDiscrete (α : Type _) : OFE α where
+  Dist _ := Eq
+  dist_eqv := Eq_Equivalence
+  eq_dist := (forall_const _).symm
   dist_lt h _ := h
 
 /-- A discrete element in an OFE -/
@@ -228,25 +233,14 @@ theorem Discrete.discrete_iff [OFE α] [Discrete α] (n) {x y : α} : x ≡ y �
 theorem Discrete.discrete_iff_0 [OFE α] [Discrete α] (n) {x y : α} : x ≡{0}≡ y ↔ x ≡{n}≡ y :=
   ⟨discrete_n, fun h => h.le (Nat.zero_le _)⟩
 
-class Leibniz (α : Type _) [OFE α] where
-  eq_of_eqv {x y : α} : x ≡ y → x = y
-export OFE.Leibniz (eq_of_eqv)
-
-theorem Equiv.to_eq {α} [OFE α] [Leibniz α] {x y : α} (h : x ≡ y) : x = y :=
-  eq_of_eqv h
-
-#rocq_ignore boolO "Canonical Leibniz OFE on `bool`; Lean uses `LeibnizO Bool`."
-#rocq_ignore natO "Canonical Leibniz OFE on `nat`; Lean uses `LeibnizO Nat`."
+#rocq_ignore boolO "Canonical Leibniz OFE on `bool`; Lean uses `ofDiscrete Bool`."
+#rocq_ignore natO "Canonical Leibniz OFE on `nat`; Lean uses `ofDiscrete Nat`."
 #rocq_ignore positiveO "Canonical Leibniz OFE on `positive`; not applicable in Lean."
 #rocq_ignore NO "Canonical Leibniz OFE on `N`; not applicable in Lean."
 #rocq_ignore ZO "Canonical Leibniz OFE on `Z`; not applicable in Lean."
-#rocq_ignore PropO "Canonical discrete OFE on `Prop`; Lean uses `LeibnizO Prop`."
+#rocq_ignore PropO "Canonical discrete OFE on `Prop`; Lean uses `ofDiscrete Prop`."
 
 #rocq_ignore ofe_leibniz_subrelation "Generalized-rewriting subrelation; not needed in Lean."
-
-@[simp] theorem Leibniz.leibniz [OFE α] [Leibniz α] {x y : α} : x ≡ y ↔ x = y :=
-  ⟨eq_of_eqv, .of_eq⟩
-export OFE.Leibniz (leibniz)
 
 /-- The setoid on `X` identifying points that agree at every step index:
 `x ≈ y ↔ ∀ n, dist n x y`. -/
@@ -275,23 +269,16 @@ by quotienting the carrier `X` by the OFE equivalence `fun x y => ∀ n, dist n 
       ⟨fun h => heqv.trans (heqv.trans (heqv.symm (hac n)) h) (hbd n),
        fun h => heqv.trans (heqv.trans (hac n) h) (heqv.symm (hbd n))⟩
   { Dist := D
-    Equiv x y := ∀ n, D n x y
     dist_eqv := by
       refine ⟨Quotient.ind fun a => heqv.refl a, fun {x y} h => ?_, fun {x y z} h₁ h₂ => ?_⟩
       · induction x, y using Quotient.ind₂ with | _ a b => exact heqv.symm h
       · induction x, y using Quotient.ind₂ with | _ a b =>
           induction z using Quotient.ind with | _ c => exact heqv.trans h₁ h₂
-    equiv_dist := .rfl
+    eq_dist {x y} := by
+      induction x, y using Quotient.ind₂ with | _ a b =>
+        exact ⟨fun h n => Quotient.exact h n, fun h => Quotient.sound fun n => h n⟩
     dist_lt := fun {n x y m} h hlt' => by
       induction x, y using Quotient.ind₂ with | _ a b => exact hlt h hlt' }
-
-theorem mkQuotient_leibniz {X : Type u} (dist : Nat → X → X → Prop)
-    (heqv : ∀ {n}, Equivalence (dist n))
-    (hlt : ∀ {n m : Nat} {x y : X}, dist n x y → m < n → dist m x y) :
-    @Leibniz _ (mkQuotient dist heqv hlt) :=
-  letI := mkQuotient dist heqv hlt
-  { eq_of_eqv := fun {x y} h => by
-      induction x, y using Quotient.ind₂ with | _ a b => exact Quotient.sound h }
 
 namespace mkQuotient
 
@@ -404,21 +391,19 @@ theorem InvImage.equivalence {α : Sort u} {β : Sort v}
 
 @[rocq_alias unit_ofe_mixin]
 instance : OFE Unit where
-  Equiv _ _ := True
   Dist _ _ _ := True
   dist_eqv := ⟨fun _ => ⟨⟩, id, fun _ => id⟩
-  equiv_dist := by simp
+  eq_dist := by simp
   dist_lt _ _ := ⟨⟩
 #rocq_ignore unitO "Use the unit type"
 #rocq_ignore unit_dist "Local Dist instance; folded into Lean's OFE Unit instance."
 
-instance : DiscreteE (() : Unit) := ⟨fun _ => trivial⟩
+instance : DiscreteE (() : Unit) := ⟨fun _ _ => trivial⟩
 
 instance [OFE α] : OFE (ULift α) where
-  Equiv x y := x.down ≡ y.down
   Dist n x y := x.down ≡{n}≡ y.down
   dist_eqv := InvImage.equivalence dist_eqv
-  equiv_dist := equiv_dist
+  eq_dist {x y} := by cases x; cases y; rw [ULift.up.injEq]; exact eq_dist
   dist_lt := dist_lt
 
 def uliftUpHom [OFE α] : α -n> ULift α where
@@ -442,10 +427,9 @@ theorem _root_.Option.Forall₂.equivalence {R : α → α → Prop}
 
 @[rocq_alias option_ofe_mixin]
 instance [OFE α] : OFE (Option α) where
-  Equiv := Option.Forall₂ Equiv
   Dist n := Option.Forall₂ (Dist n)
   dist_eqv := Option.Forall₂.equivalence dist_eqv
-  equiv_dist {x y} := by cases x <;> cases y <;> simp [Option.Forall₂]; apply equiv_dist
+  eq_dist {x y} := by cases x <;> cases y <;> simp [Option.Forall₂] <;> apply eq_dist
   dist_lt {_ x y _} := by cases x <;> cases y <;> simp [Option.Forall₂]; apply dist_lt
 #rocq_ignore optionO "Use Option"
 #rocq_ignore option_dist "Local Dist instance; folded into Lean's OFE (Option α) instance."
@@ -455,14 +439,14 @@ instance [OFE α] : OFE (Option α) where
 instance [OFE α] [OFE.Discrete α] : OFE.Discrete (Option α) where
   discrete_0 {mx my} e :=
     match mx, my with
-    | none,   none   => e
-    | none,   some _ => e
-    | some _, none   => e
+    | none,   none   => .rfl
+    | none,   some _ => e.elim
+    | some _, none   => e.elim
     | some x, some y => show x ≡ y from discrete_0 e
 
 @[simp] theorem some_eqv_some [OFE α] {x y : α} : (some x ≡ some y) ↔ x ≡ y := .rfl
-@[simp] theorem not_some_eqv_none [OFE α] {x : α} : ¬some x ≡ none := id
-@[simp] theorem not_none_eqv_some [OFE α] {x : α} : ¬none ≡ some x := id
+@[simp] theorem not_some_eqv_none [OFE α] {x : α} : ¬some x ≡ none := (· 0)
+@[simp] theorem not_none_eqv_some [OFE α] {x : α} : ¬none ≡ some x := (· 0)
 
 @[simp, rocq_alias dist_Some]
 theorem some_dist_some [OFE α] {n} {x y : α} : (some x ≡{n}≡ some y) ↔ x ≡{n}≡ y := .rfl
@@ -471,15 +455,16 @@ theorem some_dist_some [OFE α] {n} {x y : α} : (some x ≡{n}≡ some y) ↔ x
 
 theorem equiv_some [OFE α] {o : Option α} {y : α} (e : o ≡ some y) :
     ∃ z, o = some z ∧ z ≡ y := by
-  let .some x := o
-  exact ⟨x, rfl, e⟩
+  cases o with
+  | none => exact (e 0).elim
+  | some x => exact ⟨x, rfl, e⟩
 
 theorem equiv_none [OFE α] {o : Option α} : o ≡ none ↔ o = none :=
-  ⟨fun _ => let .none := o; rfl, (· ▸ .rfl)⟩
+  ⟨fun h => by cases o with | none => rfl | some _ => exact (h 0).elim, (· ▸ .rfl)⟩
 
 @[rocq_alias dist_None]
 theorem dist_none [OFE α] {o : Option α} : o ≡{n}≡ none ↔ o = none :=
-  ⟨fun _ => let .none := o; rfl, (· ▸ .rfl)⟩
+  ⟨fun h => by cases o with | none => rfl | some _ => exact h.elim, (· ▸ .rfl)⟩
 
 @[rocq_alias dist_Some_inv_r']
 theorem dist_some [OFE α] {n mx y} (h : mx ≡{n}≡ some y) :
@@ -491,17 +476,13 @@ theorem dist_some [OFE α] {n mx y} (h : mx ≡{n}≡ some y) :
     | some t => ⟨t, rfl, (e2 ▸ e1 : some t ≡{n}≡ some y)⟩
     | none => False.elim (e2 ▸ e1 : none ≡{n}≡ some y)
 
-instance [OFE α] [Leibniz α] : Leibniz (Option α) where
-  eq_of_eqv {x y} H :=
-    match x, y, H with
-    | none, none, _ => rfl
-    | some _, some _, h => congrArg some (Leibniz.eq_of_eqv h)
-
 instance [OFE α] [Discrete α] : Discrete (Option α) where
   discrete_0 {x y} H :=
     match x, y with
-    | none, none => H
+    | none, none => .rfl
     | some _, some _ => some_eqv_some.mpr (discrete_0 H)
+    | none, some _ => H.elim
+    | some _, none => H.elim
 
 @[rocq_alias Some_ne]
 instance OFE.Option.some.ne [OFE α] : OFE.NonExpansive (some : α → Option α) := ⟨fun _ _ _ => id⟩
@@ -534,14 +515,13 @@ abbrev OFEFun {α : Type _} (β : α → Type _) := ∀ a, OFE (β a)
 
 @[rocq_alias discrete_fun_ofe_mixin]
 instance [OFEFun (β : α → _)] : OFE ((x : α) → β x) where
-  Equiv f g := ∀ x, f x ≡ g x
   Dist n f g := ∀ x, f x ≡{n}≡ g x
   dist_eqv := {
     refl _ _ := dist_eqv.refl _
     symm h _ := dist_eqv.symm (h _)
     trans h1 h2 _ := dist_eqv.trans (h1 _) (h2 _)
   }
-  equiv_dist {_ _} := by simp [equiv_dist]; apply forall_comm
+  eq_dist {_ _} := by rw [funext_iff]; simp only [eq_dist]; exact forall_comm
   dist_lt h1 h2 _ := dist_lt (h1 _) h2
 #rocq_ignore discrete_funO "Use a function type"
 #rocq_ignore discrete_fun "Lean uses `(x : α) → β x` directly with `OFEFun`."
@@ -550,14 +530,13 @@ instance [OFEFun (β : α → _)] : OFE ((x : α) → β x) where
 
 @[rocq_alias ofe_mor_ofe_mixin]
 instance [OFE α] [OFE β] : OFE (α -n> β) where
-  Equiv f g := f.f ≡ g.f
   Dist n f g := f.f ≡{n}≡ g.f
   dist_eqv := {
     refl _ := dist_eqv.refl _
     symm h := dist_eqv.symm h
     trans h1 h2 := dist_eqv.trans h1 h2
   }
-  equiv_dist := equiv_dist
+  eq_dist {_ _} := Hom.ext_iff.trans eq_dist
   dist_lt := dist_lt
 #rocq_ignore ofe_morO "Use Hom type"
 #rocq_ignore ofe_mor_equiv "Inlined in OFE (α -n> β) instance"
@@ -579,19 +558,14 @@ instance [OFE α] [OFE β] [Inhabited β] : Inhabited (α -n> β) where
   default := { f := Function.const α default, ne := const_ne }
 
 instance [OFE α] [OFE β] : OFE (α -c> β) where
-  Equiv f g := Equiv f.toHom g.toHom
   Dist n f g := Dist n f.toHom g.toHom
   dist_eqv := {
     refl _ := dist_eqv.refl _
     symm h := dist_eqv.symm h
     trans h1 h2 := dist_eqv.trans h1 h2
   }
-  equiv_dist := equiv_dist
+  eq_dist {_ _} := ContractiveHom.ext_iff.trans eq_dist
   dist_lt := dist_lt
-
-instance instLeibnizHom [OFE α] [OFE β] [Leibniz α] [Leibniz β] : Leibniz (α -n> β) where
-  eq_of_eqv {x y} H := by
-    ext i; exact eq_of_eqv (H i)
 
 def applyHom [OFEFun (β : α → _)] (x : α) : ((x : α) → β x) -n> β x where
   f f := f x
@@ -617,22 +591,21 @@ def mapCodHom [OFEFun (β₁ : α → _)] [OFEFun β₂]
 
 @[rocq_alias prod_ofe_mixin]
 instance [OFE α] [OFE β] : OFE (α × β) where
-  Equiv a b := a.1 ≡ b.1 ∧ a.2 ≡ b.2
   Dist n a b := a.1 ≡{n}≡ b.1 ∧ a.2 ≡{n}≡ b.2
   dist_eqv := {
     refl _ := ⟨dist_eqv.refl _, dist_eqv.refl _⟩
     symm h := ⟨dist_eqv.symm h.1, dist_eqv.symm h.2⟩
     trans h1 h2 := ⟨dist_eqv.trans h1.1 h2.1, dist_eqv.trans h1.2 h2.2⟩
   }
-  equiv_dist {_ _} := by simp [equiv_dist, forall_and]
+  eq_dist {_ _} := by rw [Prod.ext_iff]; simp only [eq_dist, forall_and]
   dist_lt h1 h2 := ⟨dist_lt h1.1 h2, dist_lt h1.2 h2⟩
 #rocq_ignore prodO "Use product type"
 #rocq_ignore prod_dist "Implicit in Prod OFE"
 
-theorem equiv_fst [OFE α] [OFE β] {x y : α × β} (h : x ≡ y) : x.fst ≡ y.fst := h.left
-theorem equiv_snd [OFE α] [OFE β] {x y : α × β} (h : x ≡ y) : x.snd ≡ y.snd := h.right
+theorem equiv_fst [OFE α] [OFE β] {x y : α × β} (h : x ≡ y) : x.fst ≡ y.fst := fun n => (h n).left
+theorem equiv_snd [OFE α] [OFE β] {x y : α × β} (h : x ≡ y) : x.snd ≡ y.snd := fun n => (h n).right
 theorem equiv_prod_ext [OFE α] [OFE β] {x₁ x₂ : α} {y₁ y₂ : β}
-    (ex : x₁ ≡ x₂) (ey : y₁ ≡ y₂) : (x₁, y₁) ≡ (x₂, y₂) := ⟨ex, ey⟩
+    (ex : x₁ ≡ x₂) (ey : y₁ ≡ y₂) : (x₁, y₁) ≡ (x₂, y₂) := fun n => ⟨ex n, ey n⟩
 
 theorem dist_fst {n} [OFE α] [OFE β] {x y : α × β} (h : x ≡{n}≡ y) : x.fst ≡{n}≡ y.fst := h.left
 theorem dist_snd {n} [OFE α] [OFE β] {x y : α × β} (h : x ≡{n}≡ y) : x.snd ≡{n}≡ y.snd := h.right
@@ -670,15 +643,11 @@ theorem NonExpansive₂.uncurry [OFE α] [OFE β] [OFE γ] {f : α → β → γ
 instance prod.is_discrete [OFE α] [OFE β] {a : α} {b : β} [DiscreteE a] [DiscreteE b] :
     DiscreteE (a, b) := by
   constructor
-  intro y H; refine ⟨DiscreteE.discrete H.1, DiscreteE.discrete H.2⟩
+  intro y H; exact fun n => ⟨DiscreteE.discrete H.1 n, DiscreteE.discrete H.2 n⟩
 
 @[rocq_alias prod_ofe_discrete]
 instance instDiscreteProd [OFE α] [OFE β] [Discrete α] [Discrete β] : Discrete (α × β) where
-  discrete_0 H := ⟨discrete_0 H.1, discrete_0 H.2⟩
-
-instance [OFE α] [OFE β] [Leibniz α] [Leibniz β] : Leibniz (α × β) where
-  eq_of_eqv {x y} H := match x, y with
-    | ⟨_, _⟩, ⟨_, _⟩ => Prod.ext (eq_of_eqv H.1) (eq_of_eqv H.2)
+  discrete_0 H := fun n => ⟨discrete_0 H.1 n, discrete_0 H.2 n⟩
 
 section sum
 
@@ -686,10 +655,6 @@ variable [OFE α] [OFE β]
 
 @[rocq_alias sum_ofe_mixin]
 instance : OFE (α ⊕ β) where
-  Equiv
-    | .inl a, .inl b => a ≡ b
-    | .inr a, .inr b => a ≡ b
-    | _, _ => False
   Dist n
     | .inl a, .inl b => a ≡{n}≡ b
     | .inr a, .inr b => a ≡{n}≡ b
@@ -710,11 +675,12 @@ instance : OFE (α ⊕ β) where
     | .inl _, .inr _, _ => h1.elim
     | _, .inr _, .inl _ => h2.elim
   }
-  equiv_dist {a b} := match a, b with
-    | .inl _, .inl _ => equiv_dist
-    | .inr _, .inr _ => equiv_dist
-    | .inl _, .inr _ => ⟨(False.elim ·), fun x => x 0⟩
-    | .inr _, .inl _ => ⟨(False.elim ·), fun x => x 0⟩
+  eq_dist {a b} := by
+    match a, b with
+    | .inl _, .inl _ => rw [Sum.inl.injEq]; exact eq_dist
+    | .inr _, .inr _ => rw [Sum.inr.injEq]; exact eq_dist
+    | .inl _, .inr _ => exact ⟨fun h => (nomatch h), fun x => (x 0).elim⟩
+    | .inr _, .inl _ => exact ⟨fun h => (nomatch h), fun x => (x 0).elim⟩
   dist_lt {_ a b} := match a, b with
     | .inl _, .inl _ => dist_lt
     | .inr _, .inr _ => dist_lt
@@ -772,21 +738,13 @@ instance instDiscreteSum [Discrete α] [Discrete β] : Discrete (α ⊕ β) wher
     | .inl _, .inr _ => (False.elim ·)
     | .inr _, .inl _ => (False.elim ·)
 
-instance instLeibnizSum [Leibniz α] [Leibniz β] : Leibniz (α ⊕ β) where
-  eq_of_eqv {x y} := match x, y with
-    | .inl _, .inl _ => (Sum.inl.inj_iff.mpr <| eq_of_eqv <| equiv_ext_left ·)
-    | .inr _, .inr _ => (Sum.inr.inj_iff.mpr <| eq_of_eqv <| equiv_ext_right ·)
-    | .inl _, .inr _ => (False.elim ·)
-    | .inr _, .inl _ => (False.elim ·)
-
 end sum
 
 @[rocq_alias sig_ofe_mixin]
 instance [OFE α] (P : α → Prop) : OFE (Subtype P) where
-  Equiv x y := x.val ≡ y.val
   Dist n x y := x.val ≡{n}≡ y.val
   dist_eqv := ⟨fun _ => .rfl, Dist.symm, Dist.trans⟩
-  equiv_dist := equiv_dist
+  eq_dist {_ _} := Subtype.ext_iff.trans eq_dist
   dist_lt := dist_lt
 #rocq_ignore sigO "Use subtype"
 #rocq_ignore sig_equiv "Local Equiv instance; folded into Lean's OFE (Subtype P) instance."
@@ -814,7 +772,6 @@ instance Hom.toSubtype_ne [OFE α] [OFE β] : NonExpansive (Hom.toSubtype (α :=
 
 @[rocq_alias sigT_ofe_mixin]
 instance instOFESigma (P : α → Type _) [∀ x, OFE (P x)] : OFE (Sigma P) where
-  Equiv x y := ∀ n, ∃ heq : x.fst = y.fst, heq ▸ x.snd ≡{n}≡ y.snd
   Dist n x y := ∃ heq : x.fst = y.fst, heq ▸ x.snd ≡{n}≡ y.snd
   dist_eqv := {
     refl _ := ⟨rfl, .rfl⟩
@@ -826,7 +783,12 @@ instance instOFESigma (P : α → Type _) [∀ x, OFE (P x)] : OFE (Sigma P) whe
         | ⟨heq, H⟩, ⟨heq', H'⟩ =>
           ⟨heq.trans heq', by simp only at heq heq'; subst heq; subst heq'; exact H.trans H'⟩
   }
-  equiv_dist := ⟨id, id⟩
+  eq_dist {x y} := by
+    refine ⟨fun h n => h ▸ ⟨rfl, .rfl⟩, fun h => ?_⟩
+    obtain ⟨heq, _⟩ := h 0
+    obtain ⟨xf, xs⟩ := x; obtain ⟨yf, ys⟩ := y
+    simp only at heq; subst heq
+    exact congrArg _ (eq_dist.mpr fun n => (h n).2)
   dist_lt {_ x y} := match x, y with
     | ⟨x, xH⟩, ⟨y, yH⟩ => fun
       | ⟨heq, H⟩ => fun hlt => ⟨heq, by simp only at heq; subst heq; exact dist_lt H hlt⟩
@@ -1072,10 +1034,10 @@ theorem compl_const [COFE α] (a : α) : compl (Chain.const a) ≡ a :=
 
 /-- The discrete COFE obtained from an equivalence relation `Equiv` -/
 @[reducible, rocq_alias discrete_cofe]
-def ofDiscrete (Equiv : α → α → Prop) (equiv_eqv : Equivalence Equiv) : COFE α :=
-  let _ := OFE.ofDiscrete Equiv equiv_eqv
+def ofDiscrete (α : Type _) : COFE α :=
+  let _ := OFE.ofDiscrete α
   { compl := fun c => c 0
-    conv_compl := fun {_ c} => equiv_eqv.2 (c.cauchy (Nat.zero_le _)) }
+    conv_compl := fun {n c} => (c.cauchy (Nat.zero_le n)).symm }
 
 instance [COFE α] : COFE (ULift α) where
   compl c := ⟨compl (c.map uliftDownHom)⟩
@@ -1207,28 +1169,19 @@ attribute [reducible, instance] OFunctor.ofe
 
 end COFE
 
-/- Leibniz OFE structure on a type -/
-@[ext] structure LeibnizO (α : Type _) where
+/- Discrete OFE structure on a type -/
+@[ext] structure DiscreteO (α : Type _) where
   car : α
 
--- Move?
-theorem Eq_Equivalence {α : Type _} : Equivalence (@Eq α) :=
-  ⟨congrFun rfl, (Eq.symm ·), (· ▸ ·)⟩
+instance : COFE (DiscreteO α) := COFE.ofDiscrete _
 
-instance : COFE (LeibnizO α) := COFE.ofDiscrete _ Eq_Equivalence
+instance {α : Type _} : OFE.Discrete (DiscreteO α) := ⟨fun h _ => h⟩
 
-instance : Leibniz (LeibnizO α) := ⟨(·)⟩
+theorem DiscreteO.eqv_inj {x y : α} (H : DiscreteO.mk x ≡ DiscreteO.mk y) : x = y :=
+  show (DiscreteO.mk x).car = (DiscreteO.mk y).car from congrArg DiscreteO.car (H 0)
 
-instance {α : Type _} : OFE.Discrete (LeibnizO α) := ⟨congrArg id⟩
-
-@[rocq_alias leibnizO_leibniz]
-instance {α : Type _} : OFE.Leibniz (LeibnizO α) := ⟨congrArg id⟩
-
-theorem LeibnizO.eqv_inj {x y : α} (H : LeibnizO.mk x ≡ LeibnizO.mk y) : x = y :=
-  show (LeibnizO.mk x).car = (LeibnizO.mk y).car from H ▸ rfl
-
-theorem LeibnizO.dist_inj {x y : α} {n} (H : LeibnizO.mk x ≡{n}≡ LeibnizO.mk y) : x = y :=
-  LeibnizO.eqv_inj <| discrete H
+theorem DiscreteO.dist_inj {x y : α} {n} (H : DiscreteO.mk x ≡{n}≡ DiscreteO.mk y) : x = y :=
+  DiscreteO.eqv_inj <| discrete H
 
 section DiscreteFunOF
 open COFE
@@ -1242,8 +1195,8 @@ instance oFunctor_discreteFunOF {C} (F : C → OFunctorPre) [∀ c, OFunctor (F 
   ofe := _
   map f₁ f₂ := mapCodHom fun _ => OFunctor.map f₁ f₂
   map_ne.ne _ _ _ Hx _ _ Hy _ _ := OFunctor.map_ne.ne Hx Hy ..
-  map_id _ _ := OFunctor.map_id ..
-  map_comp _ _ _ _ _ _ := OFunctor.map_comp ..
+  map_id x := fun n c => OFunctor.map_id (x c) n
+  map_comp f g f' g' x := fun n c => OFunctor.map_comp f g f' g' (x c) n
 
 end DiscreteFunOF
 
@@ -1320,11 +1273,13 @@ instance oFunctorOption [OFunctor F] : OFunctor (OptionOF F) where
     cases z <;> simp [optionMap, Dist, Option.Forall₂]
     exact OFunctor.map_ne.ne Hx Hy ..
   map_id z := by
-    cases z <;> simp [optionMap, Equiv, Option.Forall₂]
-    exact OFunctor.map_id ..
-  map_comp _ _ _ _ z := by
-    cases z <;> simp [optionMap, Equiv, Option.Forall₂]
-    exact OFunctor.map_comp ..
+    cases z with
+    | none => exact .rfl
+    | some c => exact some_eqv_some.mpr (OFunctor.map_id c)
+  map_comp f g f' g' z := by
+    cases z with
+    | none => exact .rfl
+    | some c => exact some_eqv_some.mpr (OFunctor.map_comp f g f' g' c)
 
 @[rocq_alias optionOF_contractive]
 instance [OFunctorContractive F] : OFunctorContractive (OptionOF F) where
@@ -1353,7 +1308,7 @@ instance instNonExpansiveProdMap (f : A → A') (g : B → B') [NonExpansive f] 
 omit [OFE A] [OFE B] in
 theorem Prod.map_ext {f f' : A → A'} {g g' : B → B'} (Hf : ∀ a, f a ≡ f' a)
     (Hg : ∀ a, g a ≡ g' a) : Prod.map f g x ≡ Prod.map f' g' x :=
-  ⟨Hf x.fst, Hg x.snd⟩
+  fun n => ⟨Hf x.fst n, Hg x.snd n⟩
 
 omit [OFE A] [OFE B] in
 theorem Prod.map_ne {f f' : A → A'} {g g' : B → B'} (Hf : ∀ a, f a ≡{n}≡ f' a)
@@ -1377,8 +1332,8 @@ instance instOFunctorProdOF [OFunctor F1] [OFunctor F2] : OFunctor (ProdOF F1 F2
   ofe := inferInstance
   map f g := Prod.mapO (map f g) (map f g)
   map_ne.ne _ _ _ Hx _ _ Hy _ := ⟨map_ne.ne Hx Hy _, map_ne.ne Hx Hy _⟩
-  map_id _ := ⟨map_id _, map_id _⟩
-  map_comp _ _ _ _ _ := ⟨map_comp .., map_comp ..⟩
+  map_id _ := equiv_prod_ext (map_id _) (map_id _)
+  map_comp _ _ _ _ _ := equiv_prod_ext (map_comp _ _ _ _ _) (map_comp _ _ _ _ _)
 
 open OFunctorContractive in
 @[rocq_alias prodOF_contractive]
@@ -1439,8 +1394,8 @@ instance instOFunctorSumOF [OFunctor F1] [OFunctor F2] : OFunctor (SumOF F1 F2) 
     | .inl _ => equiv_inl (map_id _)
     | .inr _ => equiv_inr (map_id _)
   map_comp _ _ _ _ x := match x with
-    | .inl _ => equiv_inl (map_comp ..)
-    | .inr _ => equiv_inr (map_comp ..)
+    | .inl _ => equiv_inl (map_comp _ _ _ _ _)
+    | .inr _ => equiv_inr (map_comp _ _ _ _ _)
 
 open OFunctorContractive in
 @[rocq_alias sumOF_contractive]
@@ -1547,9 +1502,9 @@ instance instOFunctorHomOF [OFunctor F1] [OFunctor F2] : OFunctor (HomOF F1 F2) 
   ofe := inferInstance
   map f g := Hom.map (map (F := F1) g f) (map (F := F2) f g)
   map_ne.ne _ _ _ Hf _ _ Hg := NonExpansive₂.ne (map_ne.ne Hg Hf) (map_ne.ne Hf Hg)
-  map_id {_ _ _ _ _} _ := (map_id _).trans (NonExpansive.eqv (map_id _))
-  map_comp _ _ _ _ _ _ := (map_comp _ _ _ _ _).trans
-    (NonExpansive.eqv (NonExpansive.eqv (NonExpansive.eqv ((map_comp _ _ _ _ _).trans .rfl))))
+  map_id _ _ _ := ((map_id _).trans (NonExpansive.eqv (map_id _))).dist
+  map_comp _ _ _ _ _ _ _ := ((map_comp _ _ _ _ _).trans
+    (NonExpansive.eqv (NonExpansive.eqv (NonExpansive.eqv ((map_comp _ _ _ _ _).trans .rfl))))).dist
 
 open OFunctorContractive in
 @[rocq_alias ofe_morOF_contractive]
@@ -1605,7 +1560,7 @@ theorem LimitPreserving.equiv [COFE α] [COFE β] (f g : α -n> β) :
     LimitPreserving (fun x => f x ≡ g x) := by
   intro c Hfg
   refine equiv_dist.mpr fun n => ?_
-  apply (COFE.compl_map ..).symm.dist.trans
+  apply (COFE.compl_map _ _).symm.dist.trans
   apply (COFE.conv_compl' (Nat.le_refl n)).trans
   apply (Hfg _).dist.trans
   exact g.ne.ne COFE.conv_compl.symm
@@ -1810,12 +1765,12 @@ section Later
 
 @[rocq_alias later_ofe_mixin]
 instance isOFE_later [OFE A] : OFE (Later A) where
-  Equiv x y := x.car ≡ y.car
   Dist n x y := DistLater n x.car y.car
   dist_eqv := ⟨fun _ => .rfl, .symm, .trans⟩
-  equiv_dist := by
-    simp only [equiv_dist, DistLater]
-    exact ⟨by simp +contextual, fun H n => H (Nat.succ n) n (by simp)⟩
+  eq_dist {x y} := by
+    obtain ⟨a⟩ := x; obtain ⟨b⟩ := y
+    simp only [Later.next.injEq, eq_dist]
+    exact ⟨fun H n => (H n).distLater, fun H n => (H (n+1)).dist_lt (Nat.lt_succ_self n)⟩
   dist_lt Hxy Hmn _ Hkm := Hxy _ (Nat.lt_trans Hkm Hmn)
 #rocq_ignore laterO "Use the later type"
 
@@ -1852,10 +1807,6 @@ def laterMap [OFE A] [OFE B] (f : A -n> B)  : Later A -n> Later B := by
 #rocq_ignore later_map_ne' "Implicit in type of laterMap"
 #rocq_ignore later_map_proper "Derived from nonexpansivity"
 
-instance [OFE α] [Leibniz α] : Leibniz (Later α) where
-  eq_of_eqv {x y} H := match x, y with
-    | ⟨_⟩, ⟨_⟩ => (Later.next.injEq _ _).mpr (eq_of_eqv (α := α) H)
-
 end Later
 
 section LaterOF
@@ -1871,8 +1822,8 @@ instance instOFunctorLater [OFunctor F] : OFunctor (LaterOF F) where
   ofe := _
   map f g := laterMap (OFunctor.map f g)
   map_ne.ne _ _ _ Hx _ _ Hy _ _ := (OFunctor.map_ne.ne Hx Hy _).lt
-  map_id _ := OFunctor.map_id _
-  map_comp _ _ _ _ _ := OFunctor.map_comp ..
+  map_id x := fun _ m _ => (OFunctor.map_id x.car) m
+  map_comp f g f' g' x := fun _ m _ => (OFunctor.map_comp f g f' g' x.car) m
 
 @[rocq_alias laterOF_contractive]
 instance instOFunctorContractiveLater [OFunctor F] : OFunctorContractive (LaterOF F) where
@@ -1880,75 +1831,6 @@ instance instOFunctorContractiveLater [OFunctor F] : OFunctorContractive (LaterO
     OFunctor.map_ne.ne (DistLater.dist_lt H hlt).1 (DistLater.dist_lt H hlt).2 _
 
 end LaterOF
-
-namespace Leibniz
-open COFE
-
--- EXPERIMENT: Threading of Leibniz property through the recursive domain equation solver
--- https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/Bi-entailment.20and.20generalized.20rewriting/with/565019365
-class LeibnizPreservingOFunctor (F : OFunctorPre) [OFunctor F] where
-  preserves_leibniz [COFE α] [COFE β] [Leibniz α] [Leibniz β] : Leibniz (F α β)
-
-instance LeibnizPreservingOFunctor.out {F : OFunctorPre} [OFunctor F] [LeibnizPreservingOFunctor F]
-    [COFE α] [COFE β] [Leibniz α] [Leibniz β] : Leibniz (F α β) where
-  eq_of_eqv {x y} hequiv := by
-    haveI := LeibnizPreservingOFunctor.preserves_leibniz (F := F) (α := α) (β := β)
-    exact eq_of_eqv hequiv
-
-instance instLeibnizPreservingOFunctorLaterOF [OFunctor F] [LeibnizPreservingOFunctor F] :
-    LeibnizPreservingOFunctor (LaterOF F) where
-  preserves_leibniz :=
-    ⟨fun {x y} hequiv => match x, y with | ⟨_⟩, ⟨_⟩ => Later.next.inj (eq_of_eqv hequiv)⟩
-
-instance instLeibnizPreservingOFunctorConstOF [COFE T] [Leibniz T] :
-    LeibnizPreservingOFunctor (constOF T) where
-  preserves_leibniz := ⟨fun hequiv => by simp only [leibniz] at hequiv; exact hequiv⟩
-
-instance instLeibnizPreservingOFunctorIdOF :
-    LeibnizPreservingOFunctor IdOF where
-  preserves_leibniz := ⟨fun hequiv => by simp only [leibniz] at hequiv; exact hequiv⟩
-
-instance [OFunctor F] [LeibnizPreservingOFunctor F] : LeibnizPreservingOFunctor (OptionOF F) where
-  preserves_leibniz :=
-    ⟨fun {x y} hequiv =>
-        match x, y with
-        | some _, some _ => Option.some_inj.mp (eq_of_eqv hequiv)
-        | none, none => rfl
-        | some _, none => hequiv.elim
-        | none, some _ => hequiv.elim⟩
-
-instance instLeibnizPreservingOFunctorDiscreteFunOF {C} (F : C → OFunctorPre) [∀ c, OFunctor (F c)]
-    [∀ c, LeibnizPreservingOFunctor (F c)] : LeibnizPreservingOFunctor (DiscreteFunOF F) where
-  preserves_leibniz := ⟨fun hequiv => funext (fun c => eq_of_eqv (hequiv c))⟩
-
-instance instLeibnizPreservingOFunctorProdOF [OFunctor F1] [OFunctor F2]
-   [LeibnizPreservingOFunctor F1] [LeibnizPreservingOFunctor F2] :
-   LeibnizPreservingOFunctor (ProdOF F1 F2) where
-  preserves_leibniz := ⟨fun hequiv => Prod.ext (eq_of_eqv hequiv.1) (eq_of_eqv hequiv.2)⟩
-
-instance instLeibnizPreservingOFunctorSumOF [OFunctor F1] [OFunctor F2]
-    [LeibnizPreservingOFunctor F1] [LeibnizPreservingOFunctor F2] :
-    LeibnizPreservingOFunctor (SumOF F1 F2) where
-  preserves_leibniz :=
-    ⟨ fun {x y} hequiv => match x, y with
-      | .inl _, .inl _ => Sum.inl.inj_iff.mpr (eq_of_eqv (equiv_ext_left hequiv))
-      | .inr _, .inr _ => Sum.inr.inj_iff.mpr (eq_of_eqv (equiv_ext_right hequiv))⟩
-
-instance instanceLeibnizPreservingOFunctorHomOF [OFunctor F1] [OFunctor F2]
-    [LeibnizPreservingOFunctor F1] [LeibnizPreservingOFunctor F2] :
-    LeibnizPreservingOFunctor (HomOF F1 F2) where
-  preserves_leibniz := ⟨fun hequiv => by ext i; exact eq_of_eqv (hequiv i)⟩
-
-instance instanceLeibnizPreservingOFunctorSigmaOF {C} (F : C → OFunctorPre) [∀ c, OFunctor (F c)]
-    [∀ c, LeibnizPreservingOFunctor (F c)] : LeibnizPreservingOFunctor (SigmaOF F) where
-  preserves_leibniz := ⟨fun {x y} hequiv => match x, y with
-    | ⟨x, xH⟩, ⟨y, yH⟩ => by
-      refine Sigma.ext (Sigma.equiv_eq_alt.mp hequiv).choose ?_
-      cases (Sigma.equiv_eq_alt.mp hequiv).choose
-      simp only [heq_eq_eq]
-      exact (eq_of_eqv (Sigma.equiv_eq_alt.mp hequiv).choose_spec)⟩
-
-end Leibniz
 
 theorem OFE.cast_dist [Iα : OFE α] [Iβ : OFE β] {x y : α}
     (Ht : α = β) (HIt : Iα = Ht ▸ Iβ)  (H : x ≡{n}≡ y) :

--- a/Iris/Iris/Algebra/OFE.lean
+++ b/Iris/Iris/Algebra/OFE.lean
@@ -19,12 +19,7 @@ class OFE (α : Type _) where
   eq_dist : x = y ↔ ∀ n, Dist n x y
   dist_lt : Dist n x y → m < n → Dist m x y
 
-def OFE.Equiv [OFE α] (x y : α) : Prop := (∀ n, OFE.Dist n x y)
-theorem OFE.Equiv.to_eq [OFE α] {x y : α} (h : OFE.Equiv x y) : x = y := OFE.eq_dist.mpr h
-theorem OFE.equiv_dist [OFE α] {x y : α} : OFE.Equiv x y ↔ ∀ n, Dist n x y := .rfl
-
-theorem Eq_Equivalence {α : Type _} : Equivalence (@Eq α) :=
-  ⟨congrFun rfl, (Eq.symm ·), (· ▸ ·)⟩
+def OFE.Equiv [OFE α] (x y : α) : Prop := (∀ n, Dist n x y)
 
 #rocq_ignore OfeMixin "Use the OFE type class"
 #rocq_ignore ofe_mixin_of' "Not needed"
@@ -58,17 +53,20 @@ theorem Dist.le [OFE α] {m n} {x y : α} (h : x ≡{n}≡ y) (h' : m ≤ n) : x
 theorem Dist.trans [OFE α] {n} {x : α} : x ≡{n}≡ y → y ≡{n}≡ z → x ≡{n}≡ z := dist_eqv.3
 theorem Dist.of_eq [OFE α] {x y : α} : x = y → x ≡{n}≡ y := (· ▸ .rfl)
 
+theorem equiv_dist [OFE α] {x y : α} : x ≡ y ↔ ∀ n, x ≡{n}≡ y := .rfl
+
 @[rocq_alias ofe_equivalence]
 theorem equiv_eqv [ofe : OFE α] : Equivalence ofe.Equiv := by
   constructor
   · rintro x; rw [ofe.equiv_dist]; rintro n; exact Dist.rfl
-  · rintro x y; simp [ofe.equiv_dist]; rintro h n; exact Dist.symm (h n)
-  · rintro x y z; simp [ofe.equiv_dist]; rintro h₁ h₂ n; exact Dist.trans (h₁ n) (h₂ n)
+  · rintro x y; simp only [ofe.equiv_dist]; rintro h n; exact Dist.symm (h n)
+  · rintro x y z; simp only [ofe.equiv_dist]; rintro h₁ h₂ n; exact Dist.trans (h₁ n) (h₂ n)
 
 @[simp, refl] theorem Equiv.rfl [OFE α] {x : α} : x ≡ x := equiv_eqv.1 _
 @[symm] theorem Equiv.symm [OFE α] {x : α} : x ≡ y → y ≡ x := equiv_eqv.2
 theorem Equiv.trans [OFE α] {x : α} : x ≡ y → y ≡ z → x ≡ z := equiv_eqv.3
 theorem Equiv.dist [OFE α] {x : α} : x ≡ y → x ≡{n}≡ y := (equiv_dist.1 · _)
+theorem Equiv.to_eq [OFE α] {x y : α} (h : x ≡ y) : x = y := OFE.eq_dist.mpr h
 theorem Equiv.of_eq [OFE α] {x y : α} : x = y → x ≡ y := (· ▸ .rfl)
 
 instance [OFE α] : Trans OFE.Equiv OFE.Equiv (OFE.Equiv : α → α → Prop) where
@@ -189,7 +187,7 @@ instance [OFE α] [OFE β] {x : β} : Contractive (fun _ : α => x) where
 @[reducible, rocq_alias discrete_ofe_mixin]
 def ofDiscrete (α : Type _) : OFE α where
   Dist _ := Eq
-  dist_eqv := Eq_Equivalence
+  dist_eqv := ⟨congrFun rfl, (Eq.symm ·), (· ▸ ·)⟩
   eq_dist := (forall_const _).symm
   dist_lt h _ := h
 
@@ -429,7 +427,7 @@ theorem _root_.Option.Forall₂.equivalence {R : α → α → Prop}
 instance [OFE α] : OFE (Option α) where
   Dist n := Option.Forall₂ (Dist n)
   dist_eqv := Option.Forall₂.equivalence dist_eqv
-  eq_dist {x y} := by cases x <;> cases y <;> simp [Option.Forall₂] <;> apply eq_dist
+  eq_dist {x y} := by cases x <;> cases y <;> simp [Option.Forall₂, eq_dist]
   dist_lt {_ x y _} := by cases x <;> cases y <;> simp [Option.Forall₂]; apply dist_lt
 #rocq_ignore optionO "Use Option"
 #rocq_ignore option_dist "Local Dist instance; folded into Lean's OFE (Option α) instance."
@@ -536,7 +534,7 @@ instance [OFEFun (β : α → _)] : OFE ((x : α) → β x) where
     symm h _ := dist_eqv.symm (h _)
     trans h1 h2 _ := dist_eqv.trans (h1 _) (h2 _)
   }
-  eq_dist {_ _} := by rw [funext_iff]; simp only [eq_dist]; exact forall_comm
+  eq_dist {_ _} := by rw [funext_iff]; simpa only [eq_dist] using forall_comm
   dist_lt h1 h2 _ := dist_lt (h1 _) h2
 #rocq_ignore discrete_funO "Use a function type"
 #rocq_ignore discrete_fun "Lean uses `(x : α) → β x` directly with `OFEFun`."
@@ -1191,6 +1189,8 @@ end COFE
 instance : COFE (DiscreteO α) := COFE.ofDiscrete _
 
 instance {α : Type _} : OFE.Discrete (DiscreteO α) := ⟨fun h _ => h⟩
+
+#rocq_ignore leibnizO_leibniz "Not needed"
 
 theorem DiscreteO.eqv_inj {x y : α} (H : DiscreteO.mk x ≡ DiscreteO.mk y) : x = y :=
   show (DiscreteO.mk x).car = (DiscreteO.mk y).car from congrArg DiscreteO.car (H 0)

--- a/Iris/Iris/Algebra/OFE.lean
+++ b/Iris/Iris/Algebra/OFE.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Mario Carneiro
+Authors: Mario Carneiro, Sergei Stepanenko
 -/
 module
 

--- a/Iris/Iris/Algebra/ReservationMap.lean
+++ b/Iris/Iris/Algebra/ReservationMap.lean
@@ -62,21 +62,22 @@ variable [LawfulPartialMap H Pos] [OFE A]
 
 @[rocq_alias reservation_mapO]
 instance : OFE (ReservationMap A H) where
-  Equiv x y := x.data ≡ y.data ∧ x.token ≡ y.token
   Dist n x y := x.data ≡{n}≡ y.data ∧ x.token ≡{n}≡ y.token
   dist_eqv := {
     refl _ := ⟨.rfl, rfl⟩,
     symm h := ⟨h.left.symm, h.right.symm⟩,
     trans h₁ h₂ := ⟨h₁.left.trans h₂.left, h₁.right.trans h₂.right⟩
   }
-  equiv_dist :=
-    ⟨fun h n => ⟨equiv_dist.mp h.left n, h.right⟩,
-     fun h => ⟨equiv_dist.mpr (h · |>.left), (h 0).right⟩⟩
+  eq_dist {x y} := by
+    refine ⟨fun h _ => h ▸ ⟨.rfl, .rfl⟩, fun H => ?_⟩
+    obtain ⟨xd, xt⟩ := x; obtain ⟨yd, yt⟩ := y
+    simp only [ReservationMap.mk.injEq]
+    exact ⟨eq_dist.mpr fun n => (H n).1, eq_dist.mpr fun n => (H n).2⟩
   dist_lt h lt := ⟨dist_lt h.left lt, dist_lt h.right lt⟩
 
 @[rocq_alias reservation_map_ofe_discrete]
 instance instDiscreteReservationMap [Discrete A] : Discrete (ReservationMap A H) where
-  discrete_0 h := ⟨discrete_0 h.left, discrete_0 h.right⟩
+  discrete_0 h := fun n => ⟨(discrete_0 h.left) n, (discrete_0 h.right) n⟩
 
 instance instNonExpansiveReservationMapData :
     NonExpansive (ReservationMap.mkData (H := H) (A := A)) where
@@ -92,7 +93,7 @@ instance instNonExpansiveReservationMapSingleton :
 @[rocq_alias ReservationMap_discrete]
 instance instDiscreteEReservationMapMk {a : H A} [DiscreteE a] :
     DiscreteE (ReservationMap.mk a b) where
-  discrete := fun ⟨ha, hb⟩ => ⟨DiscreteE.discrete ha, DiscreteE.discrete hb⟩
+  discrete := fun h n => ⟨(DiscreteE.discrete h.1) n, (DiscreteE.discrete h.2) n⟩
 
 @[rocq_alias reservation_map_data_discrete]
 instance instDiscreteEReservationMapSingleton {a : A} [DiscreteE a] :
@@ -241,36 +242,32 @@ instance : UCMRA (ReservationMap A H) where
         refine .inr fun HK => bb ?_
         refine (mem_iff_of_validN_union (validN_token_of_validN v) i).mpr ?_
         exact .inl HK
-  assoc := ⟨CMRA.assoc, CMRA.assoc⟩
-  comm := ⟨CMRA.comm, CMRA.comm⟩
+  assoc := fun n => ⟨CMRA.assoc n, CMRA.assoc n⟩
+  comm := fun n => ⟨CMRA.comm n, CMRA.comm n⟩
   pcore_op_left {x cx} h := by
-    refine ⟨?_, ?_⟩
-    · simp [←Option.some_inj.mp h, op_data', core_data, core_op x.data]
+    refine fun n => ⟨?_, ?_⟩
+    · simp only [←Option.some_inj.mp h, op_data', core_data]; exact (core_op x.data) n
     · simp [←Option.some_inj.mp h, op_token', core_token, core_op_L]
   pcore_idem {x cx} h := by
-    refine ⟨?_, ?_⟩
-    · simp [←Option.some_inj.mp h, core_data, core_idem x.data]
+    refine fun n => ⟨?_, ?_⟩
+    · simp only [←Option.some_inj.mp h, core_data]; exact (core_idem x.data) n
     · simp [←Option.some_inj.mp h, core_token, core_idem_L]
   pcore_op_mono {x cx} h y := by
     obtain ⟨z, hz⟩ := core_op_mono x.data y.data
     obtain ⟨w, hw⟩ := core_op_mono x.token y.token
-    refine ⟨mk z w, ?_, ?_⟩
-    · simp [op_data', core_data, (Option.some_inj.mp h.symm), hz]
-    · simp only [core_token, op_token', (Option.some_inj.mp h.symm), leibniz]
-      exact hw
+    refine ⟨mk z w, fun n => ⟨?_, ?_⟩⟩
+    · simp only [op_data', core_data, (Option.some_inj.mp h.symm)]; exact hz n
+    · simp only [core_token, op_token', (Option.some_inj.mp h.symm)]; exact hw n
   extend {n x y₁ y₂} v exy := by
     obtain ⟨z₁, z₂, xzz, zy₁, zy₂⟩ := CMRA.extend (validN_data_of_validN v) exy.left
-    refine ⟨mk z₁ y₁.token, mk z₂ y₂.token, ?_, ?_, ?_⟩
-    · refine ⟨?_, ?_⟩
-      · simp [op_data', xzz]
-      · simp only [op_token', leibniz]
-        exact exy.right
-    · exact ⟨zy₁, rfl⟩
-    · exact ⟨zy₂, rfl⟩
+    exact ⟨mk z₁ y₁.token, mk z₂ y₂.token, (fun m => ⟨xzz m, exy.right⟩),
+      ⟨zy₁, rfl⟩, ⟨zy₂, rfl⟩⟩
   unit := mk ∅ ∅
   unit_valid := ⟨Heap.valid_empty, fun _ => .inr CoPset.mem_empty⟩
-  unit_left_id {x} := ⟨by simp only [op, Algebra.MonoidOps.op_left_id], pcore_op_left' rfl⟩
-  pcore_unit := ⟨Heap.core_empty, .rfl⟩
+  unit_left_id {x} := by
+    refine fun n => ⟨?_, (pcore_op_left' (OFE.Equiv.of_eq rfl)) n⟩
+    exact (Algebra.MonoidOps.op_left_id : (∅ : H A) • x.data ≡ x.data) n
+  pcore_unit := fun n => ⟨Heap.core_empty n, .rfl⟩
 
 @[simp]
 theorem op_data (x y : ReservationMap A H): (x • y).data = x.data • y.data := rfl
@@ -288,8 +285,8 @@ instance [CMRA.Discrete A] : CMRA.Discrete (ReservationMap A H) where
 
 instance instCoreIdSingleton {a : A} [CoreId a] : CoreId (singleton (H := H) k a) where
   core_id := by
-    refine ⟨?_, rfl⟩
-    simp [singleton, mkData, core_eqv_self (PartialMap.singleton k a)]
+    refine OFE.some_eqv_some.mpr fun n => ⟨?_, .rfl⟩
+    exact (core_eqv_self (PartialMap.singleton k a : H A)) n
 
 theorem split_valid {x : ReservationMap A H} (vx : ✓ x) :
     ∃ (d : H A) (t : CoPset), x ≡ mkData d • mkToken t := by
@@ -298,10 +295,10 @@ theorem split_valid {x : ReservationMap A H} (vx : ✓ x) :
   | .error =>
     exact ((not_valid_invalid (S := CoPset)) (hh ▸ (valid_token_of_valid vx))).elim
   | .valid t =>
-    refine ⟨xd, t, ?_, ?_⟩
-    · simp [mkData, mkToken, op_data, Algebra.MonoidOps.op_right_id.symm]
-    . simp only [mkData, mkToken, op_token, leibniz]
-      exact (pcore_op_left_L rfl).symm
+    refine ⟨xd, t, fun n => ⟨?_, ?_⟩⟩
+    · exact (show xd ≡ xd • (∅ : H A) from Algebra.MonoidOps.op_right_id.symm) n
+    · simp only [mkData, mkToken, op_token]
+      exact Dist.of_eq (pcore_op_left_L rfl).symm
 
 theorem split_validN {x : ReservationMap A H} (vx : ✓{n} x) :
     ∃ (d : H A) (t : CoPset), x ≡ mkData d • mkToken t := by
@@ -310,9 +307,10 @@ theorem split_validN {x : ReservationMap A H} (vx : ✓{n} x) :
   match hh : xt with
   | .error => exact ((not_valid_invalid (S := CoPset)) (hh ▸ H)).elim
   | .valid t =>
-    refine ⟨xd, t, ?_, ?_⟩
-    · simpa [mkData, mkToken, op_data] using Algebra.MonoidOps.op_right_id.symm
-    . exact (pcore_op_left' rfl).symm
+    refine ⟨xd, t, fun m => ⟨?_, ?_⟩⟩
+    · simp only [mkData, mkToken, op_data]
+      exact (Algebra.MonoidOps.op_right_id.symm) m
+    · exact ((pcore_op_left' (OFE.Equiv.of_eq rfl)).symm) m
 
 theorem valid_data {d : H A} : ✓ (mkData (H := H) d) ↔ ✓ d :=
   ⟨valid_data_of_valid, fun h => valid_iff.mpr ⟨h, ⟨⟩, fun p => .inr (mem_empty p)⟩⟩
@@ -332,17 +330,17 @@ theorem valid_token : ✓ (mkToken (H := H) (A := A) e) :=
   ⟨Heap.valid_empty, fun i => .inl (get?_empty i)⟩
 
 theorem data_op (a b : H A) : mkData (a • b) ≡ mkData a • mkData b :=
-  ⟨.rfl, (pcore_op_right_L rfl).symm⟩
+  fun _ => ⟨.rfl, Dist.of_eq (pcore_op_right_L rfl).symm⟩
 
 @[rocq_alias reservation_map_data_op]
 theorem singleton_op k (a b : A) :
     singleton (H := H) k (a • b) ≡ singleton (H := H) k a • singleton k b := by
   refine ((data_op _ _).symm.trans ?_).symm
-  exact NonExpansive.eqv (fun i => .of_eq (Heap.singleton_op_singleton i))
+  exact NonExpansive.eqv (fun n i => Dist.of_eq (Heap.singleton_op_singleton i))
 
 theorem token_op (a b : CoPset) (h : a ## b) :
     mkToken (H := H) (A := A) (a ∪ b) ≡ mkToken a • mkToken b := by
-  refine ⟨show ∅ ≡ (∅ : H A) • ∅ from Algebra.MonoidOps.op_left_id.symm, ?_⟩
+  refine fun n => ⟨(show ∅ ≡ (∅ : H A) • ∅ from Algebra.MonoidOps.op_left_id.symm) n, ?_⟩
   simp [mkToken, CMRA.op, op_token', h]
 
 theorem disj_of_validN_data_op_token {a : H A} {b : CoPset} (h : ✓{n} mkData a • mkToken b) (i : Pos) :
@@ -355,7 +353,7 @@ theorem disj_of_validN_data_op_token {a : H A} {b : CoPset} (h : ✓{n} mkData a
     simp only [mkData, mkToken, op_token] at h'
     rw [mem_iff_of_valid_union, not_or] at h'
     · exact .inr <| h'.right
-    · exact valid_of_eqv (pcore_op_left' rfl).symm valid_set
+    · exact valid_of_eqv (pcore_op_left' (OFE.Equiv.of_eq rfl)).symm valid_set
 
 theorem disj_of_valid_data_op_token (a : H A) (b : CoPset) (h : ✓ mkData a • mkToken b) (i : Pos) :
   get? a i = none ∨ i ∉ b := disj_of_validN_data_op_token (h.validN (n := 0)) i
@@ -400,7 +398,7 @@ instance {ia ib₁ ib₂ : ProofMode.InOut} {a b₁ b₂ : A} [hv : IsOp ia a ib
 @[rocq_alias reservation_map_token_union]
 theorem token_union {e₁ e₂} (he : e₁ ## e₂) :
     mkToken (H := H) (A := A) (e₁ ∪ e₂) ≡ mkToken e₁ • mkToken e₂ := by
-  refine ⟨fun i => ?_, ?_⟩
+  refine fun n => ⟨fun i => ?_, ?_⟩
   · simpa only [mkToken, get?_empty, op_data, Heap.get?_op] using .rfl
   · simp [mkToken, CMRA.op, he]
 

--- a/Iris/Iris/Algebra/UFrac.lean
+++ b/Iris/Iris/Algebra/UFrac.lean
@@ -36,11 +36,11 @@ namespace UFrac
 #rocq_ignore ufrac_pcore_instance "Use CMRA instance"
 #rocq_ignore ufrac_valid_instance "Use CMRA instance"
 
-instance : COFE UFrac := COFE.ofDiscrete _ Eq_Equivalence
-instance : OFE.Leibniz UFrac := ⟨id⟩
+@[simp] instance : COFE UFrac := COFE.ofDiscrete _
+instance : OFE.Discrete UFrac := ⟨fun h _ => h⟩
 
 @[simp] theorem dist_iff {n} {x y : UFrac} : x ≡{n}≡ y ↔ x = y := Iff.rfl
-@[simp] theorem equiv_iff {x y : UFrac} : x ≡ y ↔ x = y := Iff.rfl
+@[simp] theorem equiv_iff {x y : UFrac} : x ≡ y ↔ x = y := ⟨OFE.Equiv.to_eq, OFE.Equiv.of_eq⟩
 
 @[rocq_alias ufracR]
 instance : CMRA UFrac where
@@ -54,8 +54,8 @@ instance : CMRA UFrac where
   valid_iff_validN := ⟨fun _ _ => trivial, fun _ => trivial⟩
   validN_succ := id
   validN_op_left _ := trivial
-  assoc := ext_iff.mpr <| Subtype.ext (Rat.add_assoc ..).symm
-  comm := ext_iff.mpr <| Subtype.ext (Rat.add_comm ..)
+  assoc := OFE.Equiv.of_eq <| ext_iff.mpr <| Subtype.ext (Rat.add_assoc ..).symm
+  comm := OFE.Equiv.of_eq <| ext_iff.mpr <| Subtype.ext (Rat.add_comm ..)
   pcore_op_left H := by rcases H
   pcore_idem H := by rcases H
   pcore_op_mono H := by rcases H
@@ -81,7 +81,7 @@ theorem le_of_inc {x y : UFrac} (H : x ≼ y) : x.frac ≤ y.frac := by
 
 @[rocq_alias ufrac_cmra_discrete]
 instance : CMRA.Discrete UFrac where
-  discrete_0 := id
+  discrete_0 := fun h _ => h
   discrete_valid := id
 
 @[rocq_alias ufrac_cancelable]
@@ -97,6 +97,6 @@ instance {q : UFrac} : CMRA.IdFree q where
 set_option synthInstance.checkSynthOrder false in
 @[rocq_alias is_op_ufrac]
 instance (q : UFrac) : IsOp io1 q io2 ⟨q.frac.half⟩ io3 ⟨q.frac.half⟩ where
-  is_op := ext_iff.mpr (Qp.half_add_half q.frac).symm
+  is_op := OFE.Equiv.of_eq <| ext_iff.mpr (Qp.half_add_half q.frac).symm
 
 end UFrac

--- a/Iris/Iris/Algebra/UPred.lean
+++ b/Iris/Iris/Algebra/UPred.lean
@@ -64,15 +64,15 @@ open UPred
 
 @[rocq_alias uPredO]
 instance : OFE (UPred M) where
-  Equiv P Q := ∀ n (x : M), (p : ✓{n} x) → (P n ⟨x, p⟩ ↔ Q n ⟨x, p⟩)
   Dist n P Q := ∀ n' (x : M), n' ≤ n → (p : ✓{n'} x) → (P n' ⟨x, p⟩ ↔ Q n' ⟨x, p⟩)
   dist_eqv := {
     refl _ _ _ _ _ := .rfl
     symm H _ _ A B := (H _ _ A B).symm
     trans H1 H2 _ _ A B := (H1 _ _ A B).trans (H2 _ _ A B) }
-  equiv_dist := ⟨
-    fun Heqv _ _ _ _ Hvalid => Heqv _ _ Hvalid,
-    fun Hdist _ _ Hvalid => Hdist _ _ _ .refl Hvalid⟩
+  eq_dist {P Q} := by
+    refine ⟨fun h _ _ _ _ _ => h ▸ Iff.rfl, fun h => ?_⟩
+    ext n e
+    exact h n n e.val (Nat.le_refl n) e.property
   dist_lt Hdist Hlt _ _ Hle Hvalid :=
     Hdist _ _ (Nat.le_trans Hle (Nat.le_of_succ_le Hlt)) Hvalid
 
@@ -82,11 +82,6 @@ instance : OFE (UPred M) where
 #rocq_ignore uPred_dist "Not needed"
 #rocq_ignore uPred_ofe_mixin "Not needed"
 
-
-instance : OFE.Leibniz (UPred M) where
-  eq_of_eqv {x y} hequiv := by
-    ext n e
-    exact hequiv n e.val e.property
 
 @[rocq_alias uPred_ne]
 theorem uPred_ne {P : UPred M} {n} {m₁ m₂ : ValidAt M n} (H : (m₁ : M) ≡{n}≡ (m₂ : M)) : P n m₁ ↔ P n m₂ :=
@@ -136,10 +131,10 @@ instance [URFunctor F] : COFE.OFunctor (UPredOF F) where
   map_ne.ne _ _ _ Hx _ _ Hy _ _ z2 Hn _ := by
     simp only [uPred_map]
     exact uPred_ne <| URFunctor.map_ne.ne (Hy.le Hn) (Hx.le Hn) z2
-  map_id _ _ z _ := by
+  map_id _ _ _ z _ _ := by
     simp only [uPred_map]
     exact uPred_proper <| URFunctor.map_id z
-  map_comp f g f' g' _ _ H _ := by
+  map_comp f g f' g' _ _ _ H _ _ := by
     simp only [uPred_map]
     exact uPred_proper <| URFunctor.map_comp g' f' g f H
 
@@ -149,8 +144,5 @@ instance instUPredOFunctorContractive [URFunctorContractive F] : COFE.OFunctorCo
     refine uPred_ne (P := P) <|
       ((URFunctorContractive.map_contractive.1 (x := (x.snd, x.fst)) (y := (y.snd, y.fst))) ?_ a).le Hmn
     exact fun m Hm => ⟨(HKL m Hm).2, (HKL m Hm).1⟩
-
-instance [URFunctor F] : Leibniz.LeibnizPreservingOFunctor (UPredOF F) where
-  preserves_leibniz := inferInstance
 
 end UPred

--- a/Iris/Iris/Algebra/View.lean
+++ b/Iris/Iris/Algebra/View.lean
@@ -73,16 +73,17 @@ def dist (n : Nat) (x y : View R) : Prop := x.auth ≡{n}≡ y.auth ∧ x.frag �
 
 @[rocq_alias view_ofe_mixin]
 instance : OFE (View R) where
-  Equiv := equiv
   Dist := dist
   dist_eqv := {
     refl _ := ⟨.of_eq rfl, .of_eq rfl⟩
     symm H := ⟨H.1.symm, H.2.symm⟩
     trans H1 H2 := ⟨H1.1.trans H2.1, H1.2.trans H2.2⟩
   }
-  equiv_dist :=
-    ⟨fun H _ => ⟨H.1.dist, H.2.dist⟩,
-     fun H => ⟨equiv_dist.mpr (H · |>.1), equiv_dist.mpr (H · |>.2)⟩⟩
+  eq_dist {x y} := by
+    refine ⟨fun H _ => H ▸ ⟨.rfl, .rfl⟩, fun H => ?_⟩
+    obtain ⟨xa, xf⟩ := x; obtain ⟨ya, yf⟩ := y
+    simp only [View.mk.injEq]
+    exact ⟨eq_dist.mpr fun n => (H n).1, eq_dist.mpr fun n => (H n).2⟩
   dist_lt H Hn := ⟨dist_lt H.1 Hn, dist_lt H.2 Hn⟩
 
 #rocq_ignore viewO "Use the plain View type and typeclass inference"
@@ -101,17 +102,11 @@ instance frag.ne : NonExpansive (frag : View R → _) := ⟨fun _ _ _ H => H.2�
 
 @[rocq_alias View_discrete]
 theorem discrete {ag : Option ((DFrac) × Agree A)} (Ha : DiscreteE ag) (Hb : DiscreteE b) :
-  DiscreteE (α := View R) (mk ag b) := ⟨fun H => ⟨Ha.discrete H.1, Hb.discrete H.2⟩⟩
+  DiscreteE (α := View R) (mk ag b) := ⟨fun H n => ⟨(Ha.discrete H.1) n, (Hb.discrete H.2) n⟩⟩
 
 @[rocq_alias view_ofe_discrete]
 instance [Discrete A] [Discrete B] : Discrete (View R) where
-  discrete_0 H := ⟨discrete_0 H.1, discrete_0 H.2⟩
-
-instance instLeibniz [Leibniz A] [Leibniz B] : Leibniz (View R) where
-  eq_of_eqv {x y} h := by
-    cases x; cases y
-    simp only [View.mk.injEq]
-    exact ⟨eq_of_eqv h.1, eq_of_eqv h.2⟩
+  discrete_0 H := fun n => ⟨(discrete_0 H.1) n, (discrete_0 H.2) n⟩
 
 -- view_auth_dist_inj
 theorem auth_inj_frac [UCMRA B] {q1 q2 : DFrac} {a1 a2 : A} {n} (H : (●V{q1} a1 : View R) ≡{n}≡ ●V{q2} a2) :
@@ -134,7 +129,7 @@ theorem auth_eqv_inj [UCMRA B] {q1 q2 : DFrac} {a1 a2 : A}
 
 @[rocq_alias view_frag_inj]
 theorem frag_eqv_inj [UCMRA B] {b1 b2 : B}
-    (H : (◯V b1 : View R) ≡ ◯V b2) : b1 ≡ b2 := H.2
+    (H : (◯V b1 : View R) ≡ ◯V b2) : b1 ≡ b2 := fun n => (H n).2
 
 @[rocq_alias view_frag_dist_inj]
 theorem dist_of_frag_dist [UCMRA B] {b1 b2 : B} {n} (H : (◯V b1 : View R) ≡{n}≡ ◯V b2) :
@@ -267,9 +262,7 @@ instance : CMRA (View R) where
     rcases cx
     simp only [mk.injEq, and_imp]
     intro H1 H2
-    constructor
-    · simp only; exact H1 ▸ CMRA.core_idem _
-    · exact H2 ▸ CMRA.core_idem _
+    exact NonExpansive₂.eqv (H1 ▸ CMRA.core_idem _) (H2 ▸ CMRA.core_idem _)
   pcore_op_mono := by
     let f : (Option ((DFrac) × Agree A) × B) → View R := fun x => ⟨x.1, x.2⟩
     let g : View R → (Option ((DFrac) × Agree A) × B) := fun x => (x.auth, x.frag)
@@ -327,15 +320,16 @@ instance [Discrete A] [CMRA.Discrete B] [IsViewRelDiscrete R] : CMRA.Discrete (V
 instance : UCMRA (View R) where
   unit := ⟨UCMRA.unit, UCMRA.unit⟩
   unit_valid := IsViewRel.rel_unit
-  unit_left_id := ⟨UCMRA.unit_left_id, UCMRA.unit_left_id⟩
-  pcore_unit := ⟨.rfl, CMRA.core_eqv_self UCMRA.unit⟩
+  unit_left_id := NonExpansive₂.eqv UCMRA.unit_left_id UCMRA.unit_left_id
+  pcore_unit := OFE.some_eqv_some.mpr (NonExpansive₂.eqv .rfl (CMRA.core_eqv_self UCMRA.unit))
 
 #rocq_ignore view_empty_instance "Inlined in the UCMRA instance"
 #rocq_ignore view_ucmra_mixin "Not needed"
 
 @[rocq_alias view_auth_dfrac_op]
 theorem auth_op_auth_eqv : (●V{dq1 • dq2} a : View R) ≡ (●V{dq1} a) • ●V{dq2} a :=
-  ⟨⟨rfl, Agree.idemp.symm⟩, UCMRA.unit_left_id.symm⟩
+  NonExpansive₂.eqv (OFE.some_eqv_some.mpr (NonExpansive₂.eqv .rfl Agree.idemp.symm))
+    UCMRA.unit_left_id.symm
 
 set_option synthInstance.checkSynthOrder false in
 @[rocq_alias view_auth_dfrac_is_op]
@@ -343,7 +337,7 @@ instance isOp_view_auth_dfrac {dq dq1 dq2 : DFrac} {a : A}
     [h : IsOp io1 dq io2 dq1 io3 dq2] :
     IsOp io1 (●V{dq} a : View R) io2 (●V{dq1} a) io3 (●V{dq2} a) where
   is_op := by
-    rw [h.is_op]
+    rw [h.is_op.to_eq]
     apply auth_op_auth_eqv
 
 @[rocq_alias view_frag_op]
@@ -361,24 +355,24 @@ theorem frag_core : CMRA.core (◯V b : View R) = ◯V (CMRA.core b) := rfl
 
 @[rocq_alias view_both_core_discarded]
 theorem auth_discard_op_frag_core : CMRA.core ((●V{.discard} a) • ◯V b : View R) ≡ (●V{.discard} a) • ◯V (CMRA.core b) :=
-  ⟨.rfl, (CMRA.core_ne.eqv UCMRA.unit_left_id).trans UCMRA.unit_left_id.symm⟩
+  NonExpansive₂.eqv .rfl ((CMRA.core_ne.eqv UCMRA.unit_left_id).trans UCMRA.unit_left_id.symm)
 
 @[rocq_alias view_both_core_frac]
 theorem auth_own_op_frag_core : CMRA.core ((●V{.own q} a) • ◯V b : View R) ≡ ◯V (CMRA.core b) :=
-  ⟨trivial, CMRA.core_ne.eqv UCMRA.unit_left_id⟩
+  NonExpansive₂.eqv .rfl (CMRA.core_ne.eqv UCMRA.unit_left_id)
 
 @[rocq_alias view_auth_core_id]
 instance : CMRA.CoreId (●V{.discard} a : View R) where
-  core_id := ⟨.rfl, CMRA.core_eqv_self UCMRA.unit⟩
+  core_id := OFE.some_eqv_some.mpr (NonExpansive₂.eqv .rfl (CMRA.core_eqv_self UCMRA.unit))
 
 @[rocq_alias view_frag_core_id]
 instance [CMRA.CoreId b] : CMRA.CoreId (◯V b : View R) where
-  core_id := ⟨.rfl, CMRA.coreId_iff_core_eqv_self.mp (by trivial)⟩
+  core_id := OFE.some_eqv_some.mpr (NonExpansive₂.eqv .rfl (CMRA.coreId_iff_core_eqv_self.mp (by trivial)))
 
 @[rocq_alias view_both_core_id]
 instance [CMRA.CoreId b] : CMRA.CoreId ((●V{.discard} a : View R) • ◯V b) where
   core_id := by
-    refine ⟨.rfl, ?_⟩
+    refine OFE.some_eqv_some.mpr (NonExpansive₂.eqv .rfl ?_)
     refine (CMRA.core_ne.eqv UCMRA.unit_left_id).trans ?_
     refine (CMRA.coreId_iff_core_eqv_self.mp (by trivial)).trans ?_
     refine UCMRA.unit_left_id.symm
@@ -399,9 +393,9 @@ theorem eqv_of_valid_auth (H : ✓ ((●V{dq1} a1 : View R) • ●V{dq2} a2)) :
   equiv_dist.mpr fun _ => dist_of_validN_auth H.validN
 
 @[rocq_alias view_auth_dfrac_op_inv_L]
-theorem eq_of_valid_auth [OFE.Leibniz A]
+theorem eq_of_valid_auth
     (H : ✓ ((●V{dq1} a1 : View R) • ●V{dq2} a2)) : a1 = a2 :=
-  OFE.eq_of_eqv (eqv_of_valid_auth H)
+  (eqv_of_valid_auth H).to_eq
 
 @[rocq_alias view_auth_dfrac_validN]
 theorem auth_validN_iff : ✓{n} (●V{dq} a : View R) ↔ ✓{n}dq ∧ R n a UCMRA.unit :=
@@ -493,7 +487,7 @@ theorem auth_incN_auth_op_frag_iff : (●V{dq1} a1 : View R) ≼{n} ((●V{dq2} 
   · simp only [Auth, Frag, CMRA.IncludedN, CMRA.op]
     rintro ⟨(_|⟨dqf, af⟩),⟨⟨x1, x2⟩, y⟩⟩
     · exact ⟨.inr x1.symm, toAgree.inj x2.symm⟩
-    · exact ⟨.inl ⟨dqf, x1⟩, Agree.toAgree_includedN.mp ⟨af, x2⟩⟩
+    · exact ⟨.inl ⟨dqf, OFE.Equiv.of_eq x1⟩, Agree.toAgree_includedN.mp ⟨af, x2⟩⟩
   · rcases H with ⟨(⟨z, HRz⟩| HRa2), HRb⟩
     · calc (●V{dq1} a1 : View R)
              ≼{n} ((●V{dq1} a1) • ((◯V b) • ●V{z} a1)) := by exists ((◯V b) • ●V{z} a1)
@@ -503,7 +497,7 @@ theorem auth_incN_auth_op_frag_iff : (●V{dq1} a1 : View R) ≼{n} ((●V{dq2} 
            _ ≼{n} (◯V b) • ●V{dq1 • z} a1 :=
               incN_of_incN_of_dist .rfl (op_ne.ne <| equiv_dist.mp (auth_op_auth_eqv.symm) _)
            _ ≼{n} (◯V b) • ●V{dq2} a2 :=
-             incN_of_incN_of_dist .rfl (op_ne.ne (NonExpansive₂.ne HRz.symm HRb))
+             incN_of_incN_of_dist .rfl (op_ne.ne (NonExpansive₂.ne HRz.symm.dist HRb))
            _ ≼{n} ((●V{dq2} a2) • ◯V b) := incN_of_incN_of_dist .rfl op_commN
     · exists (◯V b)
       refine (equiv_dist.mp comm _).trans ?_
@@ -531,7 +525,7 @@ theorem auth_inc_auth_op_frag_iff : ((●V{dq1} a1 : View R) ≼ (●V{dq2} a2 :
     · exists (◯V b)
       refine .trans CMRA.comm (.trans ?_ CMRA.comm )
       apply CMRA.op_ne.eqv
-      exact Hq ▸ NonExpansive₂.eqv rfl Ha.symm
+      exact Hq ▸ NonExpansive₂.eqv .rfl Ha.symm
 
 @[rocq_alias view_auth_includedN]
 theorem auth_one_incN_auth_one_op_frag_iff : (●V a1 : View R) ≼{n} ((●V a2) • ◯V b) ↔ a1 ≡{n}≡ a2 :=
@@ -561,7 +555,8 @@ open CMRA in
 @[rocq_alias view_frag_included]
 theorem frag_inc_auth_op_frag_iff : (◯V b1 : View R) ≼ ((●V{p} a) • ◯V b2) ↔ b1 ≼ b2 := by
   constructor
-  · rintro ⟨xf, ⟨_, Hb⟩⟩
+  · rintro ⟨xf, HH⟩
+    have Hb := fun n => (HH n).2
     have Hb' : b2 ≡ b1 • xf.frag := (UCMRA.unit_left_id).symm.trans Hb
     apply (inc_iff_right <| Hb'.symm).mp
     exists xf.frag
@@ -843,11 +838,10 @@ omit [OFE B] in
 theorem map_ext {f1 f2 : A → A'} {g1 g2 : B → B'} [OFE.NonExpansive f1] [OFE.NonExpansive f2]
     (v : View R) (h1 : ∀ a, f1 a ≡ f2 a) (h2 : ∀ b, g1 b ≡ g2 b) :
     View.map R' f1 g1 v ≡ View.map R' f2 g2 v := by
-  refine ⟨?_, h2 _⟩
-  simp only [View.map]
-  split
-  · rfl
-  · exact ⟨rfl, Agree.agree_map_ext h1⟩
+  refine OFE.Equiv.of_eq ?_
+  have hf : f1 = f2 := funext fun a => (h1 a).to_eq
+  have hg : g1 = g2 := funext fun b => (h2 b).to_eq
+  rw [hf, hg]
 
 omit [OFE B] in
 theorem map_ne {f1 f2 : A → A'} {g1 g2 : B → B'} [OFE.NonExpansive f1] [OFE.NonExpansive f2]
@@ -893,7 +887,7 @@ def mapC [OFE A] [UCMRA B] [OFE A'] [UCMRA B']
       exact ⟨f a1, ⟨OFE.NonExpansive.ne ha, H n a1 b hr⟩⟩
   pcore x := by
     simp [CMRA.pcore, map, CMRA.core, Option.getD]
-    constructor
+    refine OFE.NonExpansive₂.eqv ?_ ?_
     · rcases x.auth with _|⟨fr, a⟩ <;> simp [Prod.pcore]
       rcases (CMRA.pcore fr) <;> simp
       rcases h : (CMRA.pcore a) <;> cases h <;> simp [CMRA.pcore]
@@ -901,9 +895,12 @@ def mapC [OFE A] [UCMRA B] [OFE A'] [UCMRA B']
       rcases _ : (CMRA.pcore x.frag) <;>
       rcases _ : (CMRA.pcore (g.f x.frag)) <;> simp_all
   op x y := by
-    constructor <;> simp [CMRA.Hom.op, CMRA.op, map]
-    cases x.auth <;> cases y.auth <;> simp [Prod.op]
-    exact ⟨.rfl, (Agree.map f.f).op _ _⟩
+    rcases x with ⟨xa, xf⟩; rcases y with ⟨ya, yf⟩
+    simp only [CMRA.op, map]
+    refine OFE.NonExpansive₂.eqv ?_ ?_
+    · cases xa <;> cases ya <;> simp [CMRA.op, optionOp, Prod.op]
+      exact OFE.NonExpansive₂.eqv .rfl ((Agree.map f.f).op _ _)
+    · exact CMRA.Hom.op g xf yf
 
 end ViewMap
 

--- a/Iris/Iris/BI/Algebra.lean
+++ b/Iris/Iris/BI/Algebra.lean
@@ -26,18 +26,11 @@ theorem auth_op_frag_validI [Sbi PROP] (dp : DFrac) (m : H V) k dq v :
     ∃ v' dq', ⌜✓ dp⌝ ∧ ⌜get? m k = .some v'⌝ ∧ internalCmraValid (dq', v') ∧
       internalCmraIncluded (Option.some (dq, v)) (Option.some (dq', v')) := by
   suffices H :
-    (<si_pure> SiProp.cmraValid (HeapView.Auth dp m • Frag (H := H) k dq v) ⊣⊢@{PROP}
+    (<si_pure> SiProp.cmraValid (HeapView.Auth dp m • Frag k dq v) ⊣⊢@{PROP}
     (<si_pure> ∃ x x_1, ⌜✓ dp⌝ ∧ ⌜get? m k = some x⌝ ∧ SiProp.cmraValid (x_1, x) ∧
         ∃ c, internalEq (some (x_1, x)) (some (dq, v) • c))) by
-    refine H.trans ?_
-    refine siPure_exist.trans ?_
-    refine exists_congr fun v' => ?_
-    refine siPure_exist.trans ?_
-    refine exists_congr fun dq' => ?_
-    refine siPure_and.trans ?_
-    refine and_congr siPure_pure ?_
-    refine siPure_and.trans  ?_
-    exact and_congr siPure_pure siPure_and
+    simp only [internalCmraValid, internalCmraIncluded, H.to_eq, siPure_exist.to_eq,
+      siPure_and.to_eq, siPure_pure.to_eq, BIBase.BiEntails.rfl]
   constructor
   · refine siPure_mono fun n => ?_
     simp only [SiProp.cmraValid, auth_op_frag_validN_iff]
@@ -65,9 +58,8 @@ theorem auth_op_frag_validI [Sbi PROP] (dp : DFrac) (m : H V) k dq v :
 theorem auth_op_frag_one_validI [Sbi PROP] (dp : DFrac) (m : H V) k v :
   internalCmraValid (Auth dp m • Frag k (.own One.one) v) ⊣⊢@{PROP}
     ⌜✓ dp⌝ ∧ internalCmraValid v ∧ internalEq (get? m k) (.some v) := by
-  refine .trans ?_ (and_congr_right siPure_and)
-  refine .trans ?_ (and_congr_left siPure_pure)
-  refine .trans ?_ siPure_and
+  simp only [internalCmraValid, internalEq, ←siPure_and.to_eq]
+  rw [←siPure_pure.to_eq, ←siPure_and.to_eq]
   constructor
   · refine siPure_mono fun n => ?_
     simp only [SiProp.cmraValid, auth_op_frag_one_validN_iff]
@@ -81,15 +73,12 @@ theorem auth_op_frag_validI_total [Sbi PROP] [CMRA.IsTotal V] (dp : DFrac) (m : 
   internalCmraValid (Auth dp m • Frag k dq v) ⊢@{PROP}
     ∃ v', ⌜✓ dp⌝ ∧ ⌜✓ dq⌝ ∧ ⌜get? m k = .some v'⌝ ∧
       internalCmraValid v' ∧ internalCmraIncluded v v' := by
-  refine trans ?_
-    (siPure_exist.trans <|
-      exists_congr <|
-      fun v => siPure_and.trans <|
-      and_congr siPure_pure <|
-      siPure_and.trans <|
-      and_congr siPure_pure <|
-      siPure_and.trans <|
-      and_congr siPure_pure siPure_and).mp
+  suffices H : (<si_pure> SiProp.cmraValid (HeapView.Auth dp m • Frag k dq v) ⊢@{PROP}
+      <si_pure> (∃ v', ⌜✓ dp⌝ ∧ ⌜✓ dq⌝ ∧ ⌜get? m k = some v'⌝ ∧ SiProp.cmraValid v' ∧
+        ∃ c, internalEq v' (v • c))) by
+    simp only [internalCmraValid, internalCmraIncluded, siPure_exist.to_eq, siPure_and.to_eq,
+      siPure_pure.to_eq] at H ⊢
+    exact H
   refine siPure_mono fun n hvalid => ?_
   have ⟨v', Hdp, Hdq, Hlookup, Hv', ⟨z, Hincl⟩⟩ := auth_op_frag_validN_total_iff hvalid
   apply SiProp.instBI.sExists_intro
@@ -103,8 +92,7 @@ theorem auth_op_frag_validI_total [Sbi PROP] [CMRA.IsTotal V] (dp : DFrac) (m : 
 theorem frag_op_frag_validI [Sbi PROP] k dq1 dq2 v1 v2 :
   internalCmraValid (Frag (H := H) (V := V) k dq1 v1 • Frag k dq2 v2) ⊣⊢@{PROP}
     ⌜✓ (dq1 • dq2)⌝ ∧ internalCmraValid (v1 • v2) := by
-  refine .trans ?_ (and_congr_left siPure_pure)
-  refine .trans ?_ siPure_and
+  simp only [←(and_congr_left siPure_pure).to_eq, internalCmraValid, ←siPure_and.to_eq]
   constructor
   · refine siPure_mono fun n => ?_
     simp only [SiProp.cmraValid, frag_op_validN_iff]
@@ -206,8 +194,7 @@ variable [Sbi PROP] [UCMRA A]
 @[rocq_alias auth_auth_dfrac_validI]
 theorem auth_dfrac_validI (dq : DFrac) (a : A) :
     internalCmraValid (●{dq} a : Auth A) ⊣⊢@{PROP} ⌜✓ dq⌝ ∧ internalCmraValid a := by
-  refine .trans ?_ (and_congr_left siPure_pure)
-  refine .trans ?_ siPure_and
+  simp only [←(and_congr_left siPure_pure).to_eq, internalCmraValid, ←siPure_and.to_eq]
   refine ⟨siPure_mono fun n => ?_, siPure_mono fun n => ?_⟩
   all_goals simp only [SiProp.cmraValid, auth_dfrac_validN]; exact id
 
@@ -220,8 +207,8 @@ theorem auth_validI (a : A) : internalCmraValid (● a : Auth A) ⊣⊢@{PROP} i
 theorem auth_dfrac_op_validI (dq1 dq2 : DFrac) (a1 a2 : A) :
     internalCmraValid ((●{dq1} a1) • (●{dq2} a2)) ⊣⊢@{PROP}
       ⌜✓ (dq1 • dq2)⌝ ∧ internalEq a1 a2 ∧ internalCmraValid a1 := by
-  refine .trans ?_ (and_congr_left siPure_pure)
-  refine .trans ?_ (siPure_and.trans (and_congr_right siPure_and))
+  simp only [←(and_congr_left siPure_pure).to_eq, internalEq, internalCmraValid
+    , ←(siPure_and.trans (and_congr_right siPure_and)).to_eq]
   refine ⟨siPure_mono fun n => ?_, siPure_mono fun n => ?_⟩
   all_goals simp only [SiProp.cmraValid, auth_dfrac_op_validN]; exact id
 
@@ -235,9 +222,9 @@ theorem frag_validI (a : A) :
 theorem both_dfrac_validI (dq : DFrac) (a b : A) :
     internalCmraValid ((●{dq} a) • ◯ b) ⊣⊢@{PROP}
     ⌜✓ dq⌝ ∧ internalCmraIncluded b a ∧ internalCmraValid a := by
-  refine .trans ?_ <| siPure_and.trans (and_congr siPure_pure siPure_and)
+  simp only [internalCmraValid, internalCmraIncluded, ←(and_congr siPure_pure siPure_and).to_eq]
+  simp only [←siPure_and.to_eq, BI.and_exists_right.to_eq, BI.and_exists_left.to_eq]
   refine siPure_mono_bi ?_
-  refine .trans ?_ ((and_congr_right BI.and_exists_right).trans BI.and_exists_left).symm
   refine ⟨siPure_mono fun n => ?_, ?_⟩
   · simp only [both_dfrac_validN]
     intro ⟨hv, ⟨c, hi⟩, hvn⟩
@@ -252,9 +239,8 @@ theorem both_dfrac_validI (dq : DFrac) (a b : A) :
 theorem auth_both_validI (a b : A) :
     internalCmraValid ((● a : Auth A) • ◯ b) ⊣⊢@{PROP}
       internalCmraIncluded b a ∧ internalCmraValid a := by
-  refine .trans ?_ siPure_and
+  simp only [internalCmraIncluded, internalCmraValid, ←siPure_and.to_eq, BI.and_exists_right.to_eq]
   refine siPure_mono_bi ?_
-  refine .trans ?_ BI.and_exists_right.symm
   simp only [SiProp.cmraValid, both_dfrac_validN]
   refine ⟨fun n ⟨_, ⟨⟨c, hi⟩, hvn⟩⟩ => ?_, ?_⟩
   · apply SiProp.instBI.sExists_intro

--- a/Iris/Iris/BI/BI.lean
+++ b/Iris/Iris/BI/BI.lean
@@ -22,8 +22,6 @@ theorem liftRel_eq : liftRel (@Eq α) A B ↔ A = B := by
 
 /-- Require that a separation logic with carrier type `PROP` fulfills all necessary axioms. -/
 class BI (PROP : Type _) extends COFE PROP, BI.BIBase PROP where
-  Equiv P Q := P ⊣⊢ Q
-
   entails_preorder : Preorder Entails
   equiv_iff {P Q : PROP} : (P ≡ Q) ↔ P ⊣⊢ Q := by simp
 
@@ -97,7 +95,7 @@ theorem BIBase.Entails.of_eq [BI PROP] {P Q : PROP} (h : P = Q) : P ⊢ Q := h �
 
 theorem BIBase.BiEntails.of_eq [BI PROP] {P Q : PROP} (h : P = Q) : P ⊣⊢ Q := h ▸ .rfl
 
-theorem BIBase.BiEntails.to_eq [BI PROP] [Leibniz PROP] {P Q : PROP} (h : P ⊣⊢ Q) : P = Q := (equiv_iff.mpr h).to_eq
+theorem BIBase.BiEntails.to_eq [BI PROP] {P Q : PROP} (h : P ⊣⊢ Q) : P = Q := (equiv_iff.mpr h).to_eq
 
 theorem BIBase.BiEntails.symm [BI PROP] {P Q : PROP} (h : P ⊣⊢ Q) : Q ⊣⊢ P := ⟨h.2, h.1⟩
 

--- a/Iris/Iris/BI/BigOp/BigOp.lean
+++ b/Iris/Iris/BI/BigOp/BigOp.lean
@@ -45,7 +45,6 @@ instance orMonoidOps [BI PROP] : MonoidOps (or (PROP := PROP)) iprop(False) wher
     (hunit : f u₁ ≡ u₂) : MonoidHomomorphism op₁ op₂ u₁ u₂ (· ≡ ·) f where
   rel_refl := .rfl
   rel_trans := .trans
-  rel_proper ha hb := ⟨fun h => ha.symm.trans (h.trans hb), fun h => ha.trans (h.trans hb.symm)⟩
   op_proper ha hb := MonoidOps.op_proper ha hb
   map_ne := hne
   map_op := hop
@@ -58,7 +57,6 @@ instance orMonoidOps [BI PROP] : MonoidOps (or (PROP := PROP)) iprop(False) wher
     WeakMonoidHomomorphism op₁ op₂ u₁ u₂ (· ≡ ·) f where
   rel_refl := .rfl
   rel_trans := .trans
-  rel_proper ha hb := ⟨fun h => ha.symm.trans (h.trans hb), fun h => ha.trans (h.trans hb.symm)⟩
   op_proper ha hb := MonoidOps.op_proper ha hb
   map_ne := hne
   map_op := hop
@@ -449,8 +447,6 @@ instance bi_persistently_sep_entails_weak_homomorphism [BI PROP] :
     WeakMonoidHomomorphism (sep (PROP := PROP)) sep emp emp (flip Entails) persistently where
   rel_refl := .rfl
   rel_trans := flip .trans
-  rel_proper H G := ⟨fun J => (equiv_iff.1 G).mpr.trans (J.trans (equiv_iff.1 H).mp),
-                     fun J => (equiv_iff.1 G).mp.trans (J.trans (equiv_iff.1 H).mpr)⟩
   op_proper := sep_mono
   map_ne := BI.persistently_ne
   map_op := persistently_sep_mpr
@@ -460,8 +456,6 @@ instance bi_persistently_sep_entails_homomorphism [BI PROP] :
     MonoidHomomorphism (sep (PROP := PROP)) sep emp emp (flip Entails) persistently where
   rel_refl := .rfl
   rel_trans := flip .trans
-  rel_proper H G := ⟨fun J => (equiv_iff.1 G).mpr.trans (J.trans (equiv_iff.1 H).mp),
-                     fun J => (equiv_iff.1 G).mp.trans (J.trans (equiv_iff.1 H).mpr)⟩
   op_proper := sep_mono
   map_ne := BI.persistently_ne
   map_op := persistently_sep_mpr

--- a/Iris/Iris/BI/BigOp/BigSepMap.lean
+++ b/Iris/Iris/BI/BigOp/BigSepMap.lean
@@ -41,10 +41,10 @@ theorem bigSepM_eqv_of_perm {Φ : K → V → PROP} {m₁ m₂ : M V} (h : m₁ 
     ([∗map] k ↦ v ∈ m₁, Φ k v) ⊣⊢ ([∗map] k ↦ v ∈ m₂, Φ k v) :=
   equiv_iff.mp (bigOpM_eqv_of_perm _ h)
 
-/-- A `bigSepM` over a map equivalent to the empty map is `emp`. -/
-theorem bigSepM_eqv_empty {Φ : K → V → PROP} {m : M V} (h : m ≡ₘ ∅) :
-    ([∗map] k ↦ v ∈ m, Φ k v) ⊣⊢ emp :=
-  (bigSepM_eqv_of_perm h).trans bigSepM_empty
+/-- A `bigSepM` over the empty map is `emp`. -/
+theorem bigSepM_eqv_empty {Φ : K → V → PROP} {m : M V} (h : m = ∅) :
+    ([∗map] k ↦ v ∈ m, Φ k v) ⊣⊢ emp := by
+  rw [h]; exact bigSepM_empty
 
 @[rocq_alias big_sepM_singleton]
 theorem bigSepM_singleton {Φ : K → V → PROP} {i : K} {x : V} :
@@ -438,7 +438,7 @@ theorem bigSepM_union [DecidableEq K] {Φ : K → V → PROP} {m₁ m₂ : M V} 
 theorem bigSepM_subseteq [DecidableEq K] {Φ : K → V → PROP} {m₁ m₂ : M V}
     [∀ k v, Affine (Φ k v)] (h : m₂ ⊆ m₁) :
     ([∗map] k ↦ x ∈ m₁, Φ k x) ⊢ [∗map] k ↦ x ∈ m₂, Φ k x :=
-  (equiv_iff.mp <| bigOpM_eqv_of_perm Φ <| union_difference_cancel h).2.trans <|
+  (equiv_iff.mp <| bigOpM_eqv_of_perm Φ <| equiv_iff_eq.mpr <| union_difference_cancel h).2.trans <|
   (bigSepM_union disjoint_difference_right).1.trans sep_elim_left
 
 -- FIXME: Refactor for readability
@@ -499,19 +499,7 @@ theorem bigSepM_impl_strong [DecidableEq K] {M₂ : Type _ → Type _} {V₂ : T
     ⊢ ([∗map] k ↦ y ∈ m₂, Ψ k y) ∗
       [∗map] k ↦ x ∈ filter (fun k _ => (get? m₂ k).isNone) m₁, Φ k x
   suffices P m₂ from this m₁
-  refine LawfulFiniteMap.induction_on (fun _ _ heq IH m₁ => ?hequiv) ?hemp ?hind m₂
-  case hequiv =>
-    refine (sep_mono_right ?_).trans <| (IH m₁).trans ?_
-    · refine intuitionistically_mono ?_
-      refine forall_mono fun k => ?_
-      refine forall_mono fun y => ?_
-      refine wand_mono_right ?_
-      refine imp_intro_swap ?_
-      refine pure_elim_left ?_
-      refine fun hget => pure_imp_elim (heq k ▸ hget)
-    refine sep_mono (equiv_iff.mp <| bigOpM_eqv_of_perm Ψ heq).1 ?_
-    refine (equiv_iff.mp <| bigOpM_eqv_of_perm Φ ?_).1
-    exact fun k => by cases get? m₁ k <;> simp [get?_filter, heq k]
+  refine LawfulFiniteMap.induction_on ?hemp ?hind m₂
   case hemp =>
     refine fun m₁ => ?_
     refine (sep_mono_right Affine.affine).trans ?_

--- a/Iris/Iris/BI/DerivedLawsLater.lean
+++ b/Iris/Iris/BI/DerivedLawsLater.lean
@@ -193,8 +193,6 @@ instance bi_later_monoid_sep_entails_weak_homomorphism :
     Iris.Algebra.WeakMonoidHomomorphism (sep (PROP := PROP)) sep emp emp (flip Entails) later where
   rel_refl := .rfl
   rel_trans := flip .trans
-  rel_proper H G := ⟨fun J => (equiv_iff.1 G).mpr.trans (J.trans (equiv_iff.1 H).mp),
-                     fun J => (equiv_iff.1 G).mp.trans (J.trans (equiv_iff.1 H).mpr)⟩
   op_proper := sep_mono
   map_ne := BI.later_ne
   map_op := later_sep.mpr
@@ -204,8 +202,6 @@ instance bi_later_monoid_sep_entails_homomorphism :
     Iris.Algebra.MonoidHomomorphism (sep (PROP := PROP)) sep emp emp (flip Entails) later where
   rel_refl := .rfl
   rel_trans := flip .trans
-  rel_proper H G := ⟨fun J => (equiv_iff.1 G).mpr.trans (J.trans (equiv_iff.1 H).mp),
-                     fun J => (equiv_iff.1 G).mp.trans (J.trans (equiv_iff.1 H).mpr)⟩
   op_proper := sep_mono
   map_ne := BI.later_ne
   map_op := later_sep.mpr
@@ -444,8 +440,6 @@ instance bi_laterN_sep_entails_weak_homomorphism (n : Nat) :
       (iprop(▷^[n] · )) where
   rel_refl := .rfl
   rel_trans := flip .trans
-  rel_proper H G := ⟨fun J => (equiv_iff.1 G).mpr.trans (J.trans (equiv_iff.1 H).mp),
-                     fun J => (equiv_iff.1 G).mp.trans (J.trans (equiv_iff.1 H).mpr)⟩
   op_proper := sep_mono
   map_ne := laterN_ne n
   map_op := (laterN_sep n).mpr
@@ -456,8 +450,6 @@ instance bi_laterN_sep_entails_homomorphism (n : Nat) :
       (iprop(▷^[n] · )) where
   rel_refl := .rfl
   rel_trans := flip .trans
-  rel_proper H G := ⟨fun J => (equiv_iff.1 G).mpr.trans (J.trans (equiv_iff.1 H).mp),
-                     fun J => (equiv_iff.1 G).mp.trans (J.trans (equiv_iff.1 H).mpr)⟩
   op_proper := sep_mono
   map_ne := laterN_ne n
   map_op := (laterN_sep n).mpr
@@ -645,8 +637,6 @@ instance bi_except0_sep_entails_weak_homomorphism :
       (iprop(◇ ·)) where
   rel_refl := .rfl
   rel_trans := flip .trans
-  rel_proper H G := ⟨fun J => (equiv_iff.1 G).mpr.trans (J.trans (equiv_iff.1 H).mp),
-                     fun J => (equiv_iff.1 G).mp.trans (J.trans (equiv_iff.1 H).mpr)⟩
   op_proper := sep_mono
   map_ne := except0_ne
   map_op := except0_sep.mpr
@@ -657,8 +647,6 @@ instance bi_except0_sep_entails_homomorphism :
       (iprop(◇ ·)) where
   rel_refl := .rfl
   rel_trans := flip .trans
-  rel_proper H G := ⟨fun J => (equiv_iff.1 G).mpr.trans (J.trans (equiv_iff.1 H).mp),
-                     fun J => (equiv_iff.1 G).mp.trans (J.trans (equiv_iff.1 H).mpr)⟩
   op_proper := sep_mono
   map_ne := except0_ne
   map_op := except0_sep.mpr

--- a/Iris/Iris/BI/Embedding.lean
+++ b/Iris/Iris/BI/Embedding.lean
@@ -325,7 +325,6 @@ instance embed_timeless [BiEmbedLater PROP1 PROP2] (P : PROP1) [Timeless P] :
     MonoidHomomorphism op₁ op₂ u₁ u₂ (· ≡ ·) (embed (A := PROP1) (B := PROP2)) where
   rel_refl := .rfl
   rel_trans := .trans
-  rel_proper ha hb := ⟨fun h => ha.symm.trans (h.trans hb), fun h => ha.trans (h.trans hb.symm)⟩
   op_proper ha hb := MonoidOps.op_proper ha hb
   map_ne := embed_ne
   map_op := hop
@@ -349,8 +348,6 @@ instance embed_sep_entails_homomorphism :
       (flip Entails) (embed (A := PROP1) (B := PROP2)) where
   rel_refl := .rfl
   rel_trans := flip .trans
-  rel_proper H G := ⟨fun J => (equiv_iff.1 G).mpr.trans (J.trans (equiv_iff.1 H).mp),
-                     fun J => (equiv_iff.1 G).mp.trans (J.trans (equiv_iff.1 H).mpr)⟩
   op_proper := sep_mono
   map_ne := embed_ne
   map_op := fun {x y} => (embed_sep x y).mpr

--- a/Iris/Iris/BI/Lib/FixpointBanach.lean
+++ b/Iris/Iris/BI/Lib/FixpointBanach.lean
@@ -20,8 +20,8 @@ theorem fixpoint_plain [Sbi PROP] {A : Type _} (F : (A → PROP) → A → PROP)
   refine ContractiveHom.fixpoint_ind ⟨F, inferInstance⟩ (fun f => ∀ x, Plain (f x)) ?_
       (fun _ => iprop(emp)) inferInstance HΦ ?_
   · intro _ _ H HP x
-    refine ⟨.trans (.trans (equiv_iff.mp (H x)).mpr (HP x).plain) ?_⟩
-    exact plainly_mono (equiv_iff.mp (H x)).mp
+    refine ⟨.trans (.trans (equiv_iff.mp (fun n => H n x)).mpr (HP x).plain) ?_⟩
+    exact plainly_mono (equiv_iff.mp (fun n => H n x)).mp
   · refine LimitPreserving.forall _ (fun _ => ?_)
     refine limitPreserving_plain (Φne := ⟨fun _ _ _ h => h _⟩)
 
@@ -33,8 +33,8 @@ theorem fixpoint_persistent [BI PROP] {A : Type _} (F : (A → PROP) → A → P
   refine ContractiveHom.fixpoint_ind ⟨F, inferInstance⟩ (fun f => ∀ x, Persistent (f x)) ?_
       (fun _ => iprop(emp)) inferInstance HΦ ?_
   · intro _ _ H HP x
-    refine ⟨.trans (.trans (equiv_iff.mp (H x)).mpr (HP x).persistent) ?_⟩
-    exact persistently_mono (equiv_iff.mp (H x)).mp
+    refine ⟨.trans (.trans (equiv_iff.mp (fun n => H n x)).mpr (HP x).persistent) ?_⟩
+    exact persistently_mono (equiv_iff.mp (fun n => H n x)).mp
   · refine LimitPreserving.forall _ (fun _ => ?_)
     exact limitPreserving_persistent _ (Φne := ⟨fun _ _ _ h => h _⟩)
 
@@ -46,8 +46,8 @@ theorem fixpoint_absorbing [BI PROP] {A : Type _} (F : (A → PROP) → A → PR
   refine ContractiveHom.fixpoint_ind ⟨F, inferInstance⟩ (fun f => ∀ x, Absorbing (f x)) ?_
       (fun _ => iprop(True)) inferInstance HΦ ?_
   · intro _ _ H HP x
-    refine ⟨.trans (absorbingly_mono (equiv_iff.mp (H x)).mpr) ?_⟩
-    exact (HP x).absorbing.trans (equiv_iff.mp (H x)).mp
+    refine ⟨.trans (absorbingly_mono (equiv_iff.mp (fun n => H n x)).mpr) ?_⟩
+    exact (HP x).absorbing.trans (equiv_iff.mp (fun n => H n x)).mp
   · refine LimitPreserving.forall _ (fun _ => ?_)
     exact limitPreserving_absorbing _ (Φne := ⟨fun _ _ _ h => h _⟩)
 
@@ -58,7 +58,7 @@ theorem fixpoint_affine [BI PROP] {A : Type _} (F : (A → PROP) → A → PROP)
   refine ContractiveHom.fixpoint_ind ⟨F, inferInstance⟩ (fun f => ∀ x, Affine (f x)) ?_
       (fun _ => iprop(emp)) inferInstance HΦ ?_
   · intro _ _ H HP x
-    exact ⟨.trans (.trans (equiv_iff.mp (H x)).mpr (HP x).affine) .rfl⟩
+    exact ⟨.trans (.trans (equiv_iff.mp (fun n => H n x)).mpr (HP x).affine) .rfl⟩
   · refine LimitPreserving.forall _ (fun _ => ?_)
     exact limitPreserving_affine _ (Φne := ⟨fun _ _ _ h => h _⟩)
 
@@ -76,10 +76,10 @@ theorem fixpoint_persistent_absorbing [BI PROP] {A : Type _}
       (fun x H => HΦ _ (fun x => (H x).left) (fun x => (H x).right)) ?_
   · intro _ _ H HP x
     refine ⟨⟨?_⟩, ⟨?_⟩⟩
-    · refine .trans (.trans (equiv_iff.mp (H x)).mpr (HP x).left.persistent) ?_
-      exact persistently_mono (equiv_iff.mp (H x)).mp
-    · refine (absorbingly_mono (equiv_iff.mp (H x)).mpr).trans ?_
-      exact (HP x).right.absorbing.trans (equiv_iff.mp (H x)).mp
+    · refine .trans (.trans (equiv_iff.mp (fun n => H n x)).mpr (HP x).left.persistent) ?_
+      exact persistently_mono (equiv_iff.mp (fun n => H n x)).mp
+    · refine (absorbingly_mono (equiv_iff.mp (fun n => H n x)).mpr).trans ?_
+      exact (HP x).right.absorbing.trans (equiv_iff.mp (fun n => H n x)).mp
   · refine LimitPreserving.forall _ (fun _ => ?_)
     refine LimitPreserving.and ?_ ?_
     · exact limitPreserving_persistent _ (Φne := ⟨fun _ _ _ h => h _⟩)
@@ -98,9 +98,9 @@ theorem fixpoint_persistent_affine [BI PROP] {A : Type _}
       (fun x H => HΦ _ (fun x => (H x).left) (fun x => (H x).right)) ?_
   · intro _ _ H HP x
     refine ⟨⟨?_⟩, ⟨?_⟩⟩
-    · refine .trans (.trans (equiv_iff.mp (H x)).mpr (HP x).left.persistent) ?_
-      exact persistently_mono (equiv_iff.mp (H x)).mp
-    · exact .trans (.trans (equiv_iff.mp (H x)).mpr (HP x).right.affine) .rfl
+    · refine .trans (.trans (equiv_iff.mp (fun n => H n x)).mpr (HP x).left.persistent) ?_
+      exact persistently_mono (equiv_iff.mp (fun n => H n x)).mp
+    · exact .trans (.trans (equiv_iff.mp (fun n => H n x)).mpr (HP x).right.affine) .rfl
   · refine LimitPreserving.forall _ (fun _ => ?_)
     refine LimitPreserving.and ?_ ?_
     · exact limitPreserving_persistent _ (Φne := ⟨fun _ _ _ h => h _⟩)
@@ -120,10 +120,10 @@ theorem fixpoint_plain_absorbing [Sbi PROP] {A : Type _}
       (fun x H => HΦ _ (fun x => (H x).left) (fun x => (H x).right)) ?_
   · intro _ _ H HP x
     refine ⟨⟨?_⟩, ⟨?_⟩⟩
-    · refine .trans (.trans (equiv_iff.mp (H x)).mpr (HP x).left.plain) ?_
-      exact plainly_mono (equiv_iff.mp (H x)).mp
-    · refine (absorbingly_mono (equiv_iff.mp (H x)).mpr).trans ?_
-      exact (HP x).right.absorbing.trans (equiv_iff.mp (H x)).mp
+    · refine .trans (.trans (equiv_iff.mp (fun n => H n x)).mpr (HP x).left.plain) ?_
+      exact plainly_mono (equiv_iff.mp (fun n => H n x)).mp
+    · refine (absorbingly_mono (equiv_iff.mp (fun n => H n x)).mpr).trans ?_
+      exact (HP x).right.absorbing.trans (equiv_iff.mp (fun n => H n x)).mp
   · refine LimitPreserving.forall _ (fun _ => ?_)
     refine LimitPreserving.and ?_ ?_
     · exact limitPreserving_plain _ (Φne := ⟨fun _ _ _ h => h _⟩)
@@ -142,9 +142,9 @@ theorem fixpoint_plain_affine [Sbi PROP] {A : Type _}
       (fun x H => HΦ _ (fun x => (H x).left) (fun x => (H x).right)) ?_
   · intro _ _ H HP x
     refine ⟨⟨?_⟩, ⟨?_⟩⟩
-    · refine .trans (.trans (equiv_iff.mp (H x)).mpr (HP x).left.plain) ?_
-      exact plainly_mono (equiv_iff.mp (H x)).mp
-    · exact .trans (.trans (equiv_iff.mp (H x)).mpr (HP x).right.affine) .rfl
+    · refine .trans (.trans (equiv_iff.mp (fun n => H n x)).mpr (HP x).left.plain) ?_
+      exact plainly_mono (equiv_iff.mp (fun n => H n x)).mp
+    · exact .trans (.trans (equiv_iff.mp (fun n => H n x)).mpr (HP x).right.affine) .rfl
   · refine LimitPreserving.forall _ (fun _ => ?_)
     refine LimitPreserving.and ?_ ?_
     · exact limitPreserving_plain _ (Φne := ⟨fun _ _ _ h => h _⟩)

--- a/Iris/Iris/BI/Lib/GenHeap.lean
+++ b/Iris/Iris/BI/Lib/GenHeap.lean
@@ -353,8 +353,8 @@ section updateLemmas
 
 /-- The state interpretation transports along a pointwise equivalence of
 the value heap. -/
-theorem genHeapInterp_eqv {σ₁ σ₂ : H V} (h : σ₁ = σ₂) :
-    genHeapInterp (GF := GF) σ₁ ⊢ genHeapInterp σ₂ := h ▸ .rfl
+theorem genHeapInterp_eqv {σ₁ σ₂ : H V} (h : σ₁ ≡ₘ σ₂) :
+    genHeapInterp (GF := GF) σ₁ ⊢ genHeapInterp σ₂ := equiv_iff_eq.mp h ▸ .rfl
 
 @[rocq_alias gen_heap_alloc]
 theorem genHeap_alloc [DecidableEq L] {σ : H V} {l : L} {v : V} (Hσl : get? σ l = .none) :
@@ -392,7 +392,7 @@ theorem genHeap_alloc_big [DecidableEq L] (σ' σ : H V) (Hdisj : σ' ##ₘ σ) 
     iintro Hσ
     imodintro
     isplitl [Hσ]
-    · iapply genHeapInterp_eqv LawfulPartialMap.union_empty_left.symm $$ Hσ
+    · iapply genHeapInterp_eqv (equiv_iff_eq.mpr LawfulPartialMap.union_empty_left.symm) $$ Hσ
     isplit <;> (iapply BigSepM.bigSepM_empty; itrivial)
   | hins l v σ'' Hl IH =>
     intro σ Hdisj
@@ -404,7 +404,7 @@ theorem genHeap_alloc_big [DecidableEq L] (σ' σ : H V) (Hdisj : σ' ##ₘ σ) 
     imod genHeap_alloc Hunion_l $$ Hint with ⟨Hint', Hl_pts, Hl_tok⟩
     imodintro
     isplitl [Hint']
-    · iapply genHeapInterp_eqv LawfulPartialMap.union_insert_left $$ Hint'
+    · iapply genHeapInterp_eqv (equiv_iff_eq.mpr LawfulPartialMap.union_insert_left) $$ Hint'
     isplitl [Hl_pts Hpts]
     · iapply (BigSepM.bigSepM_insert Hl) $$ [$Hpts $Hl_pts]
     iapply (BigSepM.bigSepM_insert (Φ := fun l _ => iprop(metaToken l ⊤)) Hl) $$ [$Hl_tok $Htok]
@@ -471,7 +471,7 @@ theorem genHeap_init_names [DecidableEq L] [genHeapPreS L V GF H] (σ : H V) :
   imodintro
   iexists γh, γm
   iframe Hpts Htok
-  iapply genHeapInterp_eqv LawfulPartialMap.union_empty_right $$ Hinterp
+  iapply genHeapInterp_eqv (equiv_iff_eq.mpr LawfulPartialMap.union_empty_right) $$ Hinterp
 
 /-- Initialize `genHeapGS` from a `genHeapPreS`, hiding the freshly allocated
 ghost names. -/

--- a/Iris/Iris/BI/Lib/GenHeap.lean
+++ b/Iris/Iris/BI/Lib/GenHeap.lean
@@ -353,16 +353,8 @@ section updateLemmas
 
 /-- The state interpretation transports along a pointwise equivalence of
 the value heap. -/
-theorem genHeapInterp_eqv {σ₁ σ₂ : H V} (h : σ₁ ≡ₘ σ₂) :
-    genHeapInterp (GF := GF) σ₁ ⊢ genHeapInterp σ₂ := by
-  unfold genHeapInterp
-  iintro ⟨%m, %Hdom, Hh, Hm⟩
-  iexists m
-  isplitr
-  · ipureintro
-    exact fun k hk => by unfold dom; rw [← h k]; exact Hdom k hk
-  iframe Hm
-  apply iOwn_mono (HeapView.auth_inc_of_pmap_eqv _ (LawfulPartialMap.map_equiv h.symm))
+theorem genHeapInterp_eqv {σ₁ σ₂ : H V} (h : σ₁ = σ₂) :
+    genHeapInterp (GF := GF) σ₁ ⊢ genHeapInterp σ₂ := h ▸ .rfl
 
 @[rocq_alias gen_heap_alloc]
 theorem genHeap_alloc [DecidableEq L] {σ : H V} {l : L} {v : V} (Hσl : get? σ l = .none) :
@@ -395,19 +387,6 @@ theorem genHeap_alloc_big [DecidableEq L] (σ' σ : H V) (Hdisj : σ' ##ₘ σ) 
         ([∗map] l↦_v ∈ σ', metaToken l ⊤)) := by
   revert σ Hdisj
   induction σ' using LawfulFiniteMap.induction_on with
-  | hequiv σ₁ σ₂ heqv IH =>
-    intro σ Hdisj
-    have Hdisj₁ : σ₁ ##ₘ σ := fun k ⟨h1, h2⟩ => Hdisj k ⟨by rw [← heqv k]; exact h1, h2⟩
-    have hUnion : (σ₁ ∪ σ) ≡ₘ (σ₂ ∪ σ) :=
-      LawfulPartialMap.union_equiv heqv Std.PartialMap.equiv.refl
-    iintro Hσ
-    imod IH σ Hdisj₁ $$ Hσ with ⟨Hint, Hpts, Htok⟩
-    imodintro
-    isplitl [Hint]
-    · iapply genHeapInterp_eqv hUnion $$ Hint
-    isplitl [Hpts]
-    · iapply (BigSepM.bigSepM_eqv_of_perm (Φ := fun l v => iprop(l ↦ v)) heqv) $$ Hpts
-    iapply (BigSepM.bigSepM_eqv_of_perm (Φ := fun l _ => iprop(metaToken l ⊤)) heqv) $$ Htok
   | hemp =>
     intro σ _
     iintro Hσ

--- a/Iris/Iris/BI/Lib/GenHeap.lean
+++ b/Iris/Iris/BI/Lib/GenHeap.lean
@@ -29,7 +29,7 @@ rationale.  To implement the meta machinery we use two extra pieces of ghost
 state in addition to the value map:
 
 - a `ghost_map L gname`, which associates a ghost name with each location;
-- for each such ghost name, a `ReservationMap (Agree (LeibnizO Pos))` storing
+- for each such ghost name, a `ReservationMap (Agree (DiscreteO Pos))` storing
   the actual meta data.  The indirection is required so that `meta_set` is a
   frame-preserving update that does not need to inspect `genHeapInterp`. -/
 
@@ -39,7 +39,7 @@ tree maps over positives. -/
 abbrev MetaResMap (x : Sort _) : Sort _ := Std.ExtTreeMap Pos x compare
 
 /-- The CMRA used to store the meta-data attached to a single location. -/
-abbrev MetaUR : Sort _ := ReservationMap (Agree (LeibnizO Pos)) MetaResMap
+abbrev MetaUR : Sort _ := ReservationMap (Agree (DiscreteO Pos)) MetaResMap
 
 @[rocq_alias gen_heapGpreS]
 class genHeapPreS (L V : Type _) (GF : BundledGFunctors) (H : outParam <| Type _ → Type _)
@@ -289,14 +289,14 @@ theorem meta_agree {A : Type _} [Pos.Countable A] {l : L} {N : Namespace} {x1 x2
   ipureintro
   rw [valid_iff (ReservationMap.singleton_op _ _ _).symm
     , ReservationMap.valid_singleton, toAgree_op_valid_iff_eq] at Hvalid
-  exact Pos.encode_inj (LeibnizO.eqv_inj Hvalid)
+  exact Pos.encode_inj (DiscreteO.eqv_inj (OFE.Equiv.of_eq Hvalid))
 
 @[rocq_alias meta_set]
 theorem meta_set {A : Type _} [Pos.Countable A] {l : L} {E : CoPset} {N : Namespace} (x : A)
     (he : (↑N : CoPset) ⊆ E) : metaToken (GF := GF) l E ==∗ metaInfo l N x := by
   unfold metaToken metaInfo
   iintro ⟨%γm, #Hγm, Hm⟩
-  imod iOwn_update (ReservationMap.alloc (a := toAgree (⟨Pos.Countable.encode x⟩ : LeibnizO Pos))
+  imod iOwn_update (ReservationMap.alloc (a := toAgree (⟨Pos.Countable.encode x⟩ : DiscreteO Pos))
     (he _ (coPpick_nclose N)) Agree.toAgree_valid) $$ Hm with Hm
   imodintro
   iexists γm

--- a/Iris/Iris/BI/MonPred.lean
+++ b/Iris/Iris/BI/MonPred.lean
@@ -96,13 +96,14 @@ variable {I : BiIndex} {PROP : Type _} [BI PROP]
 (Rocq `monPredO`). -/
 @[rocq_alias monPredO]
 instance : OFE (MonPred I PROP) where
-  Equiv P Q := ∀ i, P.monPred_at i ≡ Q.monPred_at i
   Dist n P Q := ∀ i, P.monPred_at i ≡{n}≡ Q.monPred_at i
   dist_eqv :=
     { refl _ _ := dist_eqv.refl _
       symm h i := dist_eqv.symm (h i)
       trans h1 h2 i := dist_eqv.trans (h1 i) (h2 i) }
-  equiv_dist {_ _} := by simp only [equiv_dist]; exact forall_comm
+  eq_dist {P Q} := by
+    refine ⟨fun h _ _ => h ▸ .rfl, fun h => ?_⟩
+    exact MonPred.ext fun i => eq_dist.mpr fun n => h n i
   dist_lt h1 h2 i := dist_lt (h1 i) h2
 
 #rocq_ignore monPred_ofe_mixin "Rocq mixin record; subsumed by the OFE instance."
@@ -376,7 +377,7 @@ theorem entails_at {P Q : MonPred I PROP} :
 
 @[rocq_alias monPred_at_equiv]
 theorem equiv_at {P Q : MonPred I PROP} :
-    (P ≡ Q) ↔ ∀ i, P.monPred_at i ≡ Q.monPred_at i := Iff.rfl
+    (P ≡ Q) ↔ ∀ i, P.monPred_at i ≡ Q.monPred_at i := forall_comm
 
 @[rocq_alias monPred_at_dist]
 theorem dist_at {n : Nat} {P Q : MonPred I PROP} :

--- a/Iris/Iris/BI/MonPred.lean
+++ b/Iris/Iris/BI/MonPred.lean
@@ -1257,7 +1257,6 @@ open Iris.BI.BigSepL Iris.BI.BigSepM Iris.BI.BigSepS
     MonoidHomomorphism op₁ op₂ u₁ u₂ (· ≡ ·) (fun P : MonPred I PROP => P.monPred_at i) where
   rel_refl := .rfl
   rel_trans := .trans
-  rel_proper ha hb := ⟨fun h => ha.symm.trans (h.trans hb), fun h => ha.trans (h.trans hb.symm)⟩
   op_proper ha hb := MonoidOps.op_proper ha hb
   map_ne := monPred_at_ne i
   map_op := hop
@@ -1333,9 +1332,6 @@ instance monPred_objectively_monoid_sep_entails_homomorphism :
       (flip Entails) MonPred.objectively where
   rel_refl {a} := show a ⊢ a from BIBase.Entails.rfl
   rel_trans {a b c} h1 h2 := BIBase.Entails.trans (show c ⊢ b from h2) (show b ⊢ a from h1)
-  rel_proper H G :=
-    ⟨fun J => BIBase.Entails.trans (equiv_iff.1 G).mpr (BIBase.Entails.trans J (equiv_iff.1 H).mp),
-     fun J => BIBase.Entails.trans (equiv_iff.1 G).mp (BIBase.Entails.trans J (equiv_iff.1 H).mpr)⟩
   op_proper {a a' b b'} h1 h2 := sep_mono (show a' ⊢ a from h1) (show b' ⊢ b from h2)
   map_ne := monPred_objectively_ne
   map_op := fun {x y} => monPred_objectively_sep_2 x y

--- a/Iris/Iris/BI/Plainly.lean
+++ b/Iris/Iris/BI/Plainly.lean
@@ -432,7 +432,6 @@ instance plainly_sep_weak_homomorphism [BIPositive PROP][BIAffine PROP] :
     (BIBase.plainly (PROP := PROP)) where
   rel_refl := .rfl
   rel_trans := .trans
-  rel_proper := BIBase.BiEntails.proper
   op_proper aa' bb' := equiv_iff.1 (sep_ne.eqv (equiv_iff.2 aa') (equiv_iff.2 bb'))
   map_ne := inferInstance
   map_op := plainly_sep
@@ -442,7 +441,6 @@ instance plainly_and_weak_homomorphism :
     (BIBase.plainly (PROP := PROP)) where
   rel_refl := .rfl
   rel_trans := .trans
-  rel_proper := BIBase.BiEntails.proper
   op_proper aa' bb' := equiv_iff.1 (and_ne.eqv (equiv_iff.2 aa') (equiv_iff.2 bb'))
   map_ne := inferInstance
   map_op := plainly_and
@@ -452,7 +450,6 @@ instance plainly_or_weak_homomorphism [SbiEmpValidExist PROP] :
     (BIBase.plainly (PROP := PROP)) where
   rel_refl := .rfl
   rel_trans := .trans
-  rel_proper := BIBase.BiEntails.proper
   op_proper aa' bb' := equiv_iff.1 (or_ne.eqv (equiv_iff.2 aa') (equiv_iff.2 bb'))
   map_ne := inferInstance
   map_op := plainly_or
@@ -475,8 +472,6 @@ instance plainly_sep_entails_weak_homomorphism :
       (BIBase.plainly (PROP := PROP)) where
   rel_refl := .rfl
   rel_trans := flip .trans
-  rel_proper H G := ⟨fun J => (equiv_iff.1 G).mpr.trans (J.trans (equiv_iff.1 H).mp),
-                     fun J => (equiv_iff.1 G).mp.trans (J.trans (equiv_iff.1 H).mpr)⟩
   op_proper := sep_mono
   map_ne := inferInstance
   map_op := plainly_sep_2
@@ -487,8 +482,6 @@ instance plainly_sep_entails_homomorphism [BIAffine PROP] :
       (BIBase.plainly (PROP := PROP)) where
   rel_refl := .rfl
   rel_trans := flip .trans
-  rel_proper H G := ⟨fun J => (equiv_iff.1 G).mpr.trans (J.trans (equiv_iff.1 H).mp),
-                     fun J => (equiv_iff.1 G).mp.trans (J.trans (equiv_iff.1 H).mpr)⟩
   op_proper := sep_mono
   map_ne := inferInstance
   map_op := plainly_sep_2

--- a/Iris/Iris/BI/Plainly.lean
+++ b/Iris/Iris/BI/Plainly.lean
@@ -688,13 +688,6 @@ instance bigSepM_plain {K} [DecidableEq K] {M A} [ι : LawfulFiniteMap M K] (Φ 
     Plain ([∗map] k↦x ∈ m, Φ k x) where
   plain := by
     induction m using Iris.Std.LawfulFiniteMap.induction_on
-    case hequiv m₁ m₂ m₁m₂ H =>
-      have h : iprop([∗map] k ↦ x ∈ m₁, Φ k x) ≡ [∗map] k ↦ x ∈ m₂, Φ k x :=
-          Algebra.BigOpM.bigOpM_eqv_of_perm (M' := M) _ m₁m₂
-      calc iprop([∗map] k ↦ x ∈ m₂, Φ k x)
-        _ ⊣⊢ [∗map] k ↦ x ∈ m₁, Φ k x := BI.equiv_iff.1 h |>.symm
-        _  ⊢ ■ [∗map] k ↦ x ∈ m₁, Φ k x := H
-        _ ⊣⊢ ■ [∗map] k ↦ x ∈ m₂, Φ k x := .ofMono plainly_mono <| BI.equiv_iff.1 h
     case hemp =>
       simp only [Algebra.BigOpM.bigOpM_empty, plain]
     case hins k v m get?_m_k IH=>

--- a/Iris/Iris/BI/SIProp.lean
+++ b/Iris/Iris/BI/SIProp.lean
@@ -110,13 +110,16 @@ def later (P : SiProp) : SiProp where
 def entails (P Q : SiProp) : Prop := ∀ n, P.holds n → Q.holds n
 
 instance : OFE SiProp where
-  Equiv P Q := ∀ {n}, P.holds n ↔ Q.holds n
   Dist n P Q := ∀ {m}, m ≤ n → (P.holds m ↔ Q.holds m)
   dist_eqv.refl _ _ _ := Iff.rfl
   dist_eqv.symm h _ hle := (h hle).symm
   dist_eqv.trans h₁ h₂ _ hle := (h₁ hle).trans (h₂ hle)
-  equiv_dist.mp heq _ _ _ := heq
-  equiv_dist.mpr h n := h n .refl
+  eq_dist {P Q} := by
+    refine ⟨?_, fun h => ?_⟩
+    · rintro rfl _ _ _; exact Iff.rfl
+    · obtain ⟨ph, hp⟩ := P; obtain ⟨qh, _⟩ := Q
+      have : ph = qh := funext fun n => propext (h n .refl)
+      subst this; rfl
   dist_lt h _ _ _ := h (by omega)
 
 #rocq_ignore siProp_ofe_mixin "Not needed in Lean."
@@ -159,8 +162,8 @@ instance : Std.Preorder (BIBase.Entails (PROP := SiProp)) where
 @[rocq_alias siPropI]
 instance instBI : BI SiProp where
   entails_preorder := inferInstance
-  equiv_iff.mp heq := ⟨fun _ => heq.mp, fun _ => heq.mpr⟩
-  equiv_iff.mpr H n := ⟨H.1 n, H.2 n⟩
+  equiv_iff.mp heq := ⟨fun n hP => (heq n .refl).mp hP, fun n hQ => (heq n .refl).mpr hQ⟩
+  equiv_iff.mpr H _ _ _ := ⟨H.1 _, H.2 _⟩
   and_ne.ne _ _ _ h₁ _ _ h₂ m h := ⟨.imp (h₁ h).mp (h₂ h).mp, .imp (h₁ h).mpr (h₂ h).mpr⟩
   or_ne.ne _ _ _ h₁ _ _ h₂ m h := ⟨.imp (h₁ h).mp (h₂ h).mp, .imp (h₁ h).mpr (h₂ h).mpr⟩
   imp_ne.ne _ _ _ h₁ _ _ h₂ m hle := {

--- a/Iris/Iris/BI/Updates.lean
+++ b/Iris/Iris/BI/Updates.lean
@@ -267,8 +267,6 @@ instance bupd_sep_homomorphism :
   Algebra.MonoidHomomorphism (M₁ := PROP) sep sep emp emp (flip Entails) bupd where
   rel_refl := .rfl
   rel_trans := flip .trans
-  rel_proper H G := ⟨fun J => (equiv_iff.1 G).mpr.trans (J.trans (equiv_iff.1 H).mp)
-    , fun J => (equiv_iff.1 G).mp.trans (J.trans (equiv_iff.1 H).mpr)⟩
   op_proper := sep_mono
   map_ne := BIUpdate.bupd_ne
   map_op := bupd_sep
@@ -470,8 +468,6 @@ instance fupd_sep_homomorphism E :
   Algebra.MonoidHomomorphism (M₁ := PROP) sep sep emp emp (flip Entails) (fupd E E) where
   rel_refl := .rfl
   rel_trans := flip .trans
-  rel_proper H G := ⟨fun J => (equiv_iff.1 G).mpr.trans (J.trans (equiv_iff.1 H).mp)
-    , fun J => (equiv_iff.1 G).mp.trans (J.trans (equiv_iff.1 H).mpr)⟩
   op_proper := sep_mono
   map_ne := BIFUpdate.ne
   map_op := fupd_sep

--- a/Iris/Iris/Examples/Fix.lean
+++ b/Iris/Iris/Examples/Fix.lean
@@ -10,19 +10,18 @@ public import Iris.Algebra.COFESolver
 @[expose] public section
 
 /-!
-This example shows that for Leibniz-preserving functors, which include but not limited to
-those built from the combinators in `OFE.lean`, the Leibniz property propagates through the
-recursive domain equation solver. As a result, the fold/unfold isomorphisms of the
-fixed point can be stated as propositional equalities (`=`) rather than mere OFE
-equivalences (`≡`); see `Dom.unfold_fold` and `Dom.fold_unfold`.
+Since `≡` coincides with `=` in every `OFE` on this branch (`OFE.eq_dist`), the
+fold/unfold isomorphisms of the recursive domain equation solver's fixed point can
+be stated as propositional equalities (`=`) rather than mere OFE equivalences
+(`≡`); see `Dom.unfold_fold` and `Dom.fold_unfold`.
 
 `DomF` is a concrete example: a domain for a simple language with values, errors,
 delayed computations, and function values. Its fixed point `Dom V E` satisfies
 `Dom V E ≅ V ⊕ E ⊕ Later(Dom V E) ⊕ Later(Dom V E -n> Dom V E)` propositionally,
-provided `V` and `E` are Leibniz OFEs.
+for any OFEs `V` and `E`.
 
-For examples, where it holds, it should provide better support for rewriting
-by relying on the default Lean tactics.
+This should provide better support for rewriting by relying on the default Lean
+tactics.
 -/
 section Fix
 open Iris OFE COFE
@@ -44,7 +43,7 @@ abbrev Dom (Val : Type _) (Err : Type _) [OFE Val] [OFE Err] [IsCOFE Val] [IsCOF
 namespace Dom
 open Iris OFE COFE
 
-variable [OFE V] [Leibniz V] [OFE E] [Leibniz E] [IsCOFE V] [IsCOFE E] [Inhabited E]
+variable [OFE V] [OFE E] [IsCOFE V] [IsCOFE E] [Inhabited E]
 
 def fold : V ⊕ E ⊕ Later (Dom V E) ⊕ Later (Dom V E -n> Dom V E) -n> Dom V E :=
   OFunctor.Fix.fold (F := DomF (Val := V) (Err := E))

--- a/Iris/Iris/Examples/Fix.lean
+++ b/Iris/Iris/Examples/Fix.lean
@@ -10,18 +10,17 @@ public import Iris.Algebra.COFESolver
 @[expose] public section
 
 /-!
-Since `≡` coincides with `=` in every `OFE` on this branch (`OFE.eq_dist`), the
-fold/unfold isomorphisms of the recursive domain equation solver's fixed point can
-be stated as propositional equalities (`=`) rather than mere OFE equivalences
-(`≡`); see `Dom.unfold_fold` and `Dom.fold_unfold`.
+Every OFE is Leibniz, so the fold/unfold isomorphisms of the recursive domain equation solver's
+fixed point can be stated as propositional equalities rather than OFE equivalences.
+See `Dom.unfold_fold` and `Dom.fold_unfold`.
 
 `DomF` is a concrete example: a domain for a simple language with values, errors,
 delayed computations, and function values. Its fixed point `Dom V E` satisfies
-`Dom V E ≅ V ⊕ E ⊕ Later(Dom V E) ⊕ Later(Dom V E -n> Dom V E)` propositionally,
+`Dom V E ≅ V ⊕ E ⊕ Later(Dom V E) ⊕ Later(Dom V E -n> Dom V E)` up to propositional equality,
 for any OFEs `V` and `E`.
 
 This should provide better support for rewriting by relying on the default Lean
-tactics.
+tactics for simplification/rewriting.
 -/
 section Fix
 open Iris OFE COFE

--- a/Iris/Iris/Examples/IProp.lean
+++ b/Iris/Iris/Examples/IProp.lean
@@ -53,7 +53,7 @@ open HeapView One DFrac Agree LeibnizO
 
 /- Define an OFunctor for the heap. Fractions are concretely `Qp`. -/
 abbrev F1 : OFunctorPre :=
-  constOF <| HeapView Nat (Agree (LeibnizO String)) Iris.Std.AssocList
+  constOF <| HeapView Nat (Agree (LeibnizO String)) (Std.ExtTreeMap Nat · compare)
 
 /- Our OFunctor is present in the global list of OFunctors. -/
 variable {GF} [ElemG GF F1]

--- a/Iris/Iris/Examples/IProp.lean
+++ b/Iris/Iris/Examples/IProp.lean
@@ -18,7 +18,7 @@ open Iris.BI COFE
 
 section Example1
 
-abbrev F0 : OFunctorPre := constOF (Agree (LeibnizO String))
+abbrev F0 : OFunctorPre := constOF (Agree (DiscreteO String))
 
 variable {GF} [E0 : ElemG GF F0]
 
@@ -49,11 +49,11 @@ end Example1
 /-! Example: a typical separating conjunction -/
 section Example2
 
-open HeapView One DFrac Agree LeibnizO
+open HeapView One DFrac Agree DiscreteO
 
 /- Define an OFunctor for the heap. Fractions are concretely `Qp`. -/
 abbrev F1 : OFunctorPre :=
-  constOF <| HeapView Nat (Agree (LeibnizO String)) (Std.ExtTreeMap Nat · compare)
+  constOF <| HeapView Nat (Agree (DiscreteO String)) (Std.ExtTreeMap Nat · compare)
 
 /- Our OFunctor is present in the global list of OFunctors. -/
 variable {GF} [ElemG GF F1]
@@ -141,8 +141,8 @@ theorem wp_unfold (e : Expr) (Φ : Value → IProp GF) :
         ∀ s, @state_interp State _ _ s -∗
           ∃ e' s', ⌜@step _ _ Value _ (e, s) = (e', s') ⌝ ∗
           ▷ |==> (@state_interp _ _ _  s' ∗ wp e' Φ)) := by
-  apply fixpoint_unfold (f := ⟨(@wp_F Expr State Value _ GF _),
-                                @OFE.ne_of_contractive _ _ _ _ (@wp_F Expr State Value _ GF _) _⟩)
+  exact fun n => fixpoint_unfold (f := ⟨(@wp_F Expr State Value _ GF _),
+                                @OFE.ne_of_contractive _ _ _ _ (@wp_F Expr State Value _ GF _) _⟩) n e Φ
 
 /- Now, we can derive some example proof rules. First let's prove a rule for pure deterministic steps: -/
 example (e e' : Expr) Φ (Hstep : ∀ {s : State}, @step _ _ Value _ (e, s) = (e', s)) :

--- a/Iris/Iris/Examples/Resources.lean
+++ b/Iris/Iris/Examples/Resources.lean
@@ -37,13 +37,13 @@ section const_agree
 abbrev γ : GType := 1
 
 @[simp]
-def MyAg (S : String) : (Option (Agree (LeibnizO String))) := some (toAgree ⟨S⟩)
+def MyAg (S : String) : (Option (Agree (DiscreteO String))) := some (toAgree ⟨S⟩)
 
 theorem MyR_always_invalid (S₁ S₂ : String) (Hne : S₁ ≠ S₂) (n : Nat) : ¬✓{n} MyAg S₁ • MyAg S₂ := by
   simp only [CMRA.ValidN, CMRA.op, MyAg, optionValidN, optionOp]
-  exact (Hne <| LeibnizO.dist_inj <| Agree.toAgree_op_validN_iff_dist.mp ·)
+  exact (Hne <| DiscreteO.dist_inj <| Agree.toAgree_op_validN_iff_dist.mp ·)
 
-def AgreeString (S : String) : UPred (Option (Agree (LeibnizO String))) := UPred.ownM (MyAg S)
+def AgreeString (S : String) : UPred (Option (Agree (DiscreteO String))) := UPred.ownM (MyAg S)
 
 example : AgreeString "I <3 iris-lean!" ⊢ (AgreeString "I don't :<" -∗ False) := by
   iintro H H2

--- a/Iris/Iris/HeapLang/PrimitiveLaws.lean
+++ b/Iris/Iris/HeapLang/PrimitiveLaws.lean
@@ -43,8 +43,8 @@ def HeapLangS : BundledGFunctors
   | 1 => ⟨constOF (DisjointLeibnizSet CoPset), by infer_instance⟩
   | 2 => ⟨constOF (DisjointLeibnizSet PosSet), by infer_instance⟩
   | 3 => ⟨Auth.AuthURF (constOF Credit), by infer_instance⟩
-  | 4 => ⟨constOF (HeapView Loc (Agree (LeibnizO (Option Val))) HeapF), by infer_instance⟩
-  | 5 => ⟨constOF (HeapView Loc (Agree (LeibnizO GName)) HeapF), by infer_instance⟩
+  | 4 => ⟨constOF (HeapView Loc (Agree (DiscreteO (Option Val))) HeapF), by infer_instance⟩
+  | 5 => ⟨constOF (HeapView Loc (Agree (DiscreteO GName)) HeapF), by infer_instance⟩
   | 6 => ⟨constOF MetaUR, by infer_instance⟩
   | _ => ⟨constOF Unit, by infer_instance⟩
 
@@ -76,11 +76,11 @@ theorem heap_adequacy [HeapLangGpreS .hasLC GF] (e : Exp) σ (φ : Val → Prop)
   intro inst κs
   imod iOwn_alloc (E := GhostMapG.elem (K := Loc) (V := Option Val) (H := HeapF))
     (HeapView.Auth (H := HeapF) (.own 1)
-      (Std.PartialMap.map (fun v : Option Val => toAgree (LeibnizO.mk v)) σ.heap))
+      (Std.PartialMap.map (fun v : Option Val => toAgree (DiscreteO.mk v)) σ.heap))
     HeapView.auth_one_valid with ⟨%γh, Hh⟩
   imod iOwn_alloc (E := GhostMapG.elem (K := Loc) (V := GName) (H := HeapF))
     (HeapView.Auth (H := HeapF) (.own 1)
-      (Std.PartialMap.map (fun g : GName => toAgree (LeibnizO.mk g))
+      (Std.PartialMap.map (fun g : GName => toAgree (DiscreteO.mk g))
         (∅ : HeapF GName)))
     HeapView.auth_one_valid with ⟨%γm, Hm⟩
   letI _ : HeapLangGS .hasLC GF := ⟨⟨γh, γm⟩⟩

--- a/Iris/Iris/HeapLang/PrimitiveLaws.lean
+++ b/Iris/Iris/HeapLang/PrimitiveLaws.lean
@@ -67,7 +67,7 @@ def HeapLangS : BundledGFunctors
   | 4 => ⟨constOF (HeapView Loc (Agree (DiscreteO (Option Val))) HeapF), by infer_instance⟩
   | 5 => ⟨constOF (HeapView Loc (Agree (DiscreteO GName)) HeapF), by infer_instance⟩
   | 6 => ⟨constOF MetaUR, by infer_instance⟩
-  | 7 => ⟨constOF (HeapView ProphId (Agree (LeibnizO (List (Val × Val)))) ProphMapF),
+  | 7 => ⟨constOF (HeapView ProphId (Agree (DiscreteO (List (Val × Val)))) ProphMapF),
           by infer_instance⟩
   | _ => ⟨constOF Unit, by infer_instance⟩
 

--- a/Iris/Iris/HeapLang/PrimitiveLaws.lean
+++ b/Iris/Iris/HeapLang/PrimitiveLaws.lean
@@ -101,14 +101,11 @@ theorem heap_adequacy [HeapLangGpreS .hasLC GF] (e : Exp) σ (φ : Val → Prop)
     adequate .NotStuck e σ (fun v _ => φ v) := by
   refine wp_adequacy (GF := GF) .NotStuck e σ φ ?_
   intro inst κs
-  imod iOwn_alloc (E := GhostMapG.elem (K := Loc) (V := Option Val) (H := HeapF))
-    (HeapView.Auth (H := HeapF) (.own 1)
+  imod iOwn_alloc (E := GhostMapG.elem) (HeapView.Auth (H := HeapF) (.own 1)
       (Std.PartialMap.map (fun v : Option Val => toAgree (DiscreteO.mk v)) σ.heap))
     HeapView.auth_one_valid with ⟨%γh, Hh⟩
-  imod iOwn_alloc (E := GhostMapG.elem (K := Loc) (V := GName) (H := HeapF))
-    (HeapView.Auth (H := HeapF) (.own 1)
-      (Std.PartialMap.map (fun g : GName => toAgree (DiscreteO.mk g))
-        (∅ : HeapF GName)))
+  imod iOwn_alloc (E := GhostMapG.elem) (HeapView.Auth (H := HeapF) (.own 1)
+      (Std.PartialMap.map (fun g : GName => toAgree (DiscreteO.mk g)) (∅ : HeapF GName)))
     HeapView.auth_one_valid with ⟨%γm, Hm⟩
   imod (ProphMap.init (H := ProphMapF) κs σ.usedProphId) with ⟨%Gproph, Hproph⟩
   letI instHeapLangGS : HeapLangGS .hasLC GF := ⟨⟨γh, γm⟩, Gproph⟩

--- a/Iris/Iris/Instances/Classical/Instance.lean
+++ b/Iris/Iris/Instances/Classical/Instance.lean
@@ -44,24 +44,24 @@ instance : Std.Preorder (Entails (PROP := HeapProp Val)) where
     apply h_xy σ
     exact h_x
 
-instance : COFE (HeapProp Val) := COFE.ofDiscrete Eq equivalence_eq
+instance : COFE (HeapProp Val) := COFE.ofDiscrete _
 
 instance : BI (HeapProp Val) where
   entails_preorder := by infer_instance
   equiv_iff {P Q} := ⟨
-    fun h : P = Q => h ▸ ⟨refl, refl⟩,
-    fun ⟨h₁, h₂⟩ => funext fun σ => propext ⟨h₁ σ, h₂ σ⟩
+    fun h => h.to_eq ▸ ⟨refl, refl⟩,
+    fun ⟨h₁, h₂⟩ => OFE.Equiv.of_eq (funext fun σ => propext ⟨h₁ σ, h₂ σ⟩)
   ⟩
 
-  and_ne          := ⟨by rintro _ _ _ rfl _ _ rfl; rfl⟩
-  or_ne           := ⟨by rintro _ _ _ rfl _ _ rfl; rfl⟩
-  imp_ne          := ⟨by rintro _ _ _ rfl _ _ rfl; rfl⟩
-  sep_ne          := ⟨by rintro _ _ _ rfl _ _ rfl; rfl⟩
-  wand_ne         := ⟨by rintro _ _ _ rfl _ _ rfl; rfl⟩
-  persistently_ne := ⟨by rintro _ _ _ rfl; rfl⟩
-  later_ne        := ⟨by rintro _ _ _ rfl; rfl⟩
-  sForall_ne {_ P Q} h := liftRel_eq.1 h ▸ rfl
-  sExists_ne {_ P Q} h := liftRel_eq.1 h ▸ rfl
+  and_ne          := ⟨by rintro _ _ _ h1 _ _ h2; exact (h1 : _ = _) ▸ (h2 : _ = _) ▸ rfl⟩
+  or_ne           := ⟨by rintro _ _ _ h1 _ _ h2; exact (h1 : _ = _) ▸ (h2 : _ = _) ▸ rfl⟩
+  imp_ne          := ⟨by rintro _ _ _ h1 _ _ h2; exact (h1 : _ = _) ▸ (h2 : _ = _) ▸ rfl⟩
+  sep_ne          := ⟨by rintro _ _ _ h1 _ _ h2; exact (h1 : _ = _) ▸ (h2 : _ = _) ▸ rfl⟩
+  wand_ne         := ⟨by rintro _ _ _ h1 _ _ h2; exact (h1 : _ = _) ▸ (h2 : _ = _) ▸ rfl⟩
+  persistently_ne := ⟨by rintro _ _ _ h; exact (h : _ = _) ▸ rfl⟩
+  later_ne        := ⟨by rintro _ _ _ h; exact (h : _ = _) ▸ rfl⟩
+  sForall_ne {_ P Q} h := (liftRel_eq.1 (h : liftRel Eq P Q)) ▸ rfl
+  sExists_ne {_ P Q} h := (liftRel_eq.1 (h : liftRel Eq P Q)) ▸ rfl
 
   pure_intro h _ _ := h
   pure_elim' h_φP σ h_φ := h_φP h_φ σ ⟨⟩

--- a/Iris/Iris/Instances/IProp/Instance.lean
+++ b/Iris/Iris/Instances/IProp/Instance.lean
@@ -447,8 +447,7 @@ theorem iSingleton_op_validN_at_γ {a : F.ap (IProp GF)} (Hv : ✓{n} mf) :
 instance iSingleton_discreteE {v : F.ap (IProp GF)} [OFE.DiscreteE v] :
     OFE.DiscreteE (iSingleton F γ v) where
   discrete {w} H := by
-    refine OFE.equiv_dist.mpr fun n => ?_
-    intro τ
+    refine OFE.equiv_dist.mpr fun n τ => ?_
     simp only [iSingleton] at ⊢
     split
     next h =>

--- a/Iris/Iris/Instances/IProp/Instance.lean
+++ b/Iris/Iris/Instances/IProp/Instance.lean
@@ -17,9 +17,6 @@ namespace Iris
 
 open COFE Std CMRA
 
-@[ext]
-theorem IProp.ext {P Q : IProp GF} : P ⊣⊢ Q → P = Q := OFE.Equiv.to_eq ∘ BI.equiv_iff.mpr
-
 /-- Apply an OFunctor at a fixed type -/
 abbrev COFE.OFunctorPre.ap (F : OFunctorPre) (T : Type _) [COFE T] :=
   F T T

--- a/Iris/Iris/Instances/IProp/Instance.lean
+++ b/Iris/Iris/Instances/IProp/Instance.lean
@@ -835,7 +835,6 @@ instance iOwn_cmra_sep_homomorphism (γ : GName) :
       UCMRA.unit iprop(emp) BiEntails (iOwn γ) where
   rel_refl := .rfl
   rel_trans := .trans
-  rel_proper := BIBase.BiEntails.proper
   op_proper aa' bb' := equiv_iff.1 (sep_ne.eqv (equiv_iff.2 aa') (equiv_iff.2 bb'))
   map_ne := iOwn_ne
   map_op := iOwn_op
@@ -866,9 +865,6 @@ instance iOwn_cmra_sep_entails_homomorphism (γ : GName) :
       UCMRA.unit iprop(emp) Entails (iOwn γ) where
   rel_refl := .rfl
   rel_trans := .trans
-  rel_proper ha hb :=
-    ⟨fun h => (equiv_iff.1 ha).mpr.trans <| h.trans (equiv_iff.1 hb).mp,
-     fun h => (equiv_iff.1 ha).mp.trans <| h.trans (equiv_iff.1 hb).mpr⟩
   op_proper := sep_mono
   map_ne := iOwn_ne
   map_op := iOwn_op.mp

--- a/Iris/Iris/Instances/IProp/Instance.lean
+++ b/Iris/Iris/Instances/IProp/Instance.lean
@@ -843,9 +843,9 @@ theorem bigOpL_iOwn {B : Type _} (γ : GName) (f : Nat → B → F.ap (IProp GF)
 @[rocq_alias big_opM_own]
 theorem bigOpM_iOwn {K : Type _} {M : Type _ → Type _} {B : Type _} [LawfulFiniteMap M K]
     [DecidableEq K] (γ : GName) (g : K → B → F.ap (IProp GF)) (m : M B) :
-    ¬ m = (∅ : M B) →
+    ¬ m ≡ₘ (∅ : M B) →
     iOwn γ ([^ CMRA.op map] k ↦ x ∈ m, g k x) ⊣⊢ [∗map] k ↦ x ∈ m, iOwn γ (g k x) :=
-  BigOpM.bigOpM_weak_hom g m
+  fun h => BigOpM.bigOpM_weak_hom g m (fun he => h (equiv_iff_eq.mpr he))
 
 @[rocq_alias big_opS_own]
 theorem bigOpS_iOwn {B : Type _} {S : Type _} [LawfulFiniteSet S B] (γ : GName)

--- a/Iris/Iris/Instances/IProp/Instance.lean
+++ b/Iris/Iris/Instances/IProp/Instance.lean
@@ -843,7 +843,7 @@ theorem bigOpL_iOwn {B : Type _} (γ : GName) (f : Nat → B → F.ap (IProp GF)
 @[rocq_alias big_opM_own]
 theorem bigOpM_iOwn {K : Type _} {M : Type _ → Type _} {B : Type _} [LawfulFiniteMap M K]
     [DecidableEq K] (γ : GName) (g : K → B → F.ap (IProp GF)) (m : M B) :
-    ¬ m ≡ₘ (∅ : M B) →
+    ¬ m = (∅ : M B) →
     iOwn γ ([^ CMRA.op map] k ↦ x ∈ m, g k x) ⊣⊢ [∗map] k ↦ x ∈ m, iOwn γ (g k x) :=
   BigOpM.bigOpM_weak_hom g m
 

--- a/Iris/Iris/Instances/IProp/Instance.lean
+++ b/Iris/Iris/Instances/IProp/Instance.lean
@@ -18,7 +18,7 @@ namespace Iris
 open COFE Std CMRA
 
 @[ext]
-theorem IProp.ext {P Q : IProp GF} : P ⊣⊢ Q → P = Q := OFE.Leibniz.eq_of_eqv ∘ BI.equiv_iff.mpr
+theorem IProp.ext {P Q : IProp GF} : P ⊣⊢ Q → P = Q := OFE.Equiv.to_eq ∘ BI.equiv_iff.mpr
 
 /-- Apply an OFunctor at a fixed type -/
 abbrev COFE.OFunctorPre.ap (F : OFunctorPre) (T : Type _) [COFE T] :=
@@ -47,8 +47,8 @@ theorem OFE.transpAp_op_mp (h_fun : F₁ = F₂) (h_inst : HEq RF₁ RF₂) {x y
 theorem OFE.transpAp_pcore_mp (h_fun : F₁ = F₂) (h_inst : HEq RF₁ RF₂) {x : F₁ T T} :
     (CMRA.pcore x).map (transpAp h_fun).mp ≡ CMRA.pcore ((transpAp h_fun).mp x) := by
   cases h_fun; cases eq_of_heq h_inst
-  simp [Equiv, Option.Forall₂]
-  cases CMRA.pcore x <;> simp [Equiv.rfl]
+  simp [Equiv]
+  cases CMRA.pcore x <;> simp
 
 theorem OFE.transpAp_validN_mp (h_fun : F₁ = F₂) (h_inst : HEq RF₁ RF₂) {x : F₁ T T} (H : ✓{n} x) :
     ✓{n} ((transpAp h_fun).mp x) := by
@@ -174,15 +174,17 @@ def IProp.foldi : FF.api τ (IPre FF) -n> FF.api τ (IProp FF) :=
 
 @[rocq_alias inG_unfold_fold]
 theorem IProp.unfoldi_foldi (x : FF.api τ (IPre FF)) : unfoldi (foldi x) ≡ x := by
+  refine OFE.equiv_dist.mpr fun n => ?_
   refine .trans (OFunctor.map_comp (F := FF τ |>.fst) ..).symm ?_
-  refine .trans ?_ (OFunctor.map_id (F := FF τ |>.fst) x)
-  apply OFunctor.map_ne.eqv <;> intro _ <;> simp [IProp.unfold, IProp.fold]
+  refine .trans ?_ (OFunctor.map_id (F := FF τ |>.fst) x).dist
+  apply OFunctor.map_ne.ne <;> intro _ <;> simp [IProp.unfold, IProp.fold]
 
 @[rocq_alias inG_fold_unfold]
 theorem IProp.foldi_unfoldi (x : FF.api τ (IProp FF)) : foldi (unfoldi x) ≡ x := by
+  refine OFE.equiv_dist.mpr fun n => ?_
   refine .trans (OFunctor.map_comp (F := FF τ |>.fst) ..).symm ?_
-  refine .trans ?_ (OFunctor.map_id (F := FF τ |>.fst) x)
-  apply OFunctor.map_ne.eqv <;> intro _ <;> simp [IProp.unfold, IProp.fold, -OFE.leibniz]
+  refine .trans ?_ (OFunctor.map_id (F := FF τ |>.fst) x).dist
+  apply OFunctor.map_ne.ne <;> intro _ <;> simp [IProp.unfold, IProp.fold]
 
 theorem IProp.unfoldi_discreteE {v : FF.api τ (IProp FF)} (hv : OFE.DiscreteE v) :
     OFE.DiscreteE (unfoldi.f v) where
@@ -263,6 +265,7 @@ instance : OFE.NonExpansive (iSingleton F γ (GF := GF)) where
 
 @[rocq_alias iRes_singleton_op]
 theorem iSingleton_op (x y : F.ap (IProp GF)) : (iSingleton F γ x) • iSingleton F γ y ≡ iSingleton F γ (x • y) := by
+  refine OFE.equiv_dist.mpr fun n => ?_
   intro τ' γ'
   simp only [iSingleton]
   split
@@ -270,8 +273,9 @@ theorem iSingleton_op (x y : F.ap (IProp GF)) : (iSingleton F γ x) • iSinglet
     subst h; simp only [CMRA.op, optionOp]
     by_cases heq : γ' = γ
     · subst heq
-      simp only [iSingleton, ↓reduceDIte, GenMap.singleton_map_in, some_eqv_some]
-      exact ((RFunctor.map (fold GF) (unfold GF)).op _ _).symm.trans (NonExpansive.eqv (bundle_op x y).symm)
+      simp only [iSingleton, ↓reduceDIte, GenMap.singleton_map_in, some_dist_some]
+      exact (((RFunctor.map (fold GF) (unfold GF)).op _ _).symm.trans
+        (NonExpansive.eqv (bundle_op x y).symm)).dist
     · simp only [iSingleton, ↓reduceDIte, singleton_map_none heq]; rfl
   next h => simp [iSingleton, h, CMRA.op, GenMap.empty_map_lookup]
 
@@ -314,8 +318,8 @@ theorem unfoldi_bundle_coreId {a : F.ap (IProp GF)} [CMRA.CoreId a] :
 
 @[rocq_alias iRes_singleton_core_id]
 instance {a : F.ap (IProp GF)} [CMRA.CoreId a] : CMRA.CoreId (iSingleton F γ a) where
-  core_id τ' γ' := by
-    show CMRA.core ((iSingleton F γ a τ').car γ') ≡ (iSingleton F γ a τ').car γ'
+  core_id n τ' γ' := by
+    show CMRA.core ((iSingleton F γ a τ').car γ') ≡{n}≡ (iSingleton F γ a τ').car γ'
     simp only [iSingleton]
     split
     next h =>
@@ -323,7 +327,7 @@ instance {a : F.ap (IProp GF)} [CMRA.CoreId a] : CMRA.CoreId (iSingleton F γ a)
       by_cases heq : γ' = γ
       · subst heq
         simp only [GenMap.singleton_map_in, CMRA.core, optionCore, CMRA.pcore, Option.bind]
-        exact unfoldi_bundle_coreId.core_id
+        exact unfoldi_bundle_coreId.core_id.dist
       · simp [singleton_map_none heq, CMRA.core, optionCore, CMRA.pcore]
     next => simp [GenMap.empty_map_lookup, CMRA.core, optionCore, CMRA.pcore]
 
@@ -445,7 +449,9 @@ theorem iSingleton_op_validN_at_γ {a : F.ap (IProp GF)} (Hv : ✓{n} mf) :
 @[rocq_alias iRes_singleton_discrete]
 instance iSingleton_discreteE {v : F.ap (IProp GF)} [OFE.DiscreteE v] :
     OFE.DiscreteE (iSingleton F γ v) where
-  discrete {w} H τ := by
+  discrete {w} H := by
+    refine OFE.equiv_dist.mpr fun n => ?_
+    intro τ
     simp only [iSingleton] at ⊢
     split
     next h =>
@@ -456,18 +462,18 @@ instance iSingleton_discreteE {v : F.ap (IProp GF)} [OFE.DiscreteE v] :
         rw [GenMap.singleton_map_in] at Hk ⊢
         rcases hw : (w E.τ).car k with _ | x <;> rw [hw] at Hk
         · exact Hk
-        · simp only [OFE.Equiv] at ⊢
+        · refine some_dist_some.mpr (OFE.Equiv.dist ?_)
           refine (NonExpansive.eqv ?_).trans (IProp.unfoldi_foldi x)
           refine (NonExpansive.eqv ?_).trans (ElemG.bundle_unbundle E _)
           refine OFE.DiscreteE.discrete ?_
           refine (ElemG.unbundle_bundle E v).dist.symm.trans ?_
           refine NonExpansive.ne <| (IProp.foldi_unfoldi _).dist.symm.trans (NonExpansive.ne Hk)
       · rw [GenMap.singleton_map_none hk] at Hk ⊢
-        exact Option.none_is_discrete.discrete Hk
+        exact (Option.none_is_discrete.discrete Hk).dist
     next h =>
       intro k; have Hk := (H τ) k
       simp [iSingleton, dif_neg h, GenMap.empty_map_lookup] at Hk ⊢
-      exact Option.none_is_discrete.discrete Hk
+      exact (Option.none_is_discrete.discrete Hk).dist
 
 end iSingleton
 

--- a/Iris/Iris/Instances/Lib/Boxes.lean
+++ b/Iris/Iris/Instances/Lib/Boxes.lean
@@ -19,7 +19,7 @@ namespace Iris
 
 open BI CMRA Agree OFE UPred IProp Std ProofMode COFE Auth ExclAuth Excl PartialMap BigSepM
 
-abbrev BoolO := LeibnizO Bool
+abbrev BoolO := DiscreteO Bool
 
 variable (GF : BundledGFunctors)
 
@@ -112,7 +112,7 @@ theorem box_own_auth_agree {γ : SliceName} {b1 b2 : Bool} :
   iintro H
   icases iOwn_cmraValid $$ H with H
   icases (prod_validI _).mp $$ H with ⟨%H, -⟩
-  ipureintro; exact LeibnizO.eqv_inj $ Iris.ExclAuth.agree_L H
+  ipureintro; exact DiscreteO.eqv_inj $ Iris.ExclAuth.agree H
 
 @[rocq_alias box_own_auth_update]
 theorem box_own_auth_update {γ : SliceName} {b1 b2: Bool} (b3 : Bool) :

--- a/Iris/Iris/Instances/Lib/GhostMap.lean
+++ b/Iris/Iris/Instances/Lib/GhostMap.lean
@@ -100,7 +100,7 @@ theorem ghost_map_elems_unseal [DecidableEq K] γ (m : H V) dq :
     simp only [BigOpM.bigOpM_empty]
     iapply iOwn_unit (γ := γ) (ε := unit)
   · imodintro
-    iapply bigOpM_iOwn _ _ _ h
+    iapply bigOpM_iOwn _ _ _ (mt equiv_iff_eq.mp h)
     unfold ghost_map_elem
     iexact H
 
@@ -356,7 +356,7 @@ theorem ghost_map_insert {γ} {m : H V} (k : K) (v : V) (Heq : get? m k = .none)
   icases H with ⟨H, $⟩
   imodintro
   iapply iOwn_mono $$ H
-  exact auth_inc_of_pmap_eqv _ map_insert
+  exact auth_inc_of_pmap_eqv _ (equiv_iff_eq.mpr map_insert)
 
 @[rocq_alias ghost_map_insert_persist]
 theorem ghost_map_insert_persist {γ} {m : H V} (k : K) (v : V) (Heq : get? m k = .none) :
@@ -373,7 +373,7 @@ theorem ghost_map_delete {γ} {m : H V} (k : K) (v : V) :
   icombine H1 H2 as G
   imod iOwn_update (update_one_delete (k := k) (v1 := toAgree (⟨v⟩ : LeibnizO V))) $$ G with G
   iapply iOwn_mono $$ G
-  exact auth_inc_of_pmap_eqv _ map_delete
+  exact auth_inc_of_pmap_eqv _ (equiv_iff_eq.mpr map_delete)
 
 @[rocq_alias ghost_map_update]
 theorem ghost_map_update {γ} {m : H V} {k : K} {v : V} (w : V) :
@@ -384,7 +384,7 @@ theorem ghost_map_update {γ} {m : H V} {k : K} {v : V} (w : V) :
   imodintro
   unfold ghost_map_auth
   iapply iOwn_mono $$ aux
-  exact auth_inc_of_pmap_eqv _ (map_equiv insert_delete.symm)
+  exact auth_inc_of_pmap_eqv _ (equiv_iff_eq.mpr (map_equiv insert_delete.symm))
 
 /-! ### Big-op versions of the above lemmas -/
 
@@ -407,9 +407,9 @@ theorem ghost_map_insert_big [DecidableEq K] {γ m} (m' : H V) (Hdisj : m' ##ₘ
     isplitl [H]
     · iapply iOwn_mono $$ H
       exact auth_inc_of_pmap_eqv _
-        (map_equiv ((union_equiv h rfl).trans union_empty_left))
+        (equiv_iff_eq.mpr (map_equiv ((union_equiv h rfl).trans union_empty_left)))
     · iapply (BigSepM.bigSepM_eqv_empty h).mpr; itrivial
-  · rw [←(bigOpM_iOwn γ _ _ h).to_eq, ←iOwn_op.to_eq]
+  · rw [←(bigOpM_iOwn γ _ _ (mt equiv_iff_eq.mp h)).to_eq, ←iOwn_op.to_eq]
     imod iOwn_update (E := GhostMapG.elem) (update_big_alloc _
         (Std.PartialMap.map (fun x ↦ toAgree ⟨x⟩) m') (DFrac.own 1)
         (disjoint_map Hdisj) DFrac.valid_own_one
@@ -418,7 +418,7 @@ theorem ghost_map_insert_big [DecidableEq K] {γ m} (m' : H V) (Hdisj : m' ##ₘ
     imodintro
     isplitl [H1]
     · iapply iOwn_mono $$ H1
-      exact auth_inc_of_pmap_eqv _ map_union
+      exact auth_inc_of_pmap_eqv _ (equiv_iff_eq.mpr map_union)
     · iapply iOwn_mono $$ H2
       exact inc_of_inc_of_eqv .rfl (BigOpM.bigOpM_map_eqv _ _ _).symm
 
@@ -456,11 +456,11 @@ theorem ghost_map_update_big [DecidableEq K] {γ m} (m0 m1 : H V) (Heq : dom m0 
     · unfold ghost_map_auth
       iapply iOwn_mono $$ H1
       exact auth_inc_of_pmap_eqv _
-        (map_equiv ((union_equiv h rfl).trans union_empty_left))
+        (equiv_iff_eq.mpr (map_equiv ((union_equiv h rfl).trans union_empty_left)))
     · iapply (BigSepM.bigSepM_eqv_empty h).mpr; itrivial
   · unfold ghost_map_elem ghost_map_auth
     icombine H1 H2 as H
-    rw [←(bigOpM_iOwn γ _ _ h).to_eq, ←iOwn_op.to_eq]
+    rw [←(bigOpM_iOwn γ _ _ (mt equiv_iff_eq.mp h)).to_eq, ←iOwn_op.to_eq]
     iapply iOwn_update $$ H
     refine Update.equiv_left (CMRA.op_right_eqv _ (BigOpM.bigOpM_map_eqv _ _ m0)) ?_
     have Heq' : dom (Std.PartialMap.map (fun x : V => toAgree (LeibnizO.mk x)) m0) =

--- a/Iris/Iris/Instances/Lib/GhostMap.lean
+++ b/Iris/Iris/Instances/Lib/GhostMap.lean
@@ -86,7 +86,7 @@ instance ghost_map_elem_fractional (γ : GName) (k : K) (v : V) :
 @[rocq_alias ghost_map_elem_as_fractional]
 instance (γ : GName) (k : K) (v : V) : AsFractional (PROP := IProp GF) (γ ↪◯MAP[k]{.own q} v)
     (fun q => γ ↪◯MAP[k]{.own q} v) q where
-  as_fractional := IProp.ext_iff.mp rfl
+  as_fractional := BIBase.BiEntails.of_eq rfl
   as_fractional_fractional := ghost_map_elem_fractional γ k v
 
 @[rocq_alias ghost_map_elems_unseal]
@@ -263,7 +263,7 @@ instance ghost_map_auth_fractional (m : H V) :
 @[rocq_alias ghost_map_auth_as_fractional]
 instance (γ : GName) (m : H V) (q : Qp) :
     AsFractional (PROP := IProp GF) (γ ↪●MAP{.own q} m) (fun q => γ ↪●MAP{.own q} m) q where
-  as_fractional := IProp.ext_iff.mp rfl
+  as_fractional := BIBase.BiEntails.of_eq rfl
   as_fractional_fractional := ghost_map_auth_fractional m
 
 @[rocq_alias ghost_map_auth_valid]

--- a/Iris/Iris/Instances/Lib/GhostMap.lean
+++ b/Iris/Iris/Instances/Lib/GhostMap.lean
@@ -95,8 +95,8 @@ theorem ghost_map_elems_unseal [DecidableEq K] γ (m : H V) dq :
     iOwn (GF := GF) (E := GhostMapG.elem) γ ([^ op map] k ↦ v ∈ m,
       Frag k dq (toAgree (⟨v⟩: LeibnizO V))) := by
   iintro H
-  by_cases h : m ≡ₘ ∅
-  · iapply OFE.NonExpansive.eqv <| OFE.NonExpansive.eqv (BigOpM.bigOpM_eqv_of_perm _ h)
+  by_cases h : m = ∅
+  · subst h
     simp only [BigOpM.bigOpM_empty]
     iapply iOwn_unit (γ := γ) (ε := unit)
   · imodintro
@@ -215,7 +215,7 @@ theorem ghost_map_alloc_strong [DecidableEq K] (P : GName → Prop) (m : H V) :
         (disjoint_empty_right _) DFrac.valid_own_one
         (all_map fun _ _ => Agree.toAgree_valid))
     refine CMRA.op_eqv ?_ (BigOpM.bigOpM_map_eqv _ _ _)
-    exact OFE.NonExpansive.eqv (PartialMap.eqv_of_Equiv union_empty_right)
+    exact OFE.NonExpansive.eqv (OFE.Equiv.of_eq union_empty_right)
 
 @[rocq_alias ghost_map_alloc_strong_empty]
 theorem ghost_map_alloc_strong_empty [DecidableEq K] (P : GName → Prop)
@@ -277,13 +277,13 @@ theorem ghost_map_auth_valid γ (dq : DFrac) (m : H V) :
 
 @[rocq_alias ghost_map_auth_valid_2]
 theorem ghost_map_auth_valid_2 {γ} {dq1 dq2 : DFrac} {m1 m2 : H V} :
-    ⊢@{IProp GF} (γ ↪●MAP{dq1} m1) -∗ (γ ↪●MAP{dq2} m2) -∗ ⌜✓ (dq1 • dq2) ∧ m1 ≡ₘ m2⌝ := by
+    ⊢@{IProp GF} (γ ↪●MAP{dq1} m1) -∗ (γ ↪●MAP{dq2} m2) -∗ ⌜✓ (dq1 • dq2) ∧ m1 = m2⌝ := by
   unfold ghost_map_auth
   iintro H1 H2
   icombine H1 H2 gives %G
   ipureintro
   have ⟨h₁, h₂⟩ := auth_op_auth_valid_iff.mp G
-  refine ⟨h₁, fun k => ?_⟩
+  refine ⟨h₁, equiv_iff_eq.mp fun k => ?_⟩
   have h := h₂ k
   simp only [get?_map, Option.map] at h
   cases h₁ : get? m1 k <;> cases h₂ : get? m2 k <;>
@@ -292,7 +292,7 @@ theorem ghost_map_auth_valid_2 {γ} {dq1 dq2 : DFrac} {m1 m2 : H V} :
 
 @[rocq_alias ghost_map_auth_agree]
 theorem ghost_map_auth_agree γ (dq1 dq2 : DFrac) (m1 m2 : H V) :
-    ⊢@{IProp GF} (γ ↪●MAP{dq1} m1) -∗ (γ ↪●MAP{dq2} m2) -∗ ⌜m1 ≡ₘ m2⌝ := by
+    ⊢@{IProp GF} (γ ↪●MAP{dq1} m1) -∗ (γ ↪●MAP{dq2} m2) -∗ ⌜m1 = m2⌝ := by
   iintro H₁ H₂
   ihave ⟨_, $⟩ := ghost_map_auth_valid_2 $$ H₁ H₂
 
@@ -384,9 +384,7 @@ theorem ghost_map_update {γ} {m : H V} {k : K} {v : V} (w : V) :
   imodintro
   unfold ghost_map_auth
   iapply iOwn_mono $$ aux
-  refine auth_inc_of_pmap_eqv _ ?_
-  intro i
-  rw [get?_map, get?_map, insert_delete i]
+  exact auth_inc_of_pmap_eqv _ (map_equiv insert_delete.symm)
 
 /-! ### Big-op versions of the above lemmas -/
 
@@ -404,11 +402,12 @@ theorem ghost_map_insert_big [DecidableEq K] {γ m} (m' : H V) (Hdisj : m' ##ₘ
   ⊢@{IProp GF} (γ ↪●MAP m) ==∗ (γ ↪●MAP (m' ∪ m)) ∗ [∗map] k ↦ v ∈ m', γ ↪◯MAP[k] v := by
   unfold ghost_map_auth ghost_map_elem
   iintro H
-  by_cases h : m' ≡ₘ ∅
+  by_cases h : m' = ∅
   · imodintro
     isplitl [H]
     · iapply iOwn_mono $$ H
-      exact auth_inc_of_pmap_eqv _ (map_equiv ((union_equiv h .refl).trans union_empty_left))
+      exact auth_inc_of_pmap_eqv _
+        (map_equiv ((union_equiv h rfl).trans union_empty_left))
     · iapply (BigSepM.bigSepM_eqv_empty h).mpr; itrivial
   · rw [←(bigOpM_iOwn γ _ _ h).to_eq, ←iOwn_op.to_eq]
     imod iOwn_update (E := GhostMapG.elem) (update_big_alloc _
@@ -443,7 +442,7 @@ theorem ghost_map_delete_big [DecidableEq K] {γ m} (m0 : H V) :
   refine Update.equiv_left (CMRA.op_right_eqv _ (BigOpM.bigOpM_map_eqv _ _ m0)) ?_
   refine (update_big_delete _ _).trans ?_
   refine Update.equiv_right ?_ .id
-  exact OFE.NonExpansive.eqv (PartialMap.eqv_of_Equiv map_difference_map)
+  exact OFE.NonExpansive.eqv (OFE.Equiv.of_eq map_difference_map)
 
 @[rocq_alias ghost_map_update_big]
 theorem ghost_map_update_big [DecidableEq K] {γ m} (m0 m1 : H V) (Heq : dom m0 = dom m1) :
@@ -451,12 +450,13 @@ theorem ghost_map_update_big [DecidableEq K] {γ m} (m0 m1 : H V) (Heq : dom m0 
     (γ ↪●MAP (m1 ∪ m)) ∗ [∗map] k ↦ v ∈ m1, γ ↪◯MAP[k] v := by
   iintro H1 H2
   imod ghost_map_elems_unseal $$ H2 with H2
-  by_cases h : m1 ≡ₘ ∅
+  by_cases h : m1 = ∅
   · imodintro
     isplitl [H1]
     · unfold ghost_map_auth
       iapply iOwn_mono $$ H1
-      exact auth_inc_of_pmap_eqv _ (map_equiv ((union_equiv h .refl).trans union_empty_left))
+      exact auth_inc_of_pmap_eqv _
+        (map_equiv ((union_equiv h rfl).trans union_empty_left))
     · iapply (BigSepM.bigSepM_eqv_empty h).mpr; itrivial
   · unfold ghost_map_elem ghost_map_auth
     icombine H1 H2 as H
@@ -470,7 +470,7 @@ theorem ghost_map_update_big [DecidableEq K] {γ m} (m0 m1 : H V) (Heq : dom m0 
       (all_map fun _ _ => Agree.toAgree_valid)).trans ?_
     refine Update.equiv_right ?_ .id
     refine CMRA.op_eqv ?_ (BigOpM.bigOpM_map_eqv _ _ _)
-    exact OFE.NonExpansive.eqv (PartialMap.eqv_of_Equiv map_union.symm)
+    exact OFE.NonExpansive.eqv (OFE.Equiv.of_eq map_union.symm)
 
 end lemmas
 

--- a/Iris/Iris/Instances/Lib/GhostMap.lean
+++ b/Iris/Iris/Instances/Lib/GhostMap.lean
@@ -20,7 +20,7 @@ open Std HeapView PartialMap Iris.Algebra CMRA BI ProofMode
 class GhostMapG (GF : BundledGFunctors)
     (K V : Type _) (H : outParam <| Type _ → Type _)
     [LawfulFiniteMap H K] where
-  elem : ElemG GF (constOF (HeapView K (Agree (LeibnizO V)) H))
+  elem : ElemG GF (constOF (HeapView K (Agree (DiscreteO V)) H))
 
 attribute [reducible, instance] GhostMapG.elem
 
@@ -93,7 +93,7 @@ instance (γ : GName) (k : K) (v : V) : AsFractional (PROP := IProp GF) (γ ↪�
 theorem ghost_map_elems_unseal [DecidableEq K] γ (m : H V) dq :
     ([∗map] k ↦ v ∈ m, γ ↪◯MAP[k]{dq} v) ==∗
     iOwn (GF := GF) (E := GhostMapG.elem) γ ([^ op map] k ↦ v ∈ m,
-      Frag k dq (toAgree (⟨v⟩: LeibnizO V))) := by
+      Frag k dq (toAgree (⟨v⟩: DiscreteO V))) := by
   iintro H
   by_cases h : m = ∅
   · subst h
@@ -204,7 +204,7 @@ theorem ghost_map_alloc_strong [DecidableEq K] (P : GName → Prop) (m : H V) :
   unfold ghost_map_elem ghost_map_auth
   iintro %Hinf
   imod iOwn_alloc_strong (E := GhostMapG.elem)
-    (Auth (DFrac.own 1) (V := Agree (LeibnizO V)) (∅ : H _)) P Hinf with ⟨%γ, %HP, G⟩
+    (Auth (DFrac.own 1) (V := Agree (DiscreteO V)) (∅ : H _)) P Hinf with ⟨%γ, %HP, G⟩
   · simpa only [auth_valid_iff] using DFrac.valid_own_one
   · iexists γ; iframe %HP
     iapply BIUpdate.mono <| sep_mono_right <| bigOpM_iOwn_entail γ _ m
@@ -284,11 +284,11 @@ theorem ghost_map_auth_valid_2 {γ} {dq1 dq2 : DFrac} {m1 m2 : H V} :
   ipureintro
   have ⟨h₁, h₂⟩ := auth_op_auth_valid_iff.mp G
   refine ⟨h₁, equiv_iff_eq.mp fun k => ?_⟩
-  have h := h₂ k
+  have h : _ ≡ _ := fun n => h₂ n k
   simp only [get?_map, Option.map] at h
   cases h₁ : get? m1 k <;> cases h₂ : get? m2 k <;>
     grind [OFE.not_none_eqv_some, OFE.not_some_eqv_none,
-      → Agree.toAgree_inj, LeibnizO.eqv_inj, OFE.some_eqv_some, Option.some.injEq]
+      → Agree.toAgree_inj, DiscreteO.eqv_inj, OFE.some_eqv_some, Option.some.injEq]
 
 @[rocq_alias ghost_map_auth_agree]
 theorem ghost_map_auth_agree γ (dq1 dq2 : DFrac) (m1 m2 : H V) :
@@ -322,7 +322,7 @@ theorem ghost_map_lookup {γ dq} {m : H V} {k : K} {dq' v} :
   icombine H1 H2 gives %G
   ipureintro
   have ⟨av', _, _, h_av', _, h⟩ := auth_op_frag_valid_total_discrete_iff G
-  cases h₂ : get? m k <;> grind [get?_map,Agree.toAgree_included, OFE.leibniz]
+  cases h₂ : get? m k <;> grind [get?_map,Agree.toAgree_included, OFE.Equiv.to_eq]
 
 @[rocq_alias ghost_map_lookup_combine_gives_1]
 instance ghost_map_lookup_combine_gives_1 γ (m : H V) (k : K) (dq1 dq2 : DFrac) (v : V) :
@@ -371,7 +371,7 @@ theorem ghost_map_delete {γ} {m : H V} (k : K) (v : V) :
   unfold ghost_map_auth ghost_map_elem
   iintro H1 H2
   icombine H1 H2 as G
-  imod iOwn_update (update_one_delete (k := k) (v1 := toAgree (⟨v⟩ : LeibnizO V))) $$ G with G
+  imod iOwn_update (update_one_delete (k := k) (v1 := toAgree (⟨v⟩ : DiscreteO V))) $$ G with G
   iapply iOwn_mono $$ G
   exact auth_inc_of_pmap_eqv _ (equiv_iff_eq.mpr map_delete)
 
@@ -463,8 +463,8 @@ theorem ghost_map_update_big [DecidableEq K] {γ m} (m0 m1 : H V) (Heq : dom m0 
     rw [←(bigOpM_iOwn γ _ _ (mt equiv_iff_eq.mp h)).to_eq, ←iOwn_op.to_eq]
     iapply iOwn_update $$ H
     refine Update.equiv_left (CMRA.op_right_eqv _ (BigOpM.bigOpM_map_eqv _ _ m0)) ?_
-    have Heq' : dom (Std.PartialMap.map (fun x : V => toAgree (LeibnizO.mk x)) m0) =
-        dom (Std.PartialMap.map (fun x : V => toAgree (LeibnizO.mk x)) m1) := by
+    have Heq' : dom (Std.PartialMap.map (fun x : V => toAgree (DiscreteO.mk x)) m0) =
+        dom (Std.PartialMap.map (fun x : V => toAgree (DiscreteO.mk x)) m1) := by
       rw [dom_map, dom_map, Heq]
     refine (update_big_replace _ _ _ Heq'
       (all_map fun _ _ => Agree.toAgree_valid)).trans ?_

--- a/Iris/Iris/Instances/Lib/LaterCredits.lean
+++ b/Iris/Iris/Instances/Lib/LaterCredits.lean
@@ -37,9 +37,8 @@ scoped instance : LeftIdentity (Add.add (α := Credit)) (0 : Credit) where
 scoped instance : LawfulLeftIdentity (Add.add (α := Credit)) (0 : Credit) := ⟨Nat.zero_add⟩
 scoped instance : LeftCancelAdd Credit := ⟨Nat.add_left_cancel⟩
 
-scoped instance : COFE Credit := COFE.ofDiscrete _ Eq_Equivalence
-scoped instance : Discrete Credit := ⟨congrArg id⟩
-scoped instance : Leibniz Credit := ⟨congrArg id⟩
+scoped instance : COFE Credit := COFE.ofDiscrete _
+scoped instance : Discrete Credit := ⟨fun h _ => h⟩
 scoped instance : UCMRA Credit := CommMonoidLike.instUCMRA
 scoped instance : CMRA.Discrete Credit := CommMonoidLike.instDiscrete
 scoped instance {a : Credit} : CMRA.Cancelable a := inferInstance
@@ -130,7 +129,8 @@ theorem lc_supply_bound {n m} : ⊢@{IProp GF} lc_supply m -∗ £ n -∗ ⌜n �
   ihave H := iOwn_cmraValid $$ H
   ihave ⟨%H, H2⟩ := auth_both_validI m n $$ H
   ipureintro
-  obtain ⟨k, rfl⟩ := H
+  obtain ⟨k, hk⟩ := H
+  rw [hk.to_eq]
   exact n.le_add_right k
 
 @[rocq_alias lc_decrease_supply]

--- a/Iris/Iris/Instances/Lib/NaInvariants.lean
+++ b/Iris/Iris/Instances/Lib/NaInvariants.lean
@@ -42,7 +42,7 @@ instance coreId_valid_empty_empty : CoreId ((valid (∅ : CoPset), valid (∅ : 
 
 instance isUnit_valid_empty_empty : IsUnit ((valid (∅ : CoPset), valid (∅ : PosSet))) where
   unit_valid := ⟨trivial, trivial⟩
-  unit_left_id := ⟨unit_left_id, unit_left_id⟩
+  unit_left_id := NonExpansive₂.eqv unit_left_id unit_left_id
   pcore_unit := coreId_valid_empty_empty.core_id
 
 namespace NonAtomicInvariant

--- a/Iris/Iris/Instances/Lib/WSat.lean
+++ b/Iris/Iris/Instances/Lib/WSat.lean
@@ -297,9 +297,7 @@ theorem ownI_alloc [W : WsatGS GF] (φ : Pos → Prop) (P : IProp GF)
     · suffices Hi : insert (liftInv I) j (toAgree (invariant_unfold P)) = liftInv (insert I j P) by
         rw [Hi]
         iexact Hown
-      refine ExtensionalPartialMap.equiv_iff_eq.mp fun k => ?_
-      simp only [get?_insert, get?_map, Option.map_map]
-      by_cases h : j = k <;> simp [h]
+      simp only [liftInv, map_insert]
     · iapply bigSepM_insert (x := P) Hget $$ [Hmap HProp HD]
       isplitl [HProp HD]
       · rw [HEQ]
@@ -340,9 +338,7 @@ theorem ownI_alloc_open [W : WsatGS GF] (φ : Pos → Prop) (P : IProp GF)
     · suffices Hi : Std.insert (liftInv I) j (toAgree (invariant_unfold P)) = liftInv (Std.insert I j P) by
         rw [Hi]
         iexact Hown
-      refine ExtensionalPartialMap.equiv_iff_eq.mp fun k => ?_
-      simp only [get?_insert, get?_map, Option.map_map]
-      by_cases h : j = k <;> simp [h]
+      simp only [liftInv, map_insert]
     · iapply bigSepM_insert (x := P) Hget $$ [Hmap HE]
       isplitl [HE]
       · iright; iassumption
@@ -371,8 +367,7 @@ theorem wsat_alloc [WP : WsatGpreS GF] :
     isplitl
     · iclear Hd
       have H : liftInv (∅ : InvMap (IProp GF)) = ∅ := by
-        refine ExtensionalPartialMap.equiv_iff_eq.mp fun _ => ?_
-        simp [get?_map, get?_empty]
+        simp only [liftInv, map_empty]
       rw [invMap, H]
       iassumption
     · iapply bigSepM_empty

--- a/Iris/Iris/Instances/Lib/WSat.lean
+++ b/Iris/Iris/Instances/Lib/WSat.lean
@@ -112,7 +112,7 @@ theorem ownE_empty : ⊢ |==> ownE (W := W) ∅ := iOwn_unit (ε := UCMRA.unit)
 @[rocq_alias ownE_op]
 theorem ownE_op {E1 E2} (Hdisj : E1 ## E2) : ownE (E1 ∪ E2) ⊣⊢@{IProp GF} ownE E1 ∗ ownE E2 := by
   refine .trans (.of_eq ?_) iOwn_op
-  rw [disj_op_union Hdisj]
+  rw [(disj_op_union Hdisj).to_eq]
   rfl
 
 @[rocq_alias ownE_disjoint]
@@ -156,7 +156,7 @@ theorem ownD_empty : ⊢@{IProp GF} |==> ownD ∅ := iOwn_unit (ε := UCMRA.unit
 @[rocq_alias ownD_op]
 theorem ownD_op {E1 E2} (Hdisj : E1 ## E2) : ownD (E1 ∪ E2) ⊣⊢@{IProp GF} ownD E1 ∗ ownD E2 := by
   refine .trans (.of_eq ?_) iOwn_op
-  rw [disj_op_union Hdisj]
+  rw [(disj_op_union Hdisj).to_eq]
   rfl
 
 @[rocq_alias ownD_disjoint]

--- a/Iris/Iris/Instances/UPred/Instance.lean
+++ b/Iris/Iris/Instances/UPred/Instance.lean
@@ -283,11 +283,10 @@ instance : BI (UPred M) where
   entails_preorder := inferInstance
   equiv_iff {_ _} := by
     constructor <;> intro HE
-    · constructor <;> intro n ⟨x, Hv⟩ H <;> refine uPred_holds_ne ?_ .refl Hv Hv H
-      · exact fun n' x _ => HE.symm n' x
-      · exact fun n' x _ => HE n' x
-    · intro n m Hv
-      exact ⟨fun H => HE.1 _ ⟨_, Hv⟩ H, fun H => HE.2 _ ⟨_, Hv⟩ H⟩
+    · exact ⟨fun n ⟨x, Hv⟩ H => (HE n n x .refl Hv).mp H,
+             fun n ⟨x, Hv⟩ H => (HE n n x .refl Hv).mpr H⟩
+    · intro n n' x _ p
+      exact ⟨fun H => HE.1 n' ⟨x, p⟩ H, fun H => HE.2 n' ⟨x, p⟩ H⟩
   and_ne.ne _ _ _ H _ _ H' _ _ Hn' Hv' := by
     constructor <;> intro H <;> rcases H with ⟨H1, H2⟩
     · constructor

--- a/Iris/Iris/ProgramLogic/AbstractWeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/AbstractWeakestPre.lean
@@ -156,7 +156,7 @@ theorem wp_inv_open_maybe_of_not_val {e : Expr} {E₁ E₂ : CoPset} {Φ : Val �
       (|={E₂, E₁}=> Wp.wp (Val := Val) Stuckness.NotStuck E₁ e Φ))
     ⊢ Wp.wp (Val := Val) Stuckness.NotStuck E₁ e Φ := by
   iintro H
-  rw [IProp.ext wp_unfold, wp.pre, Hnv]
+  rw [wp_unfold.to_eq, wp.pre, Hnv]
   simp only
   imod H with (⟨%K, %e', %Hctx, %Haux, %hato, Hwp⟩| >$)
   subst Haux

--- a/Iris/Iris/ProgramLogic/WeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/WeakestPre.lean
@@ -123,7 +123,7 @@ section Wp
 @[rocq_alias wp_unfold]
 theorem wp_unfold {s E} {e : Expr} {Φ : Val → IProp GF} :
     WP e @ s ; E {{ Φ }} ⊣⊢ wp.pre s (Wp.wp (PROP := IProp GF) s) E e Φ :=
-  BI.equiv_iff.1 <| fixpoint_unfold (f := (wp.pre s).toContractiveHom) E e Φ
+  BI.equiv_iff.1 <| fun n => fixpoint_unfold (f := (wp.pre s).toContractiveHom) n E e Φ
 
 @[rocq_alias wp_ne]
 instance wp_ne {s : Stuckness} {E} {e : Expr} :

--- a/Iris/Iris/ProofMode/InstancesInternalEq.lean
+++ b/Iris/Iris/ProofMode/InstancesInternalEq.lean
@@ -32,10 +32,10 @@ instance intoPure_internalEq [Sbi PROP] [OFE A] (a b : A)
   into_pure := discrete_eq_mp
 
 @[ipm_backtrack]
-instance (priority := default + 10) intoPure_internalEq_leibniz [Sbi PROP] [OFE A] [OFE.Leibniz A]
+instance (priority := default + 10) intoPure_internalEq_leibniz [Sbi PROP] [OFE A]
     (a b : A) [TCOr (OFE.DiscreteE a) (OFE.DiscreteE b)] :
     IntoPure (PROP := PROP) (internalEq a b) (a = b) where
-  into_pure := discrete_eq_mp.trans (pure_mono OFE.eq_of_eqv)
+  into_pure := discrete_eq_mp.trans (pure_mono OFE.Equiv.to_eq)
 
 @[rocq_alias from_modal_Next]
 instance fromModal_internalEq_next [Sbi PROP] [OFE A] (x y : A) :

--- a/Iris/Iris/Std/HeapInstances.lean
+++ b/Iris/Iris/Std/HeapInstances.lean
@@ -57,8 +57,6 @@ instance : LawfulPartialMap (K → Option ·) K where
   get?_delete_ne := by simp [get?, delete]; grind
   get?_bindAlter := by simp [get?, bindAlter]
   get?_merge {_ _ _ _ _} := by simp [get?, merge]; split <;> simp_all
-
-instance : ExtensionalPartialMap (K → Option ·) K where
   equiv_iff_eq := ⟨funext, congrFun⟩
 
 end FunPartialMap
@@ -83,160 +81,6 @@ instance instClassicalUnboundedHeap [InfiniteType K] : UnboundedHeap (K → Opti
     grind
 
 end ClassicalAllocHeap
-
-section AssociationLists
-
-/-- An association list represented as a sequence of set and remove operations. -/
-inductive AssocList (V : Type _)
-  | empty : AssocList V
-  | set : Nat → V → AssocList V → AssocList V
-  | remove : Nat → AssocList V → AssocList V
-
-open AssocList
-
-/-- Look up a value in an association list. -/
-@[simp]
-def AssocList.lookup (f : AssocList V) (k : Nat) : Option V :=
-  match f with
-  | .empty => none
-  | .set n v' rest => if n = k then some v' else rest.lookup k
-  | .remove n rest => if n = k then none else rest.lookup k
-
-/-- Update an association list by setting or removing a key. -/
-@[simp]
-def AssocList.update (f : AssocList V) (k : Nat) (v : Option V) : AssocList V :=
-  match v with
-  | some v' => f.set k v'
-  | none => f.remove k
-
-/-- Map a function over the values in an association list. -/
-@[simp]
-def AssocList.map (f : Nat → V → Option V') (g : AssocList V) : AssocList V' :=
-  match g with
-  | .empty => .empty
-  | .set n v rest =>
-      match (f n v) with
-      | .some r => .set n r (rest.map f)
-      | .none => .remove n (rest.map f)
-  | .remove n rest => .remove n (rest.map f)
-
-/-- Find a fresh key that is not present in the association list. -/
-@[simp]
-def AssocList.fresh (f : AssocList V) : Nat :=
-  match f with
-  | .empty => 0
-  | .set n _ rest => max (n + 1) rest.fresh
-  | .remove n rest => max (n + 1) rest.fresh
-
-/-- Construct an association list from a function on naturals less than N. -/
-@[simp]
-def AssocList.construct (f : Nat → Option V) (N : Nat) : AssocList V :=
-  match N with
-  | .zero => .empty
-  | .succ N' =>
-      match (f N') with
-      | some v => .set N' v (AssocList.construct f N')
-      | none => (AssocList.construct f N')
-
-/-- The specification function for `construct`: returns f n for n < N, none otherwise. -/
-@[simp]
-def AssocList.construct_spec (f : Nat → Option V) (N : Nat) : Nat → (Option V) :=
-  fun n => if n < N then f n else none
-
-/-- Updating an association list and then looking up is equivalent to the functional set. -/
-theorem AssocList.lookup_update (f : AssocList V) :
-    (f.update k v).lookup = fset (f.lookup) k v := by
-  funext k'
-  cases f <;> cases v <;> simp [fset]
-
-/-- Keys greater than or equal to `fresh` are not present in the association list. -/
-theorem AssocList.fresh_lookup_ge (f : AssocList V) n :
-    f.fresh ≤ n → f.lookup n = none := by
-  induction f <;> simp
-  case set => split <;> grind
-  case remove => grind
-
-/-- The lookup function of a constructed association list matches its specification. -/
-theorem AssocList.construct_get (f : Nat → Option V) (N : Nat) :
-    lookup (construct f N) = construct_spec f N := by
-  funext k
-  rcases Nat.lt_or_ge k N with hl | hg
-  · induction N <;> simp
-    rename_i N' IH
-    split <;> rename_i h
-    · simp only [lookup]; split
-      · simp_all
-      · rw [IH (by omega)]; simp; omega
-    · rw [if_pos hl]
-      if h : k < N' then
-        simp [IH h]; omega
-      else
-        have : k = N' := by omega
-        simp_all
-        clear this h
-        suffices ∀ N'', N' ≤ N'' → (construct f N').lookup N'' = none by grind
-        induction N' <;> simp
-        rename_i n' _
-        cases f n' <;> simp <;> grind
-  · simp; rw [if_neg (by omega)]
-    induction N <;> simp
-    split
-    · simp [lookup]; grind
-    · grind
-
-/-- Lift a binary operation to `Option`, treating `none` as an identity element. -/
-abbrev op_lift (op : V → V → V) (v1 v2 : Option V) : Option V :=
-  match v1, v2 with
-  | some v1, some v2 => some (op v1 v2)
-  | some v1, none => some v1
-  | none, some v2 => some v2
-  | none, none => none
-
-/-- PartialMap instance for AssocList. -/
-instance AssocList.instPartialMapAssocList : Iris.Std.PartialMap AssocList Nat where
-  get? f k := f.lookup k
-  insert f k v := f.update k (some v)
-  delete f k := f.update k none
-  empty := .empty
-  bindAlter f m := m.map f
-  merge op t1 t2 :=
-    construct (fun n => op_lift (op n) (t1.lookup n) (t2.lookup n)) (max t1.fresh t2.fresh)
-
-instance AssocList.instLawfulPartialMapAssocList : Iris.Std.LawfulPartialMap AssocList Nat where
-  get?_empty := by simp [get?, EmptyCollection.emptyCollection, Std.empty]
-  get?_insert_eq := by simp [get?, insert]; grind
-  get?_insert_ne := by simp [get?, insert]; grind
-  get?_delete_eq := by simp [get?, delete]
-  get?_delete_ne := by simp [get?, delete]; grind
-  get?_bindAlter {_ _ n t f} := by
-    induction t with
-    | empty => simp_all [get?, bindAlter, AssocList.map]
-    | set n' v' t' IH =>
-      simp_all [get?, bindAlter]
-      cases h1 : f n' v' <;> simp <;> split <;> rename_i h2 <;> simp_all
-    | remove n' t' IH =>
-      simp_all [get?, bindAlter]
-      split <;> simp [Option.bind]
-  get?_merge := by
-    intro _ op t1 t2 k
-    simp [PartialMap.get?, merge, construct_get, Option.merge, op_lift]
-    split
-    · rename_i h
-      cases t1.lookup k <;> cases t2.lookup k <;> simp_all
-    · rename_i h
-      rw [fresh_lookup_ge _ _ (by omega : t1.fresh ≤ k)]
-      rw [fresh_lookup_ge _ _ (by omega : t2.fresh ≤ k)]
-
-instance instAllocHeapAssocList : Iris.Std.Heap AssocList Nat where
-  notFull _ := True
-  fresh {_ f} _ := f.fresh
-  get?_fresh {_ f _} := fresh_lookup_ge f f.fresh (f.fresh.le_refl)
-
-instance instUnboundedHeapAssocList : Iris.Std.UnboundedHeap AssocList Nat where
-  notFull_empty := by simp [notFull]
-  notFull_insert_fresh {t v h} := by simp [notFull]
-
-end AssociationLists
 
 end Iris.Std
 
@@ -276,15 +120,6 @@ open Option Std.DTreeMap.Internal.Impl List TransCmp OrientedCmp LawfulEqCmp Ord
 open Iris.Std
 
 variable {K V : Type _} [Ord K] [TransOrd K] [LawfulEqOrd K]
-
-/-- TreeMap forms a Store with Option values. -/
-instance instStoreTreeMap : PartialMap (TreeMap K · compare) K where
-  get? t k := t[k]?
-  insert t k v := t.alter k (fun _ => some v)
-  delete t k := t.alter k (fun _ => none)
-  empty := ∅
-  bindAlter f t := t.filterMap f
-  merge op t1 t2 := t1.mergeWith op t2
 
 private theorem get?_foldl_alter_impl_sigma {l : List ((_ : K) × V)}
     (hinit : init.WF) (hl : l.Pairwise (fun x y => ¬ (compare x.1 y.1).isEq)) :
@@ -386,41 +221,6 @@ theorem getElem?_mergeWith' {t₁ t₂ : TreeMap K V compare} {f : K → V → V
     simp [← hval, hfind]
     simp [eq_of_compare hkv_cmp]
 
-instance : LawfulPartialMap (TreeMap K · compare) K where
-  get?_empty := by simp [Iris.Std.get?]
-  get?_insert_eq := by simp [Iris.Std.get?, Iris.Std.insert]; grind
-  get?_insert_ne := by simp [Iris.Std.get?, Iris.Std.insert]; grind
-  get?_delete_eq := by simp [Iris.Std.get?, Iris.Std.delete]
-  get?_delete_ne := by simp [Iris.Std.get?, Iris.Std.delete]; grind
-  get?_bindAlter := by simp [Iris.Std.get?, Iris.Std.bindAlter]
-  get?_merge := getElem?_mergeWith'
-
-instance : FiniteMap (TreeMap K · compare) K where
-  toList t := t.toList
-
-instance : LawfulFiniteMap (TreeMap K · compare) K where
-  toList_empty := rfl
-  toList_noDupKeys := by
-    intro V m
-    have h' : List.Pairwise (fun a b => ¬compare a b = eq) (m.toList.map (·.1)) := by
-      refine List.pairwise_map.mpr ?_
-      refine (distinct_keys_toList (t := m)).imp ?_
-      intro _ _ hab
-      exact hab
-    refine h'.imp ?_
-    intro a b hab
-    rw [compare_eq_iff_eq] at hab
-    exact hab
-  toList_get := by
-    intro V m k v
-    constructor
-    · intro h
-      exact getElem?_eq_some_iff_exists_compare_eq_eq_and_mem_toList.mpr ⟨k, compare_self, h⟩
-    · intro h
-      obtain ⟨_, hcmp, hmem⟩ := getElem?_eq_some_iff_exists_compare_eq_eq_and_mem_toList.mp h
-      rw [compare_eq_iff_eq.mp hcmp]
-      exact hmem
-
 end HeapInstance
 
 end Std.TreeMap
@@ -468,6 +268,7 @@ instance : LawfulPartialMap (ExtTreeMap K · compare) K where
   get?_delete_ne := by simp [Iris.Std.get?, Iris.Std.delete]; grind
   get?_bindAlter := by simp [Iris.Std.get?, Iris.Std.bindAlter]
   get?_merge := getElem?_mergeWith'
+  equiv_iff_eq {V m₁ m₂} := by rw [ExtTreeMap.ext_getElem?_iff]; rfl
 
 instance : FiniteMap (ExtTreeMap K · compare) K where
   toList t := t.toList
@@ -479,9 +280,6 @@ instance : LawfulFiniteMap (ExtTreeMap K · compare) K where
       refine h.imp (· <| LawfulEqOrd.compare_eq_iff_eq.mpr ·)
     exact List.pairwise_map.mpr distinct_keys_toList
   toList_get {_ m _ _} := m.mem_toList_iff_getElem?_eq_some
-
-instance : ExtensionalPartialMap (ExtTreeMap K · compare) K where
-  equiv_iff_eq {V m₁ m₂} := by rw [ExtTreeMap.ext_getElem?_iff]; rfl
 
 end HeapInstance
 

--- a/Iris/Iris/Std/PartialMap.lean
+++ b/Iris/Iris/Std/PartialMap.lean
@@ -219,11 +219,8 @@ end PartialMap
 /-- An association list has no duplicate keys -/
 def NoDupKeys (L : List (K × A)) : Prop := L.map (·.1) |>.Nodup
 
-class ExtensionalPartialMap (M : Type _ → Type _) (K : outParam (Type _))
-    extends PartialMap M K where
-  equiv_iff_eq {m₁ m₂ : M V} : PartialMap.equiv m₁ m₂ ↔ m₁ = m₂
-
-/-- Laws that a partial map implementation must satisfy. -/
+/-- Laws that a partial map implementation must satisfy. Includes extensionality
+(`equiv_iff_eq`): pointwise-equivalent maps are equal. -/
 class LawfulPartialMap (M : Type _ → Type _) (K : outParam (Type _))
     extends PartialMap M K where
   get?_empty k : get? (∅ : M V) k = none
@@ -235,8 +232,10 @@ class LawfulPartialMap (M : Type _ → Type _) (K : outParam (Type _))
       get? (bindAlter f m) k = (get? m k).bind (f k)
   get?_merge :
       get? (merge op m₁ m₂) k = Option.merge (op k) (get? m₁ k) (get? m₂ k)
+  /-- Pointwise-equivalent maps are equal (extensionality). -/
+  equiv_iff_eq {m₁ m₂ : M V} : PartialMap.equiv m₁ m₂ ↔ m₁ = m₂
 export LawfulPartialMap (get?_empty get?_insert_eq get?_insert_ne get?_delete_eq
-  get?_delete_ne get?_bindAlter get?_merge)
+  get?_delete_ne get?_bindAlter get?_merge equiv_iff_eq)
 
 class LawfulFiniteMap (M : Type _ → Type _) (K : outParam (Type _))
     extends LawfulPartialMap M K, FiniteMap M K where
@@ -340,31 +339,36 @@ theorem get?_delete_none_iff [DecidableEq K] {m : M V} {i j : K} :
   rw [get?_delete]; split <;> simp_all
 
 theorem insert_delete_cancel {m : M V} {i : K} {v : V} (h : get? m i = some v) :
-    insert (delete m i) i v ≡ₘ m := by
+    insert (delete m i) i v = m := by
+  apply equiv_iff_eq.mp
   intros j
   by_cases hij : i = j
   · rw [get?_insert_eq hij, ← h, hij]
   · rw [get?_insert_ne hij, get?_delete_ne hij]
 
 theorem delete_insert_cancel {m : M V} {i : K} {x : V} (h : get? m i = none) :
-    delete (insert m i x) i ≡ₘ m := by
+    delete (insert m i x) i = m := by
+  apply equiv_iff_eq.mp
   intro j
   by_cases hij : i = j
   · rw [get?_delete_eq hij, ← h, hij]
   · rw [get?_delete_ne hij, get?_insert_ne hij]
 
-theorem eq_empty_iff {m : M V} : (m ≡ₘ ∅) ↔ ∀ k, get? m k = none :=
-  ⟨fun h k => (h k) ▸ get?_empty k, fun h k => (h k) ▸ (get?_empty k).symm⟩
+theorem eq_empty_iff {m : M V} : (m = ∅) ↔ ∀ k, get? m k = none := by
+  rw [← equiv_iff_eq]
+  exact ⟨fun h k => (h k) ▸ get?_empty k, fun h k => (h k) ▸ (get?_empty k).symm⟩
 
 theorem delete_delete {m : M V} {i : K} :
-    delete (delete m i) i ≡ₘ delete m i := by
+    delete (delete m i) i = delete m i := by
+  apply equiv_iff_eq.mp
   intro j
   by_cases h : i = j
   · rw [get?_delete_eq h, get?_delete_eq h]
   · rw [get?_delete_ne h]
 
 theorem delete_delete_comm {m : M V} {i j : K} :
-    delete (delete m i) j ≡ₘ delete (delete m j) i := by
+    delete (delete m i) j = delete (delete m j) i := by
+  apply equiv_iff_eq.mp
   intro k
   by_cases hik : i = k <;> by_cases hjk : j = k
   · rw [get?_delete_eq hik, get?_delete_eq hjk]
@@ -373,21 +377,24 @@ theorem delete_delete_comm {m : M V} {i j : K} :
   · rw [get?_delete_ne hik, get?_delete_ne hjk, get?_delete_ne hik, get?_delete_ne hjk]
 
 theorem insert_insert_same {m : M V} {i : K} {x y : V} :
-    insert (insert m i x) i y ≡ₘ insert m i y := by
+    insert (insert m i x) i y = insert m i y := by
+  apply equiv_iff_eq.mp
   intro j
   by_cases h : i = j
   · rw [get?_insert_eq h, get?_insert_eq h]
   · rw [get?_insert_ne h, get?_insert_ne h, get?_insert_ne h]
 
 theorem insert_delete {m : M V} {i : K} {x : V} :
-    insert (delete m i) i x ≡ₘ insert m i x := by
+    insert (delete m i) i x = insert m i x := by
+  apply equiv_iff_eq.mp
   intro j
   by_cases h : i = j
   · rw [get?_insert_eq h, get?_insert_eq h]
   · rw [get?_insert_ne h, get?_delete_ne h, get?_insert_ne h]
 
 theorem insert_insert_comm {m : M V} {i j : K} {x y : V} (h : i ≠ j) :
-    insert (insert m i x) j y ≡ₘ insert (insert m j y) i x := by
+    insert (insert m i x) j y = insert (insert m j y) i x := by
+  apply equiv_iff_eq.mp
   intro k
   by_cases hik : i = k <;> by_cases hjk : j = k
   · rw [hik, hjk] at h; exact False.elim (h rfl)
@@ -396,7 +403,8 @@ theorem insert_insert_comm {m : M V} {i j : K} {x y : V} (h : i ≠ j) :
   · rw [get?_insert_ne hjk, get?_insert_ne hik, get?_insert_ne hik, get?_insert_ne hjk]
 
 theorem delete_insert_of_ne {m : M V} {i j : K} {x : V} (h : i ≠ j) :
-    delete (insert m i x) j ≡ₘ insert (delete m j) i x := by
+    delete (insert m i x) j = insert (delete m j) i x := by
+  apply equiv_iff_eq.mp
   intro k
   by_cases hik : i = k <;> by_cases hjk : j = k
   · rw [hik, hjk] at h; exact False.elim (h rfl)
@@ -404,28 +412,31 @@ theorem delete_insert_of_ne {m : M V} {i j : K} {x : V} (h : i ≠ j) :
   · rw [get?_insert_ne hik, get?_delete_eq hjk, get?_delete_eq hjk]
   · rw [get?_delete_ne hjk, get?_insert_ne hik, get?_insert_ne hik, get?_delete_ne hjk]
 
-theorem delete_empty {i : K} : delete (∅ : M V) i ≡ₘ ∅ := by
+theorem delete_empty {i : K} : delete (∅ : M V) i = ∅ := by
+  apply equiv_iff_eq.mp
   intro j
   by_cases h : i = j
   · rw [get?_delete_eq h, get?_empty]
   · rw [get?_delete_ne h, get?_empty]
 
-theorem delete_of_get? {m : M V} {i : K} (h : get? m i = none) : delete m i ≡ₘ m := by
+theorem delete_of_get? {m : M V} {i : K} (h : get? m i = none) : delete m i = m := by
+  apply equiv_iff_eq.mp
   intro j
   by_cases hij : i = j
   · rw [get?_delete_eq hij, ← h, hij]
   · rw [get?_delete_ne hij]
 
 theorem insert_get? {m : M V} {i : K} {x : V} (h : get? m i = some x) :
-    insert m i x ≡ₘ m := by
+    insert m i x = m := by
+  apply equiv_iff_eq.mp
   intro j
   by_cases hij : i = j
   · rw [get?_insert_eq hij, ← h, hij]
   · rw [get?_insert_ne hij]
 
-theorem insert_ne_empty {m : M V} {i : K} {x : V} : ¬(insert m i x ≡ₘ ∅) := by
+theorem insert_ne_empty {m : M V} {i : K} {x : V} : ¬(insert m i x = ∅) := by
   intro h
-  have : get? (insert m i x) i = none := (h i) ▸ get?_empty i
+  have : get? (insert m i x) i = none := by rw [h]; exact get?_empty i
   rw [get?_insert_eq rfl] at this
   cases this
 
@@ -464,16 +475,18 @@ theorem insert_subset_insert {m₁ m₂ : M V} {i : K} {x : V} (h : m₁ ⊆ m�
   · rw [get?_insert_ne hik] at hk ⊢
     exact h k v hk
 
-theorem singleton_ne_empty {i : K} {x : V} : ¬({[i := x]} ≡ₘ (∅ : M V)) := insert_ne_empty
+theorem singleton_ne_empty {i : K} {x : V} : ¬({[i := x]} = (∅ : M V)) := insert_ne_empty
 
-theorem delete_singleton_eq {i : K} {x : V} : delete ({[i := x]} : M V) i ≡ₘ ∅ := by
+theorem delete_singleton_eq {i : K} {x : V} : delete ({[i := x]} : M V) i = ∅ := by
+  apply equiv_iff_eq.mp
   intro j
   by_cases h : i = j
   · rw [get?_delete_eq h, get?_empty]
   · rw [get?_delete_ne h, get?_singleton_ne h, get?_empty]
 
 theorem delete_singleton_ne {i j : K} {x : V} (h : i ≠ j) :
-    delete ({[j := x]} : M V) i ≡ₘ {[j := x]} := by
+    delete ({[j := x]} : M V) i = {[j := x]} := by
+  apply equiv_iff_eq.mp
   intro k
   by_cases hik : i = k
   · rw [get?_delete_eq hik, get?_singleton_ne (hik ▸ h.symm)]
@@ -630,7 +643,8 @@ theorem disjoint_difference_right {m₁ m₂ : M V} :
   cases h_in_diff
 
 theorem union_difference_cancel {m₁ m₂ : M V} (h : m₂ ⊆ m₁) :
-    union m₂ (m₁ \ m₂) ≡ₘ m₁ := by
+    union m₂ (m₁ \ m₂) = m₁ := by
+  apply equiv_iff_eq.mp
   intro k
   simp only [PartialMap.union, get?_merge, get?_difference]
   cases hm2 : get? m₂ k with
@@ -651,22 +665,24 @@ theorem get?_union_none {m₁ m₂ : M V} {i : K} :
   cases h1 : get? m₁ i <;> cases h2 : get? m₂ i <;> simp [Option.orElse]
 
 theorem union_equiv {m₁ m₁' m₂ m₂' : M V}
-    (h₁ : m₁ ≡ₘ m₁') (h₂ : m₂ ≡ₘ m₂') : union m₁ m₂ ≡ₘ union m₁' m₂' := by
-  intro k
-  rw [get?_union, get?_union, h₁ k, h₂ k]
+    (h₁ : m₁ = m₁') (h₂ : m₂ = m₂') : union m₁ m₂ = union m₁' m₂' := by
+  rw [h₁, h₂]
 
-theorem union_empty_right {m : M V} : union m (∅ : M V) ≡ₘ m := by
+theorem union_empty_right {m : M V} : union m (∅ : M V) = m := by
+  apply equiv_iff_eq.mp
   intro k
   rw [get?_union, get?_empty]
   cases get? m k <;> rfl
 
-theorem union_empty_left {m : M V} : union (∅ : M V) m ≡ₘ m := by
+theorem union_empty_left {m : M V} : union (∅ : M V) m = m := by
+  apply equiv_iff_eq.mp
   intro k
   rw [get?_union, get?_empty]
   rfl
 
 theorem union_insert_left {m₁ m₂ : M V} {i : K} {x : V} :
-    insert (union m₁ m₂) i x ≡ₘ union (insert m₁ i x) m₂ := by
+    insert (union m₁ m₂) i x = union (insert m₁ i x) m₂ := by
+  apply equiv_iff_eq.mp
   intro k
   by_cases hik : i = k
   · subst hik
@@ -679,35 +695,39 @@ theorem get?_map {f : V → V'} {m : M V} {k : K} :
   cases get? m k <;> simp
 
 theorem map_id {m : M V} :
-    PartialMap.map id m ≡ₘ m := by
+    PartialMap.map id m = m := by
+  apply equiv_iff_eq.mp
   intro k
   rw [get?_map]
   cases get? m k <;> simp
 
-theorem map_empty {f : V → V'} : PartialMap.map f (∅ : M V) ≡ₘ (∅ : M V') := by
+theorem map_empty {f : V → V'} : PartialMap.map f (∅ : M V) = (∅ : M V') := by
+  apply equiv_iff_eq.mp
   intro k
   rw [get?_map, get?_empty, get?_empty]
   rfl
 
-theorem map_equiv {f : V → V'} {m₁ m₂ : M V} (h : m₁ ≡ₘ m₂) :
-    PartialMap.map f m₁ ≡ₘ PartialMap.map f m₂ := by
-  intro k
-  rw [get?_map, get?_map, h k]
+theorem map_equiv {f : V → V'} {m₁ m₂ : M V} (h : m₁ = m₂) :
+    PartialMap.map f m₁ = PartialMap.map f m₂ := by
+  rw [h]
 
 theorem map_insert {f : V → V'} {m : M V} {k : K} {v : V} :
-    PartialMap.map f (insert m k v) ≡ₘ insert (PartialMap.map f m) k (f v) := by
+    PartialMap.map f (insert m k v) = insert (PartialMap.map f m) k (f v) := by
+  apply equiv_iff_eq.mp
   intro i
   by_cases h : k = i <;>
     simp [h, get?_map, get?_insert_eq, get?_insert_ne]
 
 theorem map_delete {f : V → V'} {m : M V} {k : K} :
-    PartialMap.map f (delete m k) ≡ₘ delete (PartialMap.map f m) k := by
+    PartialMap.map f (delete m k) = delete (PartialMap.map f m) k := by
+  apply equiv_iff_eq.mp
   intro i
   by_cases h : k = i <;>
     simp [h, get?_map, get?_delete_eq, get?_delete_ne]
 
 theorem map_union {f : V → V'} {m₁ m₂ : M V} :
-    PartialMap.map f (m₁ ∪ m₂) ≡ₘ (PartialMap.map f m₁ ∪ PartialMap.map f m₂) := by
+    PartialMap.map f (m₁ ∪ m₂) = (PartialMap.map f m₁ ∪ PartialMap.map f m₂) := by
+  apply equiv_iff_eq.mp
   intro k
   simp only [get?_map, Union.union, PartialMap.union, get?_merge]
   cases get? m₁ k <;> cases get? m₂ k <;> simp [Option.merge]
@@ -726,7 +746,8 @@ theorem disjoint_map {f g : V → V'} {m₁ m₂ : M V}
 The conclusion uses `map` on both sides so the right-hand side type-checks. -/
 theorem map_difference_map {f : V → V'} {g : V → V'}
     {m₁ m₂ : M V} :
-    (PartialMap.map f m₁ \ PartialMap.map g m₂) ≡ₘ PartialMap.map f (m₁ \ m₂) := by
+    (PartialMap.map f m₁ \ PartialMap.map g m₂) = PartialMap.map f (m₁ \ m₂) := by
+  apply equiv_iff_eq.mp
   intro k
   simp only [get?_map, get?_difference, Option.isSome_map]
   split <;> simp
@@ -750,22 +771,25 @@ theorem get?_zip {m₁ : M V} {m₂ : M V'} {k : K} :
   cases h1 : get? m₁ k <;> cases h2 : get? m₂ k <;> simp [Option.bind]
 
 theorem map_zipWith_right {f : V → V' → V''} {g : V''' → V'} {m₁ : M V} {m₂ : M V'''} :
-    PartialMap.map (fun (v, w) => f v (g w)) (zip m₁ m₂) ≡ₘ
+    PartialMap.map (fun (v, w) => f v (g w)) (zip m₁ m₂) =
       zipWith f m₁ (PartialMap.map g m₂) := by
+  apply equiv_iff_eq.mp
   intro k
   simp [get?_map, get?_zip, get?_zipWith]
   cases get? m₁ k <;> cases get? m₂ k <;> simp [Option.bind, Option.map]
 
 theorem map_zipWith_left {f : V → V' → V''} {g : V''' → V} {m₁ : M V'''} {m₂ : M V'} :
-    PartialMap.map (fun (w, v) => f (g w) v) (zip m₁ m₂) ≡ₘ
+    PartialMap.map (fun (w, v) => f (g w) v) (zip m₁ m₂) =
       zipWith f (PartialMap.map g m₁) m₂ := by
+  apply equiv_iff_eq.mp
   intro k
   simp [get?_map, get?_zip, get?_zipWith]
   cases get? m₁ k <;> cases get? m₂ k <;> simp [Option.bind, Option.map]
 
 theorem zipWith_insert {f : V → V' → V''} {m₁ : M V} {m₂ : M V'} {k : K} {v : V} {v' : V'} :
-    zipWith f (insert m₁ k v) (insert m₂ k v') ≡ₘ
+    zipWith f (insert m₁ k v) (insert m₂ k v') =
       insert (zipWith f m₁ m₂) k (f v v') := by
+  apply equiv_iff_eq.mp
   intro k'
   by_cases h : k = k'
   · subst h
@@ -773,7 +797,8 @@ theorem zipWith_insert {f : V → V' → V''} {m₁ : M V} {m₂ : M V'} {k : K}
   · simp [get?_zipWith, get?_insert_ne h]
 
 theorem zipWith_delete {f : V → V' → V''} {m₁ : M V} {m₂ : M V'} {k : K} :
-    zipWith f (delete m₁ k) (delete m₂ k) ≡ₘ delete (zipWith f m₁ m₂) k := by
+    zipWith f (delete m₁ k) (delete m₂ k) = delete (zipWith f m₁ m₂) k := by
+  apply equiv_iff_eq.mp
   intro k'
   by_cases h : k = k'
   · subst h
@@ -782,23 +807,25 @@ theorem zipWith_delete {f : V → V' → V''} {m₁ : M V} {m₂ : M V'} {k : K}
 
 theorem zipWith_comm {f : V → V' → V''} {m₁ : M V} {m₂ : M V'} :
     (∀ v v', f v v' = f v v') →
-    zipWith f m₁ m₂ ≡ₘ zipWith f m₁ m₂ := by
-  intro _; intro _; rfl
+    zipWith f m₁ m₂ = zipWith f m₁ m₂ :=
+  fun _ => rfl
 
 -- -- FIXME: universe issue
 -- theorem zip_comm {m₁ : M V} {m₂ : M V'} :
---     PartialMap.map Prod.swap (zip m₁ m₂) ≡ₘ zip m₂ m₁ := by
+--     PartialMap.map Prod.swap (zip m₁ m₂) = zip m₂ m₁ := by
 --   sorry
 
 theorem zip_map {f : V → V'} {g : V → V''} {m : M V} :
-    zip (PartialMap.map f m) (PartialMap.map g m) ≡ₘ
+    zip (PartialMap.map f m) (PartialMap.map g m) =
       PartialMap.map (fun v => (f v, g v)) m := by
+  apply equiv_iff_eq.mp
   intro k
   simp [zip, get?_map, zipWith, get?_bindAlter]
   cases get? m k <;> simp [Option.bind, Option.map]
 
 theorem zip_fst_snd {m : M (V × V')} :
-    zip (PartialMap.map Prod.fst m) (PartialMap.map Prod.snd m) ≡ₘ m := by
+    zip (PartialMap.map Prod.fst m) (PartialMap.map Prod.snd m) = m := by
+  apply equiv_iff_eq.mp
   intro k
   simp [zip, zipWith, get?_map, get?_bindAlter]
   cases h : get? m k <;> simp [Option.bind, Option.map]
@@ -810,24 +837,26 @@ theorem isSome_zipWith {f : V → V' → V''} {m₁ : M V} {m₂ : M V'} {k : K}
   cases h1 : get? m₁ k <;> cases h2 : get? m₂ k <;> simp
 
 theorem zip_empty_left {m : M V'} :
-    zip (∅ : M V) m ≡ₘ ∅ := by
+    zip (∅ : M V) m = ∅ := by
+  apply equiv_iff_eq.mp
   intro k
   simp only [zip, zipWith, get?_bindAlter, get?_empty, Option.bind]
 
 theorem zip_empty_right {m : M V} :
-    zip m (∅ : M V') ≡ₘ ∅ := by
+    zip m (∅ : M V') = ∅ := by
+  apply equiv_iff_eq.mp
   intro k
   simp only [zip, zipWith, get?_bindAlter, get?_empty, Option.bind]
   cases h : get? m k <;> simp
 
 -- -- FIXME: universe issue
 -- theorem zip_insert {m₁ : M V} {m₂ : M V'} {k : K} {v : V} {v' : V'} :
---     zip (insert m₁ k v) (insert m₂ k v') ≡ₘ insert (zip m₁ m₂) k (v, v') := by
+--     zip (insert m₁ k v) (insert m₂ k v') = insert (zip m₁ m₂) k (v, v') := by
 --   sorry
 
 -- FIXME: universe issue
 -- theorem zip_delete {m₁ : M V} {m₂ : M V'} {k : K} :
---     zip (delete m₁ k) (delete m₂ k) ≡ₘ delete (zip m₁ m₂) k := by
+--     zip (delete m₁ k) (delete m₂ k) = delete (zip m₁ m₂) k := by
 --   sorry
 
 theorem isSome_zip {m₁ : M V} {m₂ : M V'} {k : K} :
@@ -925,7 +954,8 @@ theorem nodup_toList {m : M V} : (toList m).Nodup :=
   NoDupKeys_noDup toList_noDupKeys
 
 theorem ofList_toList [DecidableEq K] {m : M V} :
-    PartialMap.equiv (ofList (toList m)) m := by
+    ofList (toList m) = m := by
+  apply equiv_iff_eq.mp
   intro k
   rcases h : get? m k with _|v
   · refine get?_ofList_none ?_ toList_noDupKeys
@@ -934,11 +964,10 @@ theorem ofList_toList [DecidableEq K] {m : M V} :
   · exact get?_ofList_some (toList_get.mpr h) toList_noDupKeys
 
 theorem induction_on [DecidableEq K] {P : M V → Prop}
-    (hequiv : ∀ m₁ m₂, PartialMap.equiv m₁ m₂ → P m₁ → P m₂)
     (hemp : P ∅)
     (hins : ∀ i x m, get? m i = none → P m → P (PartialMap.insert m i x))
     (m : M V) : P m := by
-  apply hequiv _ _ ofList_toList
+  rw [← ofList_toList (m := m)]
   suffices ∀ l, NoDupKeys l → P (ofList l) from this _ toList_noDupKeys
   intro l hnd
   induction l with
@@ -1054,15 +1083,15 @@ theorem mem_ofList [DecidableEq K] {l : List (K × V)} {i : K} {x : V}
 
 theorem ofList_injective [DecidableEq K] {l₁ l₂ : List (K × V)}
     (hnodup1 : (l₁.map Prod.fst).Nodup) (hnodup2 : (l₂.map Prod.fst).Nodup) :
-    PartialMap.equiv (ofList l₁ : M V) (ofList l₂) → l₁.Perm l₂ := by
+    (ofList l₁ : M V) = ofList l₂ → l₁.Perm l₂ := by
   intro He
   refine (List.perm_ext_iff_of_nodup (NoDupKeys_noDup hnodup1) (NoDupKeys_noDup hnodup2)).mpr ?_
   refine fun ⟨k, v⟩ => ⟨fun H => ?_, fun H => ?_⟩
   · apply mem_of_mem_ofList (M := M)
-    rw [← He k]
+    rw [← He]
     exact get?_ofList_some H (List.nodup_iff_pairwise_ne.mpr hnodup1)
   · apply mem_of_mem_ofList (M := M)
-    rw [He k]
+    rw [He]
     exact get?_ofList_some H (List.nodup_iff_pairwise_ne.mpr hnodup2)
 
 theorem toList_insert_delete {m : M V} {k : K} {v : V} :

--- a/IrisMath/IrisMath/MeasureTheory.lean
+++ b/IrisMath/IrisMath/MeasureTheory.lean
@@ -13,23 +13,14 @@ open Iris ProbabilityTheory MeasureTheory
 
 variable {Ω : Type _} [MeasurableSpace Ω]
 
-/-- Real-valued random variable -/
-@[ext] structure RandomVariable (δ : Type _) (μ : Measure Ω) where
-  car : Ω → δ
+def aeSetoid (μ : Measure Ω) (δ : Type _) : Setoid (Ω → δ) where
+  r x y := x =ᵐ[μ] y
+  iseqv := ⟨fun _ => ae_eq_rfl, (Filter.EventuallyEq.symm ·), (ae_eq_trans · ·)⟩
 
-namespace RealRandomVariableMax
+def RandomVariable (δ : Type _) (μ : Measure Ω) : Type _ := Quotient (aeSetoid μ δ)
 
-variable {μ : Measure Ω} (δ : Type _)
-
-example : OFE (Ω → δ) where
-  Equiv x y := x =ᵐ[μ] y
-  Dist _ x y := x =ᵐ[μ] y
-  dist_eqv := {
-    refl _ := ae_eq_rfl
-    symm := (Filter.EventuallyEq.symm ·)
-    trans := (ae_eq_trans · ·)
-  }
-  equiv_dist := .symm <| forall_const _
-  dist_lt H _ := H
-
-end RealRandomVariableMax
+instance (δ : Type _) (μ : Measure Ω) : OFE (RandomVariable δ μ) where
+  Dist _ := (· = ·)
+  dist_eqv := eq_equivalence
+  eq_dist := (forall_const _).symm
+  dist_lt h _ := h


### PR DESCRIPTION
## Description
- Changes definition of OFE to relate distance to equality, instead of equivalence, with that, all OFE become Leibniz. The old definition of Equiv is replaced by \forall n, Dist n x y.
- Removes Leibniz and LeibnizPreserving (not needed anymore).
- Adds to_eq to BI interface, now it's not a property of particular instances, but part of the interface. 
- Fixes downstream proofs (mostly in the Algebra folder). 
- Short demo is in BI/Algebra, where a lot of annoying manual Equiv constructions were factored out. 

This is the first step, next, I'm going to start from the leaves of the project replacing Equiv with equality, manual Eequiv constructions with simp/rw tactics to avoid big PRs. 
Apart from the listed changes, I tried to avoid changing any interfaces, so it can be used by downstream projects only with the proposed changes to the OFE interface, and minor changes to Equiv-related proofs (if it was unfolding definition of a particular Equiv).

Also, I've not included it in the PR, but now if you import Mathlib, it becomes easy to show that (C)OFEs are a subclass (complete) ultrametric spaces, and it hopefully can be used for reusing some topology results from Mathlib (I can include it later, but probably it's better if this PR stays relatively small). 