### PR TITLE
refactor: remove unicode braces

### DIFF
--- a/Iris/Iris/BI/WeakestPre.lean
+++ b/Iris/Iris/BI/WeakestPre.lean
@@ -65,18 +65,14 @@ declare_syntax_cat wpPostcond
 -- see: https://github.com/leanprover-community/iris-lean/pull/393
 syntax " {" noWs "{ " wpPostcondInner " }" noWs "} " : wpPostcond
 syntax " [" noWs "{ " wpPostcondInner " }" noWs "] " : wpPostcond
-syntax " ⦃ " wpPostcondInner " ⦄ " : wpPostcond
-syntax " 〖 " wpPostcondInner " 〗 "  : wpPostcond
 
 syntax (name := wp) "WP " wpExpr wpPostcond : term
 
 syntax texanPostcondInner := ((ppSpace (binderIdent <|> bracketedBinder))+ ", ")? " RET " term:min "; " term:min
 declare_syntax_cat texanPostcond
 syntax " {" noWs "{ " texanPostcondInner " }" noWs "} " : texanPostcond
-syntax " ⦃ " texanPostcondInner " ⦄ " : texanPostcond
 declare_syntax_cat texanPrecond
 syntax " {" noWs "{ " term:min " }" noWs "} " : texanPrecond
-syntax " ⦃ " term:min " ⦄ " : texanPrecond
 
 syntax (name := texanTriple) texanPrecond wpExpr texanPostcond : term
 
@@ -104,11 +100,9 @@ meta def parseWpPostcondInner (stx : TSyntax `wpPostcondInner) : MacroM (TSyntax
 open Lean in
 meta def parseWpPostcond (stx : TSyntax `wpPostcond) : MacroM (TSyntax `term × Bool) := do
   match stx with
-  | `(wpPostcond| {{ $inner:wpPostcondInner }})
-  | `(wpPostcond| ⦃ $inner:wpPostcondInner ⦄) =>
+  | `(wpPostcond| {{ $inner:wpPostcondInner }}) =>
     return (←parseWpPostcondInner inner, false)
-  | `(wpPostcond| [{ $inner:wpPostcondInner }])
-  | `(wpPostcond| 〖 $inner:wpPostcondInner 〗) =>
+  | `(wpPostcond| [{ $inner:wpPostcondInner }]) =>
     return (←parseWpPostcondInner inner, true)
   | _ => Macro.throwUnsupported (α := TSyntax `term × Bool)
 
@@ -126,17 +120,16 @@ meta def wpMacro : Lean.Macro := fun stx => do
 
 @[macro texanTriple]
 meta def wpTexanTriple : Lean.Macro
-  | `(⦃ $P:term ⦄ $wpExpr ⦃ $[$[$xs]* ,]? RET $pat ; $Q:term ⦄)
   | `({{ $P:term }} $wpExpr {{ $[$[$xs]* ,]? RET $pat ; $Q:term }}) => do
 
-    let transform (xs : Array (TSyntax [`Lean.binderIdent, `Lean.Parser.Term.bracketedBinder])) : MacroM <| TSyntaxArray [`ident, `Lean.Parser.Term.hole, `Lean.Parser.Term.bracketedBinder] := 
+    let transform (xs : Array (TSyntax [`Lean.binderIdent, `Lean.Parser.Term.bracketedBinder])) : MacroM <| TSyntaxArray [`ident, `Lean.Parser.Term.hole, `Lean.Parser.Term.bracketedBinder] :=
       xs.mapM fun
         | `(binderIdent|_) => `(hole|_)
         | `(binderIdent|$i:ident) => `(ident|$i)
         | `(bracketedBinder|$x) => `(bracketedBinder|$x)
 
     let k ← match xs with
-            | some xs => 
+            | some xs =>
               let xs ← transform xs -- TSyntax cast
               `(iprop(∀ $xs*, $Q:term -∗ Φ $pat))
             | none => `($Q:term -∗ Φ $pat)

--- a/Iris/Iris/Tests/WeakestPre.lean
+++ b/Iris/Iris/Tests/WeakestPre.lean
@@ -49,28 +49,6 @@ variable (Φ : Val → PROP)
 /-- info: WP e ? [{ Φ }] : PROP -/
 #guard_msgs in #check WP e ? [{ Φ }]
 
