### PR TITLE
feat: port `modality_embed_mixin` and `IntoEmbed`

### DIFF
--- a/Iris/Iris/BI/Embedding.lean
+++ b/Iris/Iris/BI/Embedding.lean
@@ -37,7 +37,7 @@ syntax "⎡" term "⎤" : term
 macro_rules | `(iprop(⎡$P⎤)) => ``(Embed.embed iprop($P))
 
 delab_rule Embed.embed
-  | `($_ $P) => ``(iprop(⎡$P⎤))
+  | `($_ $P) => do ``(⎡$(← unpackIprop P)⎤)
 
 /-! ## The `BiEmbed` class -/
 

--- a/Iris/Iris/ProofMode/Classes.lean
+++ b/Iris/Iris/ProofMode/Classes.lean
@@ -197,8 +197,8 @@ For the IPM TC synthesis, it needs to be an `uncheckedInParam` since it should m
 if the user provides an mvar.
 -/
 @[ipm_class, rocq_alias FromModal]
-class FromModal {PROP1 : outParam $ Type _} {PROP2} [outParam $ BI PROP1] [BI PROP2] (φ : outParam $ Prop)
-    (M : outParam $ Modality PROP1 PROP2) (sel : outParam <| uncheckedInParam $ PROP1) (P : PROP2)
+class FromModal {PROP1 : outParam $ Type _} {PROP2} {α : outParam <| Type _} [outParam $ BI PROP1] [BI PROP2] (φ : outParam $ Prop)
+    (M : outParam $ Modality PROP1 PROP2) (sel : outParam <| uncheckedInParam α) (P : PROP2)
     (Q : outParam $ PROP1) where
   from_modal : φ → M.M Q ⊢ P
 export FromModal (from_modal)

--- a/Iris/Iris/ProofMode/Classes.lean
+++ b/Iris/Iris/ProofMode/Classes.lean
@@ -258,6 +258,11 @@ class IntoIH [BI PROP] (φ : Prop) (P : PROP) (Q : outParam PROP) where
   into_ih : φ → □ P ⊢ Q
 export IntoIH (into_ih)
 
+@[ipm_class, rocq_alias IntoEmbed]
+class IntoEmbed [BI PROP1] [BI PROP2] [BiEmbed PROP1 PROP2] (P : PROP2) (Q : outParam PROP1) where
+  into_embed : P ⊢ ⎡Q⎤
+export IntoEmbed (into_embed)
+
 #rocq_ignore elim_inv_tc_opaque "No tc_opaque in Lean"
 #rocq_ignore elim_modal_tc_opaque "No tc_opaque in Lean"
 #rocq_ignore from_and_tc_opaque "No tc_opaque in Lean"

--- a/Iris/Iris/ProofMode/InstancesEmbedding.lean
+++ b/Iris/Iris/ProofMode/InstancesEmbedding.lean
@@ -7,6 +7,7 @@ module
 
 public import Iris.BI
 public import Iris.ProofMode.Classes
+public import Iris.ProofMode.ModalityInstances
 
 @[expose] public section
 
@@ -26,3 +27,18 @@ instance (priority := low) asEmpValid_embed
       apply (embed_emp_valid P).mpr <| inst.as_emp_valid_0.as_emp_valid.left hd hφ
     · intro hd hP
       apply inst.as_emp_valid_0.as_emp_valid.right hd <| (embed_emp_valid P).mp hP
+
+@[rocq_alias from_modal_embed]
+instance fromModal_embed [BI PROP1] [BI PROP2] [BiEmbed PROP1 PROP2] (P : PROP1) :
+    FromModal True (modality_embed (PROP2 := PROP2)) iprop(⎡P⎤ : PROP2) iprop(⎡P⎤) P where
+  from_modal _ := .rfl
+
+@[rocq_alias into_embed_embed]
+instance intoEmbed_embed [BI PROP1] [BI PROP2] [BiEmbed PROP1 PROP2] (P : PROP1) : IntoEmbed iprop(⎡P⎤ : PROP2) P where
+  into_embed := .rfl
+
+@[rocq_alias into_embed_affinely]
+instance intoEmbed_affinely [BI PROP1] [BI PROP2] [BIUpdate PROP1] [BIUpdate PROP2]
+    [BiEmbed PROP1 PROP2] [BiEmbedBUpd PROP1 PROP2] (P : PROP2) (Q : PROP1) [inst : IntoEmbed P Q] :
+    IntoEmbed iprop(<affine> P) iprop(<affine> Q) where
+  into_embed := (affinely_mono inst.into_embed).trans <| embed_affinely_2 Q

--- a/Iris/Iris/ProofMode/InstancesInternalEq.lean
+++ b/Iris/Iris/ProofMode/InstancesInternalEq.lean
@@ -40,7 +40,7 @@ instance (priority := default + 10) intoPure_internalEq_leibniz [Sbi PROP] [OFE 
 @[rocq_alias from_modal_Next]
 instance fromModal_internalEq_next [Sbi PROP] [OFE A] (x y : A) :
     FromModal (PROP1 := PROP) (PROP2 := PROP) True (modality_laterN 1)
-      iprop(▷ (x ≡ y)) iprop(Later.next x ≡ Later.next y) iprop(x ≡ y) where
+      iprop(▷ (x ≡ y) : PROP) iprop(Later.next x ≡ Later.next y) iprop(x ≡ y) where
   from_modal _ := later_equivI_mpr x y
 
 @[rocq_alias into_laterN_Next]

--- a/Iris/Iris/ProofMode/ModalityInstances.lean
+++ b/Iris/Iris/ProofMode/ModalityInstances.lean
@@ -75,4 +75,13 @@ def modality_laterN (n : Nat) [BI PROP] : Modality PROP PROP where
   mono := (laterN_mono n ·)
   sep := (laterN_sep n).2
 
+@[rocq_alias modality_embed, rocq_alias modality_embed_mixin]
+def modality_embed [BI PROP1] [BI PROP2] [BiEmbed PROP1 PROP2] : Modality PROP1 PROP2 where
+  M := embed
+  action _ := .transform IntoEmbed
+  spec := λ p _ P h => (intuitionisticallyIf_mono h.into_embed).trans <| embed_intuitionistically_if_2 P p
+  emp := embed_emp_2
+  mono := (embed_mono ·)
+  sep := (BiEmbed.sep _ _).mpr
+
 end Modalities

--- a/Iris/Iris/ProofMode/SynthInstanceAttr.lean
+++ b/Iris/Iris/ProofMode/SynthInstanceAttr.lean
@@ -82,12 +82,12 @@ structure ClassEntry where
   Parameter kinds of class.
   For example, for class
   ```
