### PR TITLE
feat: add support for `match` in `iprop(...)`

### DIFF
--- a/Iris/Iris/BI/Notation.lean
+++ b/Iris/Iris/BI/Notation.lean
@@ -34,7 +34,7 @@ macro_rules
               $[$alts:matchAlt]*)) => do
         let alts ← alts.mapM <| fun
           | `(matchAltExpr| | $[$lhs]|* => $rhs) => `(matchAltExpr| | $[$lhs]|* => iprop($rhs))
-          | alt => return ⟨alt⟩
+          | _ => throwUnsupported
         `(match $[$g:generalizingParam]? $[$m:motive]? $[$x:matchDiscr],* with $[$alts:matchAlt]*)
 
 macro:max "iprop(" P:term " : " t:term ")" : term => `((iprop($P) : $t))

--- a/Iris/Iris/BI/Notation.lean
+++ b/Iris/Iris/BI/Notation.lean
@@ -1,16 +1,18 @@
 /-
 Copyright (c) 2022 Lars König. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Lars König
+Authors: Lars König, Alex Keizer
 -/
 module
 
 public meta import Lean.PrettyPrinter.Delaborator
 
+meta import Lean.Parser.Term
+
 public meta section
 
 namespace Iris.BI
-open Lean Lean.Macro
+open Lean Lean.Macro Lean.Parser.Term
 
 -- define `iprop` embedding in `term`
 syntax:max "iprop(" term ")" : term
@@ -27,6 +29,13 @@ macro_rules
   | `(iprop(if $c then $t else $e)) => ``(if $c then iprop($t) else iprop($e))
   | `(iprop(($P : $t)))             => ``((iprop($P) : $t))
   | `(iprop(fun $xs* => $P))        => ``(fun $xs* => iprop($P))
+  -- `iprop(match …)` expansion wraps the rhs of each match arm in `iprop(…)`
+  | `(iprop(match $[$g:generalizingParam]? $[$m:motive]? $[$x:matchDiscr],* with
+              $[$alts:matchAlt]*)) => do
+        let alts ← alts.mapM <| fun
+          | `(matchAltExpr| | $[$lhs]|* => $rhs) => `(matchAltExpr| | $[$lhs]|* => iprop($rhs))
+          | alt => return ⟨alt⟩
+        `(match $[$g:generalizingParam]? $[$m:motive]? $[$x:matchDiscr],* with $[$alts:matchAlt]*)
 
 macro:max "iprop(" P:term " : " t:term ")" : term => `((iprop($P) : $t))
 
@@ -48,5 +57,16 @@ partial def unpackIprop [Monad m] [MonadRef m] [MonadQuotation m] : Term → m T
     `(if $c then $t else $e)
   | `(($P : $t))             => do ``(($(← unpackIprop P) : $t))
   | `($t)                    => `($t:term)
+  | `(match $[$g:generalizingParam]? $[$mot:motive]? $[$x:matchDiscr],* with $[$alts:matchAlt]*) => do
+      -- The following type ascriptions look redundant, but, without them, the ``(match ...)`
+      -- syntax quotation below fails with an error about types containing metavariables.
+      let g : Option (TSyntax ``generalizingParam) := g
+      let mot : Option (TSyntax ``motive) := mot
+      let alts ← Array.mapM (as := alts) (m:=m) <| fun
+        | `(matchAltExpr| | $[$lhs]|* => $rhs) => do
+            let rhs ← unpackIprop rhs
+            `(matchAltExpr| | $[$lhs]|* => $rhs)
+        | alt => return ⟨alt⟩
+      `(match $[$g:generalizingParam]? $[$mot:motive]? $[$x:matchDiscr],* with $[$alts:matchAlt]*)
 
 end Iris.BI

--- a/Iris/Iris/BI/Notation.lean
+++ b/Iris/Iris/BI/Notation.lean
@@ -56,7 +56,6 @@ partial def unpackIprop [Monad m] [MonadRef m] [MonadQuotation m] : Term → m T
     let e ← unpackIprop e
     `(if $c then $t else $e)
   | `(($P : $t))             => do ``(($(← unpackIprop P) : $t))
-  | `($t)                    => `($t:term)
   | `(match $[$g:generalizingParam]? $[$mot:motive]? $[$x:matchDiscr],* with $[$alts:matchAlt]*) => do
       -- The following type ascriptions look redundant, but, without them, the ``(match ...)`
       -- syntax quotation below fails with an error about types containing metavariables.
@@ -68,5 +67,7 @@ partial def unpackIprop [Monad m] [MonadRef m] [MonadQuotation m] : Term → m T
             `(matchAltExpr| | $[$lhs]|* => $rhs)
         | alt => return ⟨alt⟩
       `(match $[$g:generalizingParam]? $[$mot:motive]? $[$x:matchDiscr],* with $[$alts:matchAlt]*)
+  -- Fallback case
+  | `($t)                    => `($t:term)
 
 end Iris.BI

--- a/Iris/Iris/Tests/Notation.lean
+++ b/Iris/Iris/Tests/Notation.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Lars König. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Lars König
+Authors: Lars König, Alex Keizer
 -/
 module
 
@@ -112,6 +112,24 @@ variable [BIBase PROP] (P Q R : PROP) (Ψ : Nat → PROP) (Φ : Nat → Nat → 
 #guard_msgs in #check iprop(if p then □ P else P)
 /-- info: iprop(□ P) : PROP -/
 #guard_msgs in #check iprop((□ P : PROP))
+
+/--
+info: match p with
+| true => Ψ 1
+| false => iprop(False) : PROP
+-/
+#guard_msgs in #check iprop(match p with
+  | true => term(Ψ 1)
+  | false => False)
+
+/--
+info: match true with
+| true => iprop(P ∗ Q)
+| false => iprop(P ∗ Q) : PROP
+-/
+#guard_msgs in #check iprop(match (generalizing := false) (motive := Bool → PROP) true with
+  | true | false => P ∗ Q
+)
 
 /-! ## Derived Connectives -/
 

--- a/Iris/Iris/Tests/Notation.lean
+++ b/Iris/Iris/Tests/Notation.lean
@@ -110,6 +110,8 @@ variable [BIBase PROP] (P Q R : PROP) (Ψ : Nat → PROP) (Φ : Nat → Nat → 
 
 /-- info: if p = true then iprop(□ P) else P : PROP -/
 #guard_msgs in #check iprop(if p then □ P else P)
+/-- info: iprop((if p = true then □ P else P) ∗ Q) : PROP -/
+#guard_msgs in #check iprop((if p then □ P else P) ∗ Q)
 /-- info: iprop(□ P) : PROP -/
 #guard_msgs in #check iprop((□ P : PROP))
 
@@ -119,6 +121,16 @@ info: match p with
 | false => iprop(False) : PROP
 -/
 #guard_msgs in #check iprop(match p with
+  | true => term(Ψ 1)
+  | false => False)
+
+/--
+info: iprop(□
+    match p with
+    | true => Ψ 1
+    | false => False) : PROP
+-/
+#guard_msgs in #check iprop(□ match p with
   | true => term(Ψ 1)
   | false => False)
 


### PR DESCRIPTION
## Description

This PR adds a macro expansion, such that in `iprop(match ... with ...)` the right-hand-side of each match alternative is wrapped with `iprop` again.

For example, this enables the parsing of the following:
```lean4
iprop(match p with
  | true => P ∗ Q
  | false => Q ∗ P)
```


## Checklist
* [X] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [X] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
This code is 100% human-written