### PR TITLE
feat: use `Nat.repeat` for the definition of `BIBase.laterN`

### DIFF
--- a/Iris/Iris/BI/BIBase.lean
+++ b/Iris/Iris/BI/BIBase.lean
@@ -235,8 +235,7 @@ delab_rule intuitionistically
 syntax:max "▷^[" term:45 "]" term:40 : term
 
 @[rocq_alias bi_laterN]
-def laterN [BIBase PROP] (n : Nat) (P : PROP) : PROP :=
-  match n with | .zero => P | .succ n' => later <| laterN n' P
+def laterN [BIBase PROP] (n : Nat) (P : PROP) : PROP := n.repeat later P
 
 macro_rules
   | `(iprop(▷^[$n] $P))   => ``(laterN $n iprop($P))

--- a/Iris/Iris/BI/DerivedLawsLater.lean
+++ b/Iris/Iris/BI/DerivedLawsLater.lean
@@ -397,7 +397,9 @@ instance laterN_persistent (n : Nat) (P : PROP) [Persistent P] :
     Persistent iprop(▷^[n] P) := by
   induction n with
   | zero => assumption
-  | succ n _ => exact later_persistent
+  | succ n _ =>
+    dsimp only [BIBase.laterN, Nat.repeat] at *
+    exact later_persistent
 
 instance instPersistentLaterIf [BI PROP] (P : PROP) [Persistent P] (p : Bool) :
     Persistent iprop(▷?p P) := by
@@ -408,7 +410,9 @@ instance laterN_absorbing (n : Nat) (P : PROP) [Absorbing P] :
     Absorbing iprop(▷^[n] P) := by
   induction n with
   | zero => assumption
-  | succ n _ => exact later_absorbing
+  | succ n _ =>
+    dsimp only [BIBase.laterN, Nat.repeat] at *
+    exact later_absorbing
 
 /-! ## LaterN as a monoid homomorphism -/
 

--- a/Iris/Iris/Instances/Lib/FUpd.lean
+++ b/Iris/Iris/Instances/Lib/FUpd.lean
@@ -173,7 +173,7 @@ theorem lc_fupd_add_laterN (n : Nat) {E : CoPset} {P : IProp GF} :
   induction n generalizing P with
   | zero =>
     iintro _ H
-    simp [BIBase.laterN]
+    dsimp only [BIBase.laterN, Nat.repeat]
     iexact H
   | succ n IH =>
     iintro Hf Hupd


### PR DESCRIPTION
## Description

Addresses #324.

Simple improvement. Using `dsimp` to unfold `Nat.repeat` in proofs, similar to how other uses of `Nat.repeat` are handled.

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files