-  class FromModal {PROP1 : outParam (Type _)} {PROP2} [outParam (BI PROP1)] [BI PROP2]
-    (φ : outParam $ Prop) (M : outParam $ Modality PROP1 PROP2) (sel : outParam (uncheckedInParam PROP1))
+  class FromModal {PROP1 : outParam (Type _)} {PROP2} {α} [outParam (BI PROP1)] [BI PROP2]
+    (φ : outParam $ Prop) (M : outParam $ Modality PROP1 PROP2) (sel : outParam (uncheckedInParam α))
     (P : PROP2) (Q : outParam $ PROP1) where
   from_modal : φ → M.M Q ⊢ P
   ```
-  `params := #[out, in, out, in, out, out, uncheckedIn, in, out]`
+  `params := #[out, in, out, out, in, out, out, uncheckedIn, in, out]`
   -/
   params : Array ParamKind
 

--- a/Iris/Iris/ProofMode/SynthInstanceAttr.lean
+++ b/Iris/Iris/ProofMode/SynthInstanceAttr.lean
@@ -82,7 +82,7 @@ structure ClassEntry where
   Parameter kinds of class.
   For example, for class
   ```
-  class FromModal {PROP1 : outParam (Type _)} {PROP2} {α} [outParam (BI PROP1)] [BI PROP2]
+  class FromModal {PROP1 : outParam (Type _)} {PROP2} {α : outParam <| Type _} [outParam (BI PROP1)] [BI PROP2]
     (φ : outParam $ Prop) (M : outParam $ Modality PROP1 PROP2) (sel : outParam (uncheckedInParam α))
     (P : PROP2) (Q : outParam $ PROP1) where
   from_modal : φ → M.M Q ⊢ P

--- a/Iris/Iris/ProofMode/Tactics/ModIntro.lean
+++ b/Iris/Iris/ProofMode/Tactics/ModIntro.lean
@@ -60,7 +60,7 @@ theorem modaction_sep [BI PROP1] [bi2: BI PROP2] {elhs erhs elhs' erhs'} {M : Mo
   (h1 : elhs ⊢ M.M elhs') (h2 : erhs ⊢ M.M erhs') : elhs ∗ erhs ⊢ M.M iprop(elhs' ∗ erhs') :=
   (sep_mono h1 h2).trans M.sep
 
-theorem modintro [BI PROP1] [BI PROP2] {e e'} {Φ M sel} {P : PROP2} {Q : PROP1}
+theorem modintro [BI PROP1] [BI PROP2] {e e'} {α} {Φ M} {sel : α} {P : PROP2} {Q : PROP1}
 [FromModal Φ M sel P Q] (h1 : e ⊢ M.M e') (h2 : e' ⊢ Q) (hΦ : Φ) : e ⊢ P :=
     (h1.trans (M.mono h2)).trans (from_modal hΦ)
 
@@ -166,10 +166,11 @@ def iModIntroCore {e} (hyps : @Hyps u prop bi e) (goal : Q($prop)) (sel : TSynta
     let bi' ← mkFreshExprMVarQ q(BI $prop')
     let Φ ← mkFreshExprMVarQ q(Prop)
     let M ← mkFreshExprMVarQ q(Modality $prop' $prop)
-    let sel ← elabTermEnsuringTypeQ (← `(term | iprop($sel))) prop'
+    let α : Q(Type u) ← mkFreshExprMVarQ q(Type u)
+    let sel ← elabTermEnsuringTypeQ (← `(term | iprop($sel))) α
     let Q ← mkFreshExprMVarQ q($prop')
     -- `M Q ⊢ goal`
-    let .some _ ← ProofModeM.trySynthInstanceQ q(@FromModal $prop' $prop $bi' $bi $Φ $M $sel $goal $Q)
+    let .some _ ← ProofModeM.trySynthInstanceQ q(@FromModal $prop' $prop $α $bi' $bi $Φ $M $sel $goal $Q)
       | throwError "imodintro: {goal} is not a modality{if sel.isMVar then m!"" else m!" matching {sel}"}"
     -- show the side condition
     let hΦ ← iSolveSidecondition q($Φ)

--- a/Iris/Iris/Tests/Tactics.lean
+++ b/Iris/Iris/Tests/Tactics.lean
@@ -1994,6 +1994,29 @@ example [BI PROP] [BIUpdate PROP] [BIFUpdate PROP]
   imodintro
   iexact HP
 
+/-- Tests `imodintro` with `intoEmbed_embed`. -/
+example {PROP1 PROP2 : Type u} [BI PROP1] [BI PROP2] [BiEmbed PROP1 PROP2]
+    (P Q : PROP1) : ⎡P⎤ ∗ ⎡P -∗ Q⎤ ⊢@{PROP2} ⎡Q⎤ := by
+  iintro ⟨HP, HPQ⟩
+  imodintro
+  iapply HPQ $$ HP
+
+/-- Tests `imodintro` with `intoEmbed_affinely` and `intoEmbed_embed`. -/
+example {PROP1 PROP2 : Type u} [BI PROP1] [BI PROP2] [BIUpdate PROP1] [BIUpdate PROP2]
+    [BiEmbed PROP1 PROP2] [BiEmbedBUpd PROP1 PROP2] (P : PROP1) :
+    <affine> ⎡P⎤ ⊢@{PROP2} ⎡<affine> P⎤ := by
+  iintro HP
+  imodintro
+  iassumption
+
+/- Tests `imodintro` where `intoEmbed_embed` does not apply. -/
+/-- error: imodintro: cannot transform hypothesis HQ : Q with ProofMode.IntoEmbed -/
+#guard_msgs in
+example {PROP1 PROP2 : Type u} [BI PROP1] [BI PROP2] [BiEmbed PROP1 PROP2]
+    (P : PROP1) (Q : PROP2) : ⎡P⎤ ∗ Q ⊢@{PROP2} ⎡P⎤ := by
+  iintro ⟨HP, HQ⟩
+  imodintro
+
 end imodintro
 
 section imod


### PR DESCRIPTION
## Description

Addresses #225 in full. Also addresses #219 and #235 in part.

- Modified `FromModal` so that it is on the same level of generality as the Rocq version. Adjusted the implementation of `imodintro` to accommodate the generalisation.
- Ported the type class `IntoEmbed`.
- Ported the two instances of `IntoEmbed` along with a new instance of `FromModal`.
- Ported `modality_embed` and `modality_embed_mixin`.
- Some relevant tests with `imodintro`.

### Other Changes

Added the missing `unpackIprop` for `Embed` so that the `iprop(...)` wrapper does not get printed in the proof state.

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files
