### PR TITLE
fix: remove redundant function `Hyps.evalReplace`

### DIFF
--- a/Iris/Iris/ProofMode/Expr.lean
+++ b/Iris/Iris/ProofMode/Expr.lean
@@ -493,24 +493,6 @@ def Hyps.replace : m (Option ((e' : Q($prop)) × Hyps bi e' × Q($e ⊢ $e'))) :
   let some ⟨_, hyps', pf⟩ ← hyps.replaceCore bi e ivar repl | return none
   return some ⟨_, hyps', q(replace_finish $pf)⟩
 
-def Hyps.evalReplace [Monad m] [MonadLiftT MetaM m]
-    {u} {prop : Q(Type u)} {bi : Q(BI $prop)} (ivar : IVarId)
-    (repl : (ty : Q($prop)) → m ((ty' : Q($prop)) × Q($ty ⊢ $ty'))) :
-    ∀ {e}, Hyps bi e → m (Option ((e' : Q($prop)) × Hyps bi e' × Q($e ⊢ $e')))
-  | _, .emp _ => return none
-  | _, .hyp _ name ivar' p ty _ =>
-      if ivar == ivar' then do
-        let ⟨ty', h⟩ ← repl ty
-        return some ⟨_, .mkHyp bi name ivar p ty',
-                     q(intuitionisticallyIf_mono (p := $p) $h)⟩
-      else return none
-  | _, .sep _ _ _ _ lhs rhs => do
-      if let some ⟨_, lhs', h⟩ ← lhs.evalReplace ivar repl then
-        return some ⟨_, .mkSep lhs' rhs, q(sep_mono_left $h)⟩
-      if let some ⟨_, rhs', h⟩ ← rhs.evalReplace ivar repl then
-        return some ⟨_, .mkSep lhs rhs', q(sep_mono_right $h)⟩
-      return none
-
 end replace
 
 section dependency

--- a/Iris/Iris/ProofMode/Tactics/Eval.lean
+++ b/Iris/Iris/ProofMode/Tactics/Eval.lean
@@ -10,6 +10,14 @@ public meta import Iris.ProofMode.ProofModeM
 
 namespace Iris.ProofMode
 
+public section
+open BI
+
+theorem hyps_replace_ieval [BI PROP] {P Q R : PROP}
+    (h : P ⊢ Q) : R ⊢ <pers> (P -∗ Q) :=
+  persistently_emp_intro.trans <| persistently_mono <| wand_intro <| emp_sep.mp.trans h
+
+
 public meta section
 open Lean Elab Tactic Meta Qq BI Lean.Parser.Tactic
 
@@ -65,9 +73,10 @@ private def iEvalCore {u} {prop : Q(Type u)} {bi : Q(BI $prop)} {e}
       | .pure _ =>
         throwError "ieval: pure hypotheses in the selection pattern is not supported"
       | .ipm ivar =>
-        let some ⟨newE, newHyps, pf⟩ ← evalState.newHyps.evalReplace ivar fun ty => do
+        let some ⟨newE, newHyps, pf⟩ ← evalState.newHyps.replace ivar fun _ _ ty => do
           let ⟨newTy, pf⟩ ← iEvalOne (isGoal := false) bi tac ty
-          return ⟨newTy, (pf : Q($ty ⊢ $newTy))⟩
+          let pf : Q($ty ⊢ $newTy) := pf
+          return ⟨newTy, q(hyps_replace_ieval $pf)⟩
         | throwError m!"ieval: unable to find the hypothesis {ivar.name} in the context"
         pure { newE, newHyps, pf := q($(evalState.pf).trans $pf) }
     let pf' ← addBIGoal evalState.newHyps goal


### PR DESCRIPTION
## Description

The function `Hyps.evalReplace` is redundant. We can tweak its call site and use `Hyps.replace` instead.

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files
