### PR TITLE
fix: `iinv` fails on Heaplang wp goals

### DIFF
--- a/Iris/Iris/ProgramLogic/WeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/WeakestPre.lean
@@ -42,8 +42,8 @@ class StateInterp (State : Type _) (Obs : outParam $ Type _) (GF : BundledGFunct
 export StateInterp (stateInterp)
 
 @[rocq_alias irisGS_gen]
-class IrisGS_gen (hlc : outParam HasLC) (Expr : Type _) {Val : Type _} {State : Type _}
-    {Obs : Type _} [Λ : Language Expr State Obs Val] (GF : BundledGFunctors) extends
+class IrisGS_gen (hlc : outParam $ HasLC) (Expr : outParam $ Type _) {Val : outParam $ Type _} {State : outParam $ Type _}
+    {Obs : outParam $ Type _} [Λ : Language Expr State Obs Val] (GF : BundledGFunctors) extends
     StateInterp State Obs GF, InvGS_gen hlc GF where
   /-- Number of later credits obtained from taking one step in the
   operational semantics of our language. -/

--- a/Iris/Iris/Tests/HeapLang/WeakestPre.lean
+++ b/Iris/Iris/Tests/HeapLang/WeakestPre.lean
@@ -10,6 +10,8 @@ public import Iris.Instances
 public import Iris.HeapLang.Notation
 public import Iris.HeapLang.ProofMode
 public import Iris.HeapLang.Instances
+public import Iris.HeapLang.PrimitiveLaws
+public import Iris.Instances.Lib.Invariants
 public import Iris.ProgramLogic.WeakestPre
 
 namespace Iris.HeapLang
@@ -790,3 +792,37 @@ example : ⊢@{IProp GF} WP hl(if #true then #1 else #2) {{ v, ⌜v = hl_val(#1)
 end wp_match
 
 end pure_tactics
+
+section iinv
+
+open Std ProofMode
+
+/-! Test for `iinv` on a `WP` goal.
+
+`iinv` has to synthesise `ElimInv … goal _`, where `goal` is the current `WP`
+proposition.  That goes through `elimInv_acc_without_close`, whose `ElimAcc`
+premise is discharged by `elimAcc_wp_atomic` / `elimAcc_wp_nonatomic`.  Both of
+those instance heads mention `WP e @ s ; E {{ Φ }}`, which carries an
+`IrisGS_gen hlc Expr GF` instance argument, so matching against them requires
+solving `IrisGS_gen ?hlc ?Expr ?GF` with `?Expr`, `?Val`, `?State`, `?Obs` (and
+the `Language` instance argument) still unassigned.  Unless all four of those
+are `outParam`s, they count as inputs, resolution refuses to commit, and `iinv`
+fails with "invalid invariant … (ElimInv type class synthesis failed)". -/
+
+variable {GF : BundledGFunctors} [HeapLangGS hlc GF] (N : Namespace)
+
+private def iinvTestInv (l : Loc) : IProp GF := iprop% ∃ n : Nat, l ↦ hl_val(#n)
+
+example (l : Loc) :
+    ⊢@{IProp GF} inv N (iinvTestInv l) -∗ WP hl(!(#l)) {{ v, True }} := by
+  iintro #Hinv
+  unfold iinvTestInv
+  iinv N with ⟨%n, >Hl⟩
+  · exact ⟨by simp, by infer_instance⟩
+  wp_load
+  imodintro
+  isplitl [Hl]
+  · inext; iexists n; iframe
+  exact BI.true_intro
+
+end iinv


### PR DESCRIPTION
## Description
Make `Expr`, `Val`, `State` and `Obs` of `IrisGS_gen` `outParam` so that `iinv` works on Heaplang wp goals.

Before the fix, `iinv` failed with "ElimInv type class synthesis failed", because it failed at solving `IrisGS_gen` with input mvars. 

I couldn't find a better solution. What are your thoughts? @MackieLoeffel @alvinylt 

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
