### PR TITLE
feat: add total weakest preconditions

### DIFF
--- a/Iris/Iris.lean
+++ b/Iris/Iris.lean
@@ -6,5 +6,7 @@ public import Iris.Examples
 public import Iris.HeapLang
 public import Iris.Instances
 public import Iris.ProofMode
+public import Iris.ProgramLogic.TotalAdequacy
+public import Iris.ProgramLogic.TotalEctxLifting
 public import Iris.Std
 public import Iris.Tests

--- a/Iris/Iris/BI/WeakestPre.lean
+++ b/Iris/Iris/BI/WeakestPre.lean
@@ -76,6 +76,13 @@ syntax " {" noWs "{ " term:min " }" noWs "} " : texanPrecond
 
 syntax (name := texanTriple) texanPrecond wpExpr texanPostcond : term
 
+/- Total Texan triples deliberately have no later in front of the postcondition
+continuation.  The doubled square brackets follow Iris-Rocq's TWP notation. -/
+syntax (name := totalTexanTriple)
+  "[[{" term:min "}]]" wpExpr
+  "[[{" ((ppSpace (binderIdent <|> bracketedBinder))+ ", ")?
+    "RET " term:min "; " term:min "}]]" : term
+
 open Lean in
 meta def parseWpExpr : Lean.TSyntax ``wpExpr → Lean.MacroM (TSyntax `term × TSyntax `term × TSyntax `term) := fun
   | `(wpExpr| $e @ $s ; $E) =>
@@ -134,6 +141,28 @@ meta def wpTexanTriple : Lean.Macro
               `(iprop(∀ $xs*, $Q:term -∗ Φ $pat))
             | none => `($Q:term -∗ Φ $pat)
     `(iprop(∀ Φ, $P -∗ ▷ $k -∗ (WP $wpExpr {{ Φ }})))
+  | _ => Lean.Macro.throwUnsupported
+
+@[macro totalTexanTriple]
+meta def totalWpTexanTriple : Lean.Macro
+  | `([[{ $P:term }]] $wpExpr
+      [[{ $[$[$xs]* ,]? RET $pat ; $Q:term }]]) => do
+    let transform
+        (xs : Array (TSyntax [`Lean.binderIdent, `Lean.Parser.Term.bracketedBinder])) :
+        MacroM <| TSyntaxArray [`ident, `Lean.Parser.Term.hole,
+          `Lean.Parser.Term.bracketedBinder] :=
+      xs.mapM fun
+        | `(binderIdent|_) => `(hole|_)
+        | `(binderIdent|$i:ident) => `(ident|$i)
+        | `(bracketedBinder|$x) => `(bracketedBinder|$x)
+    let k ← match xs with
+      | some xs =>
+        let xs ← transform xs
+        `(iprop(∀ $xs*, $Q:term -∗ Φ $pat))
+      | none => `($Q:term -∗ Φ $pat)
+    let (e, s, E) ← parseWpExpr wpExpr
+    `(iprop(∀ Φ, $P -∗ $k -∗
+      TotalWp.totalWp $s $E $e Φ))
   | _ => Lean.Macro.throwUnsupported
 
 meta def unexpandWpPostcondInner : TSyntax `term → PrettyPrinter.UnexpandM (TSyntax `wpPostcondInner)

--- a/Iris/Iris/ProgramLogic/TotalAdequacy.lean
+++ b/Iris/Iris/ProgramLogic/TotalAdequacy.lean
@@ -20,8 +20,15 @@ open Language Language.Notation
 relation is flipped.  This definition is constructive and means that every
 reduction tree rooted at the configuration is finite (strong normalization),
 not merely that some execution terminates.
+
+The fork-aware thread-pool predicate below is kept because it is part of the
+Iris-Rocq adequacy argument. Thread-pool ghost-state convenience APIs are not
+ported: they are unrelated to establishing total-WP termination for the
+initial single-threaded Wasm client. Fair termination, trace-sensitive
+liveness, and coinductive progress are intentionally outside this layer.
 -/
 
+@[rocq_alias sn]
 def StronglyNormalizing {α : Type _} (step : α → α → Prop) (x : α) : Prop :=
   Acc (flip step) x
 
@@ -41,9 +48,434 @@ theorem tail {α : Type _} {step : α → α → Prop} {x y : α}
     StronglyNormalizing step y :=
   H.inv Hxy
 
+theorem map {α β : Type _} {stepα : α → α → Prop}
+    {stepβ : β → β → Prop} (f : β → α)
+    (Hlift : ∀ x y, stepβ x y → stepα (f x) (f y))
+    {x : β} (H : StronglyNormalizing stepα (f x)) :
+    StronglyNormalizing stepβ x := by
+  unfold StronglyNormalizing at H ⊢
+  generalize hx : f x = z at H
+  induction H generalizing x with
+  | intro z Hz IH =>
+      subst z
+      apply Acc.intro
+      intro y Hy
+      exact IH (f y) (Hlift x y Hy) rfl
+
 end StronglyNormalizing
 
 variable {Expr State Obs Val : Type _} [Λ : Language Expr State Obs Val]
+
+section ThreadPool
+
+variable {hlc : HasLC} {GF : BundledGFunctors}
+variable [ι : IrisGS_gen hlc Expr GF]
+
+namespace twptp
+
+local instance : OFE CoPset := OFE.ofDiscrete _
+local instance : OFE Expr := OFE.ofDiscrete _
+local instance : OFE Val := OFE.ofDiscrete _
+
+private theorem step_append_inv (r₁ r₂ t' : List Expr) (σ₁ σ₂ : State)
+    (κ : List Obs) :
+    (r₁ ++ r₂, σ₁) -<κ>->ₜₚ (t', σ₂) →
+      (∃ r₁', (r₁, σ₁) -<κ>->ₜₚ (r₁', σ₂) ∧
+        t'.Perm (r₁' ++ r₂)) ∨
+      (∃ r₂', (r₂, σ₁) -<κ>->ₜₚ (r₂', σ₂) ∧
+        t'.Perm (r₁ ++ r₂')) := by
+  intro H
+  generalize hsrc : r₁ ++ r₂ = src at H
+  generalize hdst : t' = dst at H
+  cases H with
+  | @atomic e σ obs e' σ' efs Hprim p q =>
+    rcases List.append_eq_append_iff.mp hsrc.symm with
+      (⟨mid, hr₁, heq⟩ | ⟨bs, hp, hr₂⟩)
+    · cases mid with
+      | nil =>
+          simp only [List.append_nil] at hr₁
+          simp only [List.nil_append] at heq
+          subst r₁
+          subst r₂
+          exact .inr ⟨e' :: q ++ efs, .atomic Hprim [] q, by simp⟩
+      | cons a tail =>
+          simp only [List.cons_append, List.cons.injEq] at heq
+          obtain ⟨rfl, hq⟩ := heq
+          subst r₁
+          subst q
+          refine .inl ⟨p ++ e' :: tail ++ efs, .atomic Hprim p tail, ?_⟩
+          have hp := List.Perm.append_left (p ++ [e'])
+            (List.Perm.append_left tail
+              (List.perm_append_comm :
+                (r₂ ++ efs).Perm (efs ++ r₂)))
+          simpa only [List.append_assoc, List.singleton_append,
+            List.cons_append, List.nil_append] using hp
+    · subst p
+      subst r₂
+      refine .inr ⟨bs ++ e' :: q ++ efs, .atomic Hprim bs q, ?_⟩
+      simp only [List.append_assoc]
+      exact .refl _
+
+local instance : OFE (List Expr) := OFE.ofDiscrete _
+
+/-- One unfolding of the total thread-pool predicate. Every possible pool step
+must be silent, preserve the state interpretation, and recursively establish
+the predicate for the complete successor pool. -/
+@[rocq_alias twptp_pre]
+def pre (X : List Expr → IProp GF) (t₁ : List Expr) : IProp GF := iprop(
+  ∀ (t₂ : List Expr) (σ₁ : State) (ns : Nat) (κ κs : List Obs)
+      (σ₂ : State) (nt : Nat),
+    ⌜(t₁, σ₁) -<κ>->ₜₚ (t₂, σ₂)⌝ -∗
+    stateInterp σ₁ ns κs nt ={⊤}=∗
+      ∃ nt', ⌜κ = []⌝ ∗ stateInterp σ₂ (ns + 1) κs nt' ∗ X t₂)
+
+instance pre_mono_inst : BIMonoPred (pre (ι := ι)) where
+  mono_pred := by
+    intro X Y _ _
+    iintro #HXY %t₁ Hpre
+    unfold pre
+    iintro %t₂ %σ₁ %ns %κ %κs %σ₂ %nt %Hstep Hσ
+    imod Hpre $$ %t₂ %σ₁ %ns %κ %κs %σ₂ %nt %Hstep Hσ with
+      ⟨%nt', %hκ, Hσ, HX⟩
+    imodintro
+    iexists nt'
+    iframe %hκ Hσ
+    iapply HXY $$ %t₂ HX
+  mono_pred_ne.ne {X} t₁ t₂ ht := by
+    change t₁ = t₂ at ht
+    subst t₂
+    rfl
+
+@[rocq_alias twptp_pre_mono]
+theorem pre_mono (X Y : List Expr → IProp GF)
+    [NonExpansive X] [NonExpansive Y] :
+    ⊢ □ (∀ t, X t -∗ Y t) -∗
+      ∀ t, pre (ι := ι) X t -∗ pre (ι := ι) Y t :=
+  mono_pred (F := pre (ι := ι))
+
+/-- Least-fixed-point predicate governing all future reductions of a thread
+pool. This is the direct Lean counterpart of Iris-Coq's `twptp`. -/
+@[rocq_alias twptp]
+def get (t : List Expr) : IProp GF :=
+  bi_least_fixpoint (pre (ι := ι)) t
+
+instance get_ne : NonExpansive (get (ι := ι)) := by
+  constructor
+  intro n x y hxy
+  change x = y at hxy
+  subst y
+  rfl
+
+@[rocq_alias twptp_unfold]
+theorem unfold (t : List Expr) :
+    get (ι := ι) t ⊣⊢ pre (ι := ι) (get (ι := ι)) t := by
+  exact BI.equiv_iff.1 (least_fixpoint_unfold (pre (ι := ι)))
+
+@[rocq_alias twptp_ind]
+theorem induction (Ψ : List Expr → IProp GF) [NonExpansive Ψ] :
+    (⊢ □ ∀ t, pre (ι := ι) (fun t => iprop(Ψ t ∧ get (ι := ι) t)) t -∗ Ψ t) →
+    ⊢ ∀ t, get (ι := ι) t -∗ Ψ t := by
+  intro H
+  have H' : ⊢ □ ∀ t,
+      pre (ι := ι) (fun t => iprop(Ψ t ∧
+        bi_least_fixpoint (pre (ι := ι)) t)) t -∗ Ψ t := by
+    simpa only [get] using H
+  iintro %t
+  change ⊢ bi_least_fixpoint (pre (ι := ι)) t -∗ Ψ t
+  iintro Ht
+  iapply least_fixpoint_ind (F := pre (ι := ι)) (Φ := Ψ) $$ [] Ht
+  iintro !> %t' Hpre
+  iapply H' $$ %t' Hpre
+
+private theorem fold_right (Ψ : List Expr → IProp GF) [NonExpansive Ψ]
+    (t : List Expr) :
+    pre (ι := ι) (fun t => iprop(Ψ t ∧ get (ι := ι) t)) t ⊢
+      get (ι := ι) t := by
+  letI : NonExpansive
+      (fun t => iprop(Ψ t ∧ get (ι := ι) t)) := by
+    constructor
+    intro n x y hxy
+    change x = y at hxy
+    subst y
+    rfl
+  rw [(twptp.unfold (ι := ι) t).to_eq]
+  iintro Hpre
+  iapply mono_pred (F := pre (ι := ι)) $$ [] %t Hpre
+  iintro !> %u Hu
+  icases Hu with ⟨-, Hu⟩
+  iexact Hu
+
+@[rocq_alias twptp_Permutation]
+theorem permutation {t₁ t₁' : List Expr} (Hp : t₁.Perm t₁') :
+    get (ι := ι) t₁ ⊢ get (ι := ι) t₁' := by
+  let Ψ := fun t : List Expr => iprop(
+    ∀ t', ⌜t.Perm t'⌝ -∗ get (ι := ι) t')
+  have hΨ : NonExpansive Ψ := by
+    constructor
+    intro n x y hxy
+    change x = y at hxy
+    subst y
+    rfl
+  letI := hΨ
+  iintro Ht
+  iapply induction Ψ (ι := ι) ?_ $$ %t₁ Ht %t₁' %Hp
+  iintro !> %t Hpre %t' %Htt'
+  rw [(twptp.unfold (ι := ι) t').to_eq]
+  unfold pre
+  iintro %t₂ %σ₁ %ns %κ %κs %σ₂ %nt %Hstep Hσ
+  obtain ⟨t₂', H₂perm, Hstep'⟩ :=
+    Language.perm_of_step (t₁ := t') (t₁' := t) Htt'.symm Hstep
+  imod Hpre $$ %t₂' %σ₁ %ns %κ %κs %σ₂ %nt %Hstep' Hσ with
+    ⟨%nt', %hκ, Hσ, HIH⟩
+  icases HIH with ⟨HIH, -⟩
+  imodintro
+  iexists nt'
+  iframe %hκ Hσ
+  iapply HIH $$ %t₂ %H₂perm.symm
+
+@[rocq_alias twptp_app]
+theorem app (t₁ t₂ : List Expr) :
+    get (ι := ι) t₁ -∗ get (ι := ι) t₂ -∗ get (ι := ι) (t₁ ++ t₂) := by
+  let Ψ₁ := fun t₁ : List Expr => iprop(
+    ∀ t₂, get (ι := ι) t₂ -∗ get (ι := ι) (t₁ ++ t₂))
+  have hΨ₁ : NonExpansive Ψ₁ := by
+    constructor
+    intro n x y hxy
+    change x = y at hxy
+    subst y
+    rfl
+  letI := hΨ₁
+  iintro H₁
+  iapply induction Ψ₁ (ι := ι) ?_ $$ %t₁ H₁ %t₂
+  let Ψ₂ := fun t₂ : List Expr => iprop(
+    ∀ t₁, pre (ι := ι)
+      (fun t => iprop(Ψ₁ t ∧ get (ι := ι) t)) t₁ -∗
+      get (ι := ι) (t₁ ++ t₂))
+  have hΨ₂ : NonExpansive Ψ₂ := by
+    constructor
+    intro n x y hxy
+    change x = y at hxy
+    subst y
+    rfl
+  letI := hΨ₂
+  iintro !> %u₁ Hu₁ %u₂ Hu₂
+  iapply induction Ψ₂ (ι := ι) ?_ $$ %u₂ Hu₂ %u₁ Hu₁
+  iintro !> %r₂ Hr₂ %r₁ Hr₁
+  rw [(twptp.unfold (ι := ι) (r₁ ++ r₂)).to_eq]
+  unfold pre
+  iintro %t' %σ₁ %ns %κ %κs %σ₂ %nt %Hstep Hσ
+  rcases step_append_inv r₁ r₂ t' σ₁ σ₂ κ Hstep with
+    (⟨r₁', Hstep₁, Hperm⟩ | ⟨r₂', Hstep₂, Hperm⟩)
+  · imod Hr₁ $$ %r₁' %σ₁ %ns %κ %κs %σ₂ %nt %Hstep₁ Hσ with
+      ⟨%nt', %hκ, Hσ, Hr₁'⟩
+    icases Hr₁' with ⟨IH₁, -⟩
+    imodintro
+    iexists nt'
+    iframe %hκ Hσ
+    iapply permutation Hperm.symm
+    iapply IH₁ $$ %r₂
+    iapply fold_right Ψ₂ r₂ (ι := ι)
+    unfold pre
+    iexact Hr₂
+  · imod Hr₂ $$ %r₂' %σ₁ %ns %κ %κs %σ₂ %nt %Hstep₂ Hσ with
+      ⟨%nt', %hκ, Hσ, Hr₂'⟩
+    icases Hr₂' with ⟨IH₂, -⟩
+    imodintro
+    iexists nt'
+    iframe %hκ Hσ
+    iapply permutation Hperm.symm
+    iapply IH₂ $$ %r₁
+    unfold pre
+    iexact Hr₁
+
+private theorem cons (e : Expr) (es : List Expr) :
+    get (ι := ι) [e] -∗ get (ι := ι) es -∗ get (ι := ι) (e :: es) := by
+  simpa only [List.singleton_append] using app [e] es (ι := ι)
+
+private theorem cons_sep (e : Expr) (es : List Expr) :
+    get (ι := ι) [e] ∗ get (ι := ι) es ⊢ get (ι := ι) (e :: es) := by
+  iintro H
+  icases H with ⟨He, Hes⟩
+  iapply cons e es (ι := ι) $$ He Hes
+
+@[rocq_alias twptp_nil]
+theorem nil : ⊢ get (ι := ι) ([] : List Expr) := by
+  rw [(twptp.unfold (ι := ι) []).to_eq]
+  unfold pre
+  iintro %t₂ %σ₁ %ns %κ %κs %σ₂ %nt %Hstep
+  exfalso
+  generalize hsrc : ([] : List Expr) = src at Hstep
+  cases Hstep with
+  | @atomic e σ obs e' σ' efs Hprim p q =>
+      simp at hsrc
+
+private theorem step_singleton_inv (e : Expr) (t₂ : List Expr)
+    (σ₁ σ₂ : State) (κ : List Obs) :
+    ([e], σ₁) -<κ>->ₜₚ (t₂, σ₂) →
+      ∃ e₂ efs, (e, σ₁) -<κ>-> (e₂, σ₂, efs) ∧ t₂ = e₂ :: efs := by
+  intro H
+  generalize hsrc : [e] = src at H
+  generalize hdst : t₂ = dst at H
+  cases H with
+  | @atomic red σ obs red' σ' efs Hprim p q =>
+      have hpq : p = [] ∧ red = e ∧ q = [] := by
+        rcases List.append_eq_singleton_iff.mp hsrc.symm with
+          (⟨hp, hrest⟩ | ⟨hp, hrest⟩)
+        · subst p
+          simp only [List.cons.injEq] at hrest
+          exact ⟨rfl, hrest.1, hrest.2⟩
+        · simp at hrest
+      obtain ⟨rfl, rfl, rfl⟩ := hpq
+      exact ⟨red', efs, Hprim, by simp_all⟩
+
+private theorem singleton_list (es : List Expr) :
+    ([∗list] e ∈ es, get (ι := ι) [e]) ⊢ get (ι := ι) es := by
+  induction es with
+  | nil =>
+      simp only [Algebra.BigOpL.bigOpL_nil]
+      iintro _
+      exact nil (ι := ι)
+  | cons e es IH =>
+      simp only [Algebra.BigOpL.bigOpL_cons]
+      iintro Hes
+      icases Hes with ⟨He, Hes⟩
+      rw [show e :: es = [e] ++ es by simp]
+      iapply app [e] es (ι := ι) $$ He
+      iapply IH
+      iexact Hes
+
+@[rocq_alias twp_twptp]
+theorem of_twp (s : Stuckness) (e : Expr) (Φ : Val → IProp GF) :
+    WP e @ s ; ⊤ [{ Φ }] ⊢ get (ι := ι) [e] := by
+  let Ψ := fun (E : CoPset) (e : Expr) (_ : Val → IProp GF) => iprop(
+    ⌜E = ⊤⌝ -∗ get (ι := ι) [e])
+  have hΨ : NonExpansive
+      (fun x : twp.Args Expr Val GF => Ψ x.1.1 x.1.2 x.2) := by
+    constructor
+    intro n x y hxy
+    rcases x with ⟨⟨EX, eX⟩, ΦX⟩
+    rcases y with ⟨⟨EY, eY⟩, ΦY⟩
+    rcases hxy with ⟨⟨hE, he⟩, _⟩
+    change EX = EY at hE
+    change eX = eY at he
+    subst EY
+    subst eY
+    rfl
+  letI := hΨ
+  iintro He
+  iapply twp.induction s Ψ (ι := ι) ?_ $$ He %rfl
+  iintro !> %E %e %Φ
+  cases he : toVal e with
+  | some v =>
+      simp only [twp.pre, he]
+      iintro _ %hE
+      subst E
+      rw [(twptp.unfold (ι := ι) [e]).to_eq]
+      unfold pre
+      iintro %t₂ %σ₁ %ns %κ %κs %σ₂ %nt %Hstep
+      obtain ⟨e₂, efs, Hprim, rfl⟩ :=
+        step_singleton_inv e t₂ σ₁ σ₂ κ Hstep
+      have hnone := Language.val_stuck Hprim
+      rw [he] at hnone
+      cases hnone
+  | none =>
+      simp only [twp.pre, he]
+      iintro Hpre %hE
+      subst E
+      rw [(twptp.unfold (ι := ι) [e]).to_eq]
+      unfold pre
+      iintro %t₂ %σ₁ %ns %κ %κs %σ₂ %nt %Hstep Hσ
+      obtain ⟨e₂, efs, Hprim, rfl⟩ :=
+        step_singleton_inv e t₂ σ₁ σ₂ κ Hstep
+      imod Hpre $$ %σ₁ %ns %κs %nt Hσ with ⟨%_, Hpre⟩
+      imod Hpre $$ %κ %e₂ %σ₂ %efs %Hprim with
+        ⟨%hκ, Hσ, He₂, Hefs⟩
+      icases He₂ with ⟨IH₂, -⟩
+      imodintro
+      iexists (nt + efs.length)
+      iframe %hκ Hσ
+      iapply cons_sep e₂ efs (ι := ι)
+      isplitl [IH₂]
+      · iapply IH₂ $$ %rfl
+      · iapply singleton_list efs (ι := ι)
+        iapply BI.BigSepL.bigSepL_impl $$ Hefs
+        iintro !> %k %ef %Hef Hef
+        icases Hef with ⟨IHef, -⟩
+        iapply IHef $$ %rfl
+
+end twptp
+
+local instance : OFE (List Expr) := OFE.ofDiscrete _
+
+@[rocq_alias twptp_total]
+theorem twptp_total (t : List Expr) (σ : State) (ns nt : Nat) :
+    stateInterp σ ns ([] : List Obs) nt -∗ twptp.get (ι := ι) t
+      ={⊤|}=∗ ⌜StronglyNormalizing
+        (Language.ErasedStep (Expr := Expr) (State := State) (Obs := Obs))
+        (t, σ)⌝ := by
+  let Ψ := fun t : List Expr => iprop(
+    ∀ (σ : State) (ns nt : Nat),
+      StateInterp.stateInterp (GF := GF) σ ns ([] : List Obs) nt -∗
+      |={⊤|}=> ⌜StronglyNormalizing
+        (Language.ErasedStep (Expr := Expr) (State := State) (Obs := Obs))
+        (t, σ)⌝)
+  have hΨ : NonExpansive Ψ := by
+    constructor
+    intro n x y hxy
+    change x = y at hxy
+    subst y
+    rfl
+  letI := hΨ
+  iintro Hσ Ht
+  iapply twptp.induction Ψ (ι := ι) ?_ $$ %t Ht %σ %ns %nt Hσ
+  iintro !> %t
+  unfold twptp.pre
+  iintro Hpre %σ %ns %nt Hσ
+  iapply fupd_finally_mono (pure_mono StronglyNormalizing.intro)
+  iintro %cfg₂ %Hstep
+  rcases cfg₂ with ⟨t₂, σ₂⟩
+  obtain ⟨κ, Hstep⟩ := Hstep
+  imod Hpre $$ %t₂ %σ %ns %κ %([] : List Obs) %σ₂ %nt %Hstep Hσ with
+    ⟨%nt', %hκ, Hσ, Ht₂⟩
+  icases Ht₂ with ⟨IH, -⟩
+  iapply IH $$ %σ₂ %(ns + 1) %nt' Hσ
+
+end ThreadPool
+
+omit Λ in
+/-- General total adequacy. An initialized state interpretation together with
+a total weakest precondition entails strong normalization of the complete
+fork-aware language configuration. As in Iris-Coq, the chosen
+`numLatersPerStep` is abstract because TWP itself does not inspect it. -/
+@[rocq_alias twp_total]
+theorem twp_total {hlc : HasLC} {GF : BundledGFunctors}
+    [InvGpreS GF] [Language Expr State Obs Val]
+    (s : Stuckness) (e : Expr) (σ : State)
+    (Φ : Val → IProp GF) (n m : Nat)
+    (Hwp : ∀ [InvGS_gen hlc GF],
+      ⊢ |={⊤}=>
+        ∃ (stateI : State → Nat → List Obs → Nat → IProp GF)
+          (numLatersPerStep : Nat → Nat)
+          (forkPost : Val → IProp GF)
+          (mono : ∀ σ ns obs nt,
+            stateI σ ns obs nt ⊢ |={∅}=> stateI σ (ns + 1) obs nt),
+        let _ : IrisGS_gen hlc Expr GF :=
+          .mk (toStateInterp := ⟨stateI⟩) numLatersPerStep forkPost mono
+        iprop(stateI σ n [] 0 ∗
+          (£ m -∗ WP e @ s ; ⊤ [{ Φ }]))) :
+    StronglyNormalizing
+      (Language.ErasedStep (Expr := Expr) (State := State) (Obs := Obs))
+      ([e], σ) := by
+  apply pure_soundness (PROP := IProp GF)
+  apply fupd_finally_soundness hlc m ⊤
+  iintro %Hinv Hcred
+  imod Hwp with
+    ⟨%stateI, %numLatersPerStep, %forkPost, %mono, Hσ, Htwp⟩
+  letI iG : IrisGS_gen hlc Expr GF :=
+    .mk (toStateInterp := ⟨stateI⟩) numLatersPerStep forkPost mono
+  iapply twptp_total [e] σ n 0 (ι := iG) $$ Hσ
+  iapply twptp.of_twp s e Φ (ι := iG)
+  iapply Htwp $$ Hcred
 
 /-- Erased single-thread reduction. Forked expressions remain visible in the
 step witness; clients can rule them out with `LanguageNoFork`. -/
@@ -66,6 +498,22 @@ theorem exprErasedStep_noFork [LanguageNoFork Expr State Obs Val] {e₁ σ₁ e�
   have := LanguageNoFork.no_fork Hstep
   subst efs
   exact ⟨κ, Hstep⟩
+
+/-- A fork-aware total-adequacy result specializes to the single-expression
+machine when the language proves that primitive steps never fork. -/
+theorem stronglyNormalizing_expr_of_threadPool
+    [LanguageNoFork Expr State Obs Val] {e : Expr} {σ : State}
+    (H : StronglyNormalizing
+      (Language.ErasedStep (Expr := Expr) (State := State) (Obs := Obs))
+      ([e], σ)) :
+    StronglyNormalizing
+      (ExprErasedStep (Expr := Expr) (State := State) (Obs := Obs))
+      (e, σ) := by
+  apply StronglyNormalizing.map (fun ρ : Expr × State => ([ρ.1], ρ.2)) ?_ H
+  rintro ⟨e₁, σ₁⟩ ⟨e₂, σ₂⟩ ⟨κ, efs, Hstep⟩
+  have hefs : efs = [] := LanguageNoFork.no_fork Hstep
+  subst efs
+  exact ⟨κ, .atomic Hstep [] []⟩
 
 theorem value_stronglyNormalizing (v : Val) (σ : State) :
     StronglyNormalizing (ExprErasedStep (Expr := Expr) (Obs := Obs))

--- a/Iris/Iris/ProgramLogic/TotalAdequacy.lean
+++ b/Iris/Iris/ProgramLogic/TotalAdequacy.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2026 Fernando Leal. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Iris.ProgramLogic.TotalWeakestPre
+public import Iris.ProgramLogic.Adequacy
+
+namespace Iris.ProgramLogic
+
+open Iris OFE COFE BI Iris.BI Iris.Algebra Std FromMathlib LawfulSet
+open Language Language.Notation
+
+@[expose] public section
+
+/-! ## Operational termination predicates
+
+`Acc` takes the next configuration as its left argument, so the operational
+relation is flipped.  This definition is constructive and means that every
+reduction tree rooted at the configuration is finite (strong normalization),
+not merely that some execution terminates.
+-/
+
+def StronglyNormalizing {α : Type _} (step : α → α → Prop) (x : α) : Prop :=
+  Acc (flip step) x
+
+namespace StronglyNormalizing
+
+theorem intro {α : Type _} {step : α → α → Prop} {x : α}
+    (H : ∀ y, step x y → StronglyNormalizing step y) :
+    StronglyNormalizing step x :=
+  Acc.intro x H
+
+theorem of_irreducible {α : Type _} {step : α → α → Prop} {x : α}
+    (H : ∀ y, ¬ step x y) : StronglyNormalizing step x :=
+  .intro fun y Hxy => (H y Hxy).elim
+
+theorem tail {α : Type _} {step : α → α → Prop} {x y : α}
+    (H : StronglyNormalizing step x) (Hxy : step x y) :
+    StronglyNormalizing step y :=
+  H.inv Hxy
+
+end StronglyNormalizing
+
+variable {Expr State Obs Val : Type _} [Λ : Language Expr State Obs Val]
+
+/-- Erased single-thread reduction. Forked expressions remain visible in the
+step witness; clients can rule them out with `LanguageNoFork`. -/
+def ExprErasedStep : Expr × State → Expr × State → Prop
+  | (e₁, σ₁), (e₂, σ₂) =>
+      ∃ (κ : List Obs) (efs : List Expr), (e₁, σ₁) -<κ>-> (e₂, σ₂, efs)
+
+/-- The single-threaded language contract used by the Wasm-facing adequacy
+corollaries. -/
+class LanguageNoFork (Expr State Obs Val : Type _)
+    [Language Expr State Obs Val] : Prop where
+  no_fork {e₁ e₂ : Expr} {σ₁ σ₂ : State} {κ : List Obs} {efs : List Expr} :
+    (e₁, σ₁) -<κ>-> (e₂, σ₂, efs) → efs = []
+
+theorem exprErasedStep_noFork [LanguageNoFork Expr State Obs Val] {e₁ σ₁ e₂ σ₂}
+    (H : ExprErasedStep (Expr := Expr) (State := State) (Obs := Obs)
+      (e₁, σ₁) (e₂, σ₂)) :
+    ∃ κ, (e₁, σ₁) -<κ>-> (e₂, σ₂, []) := by
+  obtain ⟨κ, efs, Hstep⟩ := H
+  have := LanguageNoFork.no_fork Hstep
+  subst efs
+  exact ⟨κ, Hstep⟩
+
+theorem value_stronglyNormalizing (v : Val) (σ : State) :
+    StronglyNormalizing (ExprErasedStep (Expr := Expr) (Obs := Obs))
+      ((v : Expr), σ) := by
+  apply StronglyNormalizing.of_irreducible
+  rintro ⟨e₂, σ₂⟩ ⟨κ, efs, Hstep⟩
+  exact Language.prim_val_stuck Hstep
+
+end
+end Iris.ProgramLogic

--- a/Iris/Iris/ProgramLogic/TotalEctxLifting.lean
+++ b/Iris/Iris/ProgramLogic/TotalEctxLifting.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2026 Fernando Leal. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Iris.ProgramLogic.TotalLifting
+public import Iris.ProgramLogic.EctxLifting
+
+namespace Iris.ProgramLogic
+
+open Iris Language.Notation EctxLanguage EctxLanguage.Notation
+
+@[expose] public section
+
+/-!
+Total base-step rules for evaluation-context languages.  We intentionally stop
+at the generic deterministic/no-fork interface needed by a Wasm language.
+HeapLang primitive laws and concurrent convenience rules are not duplicated:
+they add no capability for the initial single-threaded Wasm consumer.
+-/
+
+variable {hlc : outParam HasLC} {Expr Ectx State Obs Val}
+variable [Λ : EctxLanguage Expr Ectx State Obs Val]
+variable {GF : BundledGFunctors} [ι : IrisGS_gen hlc Expr GF]
+variable {s : Stuckness} {E : CoPset} {e₁ e₂ : Expr}
+variable {Φ : Val → IProp GF}
+
+theorem twp_lift_base_step_no_fork (h : toVal e₁ = none) :
+    (∀ σ₁ ns obs nt, stateInterp σ₁ ns obs nt ={E,∅}=∗
+      ⌜BaseStep.Reducible (e₁, σ₁)⌝ ∗
+      ∀ κ e₂ σ₂ eₜ, ⌜(e₁, σ₁) -<κ>->ᵇ (e₂, σ₂, eₜ)⌝ ={∅,E}=∗
+        ⌜κ = []⌝ ∗ ⌜eₜ = []⌝ ∗
+        stateInterp σ₂ (ns + 1) obs nt ∗
+        WP e₂ @ s; E [{ Φ }])
+    ⊢ WP e₁ @ s; E [{ Φ }] := by
+  iintro H
+  iapply twp_lift_step_no_fork h
+  iintro %σ₁ %ns %obs %nt Hσ
+  imod H $$ Hσ with ⟨%Hred, H⟩
+  imodintro
+  isplit
+  · ipureintro
+    cases s
+    · exact EctxLanguage.primStep_reducible_of_baseStep_reducible Hred
+    · trivial
+  · iintro %κ %e₂ %σ₂ %eₜ %Hstep
+    have Hb := EctxLanguage.baseStep_of_primStep_of_baseStep_reducible Hred Hstep
+    iapply H $$ %κ %e₂ %σ₂ %eₜ %Hb
+
+theorem twp_lift_pure_det_base_step_no_fork [Inhabited State]
+    (h : toVal e₁ = none)
+    (Hred : ∀ σ, BaseStep.Reducible (e₁, σ))
+    (Hpure : ∀ σ κ e₂' σ₂ eₜ,
+      (e₁, σ) -<κ>->ᵇ (e₂', σ₂, eₜ) →
+      κ = [] ∧ σ₂ = σ ∧ e₂' = e₂ ∧ eₜ = []) :
+    WP e₂ @ s; E [{ Φ }] ⊢ WP e₁ @ s; E [{ Φ }] := by
+  apply twp_lift_pure_det_step_no_fork
+  · intro σ
+    cases s
+    · obtain ⟨κ, e', σ', efs, Hb⟩ := Hred σ
+      have ⟨hκ, _, _, _⟩ := Hpure σ κ e' σ' efs Hb
+      subst hκ
+      exact ⟨e', σ', efs, EctxLanguage.primStep_of_baseStep Hb⟩
+    · exact h
+  · intro σ κ e₂' σ₂ eₜ Hstep
+    exact Hpure _ _ _ _ _
+      (EctxLanguage.baseStep_of_primStep_of_baseStep_reducible (Hred σ) Hstep)
+
+end
+end Iris.ProgramLogic

--- a/Iris/Iris/ProgramLogic/TotalEctxLifting.lean
+++ b/Iris/Iris/ProgramLogic/TotalEctxLifting.lean
@@ -26,9 +26,35 @@ variable {GF : BundledGFunctors} [ι : IrisGS_gen hlc Expr GF]
 variable {s : Stuckness} {E : CoPset} {e₁ e₂ : Expr}
 variable {Φ : Val → IProp GF}
 
+@[rocq_alias twp_lift_base_step]
+theorem twp_lift_base_step (h : toVal e₁ = none) :
+    (∀ σ₁ ns obs nt, stateInterp σ₁ ns obs nt ={E,∅}=∗
+      ⌜BaseStep.ReducibleNoObs (e₁, σ₁)⌝ ∗
+      ∀ κ e₂ σ₂ eₜ, ⌜(e₁, σ₁) -<κ>->ᵇ (e₂, σ₂, eₜ)⌝ ={∅,E}=∗
+        ⌜κ = []⌝ ∗
+        stateInterp σ₂ (ns + 1) obs (nt + eₜ.length) ∗
+        WP e₂ @ s; E [{ Φ }] ∗
+        [∗list] ef ∈ eₜ, WP ef @ s; ⊤ [{ ι.forkPost }])
+    ⊢ WP e₁ @ s; E [{ Φ }] := by
+  iintro H
+  iapply twp_lift_step h
+  iintro %σ₁ %ns %obs %nt Hσ
+  imod H $$ Hσ with ⟨%Hred, H⟩
+  imodintro
+  isplit
+  · ipureintro
+    cases s
+    · exact EctxLanguage.primStep_reducibleNoObs_of_baseStep_reducibleNoObs
+        Hred
+    · trivial
+  · iintro %κ %e₂ %σ₂ %eₜ %Hstep
+    have Hb := EctxLanguage.baseStep_of_primStep_of_baseStep_reducible
+      (BaseStep.reducible_of_reducibleNoObs Hred) Hstep
+    iapply H $$ %κ %e₂ %σ₂ %eₜ %Hb
+
 theorem twp_lift_base_step_no_fork (h : toVal e₁ = none) :
     (∀ σ₁ ns obs nt, stateInterp σ₁ ns obs nt ={E,∅}=∗
-      ⌜BaseStep.Reducible (e₁, σ₁)⌝ ∗
+      ⌜BaseStep.ReducibleNoObs (e₁, σ₁)⌝ ∗
       ∀ κ e₂ σ₂ eₜ, ⌜(e₁, σ₁) -<κ>->ᵇ (e₂, σ₂, eₜ)⌝ ={∅,E}=∗
         ⌜κ = []⌝ ∗ ⌜eₜ = []⌝ ∗
         stateInterp σ₂ (ns + 1) obs nt ∗
@@ -42,30 +68,111 @@ theorem twp_lift_base_step_no_fork (h : toVal e₁ = none) :
   isplit
   · ipureintro
     cases s
-    · exact EctxLanguage.primStep_reducible_of_baseStep_reducible Hred
+    · exact EctxLanguage.primStep_reducibleNoObs_of_baseStep_reducibleNoObs Hred
     · trivial
   · iintro %κ %e₂ %σ₂ %eₜ %Hstep
-    have Hb := EctxLanguage.baseStep_of_primStep_of_baseStep_reducible Hred Hstep
+    have Hb := EctxLanguage.baseStep_of_primStep_of_baseStep_reducible
+      (BaseStep.reducible_of_reducibleNoObs Hred) Hstep
     iapply H $$ %κ %e₂ %σ₂ %eₜ %Hb
 
+@[rocq_alias twp_lift_pure_base_step_no_fork]
+theorem twp_lift_pure_base_step_no_fork [Inhabited State]
+    (Hred : ∀ σ, BaseStep.ReducibleNoObs (e₁, σ))
+    (Hpure : ∀ σ₁ κ e₂' σ₂ eₜ,
+      (e₁, σ₁) -<κ>->ᵇ (e₂', σ₂, eₜ) →
+      κ = [] ∧ σ₂ = σ₁ ∧ eₜ = []) :
+    (|={E}=> ∀ κ e₂' eₜ σ,
+      ⌜(e₁, σ) -<κ>->ᵇ (e₂', σ, eₜ)⌝ -∗
+      WP e₂' @ s; E [{ Φ }])
+    ⊢ WP e₁ @ s; E [{ Φ }] := by
+  iintro H
+  iapply twp_lift_pure_step_no_fork
+  · intro σ
+    exact EctxLanguage.primStep_reducibleNoObs_of_baseStep_reducibleNoObs
+      (Hred σ)
+  · intro σ₁ κ e₂' σ₂ eₜ Hstep
+    exact Hpure _ _ _ _ _
+      (EctxLanguage.baseStep_of_primStep_of_baseStep_reducible
+        (BaseStep.reducible_of_reducibleNoObs (Hred σ₁)) Hstep)
+  · imod H with H
+    imodintro
+    iintro %κ %e₂' %eₜ %σ %Hstep
+    have Hb := EctxLanguage.baseStep_of_primStep_of_baseStep_reducible
+      (BaseStep.reducible_of_reducibleNoObs (Hred σ)) Hstep
+    iapply H $$ %κ %e₂' %eₜ %σ %Hb
+
+@[rocq_alias twp_lift_atomic_base_step]
+theorem twp_lift_atomic_base_step (h : toVal e₁ = none) :
+    (∀ σ₁ ns obs nt, stateInterp σ₁ ns obs nt ={E}=∗
+      ⌜BaseStep.ReducibleNoObs (e₁, σ₁)⌝ ∗
+      ∀ κ e₂ σ₂ eₜ, ⌜(e₁, σ₁) -<κ>->ᵇ (e₂, σ₂, eₜ)⌝ ={E}=∗
+        ⌜κ = []⌝ ∗
+        stateInterp σ₂ (ns + 1) obs (nt + eₜ.length) ∗
+        (∃ v, ⌜toVal e₂ = some v⌝ ∧ Φ v) ∗
+        [∗list] ef ∈ eₜ, WP ef @ s; ⊤ [{ ι.forkPost }])
+    ⊢ WP e₁ @ s; E [{ Φ }] := by
+  iintro H
+  iapply twp_lift_atomic_step h
+  iintro %σ₁ %ns %obs %nt Hσ
+  imod H $$ Hσ with ⟨%Hred, H⟩
+  imodintro
+  isplit
+  · ipureintro
+    cases s
+    · exact EctxLanguage.primStep_reducibleNoObs_of_baseStep_reducibleNoObs
+        Hred
+    · trivial
+  · iintro %κ %e₂ %σ₂ %eₜ %Hstep
+    have Hb := EctxLanguage.baseStep_of_primStep_of_baseStep_reducible
+      (BaseStep.reducible_of_reducibleNoObs Hred) Hstep
+    iapply H $$ %κ %e₂ %σ₂ %eₜ %Hb
+
+@[rocq_alias twp_lift_atomic_base_step_no_fork]
+theorem twp_lift_atomic_base_step_no_fork (h : toVal e₁ = none) :
+    (∀ σ₁ ns obs nt, stateInterp σ₁ ns obs nt ={E}=∗
+      ⌜BaseStep.ReducibleNoObs (e₁, σ₁)⌝ ∗
+      ∀ κ e₂ σ₂ eₜ, ⌜(e₁, σ₁) -<κ>->ᵇ (e₂, σ₂, eₜ)⌝ ={E}=∗
+        ⌜κ = []⌝ ∗ ⌜eₜ = []⌝ ∗
+        stateInterp σ₂ (ns + 1) obs nt ∗
+        ∃ v, ⌜toVal e₂ = some v⌝ ∧ Φ v)
+    ⊢ WP e₁ @ s; E [{ Φ }] := by
+  iintro H
+  iapply twp_lift_atomic_step_no_fork h
+  iintro %σ₁ %ns %obs %nt Hσ
+  imod H $$ Hσ with ⟨%Hred, H⟩
+  imodintro
+  isplit
+  · ipureintro
+    cases s
+    · exact EctxLanguage.primStep_reducibleNoObs_of_baseStep_reducibleNoObs
+        Hred
+    · trivial
+  · iintro %κ %e₂ %σ₂ %eₜ %Hstep
+    have Hb := EctxLanguage.baseStep_of_primStep_of_baseStep_reducible
+      (BaseStep.reducible_of_reducibleNoObs Hred) Hstep
+    iapply H $$ %κ %e₂ %σ₂ %eₜ %Hb
+
+/-- Deterministic pure base-step lifting. The explicit non-value premise is
+retained to match Iris-Rocq's public theorem, although `Hred` also implies it. -/
+@[rocq_alias twp_lift_pure_det_base_step_no_fork]
 theorem twp_lift_pure_det_base_step_no_fork [Inhabited State]
-    (h : toVal e₁ = none)
-    (Hred : ∀ σ, BaseStep.Reducible (e₁, σ))
+    (_h : toVal e₁ = none)
+    (Hred : ∀ σ, BaseStep.ReducibleNoObs (e₁, σ))
     (Hpure : ∀ σ κ e₂' σ₂ eₜ,
       (e₁, σ) -<κ>->ᵇ (e₂', σ₂, eₜ) →
       κ = [] ∧ σ₂ = σ ∧ e₂' = e₂ ∧ eₜ = []) :
     WP e₂ @ s; E [{ Φ }] ⊢ WP e₁ @ s; E [{ Φ }] := by
-  apply twp_lift_pure_det_step_no_fork
+  iintro Hwp
+  iapply twp_lift_pure_det_step_no_fork
   · intro σ
-    cases s
-    · obtain ⟨κ, e', σ', efs, Hb⟩ := Hred σ
-      have ⟨hκ, _, _, _⟩ := Hpure σ κ e' σ' efs Hb
-      subst hκ
-      exact ⟨e', σ', efs, EctxLanguage.primStep_of_baseStep Hb⟩
-    · exact h
+    exact EctxLanguage.primStep_reducibleNoObs_of_baseStep_reducibleNoObs
+      (Hred σ)
   · intro σ κ e₂' σ₂ eₜ Hstep
     exact Hpure _ _ _ _ _
-      (EctxLanguage.baseStep_of_primStep_of_baseStep_reducible (Hred σ) Hstep)
+      (EctxLanguage.baseStep_of_primStep_of_baseStep_reducible
+        (BaseStep.reducible_of_reducibleNoObs (Hred σ)) Hstep)
+  · imodintro
+    iexact Hwp
 
 end
 end Iris.ProgramLogic

--- a/Iris/Iris/ProgramLogic/TotalLifting.lean
+++ b/Iris/Iris/ProgramLogic/TotalLifting.lean
@@ -31,7 +31,7 @@ variable {e e₁ e₂ : Expr} {Φ : Val → IProp GF}
 @[rocq_alias twp_lift_step]
 theorem twp_lift_step (h : toVal e₁ = none) :
     (∀ σ₁ ns obs nt, stateInterp σ₁ ns obs nt ={E,∅}=∗
-      ⌜s.MaybeReducible (e₁, σ₁)⌝ ∗
+      ⌜s.MaybeReducibleNoObs (e₁, σ₁)⌝ ∗
       ∀ κ e₂ σ₂ eₜ, ⌜(e₁, σ₁) -<κ>-> (e₂, σ₂, eₜ)⌝ ={∅,E}=∗
         ⌜κ = []⌝ ∗
         stateInterp σ₂ (ns + 1) obs (nt + eₜ.length) ∗
@@ -44,7 +44,7 @@ theorem twp_lift_step (h : toVal e₁ = none) :
 
 theorem twp_lift_step_no_fork (h : toVal e₁ = none) :
     (∀ σ₁ ns obs nt, stateInterp σ₁ ns obs nt ={E,∅}=∗
-      ⌜s.MaybeReducible (e₁, σ₁)⌝ ∗
+      ⌜s.MaybeReducibleNoObs (e₁, σ₁)⌝ ∗
       ∀ κ e₂ σ₂ eₜ, ⌜(e₁, σ₁) -<κ>-> (e₂, σ₂, eₜ)⌝ ={∅,E}=∗
         ⌜κ = []⌝ ∗ ⌜eₜ = []⌝ ∗
         stateInterp σ₂ (ns + 1) obs nt ∗
@@ -66,7 +66,7 @@ theorem twp_lift_step_no_fork (h : toVal e₁ = none) :
 @[rocq_alias twp_lift_atomic_step]
 theorem twp_lift_atomic_step (h : toVal e₁ = none) :
     (∀ σ₁ ns obs nt, stateInterp σ₁ ns obs nt ={E}=∗
-      ⌜s.MaybeReducible (e₁, σ₁)⌝ ∗
+      ⌜s.MaybeReducibleNoObs (e₁, σ₁)⌝ ∗
       ∀ κ e₂ σ₂ eₜ, ⌜(e₁, σ₁) -<κ>-> (e₂, σ₂, eₜ)⌝ ={E}=∗
         ⌜κ = []⌝ ∗
         stateInterp σ₂ (ns + 1) obs (nt + eₜ.length) ∗
@@ -93,7 +93,7 @@ theorem twp_lift_atomic_step (h : toVal e₁ = none) :
 
 theorem twp_lift_atomic_step_no_fork (h : toVal e₁ = none) :
     (∀ σ₁ ns obs nt, stateInterp σ₁ ns obs nt ={E}=∗
-      ⌜s.MaybeReducible (e₁, σ₁)⌝ ∗
+      ⌜s.MaybeReducibleNoObs (e₁, σ₁)⌝ ∗
       ∀ κ e₂ σ₂ eₜ, ⌜(e₁, σ₁) -<κ>-> (e₂, σ₂, eₜ)⌝ ={E}=∗
         ⌜κ = []⌝ ∗ ⌜eₜ = []⌝ ∗
         stateInterp σ₂ (ns + 1) obs nt ∗
@@ -113,38 +113,82 @@ theorem twp_lift_atomic_step_no_fork (h : toVal e₁ = none) :
   simp only [List.length_nil, Nat.add_zero, Algebra.BigOpL.bigOpL_nil]
   iframe %hκ Hσ Hval
 
-theorem twp_lift_pure_det_step_no_fork [Inhabited State]
-    (Hsafe : ∀ σ₁, match s with
-      | .NotStuck => PrimStep.ReducibleNoObs (e₁, σ₁)
-      | .MaybeStuck => toVal e₁ = none)
+@[rocq_alias twp_lift_pure_step_no_fork]
+theorem twp_lift_pure_step_no_fork [Inhabited State]
+    (Hsafe : ∀ σ₁, PrimStep.ReducibleNoObs (e₁, σ₁))
     (Hpure : ∀ σ₁ κ e₂' σ₂ eₜ,
       (e₁, σ₁) -<κ>-> (e₂', σ₂, eₜ) →
-      κ = [] ∧ σ₂ = σ₁ ∧ e₂' = e₂ ∧ eₜ = []) :
-    WP e₂ @ s; E [{ Φ }] ⊢ WP e₁ @ s; E [{ Φ }] := by
-  iintro Hwp
-  have hnone : toVal e₁ = none := by
-    cases s
-    · exact Language.toVal_none_of_reducible
-        (Language.reducible_of_reducibleNoObs (Hsafe default))
-    · exact Hsafe default
+      κ = [] ∧ σ₂ = σ₁ ∧ eₜ = []) :
+    (|={E}=> ∀ κ e₂' eₜ σ,
+      ⌜(e₁, σ) -<κ>-> (e₂', σ, eₜ)⌝ -∗
+      WP e₂' @ s; E [{ Φ }])
+    ⊢ WP e₁ @ s; E [{ Φ }] := by
+  iintro H
+  have hnone : toVal e₁ = none :=
+    Language.toVal_none_of_reducible
+      (Language.reducible_of_reducibleNoObs (Hsafe default))
   iapply twp_lift_step_no_fork hnone
   iintro %σ₁ %ns %obs %nt Hσ
+  imod H with H
   iapply fupd_mask_intro Std.LawfulSet.empty_subset
   iintro Hclose
   isplit
   · ipureintro
     cases s
-    · exact Language.reducible_of_reducibleNoObs (Hsafe σ₁)
+    · exact Hsafe σ₁
     · trivial
   · iintro %κ %e₂' %σ₂ %eₜ %Hstep
-    obtain ⟨rfl, rfl, rfl, rfl⟩ := Hpure _ _ _ _ _ Hstep
+    obtain ⟨rfl, rfl, rfl⟩ := Hpure _ _ _ _ _ Hstep
+    imod ι.stateInterp_mono σ₂ ns obs nt $$ Hσ with Hσ
     imod Hclose
-    ihave Hmono := ι.stateInterp_mono σ₂ ns obs nt $$ Hσ
-    imod fupd_mask_mono Std.LawfulSet.empty_subset $$ Hmono with Hσ
     imodintro
-    iframe Hσ Hwp
-    ipureintro
-    exact ⟨rfl, rfl⟩
+    iframe Hσ
+    isplit
+    · ipureintro
+      exact rfl
+    · isplit
+      · ipureintro
+        exact rfl
+      · iapply H $$ %([] : List Obs) %e₂' %([] : List Expr) %σ₂ %Hstep
+
+@[rocq_alias twp_lift_pure_det_step_no_fork]
+theorem twp_lift_pure_det_step_no_fork [Inhabited State]
+    (Hsafe : ∀ σ₁, PrimStep.ReducibleNoObs (e₁, σ₁))
+    (Hpure : ∀ σ₁ κ e₂' σ₂ eₜ,
+      (e₁, σ₁) -<κ>-> (e₂', σ₂, eₜ) →
+      κ = [] ∧ σ₂ = σ₁ ∧ e₂' = e₂ ∧ eₜ = []) :
+    (|={E}=> WP e₂ @ s; E [{ Φ }]) ⊢ WP e₁ @ s; E [{ Φ }] := by
+  iintro Hwp
+  iapply twp_lift_pure_step_no_fork Hsafe ?_
+  · intro σ₁ κ e₂' σ₂ eₜ Hstep
+    obtain ⟨hκ, hσ, _, heₜ⟩ := Hpure _ _ _ _ _ Hstep
+    exact ⟨hκ, hσ, heₜ⟩
+  · imod Hwp with Hwp
+    imodintro
+    iintro %κ %e₂' %eₜ %σ %Hstep
+    obtain ⟨_, _, he₂, _⟩ := Hpure _ _ _ _ _ Hstep
+    subst e₂'
+    iexact Hwp
+
+@[rocq_alias twp_pure_step]
+theorem twp_pure_step [Inhabited State]
+    (Hexec : PureExec φ n e₁ e₂) (Hφ : φ) :
+    WP e₂ @ s; E [{ Φ }] ⊢ WP e₁ @ s; E [{ Φ }] := by
+  replace Hexec := Hexec.pureExec Hφ
+  iinduction Hexec using Relation.Iterate.head_induction_on with
+  | rfl =>
+      iintro Hwp
+      iexact Hwp
+  | @head n e₁ e₃ _ _ IH =>
+      iintro Hwp
+      obtain ⟨Hsafe, Hdet⟩ := ‹e₁ -ᵖ-> e₃›
+      iapply twp_lift_pure_det_step_no_fork Hsafe ?_
+      · intro σ₁ κ e₂' σ₂ eₜ Hstep
+        obtain ⟨hκ, hσ, he, heₜ⟩ := Hdet Hstep
+        exact ⟨hκ, hσ.symm, he.symm, heₜ⟩
+      · imodintro
+        iapply IH
+        iexact Hwp
 
 end
 end Iris.ProgramLogic

--- a/Iris/Iris/ProgramLogic/TotalLifting.lean
+++ b/Iris/Iris/ProgramLogic/TotalLifting.lean
@@ -1,0 +1,150 @@
+/-
+Copyright (c) 2026 Fernando Leal. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Iris.ProgramLogic.TotalWeakestPre
+public import Iris.ProgramLogic.Lifting
+
+namespace Iris.ProgramLogic
+
+open Iris Language Language.Notation BI
+
+@[expose] public section
+
+/-!
+The no-fork rules in this file are the intended entry point for Wasm.  They
+make the single-threaded contract explicit (`eₜ = []`) while the underlying
+TWP remains faithful to Iris and can account for forks.
+
+All total rules require the operational observation to be empty.  This is a
+semantic requirement of Iris TWP, not proof bookkeeping.
+-/
+
+variable {hlc : outParam HasLC} {Expr State Obs Val}
+variable [Λ : Language Expr State Obs Val]
+variable {GF : BundledGFunctors} [ι : IrisGS_gen hlc Expr GF]
+variable {s : Stuckness} {E E₁ E₂ : CoPset}
+variable {e e₁ e₂ : Expr} {Φ : Val → IProp GF}
+
+@[rocq_alias twp_lift_step]
+theorem twp_lift_step (h : toVal e₁ = none) :
+    (∀ σ₁ ns obs nt, stateInterp σ₁ ns obs nt ={E,∅}=∗
+      ⌜s.MaybeReducible (e₁, σ₁)⌝ ∗
+      ∀ κ e₂ σ₂ eₜ, ⌜(e₁, σ₁) -<κ>-> (e₂, σ₂, eₜ)⌝ ={∅,E}=∗
+        ⌜κ = []⌝ ∗
+        stateInterp σ₂ (ns + 1) obs (nt + eₜ.length) ∗
+        WP e₂ @ s; E [{ Φ }] ∗
+        [∗list] ef ∈ eₜ, WP ef @ s; ⊤ [{ ι.forkPost }])
+    ⊢ WP e₁ @ s; E [{ Φ }] := by
+  rw [twp.unfold.to_eq]
+  simp only [twp.pre, h]
+  exact .rfl
+
+theorem twp_lift_step_no_fork (h : toVal e₁ = none) :
+    (∀ σ₁ ns obs nt, stateInterp σ₁ ns obs nt ={E,∅}=∗
+      ⌜s.MaybeReducible (e₁, σ₁)⌝ ∗
+      ∀ κ e₂ σ₂ eₜ, ⌜(e₁, σ₁) -<κ>-> (e₂, σ₂, eₜ)⌝ ={∅,E}=∗
+        ⌜κ = []⌝ ∗ ⌜eₜ = []⌝ ∗
+        stateInterp σ₂ (ns + 1) obs nt ∗
+        WP e₂ @ s; E [{ Φ }])
+    ⊢ WP e₁ @ s; E [{ Φ }] := by
+  iintro H
+  iapply twp_lift_step h
+  iintro %σ₁ %ns %obs %nt Hσ
+  imod H $$ Hσ with ⟨%Hred, H⟩
+  imodintro
+  iframe %Hred
+  iintro %κ %e₂ %σ₂ %eₜ %Hstep
+  imod H $$ %κ %e₂ %σ₂ %eₜ %Hstep with ⟨%hκ, %heₜ, Hσ, Hwp⟩
+  subst heₜ
+  imodintro
+  simp only [List.length_nil, Nat.add_zero, Algebra.BigOpL.bigOpL_nil]
+  iframe %hκ Hσ Hwp
+
+@[rocq_alias twp_lift_atomic_step]
+theorem twp_lift_atomic_step (h : toVal e₁ = none) :
+    (∀ σ₁ ns obs nt, stateInterp σ₁ ns obs nt ={E}=∗
+      ⌜s.MaybeReducible (e₁, σ₁)⌝ ∗
+      ∀ κ e₂ σ₂ eₜ, ⌜(e₁, σ₁) -<κ>-> (e₂, σ₂, eₜ)⌝ ={E}=∗
+        ⌜κ = []⌝ ∗
+        stateInterp σ₂ (ns + 1) obs (nt + eₜ.length) ∗
+        (∃ v, ⌜toVal e₂ = some v⌝ ∧ Φ v) ∗
+        [∗list] ef ∈ eₜ, WP ef @ s; ⊤ [{ ι.forkPost }])
+    ⊢ WP e₁ @ s; E [{ Φ }] := by
+  iintro H
+  iapply twp_lift_step h
+  iintro %σ₁ %ns %obs %nt Hσ
+  imod H $$ Hσ with ⟨%Hred, H⟩
+  iapply fupd_mask_intro Std.LawfulSet.empty_subset
+  iintro Hclose
+  isplit
+  · ipureintro
+    exact Hred
+  · iintro %κ %e₂ %σ₂ %eₜ %Hstep
+    imod Hclose with -
+    imod H $$ %κ %e₂ %σ₂ %eₜ %Hstep with
+      ⟨%hκ, Hσ, ⟨%v, %hval, HΦ⟩, Hefs⟩
+    imodintro
+    iframe %hκ Hσ Hefs
+    iapply twp.value (ToVal.coe_of_toVal_eq_some hval).symm
+    iexact HΦ
+
+theorem twp_lift_atomic_step_no_fork (h : toVal e₁ = none) :
+    (∀ σ₁ ns obs nt, stateInterp σ₁ ns obs nt ={E}=∗
+      ⌜s.MaybeReducible (e₁, σ₁)⌝ ∗
+      ∀ κ e₂ σ₂ eₜ, ⌜(e₁, σ₁) -<κ>-> (e₂, σ₂, eₜ)⌝ ={E}=∗
+        ⌜κ = []⌝ ∗ ⌜eₜ = []⌝ ∗
+        stateInterp σ₂ (ns + 1) obs nt ∗
+        ∃ v, ⌜toVal e₂ = some v⌝ ∧ Φ v)
+    ⊢ WP e₁ @ s; E [{ Φ }] := by
+  iintro H
+  iapply twp_lift_atomic_step h
+  iintro %σ₁ %ns %obs %nt Hσ
+  imod H $$ Hσ with ⟨%Hred, H⟩
+  imodintro
+  iframe %Hred
+  iintro %κ %e₂ %σ₂ %eₜ %Hstep
+  imod H $$ %κ %e₂ %σ₂ %eₜ %Hstep with
+    ⟨%hκ, %heₜ, Hσ, Hval⟩
+  subst heₜ
+  imodintro
+  simp only [List.length_nil, Nat.add_zero, Algebra.BigOpL.bigOpL_nil]
+  iframe %hκ Hσ Hval
+
+theorem twp_lift_pure_det_step_no_fork [Inhabited State]
+    (Hsafe : ∀ σ₁, match s with
+      | .NotStuck => PrimStep.ReducibleNoObs (e₁, σ₁)
+      | .MaybeStuck => toVal e₁ = none)
+    (Hpure : ∀ σ₁ κ e₂' σ₂ eₜ,
+      (e₁, σ₁) -<κ>-> (e₂', σ₂, eₜ) →
+      κ = [] ∧ σ₂ = σ₁ ∧ e₂' = e₂ ∧ eₜ = []) :
+    WP e₂ @ s; E [{ Φ }] ⊢ WP e₁ @ s; E [{ Φ }] := by
+  iintro Hwp
+  have hnone : toVal e₁ = none := by
+    cases s
+    · exact Language.toVal_none_of_reducible
+        (Language.reducible_of_reducibleNoObs (Hsafe default))
+    · exact Hsafe default
+  iapply twp_lift_step_no_fork hnone
+  iintro %σ₁ %ns %obs %nt Hσ
+  iapply fupd_mask_intro Std.LawfulSet.empty_subset
+  iintro Hclose
+  isplit
+  · ipureintro
+    cases s
+    · exact Language.reducible_of_reducibleNoObs (Hsafe σ₁)
+    · trivial
+  · iintro %κ %e₂' %σ₂ %eₜ %Hstep
+    obtain ⟨rfl, rfl, rfl, rfl⟩ := Hpure _ _ _ _ _ Hstep
+    imod Hclose
+    ihave Hmono := ι.stateInterp_mono σ₂ ns obs nt $$ Hσ
+    imod fupd_mask_mono Std.LawfulSet.empty_subset $$ Hmono with Hσ
+    imodintro
+    iframe Hσ Hwp
+    ipureintro
+    exact ⟨rfl, rfl⟩
+
+end
+end Iris.ProgramLogic

--- a/Iris/Iris/ProgramLogic/TotalWeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/TotalWeakestPre.lean
@@ -742,7 +742,7 @@ instance isExcept0Twp : IsExcept0 (WP e @ s ; E [{ Φ }]) where
 
 @[rocq_alias elim_modal_fupd_twp]
 instance (priority := default + 10) elimModalFupdTwp p :
-    ElimModal True p false iprop(|={E}=> P) P
+    ElimModal True p io false iprop(|={E}=> P) P
       (WP e @ s ; E [{ Φ }]) (WP e @ s ; E [{ Φ }]) where
   elim_modal := by
     iintro %_ ⟨H, G⟩
@@ -754,13 +754,13 @@ instance (priority := default + 10) elimModalFupdTwp p :
 
 @[rocq_alias elim_modal_bupd_twp]
 instance elimModalBupdTwp p :
-    ElimModal True p false iprop(|==> P) P
+    ElimModal True p io false iprop(|==> P) P
       (WP e @ s ; E [{ Φ }]) (WP e @ s ; E [{ Φ }]) where
   elim_modal := by
     rintro ⟨⟩
     refine BI.sep_mono (BI.intuitionisticallyIf_mono
       (BIUpdateFUpdate.fupd_of_bupd (E := E))) .rfl |>.trans ?_
-    apply elimModalFupdTwp _ |>.elim_modal ⟨⟩
+    apply elimModalFupdTwp _ |>.elim_modal ⟨⟩ (io := io)
 
 /-- The same diagnostic as partial WP: changing masks through a non-atomic
 TWP goal requires an explicit leading update. -/
@@ -768,13 +768,13 @@ TWP goal requires an explicit leading update. -/
 instance elimModalFupdTwp_wrongMask :
     ElimModal (PMError "Goal and eliminated modality must have the same mask.
     Use `iapply twp.fupd_twp; imod (fupd_mask_subseteq E₂)` to adjust the mask of your goal to `E₂`")
-      p false iprop(|={E₂}=> P) iprop(False)
+      p io false iprop(|={E₂}=> P) iprop(False)
       (WP e @ s ; E₁ [{ Φ }]) iprop(False) where
   elim_modal := nofun
 
 @[rocq_alias elim_modal_fupd_twp_atomic]
 instance elimModalFupdTwpAtomic :
-    ElimModal (Language.Atomic ↑s e) p false iprop(|={E₁,E₂}=> P) P
+    ElimModal (Language.Atomic ↑s e) p io false iprop(|={E₁,E₂}=> P) P
       (WP e @ s ; E₁ [{ Φ }])
       (WP e @ s ; E₂ [{ v, |={E₂,E₁}=> Φ v }]) where
   elim_modal := by
@@ -790,7 +790,7 @@ instance elimModalFupdTwpAtomic :
 instance elimModalFupdTwpAtomic_wrongMask :
     ElimModal (PMError "Goal and eliminated modality must have the same mask.
     Use `iapply twp.fupd_twp; imod (fupd_mask_subseteq E₂)` to adjust the mask of your goal to `E₂`")
-      p false iprop(|={E₁,E₂}=> P) iprop(False)
+      p io false iprop(|={E₁,E₂}=> P) iprop(False)
       (WP e @ s ; E₁ [{ Φ }]) iprop(False) where
   elim_modal := nofun
 

--- a/Iris/Iris/ProgramLogic/TotalWeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/TotalWeakestPre.lean
@@ -1,0 +1,566 @@
+/-
+Copyright (c) 2026 Fernando Leal. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Iris.BI.Lib.Fixpoint
+public import Iris.ProgramLogic.WeakestPre
+public import Iris.ProofMode
+
+namespace Iris
+
+open ProgramLogic Language.Notation Std OFE
+
+@[expose] public section
+
+/-!
+# Total weakest preconditions
+
+This is the least-fixed-point total weakest precondition from Iris-Rocq.  In
+contrast to ordinary WP, recursive occurrences are not guarded by a later.
+Consequently, membership in TWP is a finite derivation and adequacy can turn it
+into strong normalization.
+
+The definition remains fork-aware to stay compatible with Iris.  Wasm clients
+are expected to use the no-fork lifting rules in `TotalLifting`: the initial
+target is single-threaded Wasm, so concurrency-specific derived libraries are
+deliberately not duplicated here.
+
+As in Iris-Rocq, TWP only accepts silent operational steps.  A language with
+observable reductions must expose a silent administrative semantics or provide
+a future trace-sensitive generalization instead of discarding observations.
+-/
+
+variable {hlc : outParam HasLC} {Expr State Obs Val}
+variable [Λ : Language Expr State Obs Val]
+variable {GF : BundledGFunctors} [ι : IrisGS_gen hlc Expr GF]
+
+namespace twp
+
+local instance : OFE CoPset := OFE.ofDiscrete _
+local instance : OFE Expr := OFE.ofDiscrete _
+local instance : OFE Val := OFE.ofDiscrete _
+
+abbrev Args (Expr Val : Type _) (GF : BundledGFunctors) :=
+  (CoPset × Expr) × (Val → IProp GF)
+
+def pre (s : Stuckness)
+    (twp : CoPset → Expr → (Val → IProp GF) → IProp GF)
+    (E : CoPset) (e₁ : Expr) (Φ : Val → IProp GF) : IProp GF :=
+  match toVal e₁ with
+  | some v => iprop(|={E}=> Φ v)
+  | none => iprop(∀ (σ₁ : State) (ns : Nat) (obs : List Obs) (nt : Nat),
+      stateInterp σ₁ ns obs nt ={E,∅}=∗
+      ⌜s.MaybeReducible (e₁, σ₁)⌝ ∗
+      ∀ (κ : List Obs) e₂ σ₂ eₜ,
+        ⌜(e₁, σ₁) -<κ>-> (e₂, σ₂, eₜ)⌝ ={∅,E}=∗
+        ⌜κ = []⌝ ∗
+        stateInterp σ₂ (ns + 1) obs (nt + eₜ.length) ∗
+        twp E e₂ Φ ∗
+        [∗list] e' ∈ eₜ, twp ⊤ e' ι.forkPost)
+
+def pre' (s : Stuckness)
+    (X : Args Expr Val GF → IProp GF) : Args Expr Val GF → IProp GF
+  | ((E, e), Φ) => pre s (fun E e Φ => X ((E, e), Φ)) E e Φ
+
+instance pre'_mono (s : Stuckness) : BIMonoPred (pre' (ι := ι) s) where
+  mono_pred := by
+    intro X Y _ _
+    iintro #HXY %x
+    rcases x with ⟨⟨E, e⟩, Φ⟩
+    simp only [pre', pre]
+    iintro HX
+    cases toVal e
+    case some => iexact HX
+    case none =>
+      iintro %σ₁ %ns %obs %nt Hσ
+      imod HX $$ Hσ with ⟨%Hred, H⟩
+      imodintro
+      isplit
+      · ipureintro
+        exact Hred
+      · iintro %κ %e₂ %σ₂ %eₜ %Hstep
+        imod H $$ %κ %e₂ %σ₂ %eₜ %Hstep with ⟨%hκ, Hσ, He, Hefs⟩
+        imodintro
+        iframe %hκ Hσ
+        isplitl [He]
+        · iapply HXY $$ %((E, e₂), Φ) He
+        · iapply BI.BigSepL.bigSepL_impl $$ Hefs
+          iintro !> %k %ef %Hef Hef
+          iapply HXY $$ %((⊤, ef), ι.forkPost) Hef
+  mono_pred_ne.ne {X} a b h := by
+    rcases a with ⟨⟨E₁, e₁⟩, Φ₁⟩
+    rcases b with ⟨⟨E₂, e₂⟩, Φ₂⟩
+    rcases h with ⟨⟨hE, he⟩, hΦ⟩
+    change E₁ = E₂ at hE
+    change e₁ = e₂ at he
+    subst E₂
+    subst e₂
+    simp only [pre', pre]
+    match toVal e₁ with
+    | some v => exact BIFUpdate.ne.ne (hΦ v)
+    | none =>
+      refine BI.forall_ne fun _ => ?_
+      refine BI.forall_ne fun _ => ?_
+      refine BI.forall_ne fun _ => ?_
+      refine BI.forall_ne fun _ => ?_
+      refine BI.wand_ne.ne .rfl ?_
+      refine BIFUpdate.ne.ne ?_
+      refine BI.sep_ne.ne .rfl ?_
+      refine BI.forall_ne fun _ => ?_
+      refine BI.forall_ne fun _ => ?_
+      refine BI.forall_ne fun _ => ?_
+      refine BI.forall_ne fun _ => ?_
+      refine BI.wand_ne.ne .rfl ?_
+      refine BIFUpdate.ne.ne ?_
+      refine BI.sep_ne.ne .rfl ?_
+      refine BI.sep_ne.ne .rfl ?_
+      refine BI.sep_ne.ne ?_ ?_
+      · apply NonExpansive.ne
+        exact ⟨⟨.rfl, .rfl⟩, hΦ⟩
+      · exact .rfl
+
+def get (s : Stuckness) (E : CoPset) (e : Expr) (Φ : Val → IProp GF) : IProp GF :=
+  letI : OFE CoPset := OFE.ofDiscrete _
+  letI : OFE Expr := OFE.ofDiscrete _
+  letI : OFE Val := OFE.ofDiscrete _
+  bi_least_fixpoint (pre' (ι := ι) s) ((E, e), Φ)
+
+instance instTotalWp : TotalWp (IProp GF) Expr Val Stuckness where
+  totalWp := get
+
+section Rules
+
+local instance : OFE CoPset := OFE.ofDiscrete _
+local instance : OFE Expr := OFE.ofDiscrete _
+local instance : OFE Val := OFE.ofDiscrete _
+
+@[rocq_alias twp_unfold]
+theorem unfold {s E} {e : Expr} {Φ : Val → IProp GF} :
+    WP e @ s ; E [{ Φ }] ⊣⊢ pre s (TotalWp.totalWp (PROP := IProp GF) s) E e Φ := by
+  change bi_least_fixpoint (pre' (ι := ι) s) ((E, e), Φ) ⊣⊢ _
+  exact BI.equiv_iff.1 (least_fixpoint_unfold (pre' (ι := ι) s))
+
+@[rocq_alias twp_ind]
+theorem induction (s : Stuckness)
+    (Ψ : CoPset → Expr → (Val → IProp GF) → IProp GF)
+    [HΨ : NonExpansive (fun x : Args Expr Val GF => Ψ x.1.1 x.1.2 x.2)] :
+    (⊢ □ (∀ E e Φ,
+      pre s (fun E e Φ => iprop(Ψ E e Φ ∧ WP e @ s ; E [{ Φ }])) E e Φ -∗
+      Ψ E e Φ)) →
+    ⊢ ∀ E e Φ, WP e @ s ; E [{ Φ }] -∗ Ψ E e Φ := by
+  intro H
+  have H' : ⊢ □ (∀ E e Φ,
+      pre s (fun E e Φ =>
+        iprop(Ψ E e Φ ∧ bi_least_fixpoint (pre' (ι := ι) s) ((E, e), Φ)))
+        E e Φ -∗ Ψ E e Φ) := by
+    simpa only [TotalWp.totalWp, instTotalWp, get] using H
+  iintro %E %e %Φ
+  change ⊢ bi_least_fixpoint (pre' (ι := ι) s) ((E, e), Φ) -∗ Ψ E e Φ
+  iintro Htwp
+  iapply least_fixpoint_ind (F := pre' (ι := ι) s)
+      (Φ := fun x => Ψ x.1.1 x.1.2 x.2) $$ [] Htwp
+  iintro !> %x
+  rcases x with ⟨⟨E, e⟩, Φ⟩
+  simp only [pre']
+  iintro Hx
+  iapply H'
+  iexact Hx
+
+@[rocq_alias twp_ne]
+instance ne {s : Stuckness} {E} {e : Expr} :
+    NonExpansive (TotalWp.totalWp (PROP := IProp GF) s E e) where
+  ne {n Φ₁ Φ₂} HΦ := by
+    change bi_least_fixpoint (pre' (ι := ι) s) ((E, e), Φ₁) ≡{n}≡
+      bi_least_fixpoint (pre' (ι := ι) s) ((E, e), Φ₂)
+    apply NonExpansive.ne
+    exact ⟨⟨.rfl, .rfl⟩, fun v => HΦ v⟩
+
+@[rocq_alias twp_value_fupd']
+theorem value_fupd' {s : Stuckness} {E} {Φ : Val → IProp GF} {v : Val} :
+    WP (v : Expr) @ s ; E [{ Φ }] ⊣⊢ |={E}=> Φ v := by
+  simp [unfold.to_eq, pre, toVal_coe, BI.BIBase.BiEntails.rfl]
+
+@[rocq_alias twp_strong_mono]
+theorem strong_mono {s₁ s₂ : Stuckness} {E₁ E₂} {e : Expr}
+    {Φ Ψ : Val → IProp GF} (hs : s₁ ≤ s₂) (hE : E₁ ⊆ E₂) :
+    ⊢ WP e @ s₁ ; E₁ [{ Φ }] -∗
+      (∀ v, Φ v ={E₂}=∗ Ψ v) -∗ WP e @ s₂ ; E₂ [{ Ψ }] := by
+  let Pred := fun (E : CoPset) (e : Expr) (Φ : Val → IProp GF) => iprop(
+    ∀ E₂ Ψ, ⌜E ⊆ E₂⌝ -∗ (∀ v, Φ v ={E₂}=∗ Ψ v) -∗
+      WP e @ s₂ ; E₂ [{ Ψ }])
+  have hPred : NonExpansive
+      (fun x : Args Expr Val GF => Pred x.1.1 x.1.2 x.2) := by
+    constructor
+    intro n x y h
+    rcases x with ⟨⟨EX, eX⟩, ΦX⟩
+    rcases y with ⟨⟨EY, eY⟩, ΦY⟩
+    rcases h with ⟨⟨hE', he'⟩, hΦ⟩
+    change EX = EY at hE'
+    change eX = eY at he'
+    subst EY
+    subst eY
+    refine BI.forall_ne fun _ => ?_
+    refine BI.forall_ne fun _ => ?_
+    refine BI.wand_ne.ne .rfl ?_
+    refine BI.wand_ne.ne ?_ .rfl
+    refine BI.forall_ne fun v => ?_
+    exact BI.wand_ne.ne (hΦ v) .rfl
+  letI := hPred
+  iintro H HΦ
+  iapply induction s₁ Pred (ι := ι) ?_ $$ H
+  · iintro !> %E %e₁ %Φ₁ IH %E' %Ψ' %hE'
+    rw [unfold.to_eq]
+    unfold pre
+    cases hval : toVal e₁ with
+    | some v =>
+      dsimp only
+      iintro HpostSome
+      imod fupd_mask_mono hE' $$ IH with HΦv
+      iapply HpostSome $$ HΦv
+    | none =>
+      dsimp only
+      iintro HpostNone
+      iintro %σ₁ %ns %obs %nt Hσ
+      imod fupd_mask_subseteq hE' with Hclose
+      imod IH $$ Hσ with ⟨%Hred, Hstep⟩
+      imodintro
+      isplit
+      · ipureintro
+        simp only [LE.le] at hs
+        grind [cases Stuckness]
+      · iintro %κ %e₂ %σ₂ %eₜ %Hprim
+        imod Hstep $$ %κ %e₂ %σ₂ %eₜ %Hprim with
+          ⟨%hκ, Hσ, He₂, Hefs⟩
+        imod Hclose
+        imodintro
+        iframe %hκ Hσ
+        isplitl [He₂ HpostNone]
+        · icases He₂ with ⟨IH₂, -⟩
+          iapply IH₂ $$ %E' %Ψ' %hE' HpostNone
+        · iapply BI.BigSepL.bigSepL_impl $$ Hefs
+          iintro !> %k %ef %Hef Hef
+          icases Hef with ⟨IHef, -⟩
+          iapply IHef $$ %⊤ %ι.forkPost %LawfulSet.subset_refl
+          iintro %v Hv
+          imodintro
+          iexact Hv
+  · ipureintro
+    exact hE
+  · iexact HΦ
+
+@[rocq_alias fupd_twp]
+theorem fupd_twp {s : Stuckness} {E} {e : Expr} {Φ : Val → IProp GF} :
+    (|={E}=> WP e @ s ; E [{ Φ }]) ⊢ WP e @ s ; E [{ Φ }] := by
+  rw [unfold.to_eq]
+  iintro H
+  unfold pre
+  cases toVal e
+  · iintro %σ %ns %obs %nt Hσ
+    imod H with H
+    iapply H $$ Hσ
+  · imod H
+    iassumption
+
+@[rocq_alias twp_fupd]
+theorem twp_fupd {s : Stuckness} {E} {e : Expr} {Φ : Val → IProp GF} :
+    WP e @ s ; E [{ v, |={E}=> Φ v }] ⊢ WP e @ s ; E [{ Φ }] := by
+  iintro H
+  iapply strong_mono (Std.IsPreorder.le_refl _) LawfulSet.subset_refl $$ H
+  iintro %v Hv
+  iexact Hv
+
+@[rocq_alias twp_atomic]
+theorem atomic {s : Stuckness} {E₁ E₂ : CoPset} {e : Expr}
+    {Φ : Val → IProp GF} [hatom : Language.Atomic ↑s e] :
+    (|={E₁,E₂}=> WP e @ s ; E₂ [{ v, |={E₂,E₁}=> Φ v }])
+      ⊢ WP e @ s ; E₁ [{ Φ }] := by
+  rw [unfold.to_eq, unfold.to_eq]
+  iintro H
+  unfold pre
+  cases he : toVal e with
+  | some v =>
+    dsimp only
+    imod H
+    imod H
+    iassumption
+  | none =>
+    dsimp only
+    iintro %σ₁ %ns %obs %nt Hσ
+    imod H
+    imod H $$ Hσ with ⟨%Hred, Hstep⟩
+    imodintro
+    iframe %Hred
+    cases s
+    · iintro %κ %e₂ %σ₂ %eₜ %Hprim
+      imod Hstep $$ %κ %e₂ %σ₂ %eₜ %Hprim with
+        ⟨%hκ, Hσ, He₂, Hefs⟩
+      cases he₂ : toVal e₂ with
+      | some v₂ =>
+        icases unfold $$ He₂ with He₂
+        simp only [pre, he₂]
+        imod He₂
+        imod He₂
+        imodintro
+        iframe %hκ Hσ Hefs
+        rw [unfold.to_eq]
+        simp only [pre, he₂]
+        imodintro
+        iexact He₂
+      | none =>
+        icases unfold $$ He₂ with He₂
+        simp only [pre, he₂]
+        imod He₂ $$ %σ₂ %(ns + 1) %obs %(nt + eₜ.length) Hσ with
+          ⟨%Hred₂, _⟩
+        exact (Language.not_reducible_iff_irreducible.mpr
+          (hatom.atomic Hprim)) Hred₂ |>.elim
+    · iintro %κ %e₂ %σ₂ %eₜ %Hprim
+      imod Hstep $$ %κ %e₂ %σ₂ %eₜ %Hprim with
+        ⟨%hκ, Hσ, He₂, Hefs⟩
+      have ⟨v₂, hv₂⟩ := Option.isSome_iff_exists.mp (hatom.atomic Hprim)
+      icases unfold $$ He₂ with He₂
+      simp only [pre, hv₂]
+      imod He₂
+      imod He₂
+      imodintro
+      iframe %hκ Hσ Hefs
+      rw [unfold.to_eq]
+      simp only [pre, hv₂]
+      imodintro
+      iexact He₂
+
+@[rocq_alias twp_bind]
+theorem bind (K : Expr → Expr) [ctx : Language.Context K]
+    {s : Stuckness} {E : CoPset} {e : Expr} {Φ : Val → IProp GF} :
+    TotalWp.totalWp s E e
+      (fun v : Val => iprop(WP (K (v : Expr)) @ s ; E [{ Φ }]))
+      ⊢ WP (K e) @ s ; E [{ Φ }] := by
+  let Pred := fun (E : CoPset) (e : Expr) (Ψ : Val → IProp GF) => iprop(
+    ∀ Φ, (∀ v, Ψ v -∗ WP (K (v : Expr)) @ s ; E [{ Φ }]) -∗
+      WP (K e) @ s ; E [{ Φ }])
+  have hPred : NonExpansive
+      (fun x : Args Expr Val GF => Pred x.1.1 x.1.2 x.2) := by
+    constructor
+    intro n x y hxy
+    rcases x with ⟨⟨EX, eX⟩, ΨX⟩
+    rcases y with ⟨⟨EY, eY⟩, ΨY⟩
+    rcases hxy with ⟨⟨hE, he⟩, hΨ⟩
+    change EX = EY at hE
+    change eX = eY at he
+    subst EY
+    subst eY
+    refine BI.forall_ne fun _ => ?_
+    refine BI.wand_ne.ne ?_ .rfl
+    refine BI.forall_ne fun v => ?_
+    exact BI.wand_ne.ne (hΨ v) .rfl
+  letI := hPred
+  iintro H
+  iapply induction s Pred (ι := ι) ?_ $$ H
+  · iintro !> %E %e %Ψ
+    cases he : toVal e with
+    | some v =>
+      simp only [pre, he]
+      iintro Hpre %Φ Hcont
+      have heq := ToVal.coe_of_toVal_eq_some he
+      rw [← heq]
+      ispecialize Hcont $$ %v
+      iapply fupd_twp
+      iapply (fupd_wand_left (P := Ψ v))
+      iframe
+    | none =>
+      simp only [pre, he]
+      iintro Hpre %Φ Hcont
+      rw [unfold.to_eq]
+      unfold pre
+      simp only [ctx.toVal_eq_none_fill he]
+      iintro %σ₁ %ns %obs %nt Hσ
+      imod Hpre $$ Hσ with ⟨%Hred, Hstep⟩
+      imodintro
+      isplit
+      · ipureintro
+        cases s
+        · exact Language.Context.reducible_fill (K := K) Hred
+        · trivial
+      · iintro %κ %e₂ %σ₂ %eₜ %HKstep
+        obtain ⟨e₂', rfl, Hprim⟩ := ctx.primStep_fill_inv he HKstep
+        imod Hstep $$ %κ %e₂' %σ₂ %eₜ %Hprim with
+          ⟨%hκ, Hσ, He₂, Hefs⟩
+        imodintro
+        iframe %hκ Hσ
+        isplitl [He₂ Hcont]
+        icases He₂ with ⟨IH, -⟩
+        iapply IH $$ %Φ Hcont
+        iapply BI.BigSepL.bigSepL_impl $$ Hefs
+        iintro !> %k %ef %Hef Hef
+        icases Hef with ⟨-, Hef⟩
+        iexact Hef
+  · iintro %v Hv
+    iexact Hv
+
+@[rocq_alias twp_mono]
+theorem mono {s : Stuckness} {E} {e : Expr} {Φ Ψ : Val → IProp GF}
+    (H : ∀ v, Φ v ⊢ Ψ v) :
+    WP e @ s ; E [{ Φ }] ⊢ WP e @ s ; E [{ Ψ }] := by
+  iintro Hwp
+  iapply strong_mono (Std.IsPreorder.le_refl _) LawfulSet.subset_refl $$ Hwp
+  iintro %v Hv
+  imodintro
+  iapply H v
+  iexact Hv
+
+@[rocq_alias twp_stuck_mono]
+theorem stuck_mono {s₁ s₂ : Stuckness} {E} {e : Expr} {Φ : Val → IProp GF}
+    (H : s₁ ≤ s₂) :
+    WP e @ s₁ ; E [{ Φ }] ⊢ WP e @ s₂ ; E [{ Φ }] := by
+  iintro Hwp
+  iapply strong_mono H LawfulSet.subset_refl $$ Hwp
+  iintro %v Hv
+  imodintro
+  iexact Hv
+
+@[rocq_alias twp_stuck_weaken]
+theorem stuck_weaken {s : Stuckness} {E} {e : Expr} {Φ : Val → IProp GF} :
+    WP e @ s ; E [{ Φ }] ⊢ WP e @ E ? [{ Φ }] :=
+  stuck_mono Stuckness.le_MaybeStuck
+
+@[rocq_alias twp_mask_mono]
+theorem mask_mono {s : Stuckness} {E₁ E₂} {e : Expr} {Φ : Val → IProp GF}
+    (H : E₁ ⊆ E₂) :
+    WP e @ s ; E₁ [{ Φ }] ⊢ WP e @ s ; E₂ [{ Φ }] := by
+  iintro Hwp
+  iapply strong_mono (Std.IsPreorder.le_refl _) H $$ Hwp
+  iintro %v Hv
+  imodintro
+  iexact Hv
+
+@[rocq_alias twp_value_fupd]
+theorem value_fupd {s : Stuckness} {E} {e : Expr} {v : Val}
+    {Φ : Val → IProp GF} (h : e = (v : Expr)) :
+    WP e @ s ; E [{ Φ }] ⊣⊢ |={E}=> Φ v := by
+  subst e
+  exact value_fupd'
+
+@[rocq_alias twp_value']
+theorem value' {s : Stuckness} {E} {v : Val} {Φ : Val → IProp GF} :
+    Φ v ⊢ WP (v : Expr) @ s ; E [{ Φ }] := by
+  rw [value_fupd'.to_eq]
+  exact fupd_intro
+
+@[rocq_alias twp_value]
+theorem value {s : Stuckness} {E} {e : Expr} {v : Val} {Φ : Val → IProp GF}
+    (h : e = (v : Expr)) : Φ v ⊢ WP e @ s ; E [{ Φ }] := by
+  subst e
+  exact value'
+
+@[rocq_alias twp_frame_l]
+theorem frame_l {s : Stuckness} {E} {e : Expr} {Φ : Val → IProp GF}
+    {R : IProp GF} :
+    R ∗ WP e @ s ; E [{ Φ }] ⊢ WP e @ s ; E [{ v, R ∗ Φ v }] := by
+  iintro ⟨HR, Hwp⟩
+  iapply strong_mono (Std.IsPreorder.le_refl _) LawfulSet.subset_refl $$ Hwp
+  iintro %v HΦ
+  imodintro
+  iframe
+
+@[rocq_alias twp_frame_r]
+theorem frame_r {s : Stuckness} {E} {e : Expr} {Φ : Val → IProp GF}
+    {R : IProp GF} :
+    WP e @ s ; E [{ Φ }] ∗ R ⊢ WP e @ s ; E [{ v, Φ v ∗ R }] := by
+  rw [(BI.sep_comm (P := WP e @ s ; E [{ Φ }]) (Q := R)).to_eq]
+  refine frame_l.trans ?_
+  apply mono
+  intro v
+  exact BI.sep_comm.mp
+
+@[rocq_alias twp_wand]
+theorem wand {s : Stuckness} {E} {e : Expr} {Φ Ψ : Val → IProp GF} :
+    WP e @ s ; E [{ Φ }] ⊢
+      (∀ v, Φ v -∗ Ψ v) -∗ WP e @ s ; E [{ Ψ }] := by
+  iintro Hwp H
+  iapply strong_mono (Std.IsPreorder.le_refl _) LawfulSet.subset_refl $$ Hwp
+  iintro %v Hv
+  imodintro
+  iapply H $$ Hv
+
+@[rocq_alias twp_wp]
+theorem to_wp {s : Stuckness} {E} {e : Expr} {Φ : Val → IProp GF} :
+    WP e @ s ; E [{ Φ }] ⊢ WP e @ s ; E {{ Φ }} := by
+  iloeb as IH generalizing %E %e %Φ
+  rw [wp_unfold.to_eq, unfold.to_eq]
+  unfold wp.pre pre
+  cases hval : toVal e
+  case some v =>
+    iintro H
+    iexact H
+  case none =>
+    iintro H %σ %ns %κ %κs %nt Hσ
+    imod H $$ Hσ with ⟨%Hred, H⟩
+    imodintro
+    isplit
+    · ipureintro
+      cases s <;> simp_all [Stuckness.MaybeReducible]
+    · iintro %e₂ %σ₂ %eₜ %Hstep _
+      ihave Hnext := H $$ %κ %e₂ %σ₂ %eₜ %Hstep
+      iapply step_fupdN_intro Std.LawfulSet.empty_subset
+      rw [(BI.later_laterN _).to_eq]
+      iintro !>
+      iapply BI.laterN_intro
+      imod Hnext with ⟨%hκ, Hσ, He₂, Hefs⟩
+      subst hκ
+      simp only [List.nil_append]
+      imodintro
+      iframe Hσ
+      isplitl [He₂]
+      · iapply IH $$ He₂
+      · iapply BI.BigSepL.bigSepL_impl $$ Hefs
+        iintro !> %k %ef %Hef Hef
+        iapply IH $$ Hef
+
+section ProofMode
+
+open ProofMode
+
+variable {s : Stuckness} {E : CoPset} {e : Expr}
+variable {Φ Ψ : Val → IProp GF} {P R : IProp GF}
+
+instance frameTwp {p : Bool} [H : ∀ v, Frame p R (Φ v) (Ψ v)] :
+    Frame p R (WP e @ s ; E [{ Φ }]) (WP e @ s ; E [{ Ψ }]) where
+  frame := by
+    refine frame_l.trans ?_
+    apply mono
+    exact fun v => (H v).frame
+
+instance isExcept0Twp : IsExcept0 (WP e @ s ; E [{ Φ }]) where
+  is_except0 :=
+    calc iprop(◇ _)
+      _ ⊢ ◇ |={E}=> _ := BI.except0_mono fupd_intro
+      _ ⊢ |={E}=> _ := BIFUpdate.except0
+      _ ⊢ WP e @ s ; E [{ Φ }] := fupd_twp
+
+instance (priority := default + 10) elimModalFupdTwp p :
+    ElimModal True p false iprop(|={E}=> P) P
+      (WP e @ s ; E [{ Φ }]) (WP e @ s ; E [{ Φ }]) where
+  elim_modal := by
+    iintro %_ ⟨H, G⟩
+    icases BI.intuitionisticallyIf_elim $$ H with H
+    iapply fupd_twp
+    imod H
+    imodintro
+    iapply G $$ H
+
+instance elimModalBupdTwp p :
+    ElimModal True p false iprop(|==> P) P
+      (WP e @ s ; E [{ Φ }]) (WP e @ s ; E [{ Φ }]) where
+  elim_modal := by
+    rintro ⟨⟩
+    refine BI.sep_mono (BI.intuitionisticallyIf_mono
+      (BIUpdateFUpdate.fupd_of_bupd (E := E))) .rfl |>.trans ?_
+    apply elimModalFupdTwp _ |>.elim_modal ⟨⟩
+
+end ProofMode
+
+end Rules
+end twp
+end
+end Iris

--- a/Iris/Iris/ProgramLogic/TotalWeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/TotalWeakestPre.lean
@@ -30,11 +30,27 @@ deliberately not duplicated here.
 As in Iris-Rocq, TWP only accepts silent operational steps.  A language with
 observable reductions must expose a silent administrative semantics or provide
 a future trace-sensitive generalization instead of discarding observations.
+
+For Wasm, traps must therefore be represented deliberately: either as values
+in the language's result type, or as non-values excluded by the reducibility
+obligation. TWP does not silently reinterpret a stuck trap as successful
+termination.
 -/
 
 variable {hlc : outParam HasLC} {Expr State Obs Val}
 variable [Λ : Language Expr State Obs Val]
 variable {GF : BundledGFunctors} [ι : IrisGS_gen hlc Expr GF]
+
+/-- The stuckness-dependent reducibility condition used by total WP.
+
+Unlike partial WP's `Stuckness.MaybeReducible`, the `NotStuck` case requires
+the existence of a *silent* primitive step.  This matches Iris-Rocq's
+`reducible_no_obs` premise and prevents an observable transition from being
+used to justify TWP only to be rejected by the step clause immediately
+afterwards. -/
+abbrev Stuckness.MaybeReducibleNoObs : Stuckness → Expr × State → Prop
+  | .NotStuck, ρ => PrimStep.ReducibleNoObs ρ
+  | .MaybeStuck, _ => True
 
 namespace twp
 
@@ -45,6 +61,7 @@ local instance : OFE Val := OFE.ofDiscrete _
 abbrev Args (Expr Val : Type _) (GF : BundledGFunctors) :=
   (CoPset × Expr) × (Val → IProp GF)
 
+@[rocq_alias twp_pre]
 def pre (s : Stuckness)
     (twp : CoPset → Expr → (Val → IProp GF) → IProp GF)
     (E : CoPset) (e₁ : Expr) (Φ : Val → IProp GF) : IProp GF :=
@@ -52,7 +69,7 @@ def pre (s : Stuckness)
   | some v => iprop(|={E}=> Φ v)
   | none => iprop(∀ (σ₁ : State) (ns : Nat) (obs : List Obs) (nt : Nat),
       stateInterp σ₁ ns obs nt ={E,∅}=∗
-      ⌜s.MaybeReducible (e₁, σ₁)⌝ ∗
+      ⌜s.MaybeReducibleNoObs (e₁, σ₁)⌝ ∗
       ∀ (κ : List Obs) e₂ σ₂ eₜ,
         ⌜(e₁, σ₁) -<κ>-> (e₂, σ₂, eₜ)⌝ ={∅,E}=∗
         ⌜κ = []⌝ ∗
@@ -120,6 +137,36 @@ instance pre'_mono (s : Stuckness) : BIMonoPred (pre' (ι := ι) s) where
       · apply NonExpansive.ne
         exact ⟨⟨.rfl, .rfl⟩, hΦ⟩
       · exact .rfl
+
+@[rocq_alias twp_pre_mono]
+theorem pre_mono (s : Stuckness)
+    (X Y : CoPset → Expr → (Val → IProp GF) → IProp GF)
+    [NonExpansive (fun x : Args Expr Val GF => X x.1.1 x.1.2 x.2)]
+    [NonExpansive (fun x : Args Expr Val GF => Y x.1.1 x.1.2 x.2)] :
+    ⊢ □ (∀ E e Φ, X E e Φ -∗ Y E e Φ) -∗
+      ∀ E e Φ, pre s X E e Φ -∗ pre s Y E e Φ := by
+  iintro #H %E %e %Φ Hpre
+  unfold pre
+  cases hval : toVal e with
+  | some v =>
+      imod Hpre with Hpre
+      imodintro
+      iexact Hpre
+  | none =>
+      iintro %σ₁ %ns %obs %nt Hσ
+      imod Hpre $$ Hσ with ⟨%Hred, Hstep⟩
+      imodintro
+      iframe %Hred
+      iintro %κ %e₂ %σ₂ %eₜ %Hprim
+      imod Hstep $$ %κ %e₂ %σ₂ %eₜ %Hprim with
+        ⟨%hκ, Hσ, He₂, Hefs⟩
+      imodintro
+      iframe %hκ Hσ
+      isplitl [He₂]
+      · iapply H $$ %E %e₂ %Φ He₂
+      · iapply BI.BigSepL.bigSepL_impl $$ Hefs
+        iintro !> %k %ef %Hef Hef
+        iapply H $$ %⊤ %ef %ι.forkPost Hef
 
 def get (s : Stuckness) (E : CoPset) (e : Expr) (Φ : Val → IProp GF) : IProp GF :=
   letI : OFE CoPset := OFE.ofDiscrete _
@@ -314,7 +361,8 @@ theorem atomic {s : Stuckness} {E₁ E₂ : CoPset} {e : Expr}
         imod He₂ $$ %σ₂ %(ns + 1) %obs %(nt + eₜ.length) Hσ with
           ⟨%Hred₂, _⟩
         exact (Language.not_reducible_iff_irreducible.mpr
-          (hatom.atomic Hprim)) Hred₂ |>.elim
+          (hatom.atomic Hprim))
+          (Language.reducible_of_reducibleNoObs Hred₂) |>.elim
     · iintro %κ %e₂ %σ₂ %eₜ %Hprim
       imod Hstep $$ %κ %e₂ %σ₂ %eₜ %Hprim with
         ⟨%hκ, Hσ, He₂, Hefs⟩
@@ -380,7 +428,7 @@ theorem bind (K : Expr → Expr) [ctx : Language.Context K]
       isplit
       · ipureintro
         cases s
-        · exact Language.Context.reducible_fill (K := K) Hred
+        · exact Language.Context.reducibleNoObs_fill (K := K) Hred
         · trivial
       · iintro %κ %e₂ %σ₂ %eₜ %HKstep
         obtain ⟨e₂', rfl, Hprim⟩ := ctx.primStep_fill_inv he HKstep
@@ -397,6 +445,131 @@ theorem bind (K : Expr → Expr) [ctx : Language.Context K]
         iexact Hef
   · iintro %v Hv
     iexact Hv
+
+private theorem fold_induction_right
+    (Ψ : CoPset → Expr → (Val → IProp GF) → IProp GF)
+    (s : Stuckness) (E : CoPset) (e : Expr) (Φ : Val → IProp GF) :
+    (match toVal e with
+    | some v => iprop(|={E}=> Φ v)
+    | none => iprop(
+        ∀ (σ₁ : State) (ns : Nat) (obs : List Obs) (nt : Nat),
+          stateInterp σ₁ ns obs nt ={E,∅}=∗
+          ⌜s.MaybeReducibleNoObs (e, σ₁)⌝ ∗
+          ∀ (κ : List Obs) e₂ σ₂ eₜ,
+            ⌜(e, σ₁) -<κ>-> (e₂, σ₂, eₜ)⌝ ={∅,E}=∗
+            ⌜κ = []⌝ ∗
+            stateInterp σ₂ (ns + 1) obs (nt + eₜ.length) ∗
+            (Ψ E e₂ Φ ∧ WP e₂ @ s ; E [{ Φ }]) ∗
+            [∗list] e' ∈ eₜ,
+              (Ψ ⊤ e' ι.forkPost ∧
+                WP e' @ s ; ⊤ [{ ι.forkPost }]))) ⊢
+    WP e @ s ; E [{ Φ }] := by
+  rw [unfold.to_eq]
+  unfold pre
+  cases hval : toVal e with
+  | some =>
+      exact .rfl
+  | none =>
+      iintro H
+      iintro %σ₁ %ns %obs %nt Hσ
+      imod H $$ Hσ with ⟨%Hred, Hstep⟩
+      imodintro
+      iframe %Hred
+      iintro %κ %e₂ %σ₂ %eₜ %Hprim
+      imod Hstep $$ %κ %e₂ %σ₂ %eₜ %Hprim with
+        ⟨%hκ, Hσ, He₂, Hefs⟩
+      imodintro
+      iframe %hκ Hσ
+      isplitl [He₂]
+      · icases He₂ with ⟨-, He₂⟩
+        iexact He₂
+      · iapply BI.BigSepL.bigSepL_impl $$ Hefs
+        iintro !> %k %ef %Hef Hef
+        icases Hef with ⟨-, Hef⟩
+        iexact Hef
+
+@[rocq_alias twp_bind_inv]
+theorem bind_inv (K : Expr → Expr) [ctx : Language.Context K]
+    {s : Stuckness} {E : CoPset} {e : Expr} {Φ : Val → IProp GF} :
+    WP (K e) @ s ; E [{ Φ }] ⊢
+      TotalWp.totalWp s E e
+        (fun v : Val => iprop(WP (K (v : Expr)) @ s ; E [{ Φ }])) := by
+  let Pred := fun (E : CoPset) (e' : Expr) (Φ : Val → IProp GF) => iprop(
+    ∀ e, ⌜e' = K e⌝ -∗
+      TotalWp.totalWp s E e
+        (fun v : Val => iprop(WP (K (v : Expr)) @ s ; E [{ Φ }])))
+  have hPred : NonExpansive
+      (fun x : Args Expr Val GF => Pred x.1.1 x.1.2 x.2) := by
+    constructor
+    intro n x y hxy
+    rcases x with ⟨⟨EX, eX⟩, ΦX⟩
+    rcases y with ⟨⟨EY, eY⟩, ΦY⟩
+    rcases hxy with ⟨⟨hE, he⟩, hΦ⟩
+    change EX = EY at hE
+    change eX = eY at he
+    subst EY
+    subst eY
+    refine BI.forall_ne fun _ => ?_
+    refine BI.wand_ne.ne .rfl ?_
+    apply NonExpansive.ne
+    exact fun _ => NonExpansive.ne hΦ
+  letI := hPred
+  iintro H
+  iapply induction s Pred (ι := ι) ?_ $$ H %e %rfl
+  iintro !> %E %e' %Φ IH %e %heq
+  subst e'
+  rw [unfold.to_eq]
+  unfold pre
+  cases he : toVal e with
+  | some v =>
+      dsimp only
+      have heq := ToVal.coe_of_toVal_eq_some he
+      subst e
+      imodintro
+      iapply fold_induction_right Pred s E (K (v : Expr)) Φ
+      iexact IH
+  | none =>
+      dsimp only
+      have hK : toVal (K e) = none := ctx.toVal_eq_none_fill he
+      let unfolded := iprop(
+        ∀ (σ₁ : State) (ns : Nat) (obs : List Obs) (nt : Nat),
+            stateInterp σ₁ ns obs nt ={E,∅}=∗
+            ⌜s.MaybeReducibleNoObs (K e, σ₁)⌝ ∗
+            ∀ (κ : List Obs) e₂ σ₂ eₜ,
+              ⌜(K e, σ₁) -<κ>-> (e₂, σ₂, eₜ)⌝ ={∅,E}=∗
+              ⌜κ = []⌝ ∗
+              stateInterp σ₂ (ns + 1) obs (nt + eₜ.length) ∗
+              (Pred E e₂ Φ ∧ WP e₂ @ s ; E [{ Φ }]) ∗
+              [∗list] e' ∈ eₜ,
+                (Pred ⊤ e' ι.forkPost ∧
+                  WP e' @ s ; ⊤ [{ ι.forkPost }]))
+      have hIH :
+          (match toVal (K e) with
+          | some v => iprop(|={E}=> Φ v)
+          | none => unfolded) ⊢ unfolded := by
+        simp only [hK]
+        exact .rfl
+      icases hIH $$ IH with IH
+      iintro %σ₁ %ns %obs %nt Hσ
+      imod IH $$ Hσ with ⟨%Hred, Hstep⟩
+      imodintro
+      isplit
+      · ipureintro
+        cases s
+        · exact Language.Context.reducibleNoObs_fill_inv (K := K) he Hred
+        · trivial
+      · iintro %κ %e₂ %σ₂ %eₜ %Hprim
+        imod Hstep $$ %κ %(K e₂) %σ₂ %eₜ
+          %(ctx.primStep_fill Hprim) with ⟨%hκ, Hσ, He₂, Hefs⟩
+        imodintro
+        iframe %hκ Hσ
+        isplitl [He₂]
+        · icases He₂ with ⟨IH₂, -⟩
+          iapply IH₂ $$ %e₂ %rfl
+        · iapply BI.BigSepL.bigSepL_impl $$ Hefs
+          iintro !> %k %ef %Hef Hef
+          icases Hef with ⟨-, Hef⟩
+          iexact Hef
 
 @[rocq_alias twp_mono]
 theorem mono {s : Stuckness} {E} {e : Expr} {Φ Ψ : Val → IProp GF}
@@ -483,6 +656,30 @@ theorem wand {s : Stuckness} {E} {e : Expr} {Φ Ψ : Val → IProp GF} :
   imodintro
   iapply H $$ Hv
 
+@[rocq_alias twp_wand_l]
+theorem wand_l {s : Stuckness} {E} {e : Expr} {Φ Ψ : Val → IProp GF} :
+    (∀ v, Φ v -∗ Ψ v) ∗ WP e @ s ; E [{ Φ }] ⊢
+      WP e @ s ; E [{ Ψ }] := by
+  iintro ⟨H, Hwp⟩
+  iapply wand $$ Hwp H
+
+@[rocq_alias twp_wand_r]
+theorem wand_r {s : Stuckness} {E} {e : Expr} {Φ Ψ : Val → IProp GF} :
+    WP e @ s ; E [{ Φ }] ∗ (∀ v, Φ v -∗ Ψ v) ⊢
+      WP e @ s ; E [{ Ψ }] := by
+  iintro ⟨Hwp, H⟩
+  iapply wand $$ Hwp H
+
+@[rocq_alias twp_frame_wand]
+theorem frame_wand {s : Stuckness} {E} {e : Expr}
+    {Φ : Val → IProp GF} {R : IProp GF} :
+    R ⊢ (WP e @ s ; E [{ v, R -∗ Φ v }]) -∗
+      WP e @ s ; E [{ Φ }] := by
+  iintro HR Hwp
+  iapply wand $$ Hwp
+  iintro %v HΦ
+  iapply HΦ $$ HR
+
 @[rocq_alias twp_wp]
 theorem to_wp {s : Stuckness} {E} {e : Expr} {Φ : Val → IProp GF} :
     WP e @ s ; E [{ Φ }] ⊢ WP e @ s ; E {{ Φ }} := by
@@ -499,7 +696,9 @@ theorem to_wp {s : Stuckness} {E} {e : Expr} {Φ : Val → IProp GF} :
     imodintro
     isplit
     · ipureintro
-      cases s <;> simp_all [Stuckness.MaybeReducible]
+      cases s
+      · exact Language.reducible_of_reducibleNoObs Hred
+      · trivial
     · iintro %e₂ %σ₂ %eₜ %Hstep _
       ihave Hnext := H $$ %κ %e₂ %σ₂ %eₜ %Hstep
       iapply step_fupdN_intro Std.LawfulSet.empty_subset
@@ -521,9 +720,10 @@ section ProofMode
 
 open ProofMode
 
-variable {s : Stuckness} {E : CoPset} {e : Expr}
+variable {s : Stuckness} {E E₁ E₂ : CoPset} {e : Expr}
 variable {Φ Ψ : Val → IProp GF} {P R : IProp GF}
 
+@[rocq_alias frame_twp]
 instance frameTwp {p : Bool} [H : ∀ v, Frame p R (Φ v) (Ψ v)] :
     Frame p R (WP e @ s ; E [{ Φ }]) (WP e @ s ; E [{ Ψ }]) where
   frame := by
@@ -531,6 +731,8 @@ instance frameTwp {p : Bool} [H : ∀ v, Frame p R (Φ v) (Ψ v)] :
     apply mono
     exact fun v => (H v).frame
 
+-- Iris-Rocq reuses the module-qualified name `is_except_0_wp` here; that alias
+-- is already assigned to partial WP in Lean, so this instance is left unaliased.
 instance isExcept0Twp : IsExcept0 (WP e @ s ; E [{ Φ }]) where
   is_except0 :=
     calc iprop(◇ _)
@@ -538,6 +740,7 @@ instance isExcept0Twp : IsExcept0 (WP e @ s ; E [{ Φ }]) where
       _ ⊢ |={E}=> _ := BIFUpdate.except0
       _ ⊢ WP e @ s ; E [{ Φ }] := fupd_twp
 
+@[rocq_alias elim_modal_fupd_twp]
 instance (priority := default + 10) elimModalFupdTwp p :
     ElimModal True p false iprop(|={E}=> P) P
       (WP e @ s ; E [{ Φ }]) (WP e @ s ; E [{ Φ }]) where
@@ -549,6 +752,7 @@ instance (priority := default + 10) elimModalFupdTwp p :
     imodintro
     iapply G $$ H
 
+@[rocq_alias elim_modal_bupd_twp]
 instance elimModalBupdTwp p :
     ElimModal True p false iprop(|==> P) P
       (WP e @ s ; E [{ Φ }]) (WP e @ s ; E [{ Φ }]) where
@@ -557,6 +761,38 @@ instance elimModalBupdTwp p :
     refine BI.sep_mono (BI.intuitionisticallyIf_mono
       (BIUpdateFUpdate.fupd_of_bupd (E := E))) .rfl |>.trans ?_
     apply elimModalFupdTwp _ |>.elim_modal ⟨⟩
+
+/-- The same diagnostic as partial WP: changing masks through a non-atomic
+TWP goal requires an explicit leading update. -/
+@[rocq_alias elim_modal_fupd_twp_wrong_mask]
+instance elimModalFupdTwp_wrongMask :
+    ElimModal (PMError "Goal and eliminated modality must have the same mask.
+    Use `iapply twp.fupd_twp; imod (fupd_mask_subseteq E₂)` to adjust the mask of your goal to `E₂`")
+      p false iprop(|={E₂}=> P) iprop(False)
+      (WP e @ s ; E₁ [{ Φ }]) iprop(False) where
+  elim_modal := nofun
+
+@[rocq_alias elim_modal_fupd_twp_atomic]
+instance elimModalFupdTwpAtomic :
+    ElimModal (Language.Atomic ↑s e) p false iprop(|={E₁,E₂}=> P) P
+      (WP e @ s ; E₁ [{ Φ }])
+      (WP e @ s ; E₂ [{ v, |={E₂,E₁}=> Φ v }]) where
+  elim_modal := by
+    rintro hatomic
+    iintro ⟨H, G⟩
+    icases BI.intuitionisticallyIf_elim $$ H with H
+    iapply atomic
+    imod H
+    imodintro
+    iapply G $$ H
+
+@[rocq_alias elim_modal_fupd_twp_atomic_wrong_mask]
+instance elimModalFupdTwpAtomic_wrongMask :
+    ElimModal (PMError "Goal and eliminated modality must have the same mask.
+    Use `iapply twp.fupd_twp; imod (fupd_mask_subseteq E₂)` to adjust the mask of your goal to `E₂`")
+      p false iprop(|={E₁,E₂}=> P) iprop(False)
+      (WP e @ s ; E₁ [{ Φ }]) iprop(False) where
+  elim_modal := nofun
 
 end ProofMode
 

--- a/Iris/Iris/Tests.lean
+++ b/Iris/Iris/Tests.lean
@@ -6,4 +6,5 @@ public import Iris.Tests.Notation
 public import Iris.Tests.Tactics
 public import Iris.Tests.HeapLang
 public import Iris.Tests.Language
+public import Iris.Tests.TotalWeakestPre
 public import Iris.Tests.WeakestPre

--- a/Iris/Iris/Tests/TotalWeakestPre.lean
+++ b/Iris/Iris/Tests/TotalWeakestPre.lean
@@ -1,0 +1,375 @@
+/-
+Copyright (c) 2026 Fernando Leal. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Iris.ProgramLogic.TotalAdequacy
+public import Iris.ProgramLogic.TotalLifting
+public import Iris.Examples.ClosedProofs
+public import Iris.HeapLang.Instances
+
+namespace Iris.Tests.TotalWeakestPre
+
+open Iris BI ProgramLogic ProgramLogic.Language ProgramLogic.Language.Notation
+open Std LawfulSet
+
+/-!
+An intentionally small total-correctness test language. It is deterministic
+except for `branch`: both branch successors decrease the same structural
+measure, which checks that TWP proves termination of *all* successors rather
+than merely finding a terminating execution.
+
+`put` changes the machine state, `stuck` has no successor, steps never fork,
+and all genuine reductions are silent. The latter two properties model the
+initial Wasm integration contract.
+-/
+
+inductive Expr where
+  | val : Nat → Expr
+  | tick : Nat → Expr
+  | put : Nat → Expr
+  | branch : Nat → Expr
+  | observe : Expr
+  | stuck : Expr
+deriving DecidableEq, Repr
+
+abbrev Val := Nat
+abbrev State := Nat
+abbrev Obs := Unit
+
+instance : ToVal Expr Val where
+  toVal
+    | .val n => some n
+    | _ => none
+  ofVal := .val
+  coe_of_toVal_eq_some := by
+    intro e v h
+    cases e <;> simp_all
+  toVal_coe := by simp
+
+inductive Step : Expr → State → List Obs → Expr → State → List Expr → Prop
+  | tickSucc (n σ) : Step (.tick (n + 1)) σ [] (.tick n) σ []
+  | tickZero (σ) : Step (.tick 0) σ [] (.val 0) σ []
+  | put (n σ) : Step (.put n) σ [] (.val n) n []
+  | branchLeft (n σ) : Step (.branch (n + 1)) σ [] (.branch n) σ []
+  | branchRight (n σ) : Step (.branch (n + 1)) σ [] (.tick n) σ []
+  | branchZero (σ) : Step (.branch 0) σ [] (.val 0) σ []
+  | observe (σ) : Step .observe σ [()] (.val 0) σ []
+
+instance : PrimStep Expr State (List Obs) where
+  primStep
+    | (e₁, σ₁), κ, (e₂, σ₂, efs) => Step e₁ σ₁ κ e₂ σ₂ efs
+
+instance : Language Expr State Obs Val where
+  val_stuck := by
+    intro e σ κ e' σ' efs H
+    cases H <;> rfl
+
+instance : LanguageNoFork Expr State Obs Val where
+  no_fork H := by cases H <;> rfl
+
+theorem step_noFork {e₁ e₂ : Expr} {σ₁ σ₂ : State}
+    {κ : List Obs} {efs : List Expr}
+    (H : (e₁, σ₁) -<κ>-> (e₂, σ₂, efs)) : efs = [] := by
+  cases H <;> rfl
+
+section Proofs
+
+noncomputable abbrev GF := Iris.Examples.ClosedProofs.GF
+
+variable [InvGS_gen .hasNoLC GF]
+
+noncomputable local instance testIrisGS : IrisGS_gen .hasNoLC Expr GF where
+  toStateInterp := ⟨fun _ _ _ _ => iprop(True)⟩
+  numLatersPerStep := fun _ => 0
+  forkPost := fun _ => iprop(True)
+  stateInterp_mono := by
+    intro σ ns obs nt
+    iintro _
+    imodintro
+    itrivial
+
+theorem tick_twp (n : Nat) :
+    ⊢ WP (Expr.tick n) @ Stuckness.NotStuck ; ⊤ [{
+      fun v : Val => (iprop(⌜v = 0⌝) : IProp GF) }] := by
+  induction n with
+  | zero =>
+      iapply twp_lift_pure_det_step_no_fork
+        (e₂ := Expr.val 0)
+      · intro σ
+        exact ⟨.val 0, σ, [], Step.tickZero σ⟩
+      · intro σ₁ κ e₂' σ₂ efs H
+        cases H
+        exact ⟨rfl, rfl, rfl, rfl⟩
+      · imodintro
+        iapply twp.value rfl
+        ipureintro
+        rfl
+  | succ n IH =>
+      iapply twp_lift_pure_det_step_no_fork
+        (e₂ := Expr.tick n)
+      · intro σ
+        exact ⟨.tick n, σ, [], Step.tickSucc n σ⟩
+      · intro σ₁ κ e₂' σ₂ efs H
+        cases H
+        exact ⟨rfl, rfl, rfl, rfl⟩
+      · imodintro
+        iapply IH
+
+omit [InvGS_gen .hasNoLC GF] in
+theorem tick_purePrimStep_succ (n : Nat) :
+    Expr.tick (n + 1) -ᵖ-> Expr.tick n where
+  safe σ := ⟨.tick n, σ, [], Step.tickSucc n σ⟩
+  deterministic H := by
+    cases H
+    exact ⟨rfl, rfl, rfl, rfl⟩
+
+omit [InvGS_gen .hasNoLC GF] in
+theorem tick_purePrimStep_zero :
+    Expr.tick 0 -ᵖ-> Expr.val 0 where
+  safe σ := ⟨.val 0, σ, [], Step.tickZero σ⟩
+  deterministic H := by
+    cases H
+    exact ⟨rfl, rfl, rfl, rfl⟩
+
+omit [InvGS_gen .hasNoLC GF] in
+theorem tick_pureExec (n : Nat) :
+    PureExec True (n + 1) (Expr.tick n) (Expr.val 0) where
+  pureExec _ := by
+    induction n with
+    | zero =>
+        exact .once tick_purePrimStep_zero
+    | succ n IH =>
+        exact .head (tick_purePrimStep_succ n) IH
+
+/-- Checks the no-credit multi-step `PureExec` rule independently of the
+structural proof above. -/
+theorem tick_twp_via_pureExec (n : Nat) :
+    ⊢ WP (Expr.tick n) @ Stuckness.NotStuck ; ⊤ [{
+      fun v : Val => (iprop(⌜v = 0⌝) : IProp GF) }] := by
+  iapply twp_pure_step (tick_pureExec n) trivial
+  iapply twp.value rfl
+  ipureintro
+  rfl
+
+theorem put_twp (n : Nat) :
+    ⊢ WP (Expr.put n) @ Stuckness.NotStuck ; ⊤ [{
+      fun v : Val => (iprop(⌜v = n⌝) : IProp GF) }] := by
+  iapply twp_lift_atomic_step_no_fork (e₁ := Expr.put n) rfl
+  iintro %σ %ns %obs %nt _
+  imodintro
+  isplit
+  · ipureintro
+    exact ⟨.val n, n, [], Step.put n σ⟩
+  · iintro %κ %e₂ %σ₂ %efs %Hstep
+    cases Hstep
+    imodintro
+    isplit
+    · ipureintro
+      rfl
+    · isplit
+      · ipureintro
+        rfl
+      · isplit
+        · itrivial
+        · iexists n
+          isplit
+          · ipureintro
+            rfl
+          · ipureintro
+            rfl
+
+theorem branch_twp (n : Nat) :
+    ⊢ WP (Expr.branch n) @ Stuckness.NotStuck ; ⊤ [{
+      fun v : Val => (iprop(⌜v = 0⌝) : IProp GF) }] := by
+  induction n with
+  | zero =>
+      iapply twp_lift_pure_det_step_no_fork
+        (e₂ := Expr.val 0)
+      · intro σ
+        exact ⟨.val 0, σ, [], Step.branchZero σ⟩
+      · intro σ₁ κ e₂' σ₂ efs H
+        cases H
+        exact ⟨rfl, rfl, rfl, rfl⟩
+      · imodintro
+        iapply twp.value rfl
+        ipureintro
+        rfl
+  | succ n IH =>
+      iapply twp_lift_step_no_fork (e₁ := Expr.branch (n + 1)) rfl
+      iintro %σ %ns %obs %nt _
+      iapply fupd_mask_intro empty_subset
+      iintro Hclose
+      isplit
+      · ipureintro
+        exact ⟨.branch n, σ, [], Step.branchLeft n σ⟩
+      · iintro %κ %e₂ %σ₂ %efs %Hstep
+        cases Hstep
+        · imod Hclose
+          imodintro
+          isplit
+          · ipureintro
+            rfl
+          · isplit
+            · ipureintro
+              rfl
+            · isplitl []
+              · change ⊢ iprop(True)
+                itrivial
+              · iapply IH
+        · imod Hclose
+          imodintro
+          isplit
+          · ipureintro
+            rfl
+          · isplit
+            · ipureintro
+              rfl
+            · isplitl []
+              · change ⊢ iprop(True)
+                itrivial
+              · iapply tick_twp n
+
+end Proofs
+
+section CoreRuleChecks
+
+variable {e : Expr} {Φ : Val → IProp GF} {P : IProp GF}
+variable [InvGS_gen .hasNoLC GF]
+noncomputable local instance : IrisGS_gen .hasNoLC Expr GF := testIrisGS
+
+example :
+    WP e @ Stuckness.NotStuck ; ⊤ [{ Φ }] ⊢
+      WP e @ Stuckness.NotStuck ; ⊤ {{ Φ }} :=
+  twp.to_wp
+
+example :
+    P ∗ WP e @ Stuckness.NotStuck ; ⊤ [{ Φ }] ⊢
+      WP e @ Stuckness.NotStuck ; ⊤ [{ v, P ∗ Φ v }] :=
+  twp.frame_l
+
+example :
+    WP (id e) @ Stuckness.NotStuck ; ⊤ [{ Φ }] ⊢
+      TotalWp.totalWp Stuckness.NotStuck ⊤ e
+        (fun v : Val => iprop(
+          WP (id (v : Expr)) @ Stuckness.NotStuck ; ⊤ [{ Φ }])) :=
+  twp.bind_inv id
+
+example :
+    TotalWp.totalWp Stuckness.NotStuck ⊤ e
+      (fun v : Val => iprop(
+        WP (id (v : Expr)) @ Stuckness.NotStuck ; ⊤ [{ Φ }])) ⊢
+      WP (id e) @ Stuckness.NotStuck ; ⊤ [{ Φ }] :=
+  twp.bind id
+
+end CoreRuleChecks
+
+section HeapLangPureSmoke
+
+open Iris.HeapLang
+
+variable [InvGS_gen .hasNoLC GF]
+
+noncomputable local instance heapIrisGS :
+    IrisGS_gen .hasNoLC Iris.HeapLang.Exp GF where
+  toStateInterp := ⟨fun _ _ _ _ => iprop(True)⟩
+  numLatersPerStep := fun _ => 0
+  forkPost := fun _ => iprop(True)
+  stateInterp_mono := by
+    intro σ ns obs nt
+    iintro _
+    imodintro
+    itrivial
+
+/-- Existing HeapLang `PureExec` instances are immediately reusable by TWP;
+HeapLang-specific stateful primitive laws remain intentionally out of scope. -/
+theorem heapLang_add_twp :
+    ⊢ WP hl(#1 + #2) @ Stuckness.NotStuck ; ⊤ [{
+      fun v : Iris.HeapLang.Val =>
+        (iprop(⌜v = hl_val(#3)⌝) : IProp GF) }] := by
+  iapply twp_pure_step
+    (instPureExecBinOp (op := .plus)
+      (v1 := hl_val(#1)) (v2 := hl_val(#2)) (v' := hl_val(#3)))
+    (by rfl)
+  iapply twp.value rfl
+  ipureintro
+  rfl
+
+end HeapLangPureSmoke
+
+theorem branch_stronglyNormalizing (n initialState : Nat) :
+    StronglyNormalizing
+      (Language.ErasedStep (Expr := Expr) (State := State) (Obs := Obs))
+      ([Expr.branch n], initialState) := by
+  apply twp_total (hlc := .hasNoLC) (GF := GF)
+    Stuckness.NotStuck (Expr.branch n) initialState
+    (fun v : Val => (iprop(⌜v = 0⌝) : IProp GF)) 0 0
+  iintro %Hinv
+  imodintro
+  iexists
+    (fun (_ : State) (_ : Nat) (_ : List Obs) (_ : Nat) =>
+      (iprop(True) : IProp GF)),
+    (fun _ => 0),
+    (fun _ : Val => (iprop(True) : IProp GF)),
+    (fun _ _ _ _ => by
+      iintro _
+      imodintro
+      itrivial)
+  dsimp only
+  isplitl []
+  · itrivial
+  · iintro _
+    iapply branch_twp n
+
+theorem branch_singleMachine_stronglyNormalizing (n initialState : Nat) :
+    StronglyNormalizing
+      (ExprErasedStep (Expr := Expr) (State := State) (Obs := Obs))
+      (Expr.branch n, initialState) :=
+  stronglyNormalizing_expr_of_threadPool
+    (branch_stronglyNormalizing n initialState)
+
+theorem put_stronglyNormalizing (n initialState : Nat) :
+    StronglyNormalizing
+      (Language.ErasedStep (Expr := Expr) (State := State) (Obs := Obs))
+      ([Expr.put n], initialState) := by
+  apply twp_total (hlc := .hasNoLC) (GF := GF)
+    Stuckness.NotStuck (Expr.put n) initialState
+    (fun v : Val => (iprop(⌜v = n⌝) : IProp GF)) 0 0
+  iintro %Hinv
+  imodintro
+  iexists
+    (fun (_ : State) (_ : Nat) (_ : List Obs) (_ : Nat) =>
+      (iprop(True) : IProp GF)),
+    (fun _ => 0),
+    (fun _ : Val => (iprop(True) : IProp GF)),
+    (fun _ _ _ _ => by
+      iintro _
+      imodintro
+      itrivial)
+  dsimp only
+  isplitl []
+  · itrivial
+  · iintro _
+    iapply put_twp n
+
+/-! Negative semantic boundary checks. `stuck` is a non-value without a
+successor, and `observe` has only a non-silent successor. Consequently neither
+can satisfy the `.NotStuck` reducibility premise of TWP. The no-fork lifting
+API separately exposes `eₜ = []` as a proof obligation, so a forking rule
+cannot be passed to it. -/
+
+example : toVal Expr.stuck = (none : Option Val) := rfl
+
+example (σ : State) : PrimStep.Irreducible (Expr.stuck, σ) := by
+  intro κ e₂ σ₂ efs H
+  cases H
+
+example (σ : State) : PrimStep.Reducible (Expr.observe, σ) :=
+  ⟨[()], .val 0, σ, [], Step.observe σ⟩
+
+example (σ : State) : ¬ PrimStep.ReducibleNoObs (Expr.observe, σ) := by
+  rintro ⟨e₂, σ₂, efs, H⟩
+  cases H
+
+end Iris.Tests.TotalWeakestPre

--- a/Iris/Iris/Tests/WeakestPre.lean
+++ b/Iris/Iris/Tests/WeakestPre.lean
@@ -118,6 +118,22 @@ variable (Φ : Val → PROP)
 
 end TestWP
 
+section TestTotalTexanTriple
+
+set_option linter.unusedVariables false
+
+variable (PROP Expr Val : Type _) [BI PROP]
+variable [TotalWp PROP Expr Val Stuckness]
+variable (e : Expr) (P Q : PROP) (v : Val)
+
+/-- info: iprop(∀ Φ, P -∗ (Q -∗ Φ v) -∗ WP e [{ Φ }] ) : PROP -/
+#guard_msgs in #check [[{ P }]] e [[{ RET v; Q }]]
+
+/-- info: iprop(∀ Φ, P -∗ (∀ x, Q -∗ Φ x) -∗ WP e [{ Φ }] ) : PROP -/
+#guard_msgs in #check [[{ P }]] e [[{ x, RET x; Q }]]
+
+end TestTotalTexanTriple
+
 section TestTexanTriple
 
 set_option linter.unusedVariables false


### PR DESCRIPTION
## Summary

- add a faithful Iris-Rocq total weakest-precondition core based on BI least fixpoints
- add total primitive and evaluation-context lifting rules, including deterministic no-fork APIs intended for single-threaded Wasm semantics
- add fork-aware total adequacy and strong-normalization theorems, with sequential corollaries
- add proof-mode framing/update instances and a conversion from TWP to partial WP
- add a deterministic test language covering multi-step execution, state changes, nondeterministic countdown branching, no-fork adequacy, stuck terms, and observable steps
- add a HeapLang pure-execution smoke test while documenting deferred HeapLang-specific and concurrency-specific APIs

## Motivation

This provides the total-correctness layer needed to prove termination of first-order, single-threaded Wasm-style programs while keeping the generic definition and adequacy result compatible with Iris-Rocq's fork-aware semantics. Silent reductions and explicit trap modeling are documented as part of the Wasm integration contract.

## Upstream compatibility

The branch is rebased onto current `master` (`3d3dfe0`) and its TWP proof-mode instances follow the new `ElimModal` `InOut` parameter introduced upstream.

## Validation

- `lake build` — all 269 jobs passed
- Lean language-server diagnostics — zero errors and zero warnings in all added/modified TWP modules, tests, and aggregate imports
- axiom checks for `Iris.twp.to_wp`, `Iris.ProgramLogic.twp_total`, and the end-to-end strong-normalization test — only `propext`, `Classical.choice`, and `Quot.sound`
- `git diff --check` — clean
