### PR TITLE
feat: texan triple minor improvements

### DIFF
--- a/Iris/Iris/BI/WeakestPre.lean
+++ b/Iris/Iris/BI/WeakestPre.lean
@@ -40,7 +40,7 @@ instance : Std.IsPreorder Stuckness where
 @[simp] theorem le_MaybeStuck {s : Stuckness} : s ≤ MaybeStuck := by
   cases s <;> grind only [Stuckness, LE.le, instLE]
 
-@[simp] theorem NotSuck_le {s : Stuckness} : NotStuck ≤ s := by
+@[simp] theorem NotStuck_le {s : Stuckness} : NotStuck ≤ s := by
   cases s <;> grind only [Stuckness, LE.le, instLE]
 
 end Stuckness

--- a/Iris/Iris/BI/WeakestPre.lean
+++ b/Iris/Iris/BI/WeakestPre.lean
@@ -63,8 +63,8 @@ declare_syntax_cat wpPostcond
 -- example {a : PUnit.{i}} : PUnit.{i} := a
 --                      ^^
 -- see: https://github.com/leanprover-community/iris-lean/pull/393
-syntax " {" "{ " wpPostcondInner " }" "} " : wpPostcond
-syntax " [" "{ " wpPostcondInner " }" "] " : wpPostcond
+syntax " {" noWs "{ " wpPostcondInner " }" noWs "} " : wpPostcond
+syntax " [" noWs "{ " wpPostcondInner " }" noWs "] " : wpPostcond
 syntax " ⦃ " wpPostcondInner " ⦄ " : wpPostcond
 syntax " 〖 " wpPostcondInner " 〗 "  : wpPostcond
 
@@ -72,10 +72,10 @@ syntax (name := wp) "WP " wpExpr wpPostcond : term
 
 syntax texanPostcondInner := (ident+ ", ")? " RET " term:min "; " term:min
 declare_syntax_cat texanPostcond
-syntax " {" "{ " texanPostcondInner " }" "} " : texanPostcond
+syntax " {" noWs "{ " texanPostcondInner " }" noWs "} " : texanPostcond
 syntax " ⦃ " texanPostcondInner " ⦄ " : texanPostcond
 declare_syntax_cat texanPrecond
-syntax " {" "{ " term:min " }" "} " : texanPrecond
+syntax " {" noWs "{ " term:min " }" noWs "} " : texanPrecond
 syntax " ⦃ " term:min " ⦄ " : texanPrecond
 
 syntax (name := texanTriple) texanPrecond wpExpr texanPostcond : term

--- a/Iris/Iris/BI/WeakestPre.lean
+++ b/Iris/Iris/BI/WeakestPre.lean
@@ -70,7 +70,7 @@ syntax " 〖 " wpPostcondInner " 〗 "  : wpPostcond
 
 syntax (name := wp) "WP " wpExpr wpPostcond : term
 
-syntax texanPostcondInner := (ident+ ", ")? " RET " term:min "; " term:min
+syntax texanPostcondInner := ((ppSpace (binderIdent <|> bracketedBinder))+ ", ")? " RET " term:min "; " term:min
 declare_syntax_cat texanPostcond
 syntax " {" noWs "{ " texanPostcondInner " }" noWs "} " : texanPostcond
 syntax " ⦃ " texanPostcondInner " ⦄ " : texanPostcond
@@ -126,10 +126,18 @@ meta def wpMacro : Lean.Macro := fun stx => do
 
 @[macro texanTriple]
 meta def wpTexanTriple : Lean.Macro
