### PR TITLE
feat: port all missing theorems in `BI/DerivedLaws.lean` and `BI/DerivedLawsLater.lean`

### DIFF
--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -2280,6 +2280,17 @@ theorem bigOp_sep_cons [BI PROP] {P : PROP} {Ps : List PROP} :
 theorem bigOp_and_cons [BI PROP] {P : PROP} {Ps : List PROP} :
     [∧] (P :: Ps) ⊣⊢ P ∧ [∧] Ps := bigOp_cons
 
+@[rocq_alias bi.persistent_absorbingly_affinely]
+theorem persistent_absorbingly_affinely [BI PROP] {P : PROP}
+    [Persistent P] [Absorbing P] : <absorb> <affine> P ⊣⊢ P :=
+  ⟨(sep_mono_right affinely_elim).trans absorbing, absorbingly_affinely_intro_of_persistent⟩
+
+@[rocq_alias bi.persistent_and_sep_assoc]
+theorem persistent_and_sep_assoc [BI PROP] {P Q R : PROP}
+    [Persistent P] [Absorbing P] : P ∧ (Q ∗ R) ⊣⊢ (P ∧ Q) ∗ R :=
+  (and_congr_left persistently_iff.symm).trans <| persistently_and_sep_assoc.trans <|
+    sep_congr_left <| and_congr_left persistently_iff
+
 @[rocq_alias bi.persistent_impl_wand_affinely]
 theorem persistent_impl_wand_affinely [BI PROP] {P Q : PROP} [Persistent P] [Absorbing P] :
     (P → Q) ⊣⊢ (<affine> P -∗ Q) := by

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -891,6 +891,11 @@ instance affinely_affine [BI PROP] (P : PROP) : Affine iprop(<affine> P) where
 instance [BIBase PROP] : Inhabited PROP where
   default := emp
 
+@[rocq_alias bi.pure_impl_forall]
+theorem pure_imp_forall [BI PROP] {φ : Prop} {P : PROP} :
+    (⌜φ⌝ → P) ⊣⊢ (∀ _ : φ, P) :=
+  ⟨forall_intro pure_imp_elim, imp_intro_swap <| pure_elim_left (forall_elim ·)⟩
+
 /-! # Absorbing -/
 
 @[rocq_alias bi.absorbingly_ne]
@@ -2273,3 +2278,5 @@ theorem bi_emp_valid_mono [BI PROP] {P Q : PROP} (h : P ⊢ Q) : (⊢ P) → ⊢
 @[rocq_alias bi.bi_emp_valid_flip_mono]
 theorem bi_emp_valid_flip_mono [BI PROP] {P Q : PROP} (h : P ⊣⊢ Q) : (⊢ P) ↔ ⊢ Q :=
   ⟨(·.trans h.1), (·.trans h.2)⟩
+
+-/

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -1152,7 +1152,7 @@ instance bi_affine_positive [BI PROP] [BIAffine PROP] : BIPositive PROP where
   affinely_sep_l := (affine_affinely _).1.trans (sep_mono_left (affine_affinely _).2)
 
 @[rocq_alias bi.impl_wand_1]
-theorem imp_wand [BI PROP] [BIAffine PROP] {P Q : PROP} : (P → Q) ⊢ P -∗ Q :=
+theorem imp_wand_1 [BI PROP] [BIAffine PROP] {P Q : PROP} : (P → Q) ⊢ P -∗ Q :=
   wand_intro <| sep_and.trans imp_elim_left
 
 theorem pure_sep [BI PROP] {φ1 φ2 : Prop} : ⌜φ1⌝ ∗ (⌜φ2⌝ : PROP) ⊣⊢ ⌜φ1 ∧ φ2⌝ :=
@@ -1372,7 +1372,7 @@ theorem persistently_imp_wand [BI PROP] [BIAffine PROP] {P Q : PROP} :
 
 @[rocq_alias bi.impl_wand_persistently]
 theorem imp_wand_persistently [BI PROP] [BIAffine PROP] {P Q : PROP} :
-    (<pers> P → Q) ⊣⊢ (<pers> P -∗ Q) := ⟨imp_wand, imp_wand_persistently_mpr⟩
+    (<pers> P → Q) ⊣⊢ (<pers> P -∗ Q) := ⟨imp_wand_1, imp_wand_persistently_mpr⟩
 
 @[rocq_alias bi.wand_alt]
 theorem wand_iff_exists_persistently [BI PROP] [BIAffine PROP] {P Q : PROP} :
@@ -2249,6 +2249,13 @@ theorem bigOp_sep_cons [BI PROP] {P : PROP} {Ps : List PROP} :
 
 theorem bigOp_and_cons [BI PROP] {P : PROP} {Ps : List PROP} :
     [∧] (P :: Ps) ⊣⊢ P ∧ [∧] Ps := bigOp_cons