-/-- info: WP e @ s ; E {{ Φ }} : PROP -/
-#guard_msgs in #check WP e @ s ; E ⦃ Φ ⦄
-/-- info: WP e @ E {{ Φ }} : PROP -/
-#guard_msgs in #check WP e @ E ⦃ Φ ⦄
-/-- info: WP e @ E ? {{ Φ }} : PROP -/
-#guard_msgs in #check WP e @ E ? ⦃ Φ ⦄
-/-- info: WP e {{ Φ }} : PROP -/
-#guard_msgs in #check WP e ⦃ Φ ⦄
-/-- info: WP e ? {{ Φ }} : PROP -/
-#guard_msgs in #check WP e ? ⦃ Φ ⦄
-
-/-- info: WP e @ s ; E [{ Φ }] : PROP -/
-#guard_msgs in #check WP e @ s ; E 〖 Φ 〗
-/-- info: WP e @ E [{ Φ }] : PROP -/
-#guard_msgs in #check WP e @ E 〖 Φ 〗
-/-- info: WP e @ E ? [{ Φ }] : PROP -/
-#guard_msgs in #check WP e @ E ? 〖 Φ 〗
-/-- info: WP e [{ Φ }] : PROP -/
-#guard_msgs in #check WP e 〖 Φ 〗
-/-- info: WP e ? [{ Φ }] : PROP -/
-#guard_msgs in #check WP e ? 〖 Φ 〗
-
 -- Base binder cases
 variable (Φ : PROP)
 
@@ -96,28 +74,6 @@ variable (Φ : PROP)
 /-- info: WP e ? [{ v, Φ }] : PROP -/
 #guard_msgs in #check WP e ? [{v,  Φ }]
 
-/-- info: WP e @ s ; E {{ v, Φ }} : PROP -/
-#guard_msgs in #check WP e @ s ; E ⦃v, Φ⦄
-/-- info: WP e @ E {{ v, Φ }} : PROP -/
-#guard_msgs in #check WP e @ E ⦃v, Φ⦄
-/-- info: WP e @ E ? {{ v, Φ }} : PROP -/
-#guard_msgs in #check WP e @ E ? ⦃v, Φ⦄
-/-- info: WP e {{ v, Φ }} : PROP -/
-#guard_msgs in #check WP e ⦃v, Φ⦄
-/-- info: WP e ? {{ v, Φ }} : PROP -/
-#guard_msgs in #check WP e ? ⦃v, Φ⦄
-
-/-- info: WP e @ s ; E [{ v, Φ }] : PROP -/
-#guard_msgs in #check WP e @ s ; E 〖v, Φ〗
-/-- info: WP e @ E [{ v, Φ }] : PROP -/
-#guard_msgs in #check WP e @ E 〖v, Φ〗
-/-- info: WP e @ E ? [{ v, Φ }] : PROP -/
-#guard_msgs in #check WP e @ E ? 〖v, Φ〗
-/-- info: WP e [{ v, Φ }] : PROP -/
-#guard_msgs in #check WP e 〖v, Φ〗
-/-- info: WP e ? [{ v, Φ }] : PROP -/
-#guard_msgs in #check WP e ? 〖v, Φ〗
-
 -- BI binder cases
 variable [BI PROP]
 
@@ -134,11 +90,6 @@ variable [BI PROP]
 #guard_msgs in #check WP e ? [{v, Φ ∗ Φ}]
 /-- info: WP e ? [{ v, Φ -∗ Φ }] : PROP -/
 #guard_msgs in #check WP e ? [{v, Φ -∗ Φ}]
-
-/-- info: WP e ? {{ v, Φ ∗ Φ }} : PROP -/
-#guard_msgs in #check WP e ? ⦃v, Φ ∗ Φ⦄
-/-- info: WP e ? [{ v, Φ ∗ Φ }] : PROP -/
-#guard_msgs in #check WP e ? 〖v, Φ ∗ Φ〗
 
 /-- info: WP e @ E {{ v, Φ ∗ Φ }} : PROP -/
 #guard_msgs in #check WP e @ E {{v, Φ ∗ Φ}}
@@ -160,10 +111,6 @@ variable (Φ : Val → PROP)
 #guard_msgs in #check WP e ? [{v, Φ v ∗ Φ v}]
 /-- info: WP e ? [{ v, Φ v -∗ Φ v }] : PROP -/
 #guard_msgs in #check WP e ? [{v, Φ v -∗ Φ v}]