-  | `(⦃ $P:term ⦄ $wpExpr ⦃ $[$[$xs:ident]* ,]? RET $pat ; $Q:term ⦄)
-  | `({{ $P:term }} $wpExpr {{ $[$[$xs:ident]* ,]? RET $pat ; $Q:term }}) => do
+  | `(⦃ $P:term ⦄ $wpExpr ⦃ $[$[$xs]* ,]? RET $pat ; $Q:term ⦄)
+  | `({{ $P:term }} $wpExpr {{ $[$[$xs]* ,]? RET $pat ; $Q:term }}) => do
+
+    let transform (xs : Array (TSyntax [`Lean.binderIdent, `Lean.Parser.Term.bracketedBinder])) : MacroM <| TSyntaxArray [`ident, `Lean.Parser.Term.hole, `Lean.Parser.Term.bracketedBinder] := 
+      xs.mapM fun
+        | `(binderIdent|_) => `(hole|_)
+        | `(binderIdent|$i:ident) => `(ident|$i)
+        | `(bracketedBinder|$x) => `(bracketedBinder|$x)
+
     let k ← match xs with
             | some xs => 
+              let xs ← transform xs -- TSyntax cast
               `(iprop(∀ $xs*, $Q:term -∗ Φ $pat))
             | none => `($Q:term -∗ Φ $pat)
     `(iprop(∀ Φ, $P -∗ ▷ $k -∗ (WP $wpExpr {{ Φ }})))

--- a/Iris/Iris/BI/WeakestPre.lean
+++ b/Iris/Iris/BI/WeakestPre.lean
@@ -129,8 +129,9 @@ meta def wpTexanTriple : Lean.Macro
   | `(⦃ $P:term ⦄ $wpExpr ⦃ $[$[$xs:ident]* ,]? RET $pat ; $Q:term ⦄)
   | `({{ $P:term }} $wpExpr {{ $[$[$xs:ident]* ,]? RET $pat ; $Q:term }}) => do
     let k ← match xs with
-            | some xs => `(∀ $xs*, $Q:term → Φ $pat)
-            | none => `($Q:term → Φ $pat)
+            | some xs => 
+              `(iprop(∀ $xs*, $Q:term -∗ Φ $pat))
+            | none => `($Q:term -∗ Φ $pat)
     `(iprop(∀ Φ, $P -∗ ▷ $k -∗ (WP $wpExpr {{ Φ }})))
   | _ => Lean.Macro.throwUnsupported
 

--- a/Iris/Iris/Tests/WeakestPre.lean
+++ b/Iris/Iris/Tests/WeakestPre.lean
@@ -183,64 +183,64 @@ variable [BI PROP]
 variable (e : Expr)(s : A)(E : CoPset)
 variable (P Q : PROP)
 
-/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q → Φ (x + y)) -∗ WP e @ s ; E {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q -∗ Φ (x + y)) -∗ WP e @ s ; E {{ Φ }} ) : PROP -/
 #guard_msgs in #check {{ P }} e @ s ; E {{ x y , RET (x+y) ; Q }}
 
-/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q → Φ (x + y)) -∗ WP e @ E {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q -∗ Φ (x + y)) -∗ WP e @ E {{ Φ }} ) : PROP -/
 #guard_msgs in #check {{ P }} e @ E {{ x y , RET (x+y) ; Q }}
 
-/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q → Φ (x + y)) -∗ WP e @ E ? {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q -∗ Φ (x + y)) -∗ WP e @ E ? {{ Φ }} ) : PROP -/
 #guard_msgs in #check {{ P }} e @ E ? {{ x y , RET (x+y) ; Q }}
 
-/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q → Φ (x + y)) -∗ WP e {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q -∗ Φ (x + y)) -∗ WP e {{ Φ }} ) : PROP -/
 #guard_msgs in #check {{ P }} e {{ x y , RET (x+y) ; Q }}
 
-/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q → Φ (x + y)) -∗ WP e ? {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q -∗ Φ (x + y)) -∗ WP e ? {{ Φ }} ) : PROP -/
 #guard_msgs in #check {{ P }} e ? {{ x y , RET (x+y) ; Q }}
 
-/-- info: iprop(∀ Φ, P -∗ ▷ (Q → Φ 0) -∗ WP e @ s ; E {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ ▷ (Q -∗ Φ 0) -∗ WP e @ s ; E {{ Φ }} ) : PROP -/
 #guard_msgs in #check {{ P }} e @ s ; E {{ RET 0 ; Q }}
 
-/-- info: iprop(∀ Φ, P -∗ ▷ (Q → Φ 0) -∗ WP e @ E {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ ▷ (Q -∗ Φ 0) -∗ WP e @ E {{ Φ }} ) : PROP -/
 #guard_msgs in #check {{ P }} e @ E {{ RET 0 ; Q }}
 
-/-- info: iprop(∀ Φ, P -∗ ▷ (Q → Φ 0) -∗ WP e @ E ? {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ ▷ (Q -∗ Φ 0) -∗ WP e @ E ? {{ Φ }} ) : PROP -/
 #guard_msgs in #check {{ P }} e @ E ? {{ RET 0 ; Q }}
 
-/-- info: iprop(∀ Φ, P -∗ ▷ (Q → Φ 0) -∗ WP e {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ ▷ (Q -∗ Φ 0) -∗ WP e {{ Φ }} ) : PROP -/
 #guard_msgs in #check {{ P }} e {{ RET 0 ; Q }}
 
-/-- info: iprop(∀ Φ, P -∗ ▷ (Q → Φ 0) -∗ WP e ? {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ ▷ (Q -∗ Φ 0) -∗ WP e ? {{ Φ }} ) : PROP -/
 #guard_msgs in #check {{ P }} e ? {{ RET 0 ; Q }}
 
-/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q → Φ (x + y)) -∗ WP e @ s ; E {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q -∗ Φ (x + y)) -∗ WP e @ s ; E {{ Φ }} ) : PROP -/
 #guard_msgs in #check ⦃ P ⦄ e @ s ; E ⦃ x y , RET (x+y) ; Q ⦄
 
-/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q → Φ (x + y)) -∗ WP e @ E {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q -∗ Φ (x + y)) -∗ WP e @ E {{ Φ }} ) : PROP -/
 #guard_msgs in #check ⦃ P ⦄ e @ E ⦃ x y , RET (x+y) ; Q ⦄
 
-/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q → Φ (x + y)) -∗ WP e @ E ? {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q -∗ Φ (x + y)) -∗ WP e @ E ? {{ Φ }} ) : PROP -/
 #guard_msgs in #check ⦃ P ⦄ e @ E ? ⦃ x y , RET (x+y) ; Q ⦄
 
-/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q → Φ (x + y)) -∗ WP e {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q -∗ Φ (x + y)) -∗ WP e {{ Φ }} ) : PROP -/
 #guard_msgs in #check ⦃ P ⦄ e ⦃ x y , RET (x+y) ; Q ⦄
 
-/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q → Φ (x + y)) -∗ WP e ? {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q -∗ Φ (x + y)) -∗ WP e ? {{ Φ }} ) : PROP -/
 #guard_msgs in #check ⦃ P ⦄ e ? ⦃ x y , RET (x+y) ; Q ⦄
 
-/-- info: iprop(∀ Φ, P -∗ ▷ (Q → Φ 0) -∗ WP e @ s ; E {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ ▷ (Q -∗ Φ 0) -∗ WP e @ s ; E {{ Φ }} ) : PROP -/
 #guard_msgs in #check ⦃ P ⦄ e @ s ; E ⦃ RET 0 ; Q ⦄
 
-/-- info: iprop(∀ Φ, P -∗ ▷ (Q → Φ 0) -∗ WP e @ E {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ ▷ (Q -∗ Φ 0) -∗ WP e @ E {{ Φ }} ) : PROP -/
 #guard_msgs in #check ⦃ P ⦄ e @ E ⦃ RET 0 ; Q ⦄
 
-/-- info: iprop(∀ Φ, P -∗ ▷ (Q → Φ 0) -∗ WP e @ E ? {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ ▷ (Q -∗ Φ 0) -∗ WP e @ E ? {{ Φ }} ) : PROP -/
 #guard_msgs in #check ⦃ P ⦄ e @ E ? ⦃ RET 0 ; Q ⦄
 
-/-- info: iprop(∀ Φ, P -∗ ▷ (Q → Φ 0) -∗ WP e {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ ▷ (Q -∗ Φ 0) -∗ WP e {{ Φ }} ) : PROP -/
 #guard_msgs in #check ⦃ P ⦄ e ⦃ RET 0 ; Q ⦄
 
-/-- info: iprop(∀ Φ, P -∗ ▷ (Q → Φ 0) -∗ WP e ? {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ ▷ (Q -∗ Φ 0) -∗ WP e ? {{ Φ }} ) : PROP -/
 #guard_msgs in #check ⦃ P ⦄ e ? ⦃ RET 0 ; Q ⦄
 
 end TestTexanTriple
@@ -288,31 +288,31 @@ variable (PROP : Type _) [BI PROP]
 variable [Wp PROP Exp Val Stuckness]
 variable (E : CoPset) (P Q : PROP)
 
-/-- info: iprop(∀ Φ, P -∗ ▷ (Q → Φ hl_val(#1)) -∗ WP hl(#1) {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ ▷ (Q -∗ Φ hl_val(#1)) -∗ WP hl(#1) {{ Φ }} ) : PROP -/
 #guard_msgs in #check {{ P }} hl(#1) {{ RET hl_val(#1); Q }}
-/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q → Φ x) -∗ WP hl((#1 + #2)) {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q -∗ Φ x) -∗ WP hl((#1 + #2)) {{ Φ }} ) : PROP -/
 #guard_msgs in #check {{ P }} hl(#1 + #2) {{ x, RET x; Q }}
-/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q → Φ x) -∗ WP hl((#1 < #2)) {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q -∗ Φ x) -∗ WP hl((#1 < #2)) {{ Φ }} ) : PROP -/
 #guard_msgs in #check {{ P }} hl(#1 < #2) {{ x, RET x; Q }}
 /--
-info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q → Φ x) -∗ WP hl(if (#0 < #1) then #1 else #2) {{ Φ }} ) : PROP
+info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q -∗ Φ x) -∗ WP hl(if (#0 < #1) then #1 else #2) {{ Φ }} ) : PROP
 -/
 #guard_msgs in #check {{ P }} hl(if #0 < #1 then #1 else #2) {{ x, RET x; Q }}
-/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q → Φ x) -∗ WP hl((λ x, x)) {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q -∗ Φ x) -∗ WP hl((λ x, x)) {{ Φ }} ) : PROP -/
 #guard_msgs in #check {{ P }} hl(λ x, x) {{ x, RET x; Q }}
-/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q → Φ x) -∗ WP hl((rec f x := f x)) {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q -∗ Φ x) -∗ WP hl((rec f x := f x)) {{ Φ }} ) : PROP -/
 #guard_msgs in #check {{ P }} hl(rec f x := f x) {{ x, RET x; Q }}
-/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q → Φ x) -∗ WP hl(#1; #2) {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q -∗ Φ x) -∗ WP hl(#1; #2) {{ Φ }} ) : PROP -/
 #guard_msgs in #check {{ P }} hl(#1; #2) {{ x, RET x; Q }}
-/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q → Φ x) -∗ WP hl((#1, #2)) {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q -∗ Φ x) -∗ WP hl((#1, #2)) {{ Φ }} ) : PROP -/
 #guard_msgs in #check {{ P }} hl((#1, #2)) {{ x, RET x; Q }}
-/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q → Φ x) -∗ WP hl(ref(#0)) {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q -∗ Φ x) -∗ WP hl(ref(#0)) {{ Φ }} ) : PROP -/
 #guard_msgs in #check {{ P }} hl(ref(#0)) {{ x, RET x; Q }}
 /--
-info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q → Φ x) -∗ WP hl(if (#1 < #2) then (#1 + #1) else #0) {{ Φ }} ) : PROP
+info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q -∗ Φ x) -∗ WP hl(if (#1 < #2) then (#1 + #1) else #0) {{ Φ }} ) : PROP
 -/
 #guard_msgs in #check {{ P }} hl(if #1 < #2 then #1 + #1 else #0) {{ x, RET x; Q }}
-/-- info: iprop(∀ Φ, P -∗ (▷ ∀ v, ⌜v = hl_val(#1)⌝ → Φ v) -∗ WP hl(#1) {{ Φ }} ) : PROP -/
+/-- info: iprop(∀ Φ, P -∗ (▷ ∀ v, ⌜v = hl_val(#1)⌝ -∗ Φ v) -∗ WP hl(#1) {{ Φ }} ) : PROP -/
 #guard_msgs in #check ({{ P }} hl(#1) {{ v, RET v; ⌜v = hl_val(#1)⌝ }} : PROP)
 
 end HeapLangTestTexanTriple


### PR DESCRIPTION
## Description
- Corrects a minor typo in `BI/WeakestPre.lean`
- Disallows writing `{ { P }} e {{ Q }}`, that is, whitespace between the `{` for both texan triples and weakest preconditions
- Fixes the definition for texan triples, which was using `→` instead of `-∗`
- Allows, in the definition of texan triples, to specify the types of the newly introduced binders (basically, it follows more closely the type of syntax nodes that are allowed as binders in a `forall`)