+
+@[rocq_alias bi.persistent_impl_wand_affinely]
+theorem persistent_impl_wand_affinely [BI PROP] {P Q : PROP} [Persistent P] [Absorbing P] :
+    (P → Q) ⊣⊢ (<affine> P -∗ Q) := by
+  constructor
+  · exact wand_intro_left <| persistent_and_affinely_sep_left.mpr.trans imp_elim_right
+  · exact imp_intro_swap <| persistent_and_affinely_sep_left.mp.trans wand_elim_right
 
 /-! # Limits -/
 

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -1654,12 +1654,10 @@ theorem intuitionistically_wand [BI PROP] {P Q : PROP} : (□ P -∗ Q) ⊣⊢ (
 theorem self_sep_intuitionistically [BI PROP] {P : PROP} :
     □ P ⊣⊢ emp ∧ (P ∗ □ P) := by
   constructor
-  · apply and_intro
-    · exact intuitionistically_elim_emp
-    · apply intuitionistically_sep_idem.mpr.trans <| sep_mono_left intuitionistically_elim
-  · apply and_mono
-    · rfl
-    · exact (sep_mono_right (and_elim_r)).trans self_sep_persistently.mp
+  · refine and_intro intuitionistically_elim_emp ?_
+    exact intuitionistically_sep_idem.mpr.trans <| sep_mono_left intuitionistically_elim
+  · refine and_mono .rfl ?_
+    exact (sep_mono_right <| and_elim_r).trans self_sep_persistently.mp
 
 @[rocq_alias bi.intuitionistically_intro]
 theorem intuitionistically_intro [BI PROP] {P Q : PROP}

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -2222,6 +2222,15 @@ theorem persistent_and_sep [BI PROP] [BIAffine PROP] {P Q : PROP} :
   | TCOr.r => (and_congr_right persistently_iff.symm).trans <|
               and_persistently_iff_sep.trans (sep_congr_right persistently_iff)
 
+
+@[rocq_alias bi.impl_wand_2]
+theorem imp_wand_2 [BI PROP] {P Q : PROP} [Persistent P] :
+    (P -∗ Q) ⊢ P → Q := imp_intro <| persistent_and_sep_mp.trans wand_elim_left
+
+@[rocq_alias bi.impl_wand]
+theorem imp_wand [BI PROP] [BIAffine PROP] {P Q : PROP} [Persistent P] :
+    (P → Q) ⊣⊢ (P -∗ Q) := ⟨imp_wand_1, imp_wand_2⟩
+
 @[rocq_alias bi.persistent_sep_dup_1]
 theorem persistent_sep_dup_mp [BI PROP] {P : PROP} [inst : Persistent P] : P ⊢ P ∗ P :=
   and_self.mpr.trans persistent_and_sep_mp

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -618,7 +618,10 @@ theorem wandIff_trans [BI PROP] {P Q R : PROP} :
     (P ∗-∗ Q) ∗ (Q ∗-∗ R) ⊢ (P ∗-∗ R) := by
   apply and_intro
   · exact (sep_mono and_elim_l and_elim_l).trans wand_trans
-  · exact (sep_mono and_elim_r and_elim_r).trans <| sep_comm.mp.trans wand_trans
+  · calc
+      _ ⊢ (Q -∗ P) ∗ (R -∗ Q) := sep_mono and_elim_r and_elim_r
+      _ ⊢ (R -∗ Q) ∗ (Q -∗ P) := sep_comm.mp
+      _ ⊢ R -∗ P              := wand_trans
 
 @[rocq_alias bi.exist_wand_forall]
 theorem exists_wand_forall [BI PROP] {P : PROP} {Ψ : α → PROP} :

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -799,6 +799,26 @@ theorem pure_alt {PROP : Type _} [BI PROP] (φ : Prop) :
     (⌜φ⌝ : PROP) ⊣⊢ ∃ _ : φ, True :=
   (pure_congr ⟨fun h => ⟨h, trivial⟩, fun ⟨h, _⟩ => h⟩).trans pure_exists.symm
 
+@[rocq_alias bi.pure_wand_forall]
+theorem pure_wand_forall [BI PROP] {φ : Prop} {P : PROP} [Absorbing P] :
+    (⌜φ⌝ -∗ P) ⊣⊢ (∀ _ : φ, P) := by
+  constructor
+  · apply forall_intro
+    intro hφ
+    calc
+      _ ⊢ (⌜φ⌝ -∗ P) ∗ emp := sep_emp.mpr
+      _ ⊢ (⌜φ⌝ -∗ P) ∗ ⌜φ⌝ := sep_mono_right <| pure_intro hφ
+      _ ⊢ P                := wand_elim_left
+  · apply wand_intro_left
+    apply wand_elim
+    apply pure_elim'
+    intro hφ
+    apply wand_intro_left
+    calc
+      _ ⊢ P ∗ True := sep_mono_left <| forall_elim hφ
+      _ ⊢ True ∗ P := sep_comm.mp
+      _ ⊢ P        := absorbing
+
 /-! # Affine -/
 
 @[rocq_alias bi.affinely_ne]
@@ -1172,6 +1192,26 @@ theorem pure_wand_mpr [BI PROP] {φ1 φ2 : Prop} : ⌜φ1 → φ2⌝ ⊢ (⌜φ1
 theorem pure_wand [BI PROP] {φ1 φ2 : Prop} : (⌜φ1⌝ -∗ (⌜φ2⌝ : PROP)) ⊣⊢ ⌜φ1 → φ2⌝ := by
   refine ⟨(imp_intro_swap ?_).trans pure_imp.2, pure_wand_mpr⟩
   exact pure_elim_left fun h => true_sep_mpr.trans (eq_true h ▸ wand_elim_right)
+
+/-! # Decidable pure propositions -/
+
+@[rocq_alias bi.decide_bi_True]
+theorem decide_true [BI PROP] (φ : Prop) [Decidable φ] (P : PROP) :
+    (if φ then P else iprop(True)) ⊣⊢ (⌜φ⌝ → P) := by
+  by_cases h : φ
+  · rw [if_pos h]
+    exact ((imp_congr_left (pure_true h)).trans true_imp).symm
+  · rw [if_neg h]
+    exact ((imp_congr_left (pure_false h)).trans false_imp).symm
+
+@[rocq_alias bi.decide_emp]
+theorem decide_emp [BI PROP] [BIAffine PROP] (φ : Prop) [Decidable φ] (P : PROP) :
+    (if φ then P else iprop(emp)) ⊣⊢ (⌜φ⌝ → P) := by
+  by_cases h : φ
+  · rw [if_pos h]
+    exact ((imp_congr_left <| pure_true h).trans true_imp).symm
+  · rw [if_neg h]
+    exact true_emp.symm.trans ((imp_congr_left <| pure_false h).trans false_imp).symm
 
 /-! # Properties of the persistence modality -/
 
@@ -2332,6 +2372,12 @@ theorem LimitPreserving.entails [BI PROP] [COFE A] (Φ Ψ : A → PROP) [Φne : 
     refine equiv_iff.1 ?_
     refine LimitPreserving.equiv f g _ ?_
     exact (equiv_iff.mpr <| h' ·)
+
+@[rocq_alias bi.limit_preserving_emp_valid]
+theorem limitPreserving_emp_valid [BI PROP] [COFE A] (Φ : A → PROP)
+    [OFE.NonExpansive Φ] : LimitPreserving (fun x => ⊢ Φ x) := by
+  refine fun c h => ?_
+  exact LimitPreserving.entails (fun _ => iprop(emp)) Φ c h
 
 @[rocq_alias bi.limit_preserving_Persistent]
 instance limitPreserving_persistent [BI PROP] [COFE A] (Φ : A → PROP) [Φne : OFE.NonExpansive Φ] :

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -24,8 +24,11 @@ open Iris.Std BI
 /- Necessary for `calc`-style proofs. -/
 instance entails_trans' [BI PROP] : Trans (α := PROP) Entails Entails Entails where
   trans h1 h2 := h1.trans h2
+
+@[rocq_alias entails_anti_sym]
 instance entails_antisymm [BI PROP] : Antisymmetric (α := PROP) BiEntails Entails where
   antisymm h1 h2 := ⟨h1, h2⟩
+
 #rocq_ignore bi.entails_proper "Derivable from _ne with NonExpansive.eqv."
 
 instance equiv_trans [BI PROP] : Trans (α := PROP) BiEntails BiEntails BiEntails where
@@ -36,6 +39,8 @@ instance equiv_entails_trans [BI PROP] : Trans (α := PROP) BiEntails Entails En
 
 instance entails_equiv_trans [BI PROP] : Trans (α := PROP) Entails BiEntails Entails where
   trans h1 h2 := h1.trans h2.1
+
+#rocq_ignore bi.equiv_entails_2 "Use the BiEntails constructor directly"
 
 /-! # Logic -/
 
@@ -717,8 +722,9 @@ theorem pure_elim [BI PROP] (φ : Prop) {Q R : PROP} (h1 : Q ⊢ ⌜φ⌝) (h2 :
 @[rocq_alias bi.pure_mono]
 theorem pure_mono [BI PROP] {φ1 φ2 : Prop} (h : φ1 → φ2) : ⌜φ1⌝ ⊢ (⌜φ2⌝ : PROP) :=
   pure_elim' <| pure_intro ∘ h
-#rocq_ignore bi.pure_mono' "Use _mono."
+#rocq_ignore bi.pure_mono' "Use pure_mono."
 #rocq_ignore bi.pure_proper "Derivable from _ne with NonExpansive.eqv."
+#rocq_ignore bi.pure_flip_mono "No Proper type class in Lean. Use pure_mono directly."
 
 theorem pure_congr [BI PROP] {φ1 φ2 : Prop} (h : φ1 ↔ φ2) : ⌜φ1⌝ ⊣⊢ (⌜φ2⌝ : PROP) :=
   ⟨pure_mono h.1,pure_mono h.2⟩
@@ -1573,6 +1579,7 @@ theorem intuitionistically_and_sep [BI PROP] {P Q : PROP} : □ (P ∧ Q) ⊣⊢
 theorem intuitionistically_sep_idem [BI PROP] {P : PROP} : □ P ∗ □ P ⊣⊢ □ P :=
   and_sep_intuitionistically.symm.trans and_self
 
+@[rocq_alias bi.impl_wand_intuitionistically]
 theorem intuitionistically_wand [BI PROP] {P Q : PROP} : (□ P -∗ Q) ⊣⊢ (<pers> P → Q) :=
   ⟨imp_intro <| persistently_and_intuitionistically_sep_right.1.trans wand_elim_left,
    wand_intro <|persistently_and_intuitionistically_sep_right.2.trans imp_elim_left⟩

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -2222,6 +2222,14 @@ theorem persistent_and_sep [BI PROP] [BIAffine PROP] {P Q : PROP} :
   | TCOr.r => (and_congr_right persistently_iff.symm).trans <|
               and_persistently_iff_sep.trans (sep_congr_right persistently_iff)
 
+@[rocq_alias bi.persistent_sep_dup_1]
+theorem persistent_sep_dup_mp [BI PROP] {P : PROP} [inst : Persistent P] : P ⊢ P ∗ P :=
+  and_self.mpr.trans persistent_and_sep_mp
+
+@[rocq_alias bi.persistent_sep_dup]
+theorem persistent_sep_dup [BI PROP] {P : PROP} [Persistent P]
+    [TCOr (Affine P) (Absorbing P)] : P ⊣⊢ P ∗ P :=
+  ⟨persistent_sep_dup_mp, sep_elim_left⟩
 
 @[rocq_alias bi.persistent_entails_l]
 theorem persistent_entails_right [BI PROP] {P Q : PROP} [Persistent Q] (H : P ⊢ Q) : P ⊢ Q ∗ P :=

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -673,6 +673,13 @@ theorem equiv_iff_thm [BI PROP] {P Q : PROP} (h : P ⊣⊢ Q) : ⊢ iprop(P ↔ 
   · exact imp_intro <| and_elim_r.trans h.mp
   · exact imp_intro <| and_elim_r.trans h.mpr
 
+@[rocq_alias bi.iff_equiv]
+theorem iff_equiv [BI PROP] {P Q : PROP} [Affine P] [Affine Q] (h : ⊢ iprop(P ↔ Q)) :
+    P ⊣⊢ Q := by
+  constructor
+  · exact (and_intro .rfl ((Affine.affine).trans (h.trans and_elim_l))).trans imp_elim_right
+  · exact (and_intro .rfl ((Affine.affine).trans (h.trans and_elim_r))).trans imp_elim_right
+
 @[rocq_alias bi.wand_iff_ne]
 instance wandIff_ne [BI PROP] : OFE.NonExpansive₂ (wandIff (PROP := PROP)) :=
   ⟨fun {_ _ _} h₁ {_ _} h₂ => and_ne.ne (wand_ne.ne h₁ h₂) (wand_ne.ne h₂ h₁)⟩

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -633,9 +633,13 @@ theorem and_parallel [BI PROP] {P1 P2 Q1 Q2 : PROP} :
     ⊢ (P1 ∧ P2) -∗ ((P1 -∗ Q1) ∧ (P2 -∗ Q2)) -∗ Q1 ∧ Q2 := by
   apply wand_intro
   apply wand_intro
-  apply and_intro <;> apply wand_elim <;> apply wand_intro
-  · exact (sep_mono (emp_sep.mp.trans and_elim_l) and_elim_l).trans wand_elim_right
-  · exact (sep_mono (emp_sep.mp.trans and_elim_r) and_elim_r).trans wand_elim_right
+  apply and_intro
+  · apply wand_elim
+    apply wand_intro
+    exact (sep_mono (emp_sep.mp.trans and_elim_l) and_elim_l).trans wand_elim_right
+  · apply wand_elim
+    apply wand_intro
+    exact (sep_mono (emp_sep.mp.trans and_elim_r) and_elim_r).trans wand_elim_right
 
 @[rocq_alias bi.iff_ne]
 instance iff_ne [BI PROP] : OFE.NonExpansive₂ (BIBase.iff (PROP := PROP)) :=

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -824,16 +824,14 @@ theorem pure_alt {PROP : Type _} [BI PROP] (φ : Prop) :
 theorem pure_wand_forall [BI PROP] {φ : Prop} {P : PROP} [Absorbing P] :
     (⌜φ⌝ -∗ P) ⊣⊢ (∀ _ : φ, P) := by
   constructor
-  · apply forall_intro
-    intro hφ
+  · refine forall_intro fun hφ => ?_
     calc
       _ ⊢ (⌜φ⌝ -∗ P) ∗ emp := sep_emp.mpr
       _ ⊢ (⌜φ⌝ -∗ P) ∗ ⌜φ⌝ := sep_mono_right <| pure_intro hφ
       _ ⊢ P                := wand_elim_left
   · apply wand_intro_left
     apply wand_elim
-    apply pure_elim'
-    intro hφ
+    refine pure_elim' fun hφ => ?_
     apply wand_intro_left
     calc
       _ ⊢ P ∗ True := sep_mono_left <| forall_elim hφ

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -613,6 +613,33 @@ instance iff_ne [BI PROP] : OFE.NonExpansive₂ (BIBase.iff (PROP := PROP)) :=
 theorem iff_refl_alias [BI PROP] {Q P : PROP} : Q ⊢ iprop(P ↔ P) :=
   true_intro.trans <| and_intro (imp_intro and_elim_r) (imp_intro and_elim_r)
 
+@[rocq_alias bi.iff_sym]
+theorem iff_sym [BI PROP] {P Q : PROP} : (P ↔ Q) ⊣⊢ (Q ↔ P) :=
+  ⟨and_intro and_elim_r and_elim_l, and_intro and_elim_r and_elim_l⟩
+
+@[rocq_alias bi.iff_trans]
+theorem iff_trans [BI PROP] {P Q R : PROP} : (P ↔ Q) ∧ (Q ↔ R) ⊢ (P ↔ R) := by
+  apply and_intro
+  · exact (and_mono and_elim_l and_elim_l).trans imp_trans
+  · calc
+      _ ⊢ (Q → P) ∧ (R → Q) := and_mono and_elim_r and_elim_r
+      _ ⊢ (R → Q) ∧ (Q → P) := and_comm.mp
+      _ ⊢ R → P             := imp_trans
+
+@[rocq_alias bi.entails_impl]
+theorem entails_imp [BI PROP] {P Q : PROP} (h : P ⊢ Q) : ⊢ P → Q :=
+  imp_intro <| and_elim_r.trans h
+
+@[rocq_alias bi.impl_entails]
+theorem imp_entails [BI PROP] {P Q : PROP} [inst : Affine P] (h : ⊢ P → Q) : P ⊢ Q :=
+  imp_mp (inst.affine.trans h) .rfl
+
+@[rocq_alias bi.equiv_iff]
+theorem equiv_iff_thm [BI PROP] {P Q : PROP} (h : P ⊣⊢ Q) : ⊢ iprop(P ↔ Q) := by
+  apply and_intro
+  · exact imp_intro <| and_elim_r.trans h.mp
+  · exact imp_intro <| and_elim_r.trans h.mpr
+
 @[rocq_alias bi.wand_iff_ne]
 instance wandIff_ne [BI PROP] : OFE.NonExpansive₂ (wandIff (PROP := PROP)) :=
   ⟨fun {_ _ _} h₁ {_ _} h₂ => and_ne.ne (wand_ne.ne h₁ h₂) (wand_ne.ne h₂ h₁)⟩
@@ -641,6 +668,16 @@ theorem equiv_wandIff [BI PROP] {P Q : PROP} (h : P ⊣⊢ Q) : ⊢ P ∗-∗ Q 
 @[rocq_alias bi.wand_iff_equiv]
 theorem wandIff_equiv [BI PROP] {P Q : PROP} (h : ⊢ P ∗-∗ Q) : P ⊣⊢ Q :=
   ⟨wand_entails (h.trans and_elim_l), wand_entails (h.trans and_elim_r)⟩
+
+@[rocq_alias bi.bi_or_monoid]
+instance bi_or_monoid [BI PROP] : LawfulBigOp or (iprop(False) : PROP) BiEntails where
+  refl := .rfl
+  symm h := h.symm
+  trans h1 h2 := h1.trans h2
+  comm := or_comm
+  assoc := or_assoc
+  left_id := left_id
+  congr_l := or_congr_left
 
 /-! # Pure -/
 

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Lars König. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Lars König, Mario Carneiro, Markus de Medeiros, Michael Sammler
+Authors: Lars König, Mario Carneiro, Markus de Medeiros, Michael Sammler, Alvin Tang
 -/
 module
 

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -690,8 +690,16 @@ theorem equiv_iff_thm [BI PROP] {P Q : PROP} (h : P ⊣⊢ Q) : ⊢ iprop(P ↔ 
 theorem iff_equiv [BI PROP] {P Q : PROP} [Affine P] [Affine Q] (h : ⊢ iprop(P ↔ Q)) :
     P ⊣⊢ Q := by
   constructor
-  · exact (and_intro .rfl ((Affine.affine).trans (h.trans and_elim_l))).trans imp_elim_right
-  · exact (and_intro .rfl ((Affine.affine).trans (h.trans and_elim_r))).trans imp_elim_right
+  · refine (and_intro .rfl ?_).trans imp_elim_right
+    calc
+      _ ⊢ emp := Affine.affine
+      _ ⊢ (P ↔ Q) := h
+      _ ⊢ P → Q := and_elim_l
+  · refine (and_intro .rfl ?_).trans imp_elim_right
+    calc
+      _ ⊢ emp := Affine.affine
+      _ ⊢ (P ↔ Q) := h
+      _ ⊢ Q → P := and_elim_r
 
 @[rocq_alias bi.wand_iff_ne]
 instance wandIff_ne [BI PROP] : OFE.NonExpansive₂ (wandIff (PROP := PROP)) :=

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -2392,9 +2392,8 @@ theorem LimitPreserving.entails [BI PROP] [COFE A] (Φ Ψ : A → PROP) [Φne : 
 
 @[rocq_alias bi.limit_preserving_emp_valid]
 theorem limitPreserving_emp_valid [BI PROP] [COFE A] (Φ : A → PROP)
-    [OFE.NonExpansive Φ] : LimitPreserving (fun x => ⊢ Φ x) := by
-  refine fun c h => ?_
-  exact LimitPreserving.entails (fun _ => iprop(emp)) Φ c h
+    [OFE.NonExpansive Φ] : LimitPreserving (fun x => ⊢ Φ x) :=
+  LimitPreserving.entails (fun _ => iprop(emp)) Φ
 
 @[rocq_alias bi.limit_preserving_Persistent]
 instance limitPreserving_persistent [BI PROP] [COFE A] (Φ : A → PROP) [Φne : OFE.NonExpansive Φ] :

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -726,7 +726,7 @@ theorem pure_elim [BI PROP] (φ : Prop) {Q R : PROP} (h1 : Q ⊢ ⌜φ⌝) (h2 :
   (and_self (PROP := PROP)).2.trans <| imp_elim <| h1.trans <| pure_elim' fun h =>
     imp_intro_swap <| and_elim_l.trans (h2 h)
 
-@[rocq_alias bi.pure_mono]
+@[rw_mono_rule, rocq_alias bi.pure_mono]
 theorem pure_mono [BI PROP] {φ1 φ2 : Prop} (h : φ1 → φ2) : ⌜φ1⌝ ⊢ (⌜φ2⌝ : PROP) :=
   pure_elim' <| pure_intro ∘ h
 #rocq_ignore bi.pure_mono' "Use pure_mono."

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -641,10 +641,14 @@ theorem and_parallel [BI PROP] {P1 P2 Q1 Q2 : PROP} :
   apply and_intro
   · apply wand_elim
     apply wand_intro
-    exact (sep_mono (emp_sep.mp.trans and_elim_l) and_elim_l).trans wand_elim_right
+    refine (sep_mono_right and_elim_l).trans ?_
+    refine (sep_mono_left <| emp_sep.mp.trans and_elim_l).trans ?_
+    exact wand_elim_right
   · apply wand_elim
     apply wand_intro
-    exact (sep_mono (emp_sep.mp.trans and_elim_r) and_elim_r).trans wand_elim_right
+    refine (sep_mono_right and_elim_r).trans ?_
+    refine (sep_mono_left <| emp_sep.mp.trans and_elim_r).trans ?_
+    exact wand_elim_right
 
 @[rocq_alias bi.iff_ne]
 instance iff_ne [BI PROP] : OFE.NonExpansive₂ (BIBase.iff (PROP := PROP)) :=

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -1591,6 +1591,11 @@ theorem intuitionistically_wand [BI PROP] {P Q : PROP} : (□ P -∗ Q) ⊣⊢ (
   ⟨imp_intro <| persistently_and_intuitionistically_sep_right.1.trans wand_elim_left,
    wand_intro <|persistently_and_intuitionistically_sep_right.2.trans imp_elim_left⟩
 
+@[rocq_alias bi.intuitionistically_intro]
+theorem intuitionistically_intro [BI PROP] {P Q : PROP}
+    [Affine P] [Persistent P] (h : P ⊢ Q) : P ⊢ □ Q :=
+  intuitionistic_alias.trans <| intuitionistically_mono h
+
 theorem affinely_self_sep_intuitionistically [BI PROP] {P : PROP} :
     <affine> (P ∗ □ P) ⊣⊢ □ P :=
   ⟨affinely_mono <| (sep_mono_right persistently_of_intuitionistically).trans self_sep_persistently.1,

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -1591,6 +1591,17 @@ theorem intuitionistically_wand [BI PROP] {P Q : PROP} : (□ P -∗ Q) ⊣⊢ (
   ⟨imp_intro <| persistently_and_intuitionistically_sep_right.1.trans wand_elim_left,
    wand_intro <|persistently_and_intuitionistically_sep_right.2.trans imp_elim_left⟩
 
+@[rocq_alias bi.intuitionistically_alt_fixpoint]
+theorem self_sep_intuitionistically [BI PROP] {P : PROP} :
+    □ P ⊣⊢ emp ∧ (P ∗ □ P) := by
+  constructor
+  · apply and_intro
+    · exact intuitionistically_elim_emp
+    · apply intuitionistically_sep_idem.mpr.trans <| sep_mono_left intuitionistically_elim
+  · apply and_mono
+    · rfl
+    · exact (sep_mono_right (and_elim_r)).trans self_sep_persistently.mp
+
 @[rocq_alias bi.intuitionistically_intro]
 theorem intuitionistically_intro [BI PROP] {P Q : PROP}
     [Affine P] [Persistent P] (h : P ⊢ Q) : P ⊢ □ Q :=

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -1594,7 +1594,8 @@ theorem affinely_self_sep_intuitionistically [BI PROP] {P : PROP} :
 theorem intuitionistically_imp_wand [BI PROP] {P Q : PROP} : □ (P -∗ Q) ⊢ □ (P → Q) :=
   affinely_mono persistently_imp_wand_mpr
 
-theorem imp_iff_exists_persistently [BI PROP] [BIAffine PROP] {P Q : PROP} :
+@[rocq_alias bi.impl_alt]
+theorem imp_iff_exists_persistently [BI PROP] {P Q : PROP} :
     (P → Q) ⊣⊢ ∃ R, R ∧ <pers> (P ∧ R -∗ Q) := by
   constructor
   · refine (and_true.2.trans ?_).trans (exists_intro iprop(P → Q))

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -628,8 +628,10 @@ theorem exists_wand_forall [BI PROP] {P : PROP} {Ψ : α → PROP} :
     ((∃ x, Ψ x) -∗ P) ⊣⊢ (∀ x, Ψ x -∗ P) := by
   constructor
   · exact forall_intro (wand_mono_left <| exists_intro ·)
-  · exact wand_intro <| sep_exists_left.mp.trans <| exists_elim fun x =>
-      (sep_mono_left (forall_elim x)).trans wand_elim_left
+  · apply wand_intro
+    refine sep_exists_left.mp.trans ?_
+    refine exists_elim fun x => ?_
+    exact (sep_mono_left <| forall_elim x).trans wand_elim_left
 
 @[rocq_alias bi.and_parallel]
 theorem and_parallel [BI PROP] {P1 P2 Q1 Q2 : PROP} :

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -2298,6 +2298,13 @@ theorem persistent_impl_wand_affinely [BI PROP] {P Q : PROP} [Persistent P] [Abs
   · exact wand_intro_left <| persistent_and_affinely_sep_left.mpr.trans imp_elim_right
   · exact imp_intro_swap <| persistent_and_affinely_sep_left.mp.trans wand_elim_right
 
+@[rocq_alias bi.from_option_persistent]
+instance from_option_persistent [BI PROP] {P : PROP} {Ψ : α → PROP} {mx : Option α}
+    [inst : ∀ x, Persistent (Ψ x)] [Persistent P] : Persistent (mx.elim P Ψ) := by
+  cases mx with
+  | none => assumption
+  | some x => apply inst
+
 /-! # Limits -/
 
 @[rocq_alias bi.limit_preserving_entails]

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -25,7 +25,7 @@ open Iris.Std BI
 instance entails_trans' [BI PROP] : Trans (α := PROP) Entails Entails Entails where
   trans h1 h2 := h1.trans h2
 
-@[rocq_alias entails_anti_sym]
+@[rocq_alias bi.entails_anti_sym]
 instance entails_antisymm [BI PROP] : Antisymmetric (α := PROP) BiEntails Entails where
   antisymm h1 h2 := ⟨h1, h2⟩
 

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -604,6 +604,17 @@ theorem wandIff_congr_right [BI PROP] {P Q Q' : PROP} (h : Q ⊣⊢ Q') : (P ∗
 @[rocq_alias bi.wand_iff_refl]
 theorem wandIff_refl [BI PROP] {P : PROP} : ⊢ P ∗-∗ P := and_intro wand_rfl wand_rfl
 
+@[rocq_alias bi.wand_iff_sym]
+theorem wandIff_sym [BI PROP] {P Q : PROP} : (P ∗-∗ Q) ⊣⊢ (Q ∗-∗ P) :=
+  ⟨and_symm, and_symm⟩
+
+@[rocq_alias bi.wand_iff_trans]
+theorem wandIff_trans [BI PROP] {P Q R : PROP} :
+    (P ∗-∗ Q) ∗ (Q ∗-∗ R) ⊢ (P ∗-∗ R) := by
+  apply and_intro
+  · exact (sep_mono and_elim_l and_elim_l).trans wand_trans
+  · exact (sep_mono and_elim_r and_elim_r).trans <| sep_comm.mp.trans wand_trans
+
 @[rocq_alias bi.iff_ne]
 instance iff_ne [BI PROP] : OFE.NonExpansive₂ (BIBase.iff (PROP := PROP)) :=
   ⟨fun {_ _ _} h₁ {_ _} h₂ => and_ne.ne (imp_ne.ne h₁ h₂) (imp_ne.ne h₂ h₁)⟩
@@ -2278,5 +2289,3 @@ theorem bi_emp_valid_mono [BI PROP] {P Q : PROP} (h : P ⊢ Q) : (⊢ P) → ⊢
 @[rocq_alias bi.bi_emp_valid_flip_mono]
 theorem bi_emp_valid_flip_mono [BI PROP] {P Q : PROP} (h : P ⊣⊢ Q) : (⊢ P) ↔ ⊢ Q :=
   ⟨(·.trans h.1), (·.trans h.2)⟩
-
--/

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -615,6 +615,23 @@ theorem wandIff_trans [BI PROP] {P Q R : PROP} :
   · exact (sep_mono and_elim_l and_elim_l).trans wand_trans
   · exact (sep_mono and_elim_r and_elim_r).trans <| sep_comm.mp.trans wand_trans
 
+@[rocq_alias bi.exist_wand_forall]
+theorem exists_wand_forall [BI PROP] {P : PROP} {Ψ : α → PROP} :
+    ((∃ x, Ψ x) -∗ P) ⊣⊢ (∀ x, Ψ x -∗ P) := by
+  constructor
+  · exact forall_intro (wand_mono_left <| exists_intro ·)
+  · exact wand_intro <| sep_exists_left.mp.trans <| exists_elim fun x =>
+      (sep_mono_left (forall_elim x)).trans wand_elim_left
+
+@[rocq_alias bi.and_parallel]
+theorem and_parallel [BI PROP] {P1 P2 Q1 Q2 : PROP} :
+    ⊢ (P1 ∧ P2) -∗ ((P1 -∗ Q1) ∧ (P2 -∗ Q2)) -∗ Q1 ∧ Q2 := by
+  apply wand_intro
+  apply wand_intro
+  apply and_intro <;> apply wand_elim <;> apply wand_intro
+  · exact (sep_mono (emp_sep.mp.trans and_elim_l) and_elim_l).trans wand_elim_right
+  · exact (sep_mono (emp_sep.mp.trans and_elim_r) and_elim_r).trans wand_elim_right
+
 @[rocq_alias bi.iff_ne]
 instance iff_ne [BI PROP] : OFE.NonExpansive₂ (BIBase.iff (PROP := PROP)) :=
   ⟨fun {_ _ _} h₁ {_ _} h₂ => and_ne.ne (imp_ne.ne h₁ h₂) (imp_ne.ne h₂ h₁)⟩

--- a/Iris/Iris/BI/DerivedLawsLater.lean
+++ b/Iris/Iris/BI/DerivedLawsLater.lean
@@ -261,6 +261,9 @@ instance later_contractive_bi_loeb [BILaterContractive PROP] : BILoeb PROP where
     refine equiv_iff.mp ?_ |>.mp
     exact fixpoint_unfold Flöb
 
+@[rocq_alias not_not_later_False]
+theorem not_not_later_False [BILoeb PROP] : ⊢@{PROP} ¬ ¬ ▷ False := entails_imp loeb
+
 /-! # LaterN -/
 
 @[rocq_alias bi.laterN_ne]

--- a/Iris/Iris/BI/DerivedLawsLater.lean
+++ b/Iris/Iris/BI/DerivedLawsLater.lean
@@ -161,6 +161,8 @@ instance later_persistent {P : PROP} [Persistent P] : Persistent iprop(▷ P) wh
 instance later_absorbing {P : PROP} [Absorbing P] : Absorbing iprop(▷ P) where
   absorbing := later_absorbingly.mpr.trans <| later_mono absorbing
 
+#rocq_ignore bi.laterN_iter "laterN in Lean is defined using Nat.repeat directly"
+
 /-! ## Later as a monoid homomorphism
 
 These instances ported from Rocq `bi_later_monoid_*` in

--- a/Iris/Iris/BI/DerivedLawsLater.lean
+++ b/Iris/Iris/BI/DerivedLawsLater.lean
@@ -264,7 +264,7 @@ instance later_contractive_bi_loeb [BILaterContractive PROP] : BILoeb PROP where
     refine equiv_iff.mp ?_ |>.mp
     exact fixpoint_unfold Flöb
 
-@[rocq_alias not_not_later_False]
+@[rocq_alias bi.not_not_later_False]
 theorem not_not_later_False [BILoeb PROP] : ⊢@{PROP} ¬ ¬ ▷ False := entails_imp loeb
 
 @[rocq_alias bi.löb_alt_wand]

--- a/Iris/Iris/BI/DerivedLawsLater.lean
+++ b/Iris/Iris/BI/DerivedLawsLater.lean
@@ -163,6 +163,9 @@ instance later_absorbing {P : PROP} [Absorbing P] : Absorbing iprop(▷ P) where
 
 #rocq_ignore bi.laterN_iter "laterN in Lean is defined using Nat.repeat directly"
 
+theorem later_imp_and {P S : PROP} : ▷ (S → P) ∧ S ⊢ ▷ P :=
+  ((and_mono_right later_intro).trans later_and.mpr).trans <| later_mono <| and_comm.mp.trans imp_elim_right
+
 /-! ## Later as a monoid homomorphism
 
 These instances ported from Rocq `bi_later_monoid_*` in
@@ -263,6 +266,35 @@ instance later_contractive_bi_loeb [BILaterContractive PROP] : BILoeb PROP where
 
 @[rocq_alias not_not_later_False]
 theorem not_not_later_False [BILoeb PROP] : ⊢@{PROP} ¬ ¬ ▷ False := entails_imp loeb
+
+@[rocq_alias bi.löb_alt_wand]
+theorem loeb_alt_wand [BIAffine PROP] :
+    BILoeb PROP ↔ ∀ P : PROP, □ (▷ P -∗ P) ⊢ P := by
+  constructor <;> intro h
+  · apply loeb_wand
+  · constructor
+    intro _ hP
+    apply loeb_weak_of_strong _ hP
+    intro P
+    refine imp_iff_exists_persistently.mp.trans ?_
+    refine exists_elim fun S => ?_
+    apply imp_elim_swap
+    refine intuitionistically_into_persistently.mpr.trans ?_
+    apply imp_intro
+    calc
+      _ ⊢ □ (▷ (S → P) -∗ S → P) ∧ S := and_mono_left ?_
+      _ ⊢ S ∧ □ (▷ (S → P) -∗ S → P) := and_comm.mp
+      _ ⊢ S ∧ (S → P)                 := and_mono_right <| h _
+      _ ⊢ P                           := imp_elim_right
+    apply intuitionistically_intro_intuitionistically
+    apply wand_intro
+    apply imp_intro
+    calc
+      _ ⊢ (<pers> (▷ P ∧ S -∗ P) ∧ ▷ (S → P)) ∧ S := and_mono_left persistently_and_intuitionistically_sep_left.mpr
+      _ ⊢ <pers> (▷ P ∧ S -∗ P) ∧ ▷ (S → P) ∧ S   := and_assoc.mp
+      _ ⊢ □ (▷ P ∧ S -∗ P) ∗ (▷ (S → P) ∧ S)      := persistently_and_intuitionistically_sep_left.mp
+      _ ⊢ (▷ P ∧ S -∗ P) ∗ ▷ P ∧ S                := sep_mono intuitionistically_elim <| and_intro later_imp_and and_elim_r
+      _ ⊢ P                                         := wand_elim_left
 
 /-! # LaterN -/
 

--- a/Iris/Iris/BI/DerivedLawsLater.lean
+++ b/Iris/Iris/BI/DerivedLawsLater.lean
@@ -241,7 +241,7 @@ theorem loeb_wand_intuitionistically [BILoeb PROP] {P : PROP} :
   exact intuitionistically_sep_mpr.trans (intuitionistically_mono wand_elim_right)
 
 @[rocq_alias bi.löb_wand]
-theorem loeb_wand [BILoeb PROP] {P : PROP} : □ (▷ P -∗ P) ⊢ P :=
+theorem loeb_wand [BILoeb PROP] (P : PROP) : □ (▷ P -∗ P) ⊢ P :=
   (intuitionistically_mono (wand_mono intuitionistically_elim .rfl)).trans
     loeb_wand_intuitionistically
 
@@ -270,31 +270,27 @@ theorem not_not_later_False [BILoeb PROP] : ⊢@{PROP} ¬ ¬ ▷ False := entail
 @[rocq_alias bi.löb_alt_wand]
 theorem loeb_alt_wand [BIAffine PROP] :
     BILoeb PROP ↔ ∀ P : PROP, □ (▷ P -∗ P) ⊢ P := by
-  constructor <;> intro h
-  · apply loeb_wand
-  · constructor
-    intro _ hP
-    apply loeb_weak_of_strong _ hP
-    intro P
-    refine imp_iff_exists_persistently.mp.trans ?_
-    refine exists_elim fun S => ?_
-    apply imp_elim_swap
-    refine intuitionistically_into_persistently.mpr.trans ?_
-    apply imp_intro
-    calc
-      _ ⊢ □ (▷ (S → P) -∗ S → P) ∧ S := and_mono_left ?_
-      _ ⊢ S ∧ □ (▷ (S → P) -∗ S → P) := and_comm.mp
-      _ ⊢ S ∧ (S → P)                 := and_mono_right <| h _
-      _ ⊢ P                           := imp_elim_right
-    apply intuitionistically_intro_intuitionistically
-    apply wand_intro
-    apply imp_intro
-    calc
-      _ ⊢ (<pers> (▷ P ∧ S -∗ P) ∧ ▷ (S → P)) ∧ S := and_mono_left persistently_and_intuitionistically_sep_left.mpr
-      _ ⊢ <pers> (▷ P ∧ S -∗ P) ∧ ▷ (S → P) ∧ S   := and_assoc.mp
-      _ ⊢ □ (▷ P ∧ S -∗ P) ∗ (▷ (S → P) ∧ S)      := persistently_and_intuitionistically_sep_left.mp
-      _ ⊢ (▷ P ∧ S -∗ P) ∗ ▷ P ∧ S                := sep_mono intuitionistically_elim <| and_intro later_imp_and and_elim_r
-      _ ⊢ P                                         := wand_elim_left
+  refine ⟨fun _ => loeb_wand, fun h => ⟨fun hP => ?_⟩⟩
+  refine loeb_weak_of_strong (fun P => ?_) hP
+  refine imp_iff_exists_persistently.mp.trans ?_
+  refine exists_elim fun S => ?_
+  apply imp_elim_swap
+  refine intuitionistically_into_persistently.mpr.trans ?_
+  apply imp_intro
+  calc
+    _ ⊢ □ (▷ (S → P) -∗ S → P) ∧ S := and_mono_left ?_
+    _ ⊢ S ∧ □ (▷ (S → P) -∗ S → P) := and_comm.mp
+    _ ⊢ S ∧ (S → P)                 := and_mono_right <| h _
+    _ ⊢ P                           := imp_elim_right
+  apply intuitionistically_intro_intuitionistically
+  apply wand_intro
+  apply imp_intro
+  calc
+    _ ⊢ (<pers> (▷ P ∧ S -∗ P) ∧ ▷ (S → P)) ∧ S := and_mono_left persistently_and_intuitionistically_sep_left.mpr
+    _ ⊢ <pers> (▷ P ∧ S -∗ P) ∧ ▷ (S → P) ∧ S   := and_assoc.mp
+    _ ⊢ □ (▷ P ∧ S -∗ P) ∗ (▷ (S → P) ∧ S)      := persistently_and_intuitionistically_sep_left.mp
+    _ ⊢ (▷ P ∧ S -∗ P) ∗ ▷ P ∧ S                := sep_mono intuitionistically_elim <| and_intro later_imp_and and_elim_r
+    _ ⊢ P                                         := wand_elim_left
 
 /-! # LaterN -/
 

--- a/Iris/Iris/BI/Plainly.lean
+++ b/Iris/Iris/BI/Plainly.lean
@@ -300,7 +300,7 @@ theorem plainly_impl_wand : ■ (P → Q) ⊣⊢ ■ (P -∗ Q) := by
 
 @[rocq_alias impl_wand_plainly]
 theorem impl_wand_plainly : (■ P → Q) ⊣⊢ (■ P -∗ Q) :=
-  ⟨imp_wand, impl_wand_plainly_2⟩
+  ⟨imp_wand_1, impl_wand_plainly_2⟩
 
 end AffineBI
 


### PR DESCRIPTION
## Description

Port all missing theorems and instances in [`BI/DerivedLaws.lean`](https://github.com/leanprover-community/iris-lean/blob/master/Iris/Iris/BI/DerivedLaws.lean) and [`BI/DerivedLawsLater.lean`](https://github.com/leanprover-community/iris-lean/blob/master/Iris/Iris/BI/DerivedLawsLater.lean).

<details>

<summary><b>Checklist of theorems and instances being ported</b></summary>

- [x] `bi.and_parallel`
- [x] `bi.bi_or_monoid`
- [x] `bi.decide_bi_True`
- [x] `bi.decide_emp`
- [x] `bi.entails_anti_sym` (already exists, added missing `rocq_alias` annotation)
- [x] `bi.entails_impl`
- [x] `bi.equiv_entails_2` (ignored, the `BiEntails` constructor) can be used directly)
- [x] `bi.equiv_iff`
- [x] `bi.exist_wand_forall`
- [x] `bi.from_option_persistent`
- [x] `bi.iff_equiv`
- [x] `bi.iff_sym`
- [x] `bi.iff_trans`
- [x] `bi.impl_alt`
- [x] `bi.impl_entails`
- [x] `bi.impl_wand`
- [x] `bi.impl_wand_2`
- [x] `bi.impl_wand_intuitionistically`
- [x] `bi.intuitionistically_alt_fixpoint`
- [x] `bi.intuitionistically_intro`
- [x] `bi.limit_preserving_emp_valid`
- [x] `bi.persistent_absorbingly_affinely`
- [x] `bi.persistent_and_sep_assoc`
- [x] `bi.persistent_impl_wand_affinely`
- [x] `bi.persistent_sep_dup`
- [x] `bi.persistent_sep_dup_1`
- [x] `bi.pure_flip_mono` (ignored, specific to the `Proper` type class in Rocq)
- [x] `bi.pure_impl_forall`
- [x] `bi.pure_wand_forall`
- [x] `bi.wand_iff_sym`
- [x] `bi.wand_iff_trans`
- [x] `bi.laterN_iter` (ignored, `laterN` in Lean is itself defined using `Nat.repeat`, #324)
- [x] `bi.löb_alt_wand`
- [x] `bi.not_not_later_False`

</details>

The theorem `bi.wandM_sound` is ported in #470.

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files