-/-- info: WP e ? {{ v, Φ v ∗ Φ v }} : PROP -/
-#guard_msgs in #check WP e ? ⦃v, Φ v ∗ Φ v⦄
-/-- info: WP e ? [{ v, Φ v ∗ Φ v }] : PROP -/
-#guard_msgs in #check WP e ? 〖v, Φ v ∗ Φ v〗
 /-- info: WP e @ E {{ v, Φ v ∗ Φ v }} : PROP -/
 #guard_msgs in #check WP e @ E {{v, Φ v ∗ Φ v}}
 /-- info: WP e {{ v, Φ v -∗ Φ v }} : PROP -/
@@ -212,36 +159,6 @@ variable (P Q : PROP)
 
 /-- info: iprop(∀ Φ, P -∗ ▷ (Q -∗ Φ 0) -∗ WP e ? {{ Φ }} ) : PROP -/
 #guard_msgs in #check {{ P }} e ? {{ RET 0 ; Q }}
-
-/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q -∗ Φ (x + y)) -∗ WP e @ s ; E {{ Φ }} ) : PROP -/
-#guard_msgs in #check ⦃ P ⦄ e @ s ; E ⦃ x y , RET (x+y) ; Q ⦄
-
-/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q -∗ Φ (x + y)) -∗ WP e @ E {{ Φ }} ) : PROP -/
-#guard_msgs in #check ⦃ P ⦄ e @ E ⦃ x y , RET (x+y) ; Q ⦄
-
-/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q -∗ Φ (x + y)) -∗ WP e @ E ? {{ Φ }} ) : PROP -/
-#guard_msgs in #check ⦃ P ⦄ e @ E ? ⦃ x y , RET (x+y) ; Q ⦄
-
-/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q -∗ Φ (x + y)) -∗ WP e {{ Φ }} ) : PROP -/
-#guard_msgs in #check ⦃ P ⦄ e ⦃ x y , RET (x+y) ; Q ⦄
-
-/-- info: iprop(∀ Φ, P -∗ (▷ ∀ x y, Q -∗ Φ (x + y)) -∗ WP e ? {{ Φ }} ) : PROP -/
-#guard_msgs in #check ⦃ P ⦄ e ? ⦃ x y , RET (x+y) ; Q ⦄
-
-/-- info: iprop(∀ Φ, P -∗ ▷ (Q -∗ Φ 0) -∗ WP e @ s ; E {{ Φ }} ) : PROP -/
-#guard_msgs in #check ⦃ P ⦄ e @ s ; E ⦃ RET 0 ; Q ⦄
-
-/-- info: iprop(∀ Φ, P -∗ ▷ (Q -∗ Φ 0) -∗ WP e @ E {{ Φ }} ) : PROP -/
-#guard_msgs in #check ⦃ P ⦄ e @ E ⦃ RET 0 ; Q ⦄
-
-/-- info: iprop(∀ Φ, P -∗ ▷ (Q -∗ Φ 0) -∗ WP e @ E ? {{ Φ }} ) : PROP -/
-#guard_msgs in #check ⦃ P ⦄ e @ E ? ⦃ RET 0 ; Q ⦄
-
-/-- info: iprop(∀ Φ, P -∗ ▷ (Q -∗ Φ 0) -∗ WP e {{ Φ }} ) : PROP -/
-#guard_msgs in #check ⦃ P ⦄ e ⦃ RET 0 ; Q ⦄
-
-/-- info: iprop(∀ Φ, P -∗ ▷ (Q -∗ Φ 0) -∗ WP e ? {{ Φ }} ) : PROP -/
-#guard_msgs in #check ⦃ P ⦄ e ? ⦃ RET 0 ; Q ⦄
 
 end TestTexanTriple
 
@@ -316,5 +233,3 @@ info: iprop(∀ Φ, P -∗ (▷ ∀ x, Q -∗ Φ x) -∗ WP hl(if (#1 < #2) then
 #guard_msgs in #check ({{ P }} hl(#1) {{ v, RET v; ⌜v = hl_val(#1)⌝ }} : PROP)
 
 end HeapLangTestTexanTriple
-
-


### PR DESCRIPTION
## Description
Removes unicode braces.

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
