### PR TITLE
feat: add unbounded heap for ExtTreeMap

### DIFF
--- a/Iris/Iris/Std/HeapInstances.lean
+++ b/Iris/Iris/Std/HeapInstances.lean
@@ -281,32 +281,24 @@ instance : LawfulFiniteMap (ExtTreeMap K · compare) K where
     exact List.pairwise_map.mpr distinct_keys_toList
   toList_get {_ m _ _} := m.mem_toList_iff_getElem?_eq_some
 
-noncomputable instance instUnboundedHeapCompare [InfiniteType K] :
+end HeapInstance
+end Std.ExtTreeMap
+
+namespace Classical
+
+open Std Iris.Std
+variable {K} [Ord K] [TransOrd K] [LawfulEqOrd K]
+
+noncomputable scoped instance instUnboundedHeapCompare [InfiniteType K] :
     UnboundedHeap (ExtTreeMap K · compare) K where
   notFull _ := True
-  fresh {_} {m} _ :=
-    (Iris.Std.List.fresh
-      ((LawfulFiniteMap.toList (M := fun V => ExtTreeMap K V compare) m).map Prod.fst)).choose
-  get?_fresh {_} {m} {_} := by
-    let freshKey :=
-      (Iris.Std.List.fresh
-        ((LawfulFiniteMap.toList (M := fun V => ExtTreeMap K V compare) m).map Prod.fst)).choose
-    change get? m freshKey = none
-    have freshKey_not_mem :
-        freshKey ∉
-          (LawfulFiniteMap.toList (M := fun V => ExtTreeMap K V compare) m).map Prod.fst :=
-      (Iris.Std.List.fresh
-        ((LawfulFiniteMap.toList (M := fun V => ExtTreeMap K V compare) m).map Prod.fst)).choose_spec
-    cases hget : get? m freshKey with
-    | none => rfl
-    | some v =>
-      exfalso
-      apply freshKey_not_mem
-      apply List.mem_map.mpr
-      exact ⟨(freshKey, v), LawfulFiniteMap.toList_get.mpr hget, rfl⟩
+  fresh {_} {m} _ := m.keys.fresh.choose
+  get?_fresh {V} {m} {_} := by
+    change m.get? m.keys.fresh.choose = none
+    grind
   notFull_empty := trivial
   notFull_insert_fresh := trivial
 
-end HeapInstance
+end Classical
 
-end Std.ExtTreeMap
+section

--- a/Iris/Iris/Std/HeapInstances.lean
+++ b/Iris/Iris/Std/HeapInstances.lean
@@ -22,7 +22,7 @@ instances for types from the Lean standard library.
 - Classical functions into `Option`: `UnboundedHeap`
 - Association lists: `UnboundedHeap`
 - `TreeMap`: `PartialMap`
-- `ExtTreeMap`: `PartialMap`
+- `ExtTreeMap`: `UnboundedHeap`
 -/
 
 @[expose] public section
@@ -280,6 +280,32 @@ instance : LawfulFiniteMap (ExtTreeMap K · compare) K where
       refine h.imp (· <| LawfulEqOrd.compare_eq_iff_eq.mpr ·)
     exact List.pairwise_map.mpr distinct_keys_toList
   toList_get {_ m _ _} := m.mem_toList_iff_getElem?_eq_some
+
+noncomputable instance instUnboundedHeapCompare [InfiniteType K] :
+    UnboundedHeap (ExtTreeMap K · compare) K where
+  notFull _ := True
+  fresh {_} {m} _ :=
+    (Iris.Std.List.fresh
+      ((LawfulFiniteMap.toList (M := fun V => ExtTreeMap K V compare) m).map Prod.fst)).choose
+  get?_fresh {_} {m} {_} := by
+    let freshKey :=
+      (Iris.Std.List.fresh
+        ((LawfulFiniteMap.toList (M := fun V => ExtTreeMap K V compare) m).map Prod.fst)).choose
+    change get? m freshKey = none
+    have freshKey_not_mem :
+        freshKey ∉
+          (LawfulFiniteMap.toList (M := fun V => ExtTreeMap K V compare) m).map Prod.fst :=
+      (Iris.Std.List.fresh
+        ((LawfulFiniteMap.toList (M := fun V => ExtTreeMap K V compare) m).map Prod.fst)).choose_spec
+    cases hget : get? m freshKey with
+    | none => rfl
+    | some v =>
+      exfalso
+      apply freshKey_not_mem
+      apply List.mem_map.mpr
+      exact ⟨(freshKey, v), LawfulFiniteMap.toList_get.mpr hget, rfl⟩
+  notFull_empty := trivial
+  notFull_insert_fresh := trivial
 
 end HeapInstance
 


### PR DESCRIPTION
## Description

Closes #126.

Instantiate `UnboundedHeap` for `ExtTreeMap K · compare` when the key type is infinite. The fresh key is chosen outside the finite key projection of the map's lawful `toList`; `LawfulFiniteMap.toList_get` then proves that lookup at this key is `none`.

As requested in the issue, `notFull` is `True`, so emptiness and preservation after fresh insertion are immediate.

## Validation

- `lake build Iris.Std.HeapInstances`
- `lake build` (260 jobs)
- `git diff --check`

## Checklist

- [x] The change follows the project's Lean naming and style conventions.
- [x] No authors-list update is appropriate for this focused instance addition.
