### PR TITLE
feat: Port `IntoWand'` and instances

### DIFF
--- a/Iris/Iris/ProofMode/Classes.lean
+++ b/Iris/Iris/ProofMode/Classes.lean
@@ -78,55 +78,46 @@ class FromWand {PROP} [BI PROP] (P : PROP) (io : InOut)
   from_wand : (Q1 -∗ Q2) ⊢ P
 export FromWand (from_wand)
 
-/--
-[WandMode.Side] names which of the two slots of a two-sided class is the input,
-in the modings that have one: `argument` or `result`.
--/
 inductive WandMode.Side where
   | argument
   | result
 
 /--
-[WandMode] describes the modings of a two-sided class such as `IntoWand`, by
-recording whether each of the argument and result slots is an input or an output.
+[WandMode] describes the modings of a two-sided class `IntoWand`, by recording whether each of the
+argument and result slots is an input or an output.
 
-`unknown` leaves both slots as outputs, and corresponds to Rocq's `IntoWand`
-(Hint Mode `! - -`). `balancing s` makes the slot `s` an input, and corresponds to
-Rocq's `IntoWand'` (Hint Modes `! ! -` and `! - !`).
+`unknown` leaves both slots as outputs, and corresponds to Rocq's `IntoWand` (Hint Mode `- -`).
+`matching s` makes the slot `s` an input, and corresponds to Rocq's `IntoWand'`
+(Hint Modes `! -` and `- !`).
+
+The priority of `matching` mode instances (such as `intoWand_bupd_args`) must stay below that of
+every instance with `unknown` (such as `intoWand_bupd`). This mirrors the priority `100` on
+Rocq's `into_wand_wand'`.
 -/
 inductive WandMode where
   | unknown
-  | balancing (s : WandMode.Side)
+  | matching (s : WandMode.Side)
 
 meta section
 
 /-- Whether the argument slot of a class at mode `m` is an input or an output. -/
 @[reducible]
-def WandMode.Side.argIO : WandMode.Side → InOut
-  | .argument => .in
-  | .result => .out
-
-/-- Whether the result slot of a class at mode `m` is an input or an output. -/
-@[reducible]
-def WandMode.Side.resIO : WandMode.Side → InOut
-  | .argument => .out
-  | .result => .in
-
-/-- Whether the argument slot of a class at mode `m` is an input or an output. -/
-@[reducible]
 def WandMode.argIO : WandMode → InOut
   | .unknown => .out
-  | .balancing s => s.argIO
+  | .matching .argument => .in
+  | .matching .result => .out
+
 
 /-- Whether the result slot of a class at mode `m` is an input or an output. -/
 @[reducible]
 def WandMode.resIO : WandMode → InOut
   | .unknown => .out
-  | .balancing s => s.resIO
+  | .matching .argument => .out
+  | .matching .result => .in
 
 end
 
-#rocq_ignore IntoWand' "the `WandMode` parameter of `IntoWand` subsumes it"
+#rocq_ignore IntoWand' "the `matching` mode of `IntoWand` subsumes it"
 
 @[ipm_class, rocq_alias IntoWand]
 class IntoWand {PROP} [BI PROP] (p q : Bool) (R : PROP) (m : WandMode)

--- a/Iris/Iris/ProofMode/Classes.lean
+++ b/Iris/Iris/ProofMode/Classes.lean
@@ -78,12 +78,60 @@ class FromWand {PROP} [BI PROP] (P : PROP) (io : InOut)
   from_wand : (Q1 -∗ Q2) ⊢ P
 export FromWand (from_wand)
 
-#rocq_ignore IntoWand' "not used in Lean"
+/--
+[WandMode.Side] names which of the two slots of a two-sided class is the input,
+in the modings that have one: `argument` or `result`.
+-/
+inductive WandMode.Side where
+  | argument
+  | result
+
+/--
+[WandMode] describes the modings of a two-sided class such as `IntoWand`, by
+recording whether each of the argument and result slots is an input or an output.
+
+`unknown` leaves both slots as outputs, and corresponds to Rocq's `IntoWand`
+(Hint Mode `! - -`). `balancing s` makes the slot `s` an input, and corresponds to
+Rocq's `IntoWand'` (Hint Modes `! ! -` and `! - !`).
+-/
+inductive WandMode where
+  | unknown
+  | balancing (s : WandMode.Side)
+
+meta section
+
+/-- Whether the argument slot of a class at mode `m` is an input or an output. -/
+@[reducible]
+def WandMode.Side.argIO : WandMode.Side → InOut
+  | .argument => .in
+  | .result => .out
+
+/-- Whether the result slot of a class at mode `m` is an input or an output. -/
+@[reducible]
+def WandMode.Side.resIO : WandMode.Side → InOut
+  | .argument => .out
+  | .result => .in
+
+/-- Whether the argument slot of a class at mode `m` is an input or an output. -/
+@[reducible]
+def WandMode.argIO : WandMode → InOut
+  | .unknown => .out
+  | .balancing s => s.argIO
+
+/-- Whether the result slot of a class at mode `m` is an input or an output. -/
+@[reducible]
+def WandMode.resIO : WandMode → InOut
+  | .unknown => .out
+  | .balancing s => s.resIO
+
+end
+
+#rocq_ignore IntoWand' "the `WandMode` parameter of `IntoWand` subsumes it"
 
 @[ipm_class, rocq_alias IntoWand]
-class IntoWand {PROP} [BI PROP] (p q : Bool) (R : PROP)
-  (ioP : InOut) (P : semiOutParamIPM ioP PROP)
-  (ioQ : InOut) (Q : semiOutParamIPM ioQ PROP) where
+class IntoWand {PROP} [BI PROP] (p q : Bool) (R : PROP) (m : WandMode)
+  (P : semiOutParamIPM m.argIO PROP)
+  (Q : semiOutParamIPM m.resIO PROP) where
   into_wand : □?p R ⊢ □?q P -∗ Q
 export IntoWand (into_wand)
 

--- a/Iris/Iris/ProofMode/Instances.lean
+++ b/Iris/Iris/ProofMode/Instances.lean
@@ -63,7 +63,7 @@ instance fromWand_wandM [BI PROP] (mP1 : Option PROP) (P2 : PROP) :
   from_wand := wandM_sound.mpr
 
 -- IntoWand
--- These three bridge `IntoWand'` goals back into `IntoWand` at priority `100`.
+-- These three instances change `IntoWand'` goals to `IntoWand` at priority `100`.
 -- The `WandMode` parameter of `IntoWand` makes the two classes one, so the args
 -- instances match such goals directly and `(priority := low)` orders them last.
 #rocq_ignore into_wand_wand' "Subsumed by the `WandMode` parameter of `IntoWand`"
@@ -121,8 +121,8 @@ instance intoWand_affinely (p q : Bool) [BI PROP] (R P Q : PROP) [h : IntoWand p
 
 @[rocq_alias into_wand_affine_args]
 instance (priority := low) intoWand_affinely_args (q : Bool) [BI PROP]
-    (s : WandMode.Side) (R P Q : PROP) [h : IntoWand true q R (.balancing s) P Q] :
-    IntoWand true q R (.balancing s) iprop(<affine> P) iprop(<affine> Q) where
+    (s : WandMode.Side) (R P Q : PROP) [h : IntoWand true q R (.matching s) P Q] :
+    IntoWand true q R (.matching s) iprop(<affine> P) iprop(<affine> Q) where
   into_wand := wand_intro <|
     (sep_mono_left <| (affine_affinely _).2.trans <| affinely_mono h.1).trans <|
     (sep_mono_right <| (intuitionisticallyIf_affinely (p := q)).1).trans <|

--- a/Iris/Iris/ProofMode/Instances.lean
+++ b/Iris/Iris/ProofMode/Instances.lean
@@ -63,42 +63,45 @@ instance fromWand_wandM [BI PROP] (mP1 : Option PROP) (P2 : PROP) :
   from_wand := wandM_sound.mpr
 
 -- IntoWand
-#rocq_ignore into_wand_wand' "IntoWand' is not used in Lean"
-#rocq_ignore into_wand_impl' "IntoWand' is not used in Lean"
-#rocq_ignore into_wand_wandM' "IntoWand' is not used in Lean"
+-- These three bridge `IntoWand'` goals back into `IntoWand` at priority `100`.
+-- The `WandMode` parameter of `IntoWand` makes the two classes one, so the args
+-- instances match such goals directly and `(priority := low)` orders them last.
+#rocq_ignore into_wand_wand' "Subsumed by the `WandMode` parameter of `IntoWand`"
+#rocq_ignore into_wand_impl' "Subsumed by the `WandMode` parameter of `IntoWand`"
+#rocq_ignore into_wand_wandM' "Subsumed by the `WandMode` parameter of `IntoWand`"
 
 @[rocq_alias into_wand_wand]
-instance intoWand_wand (p q : Bool) [BI PROP] (P Q P' : PROP) [h : FromAssumption q ioP P P'] :
-    IntoWand p q iprop(P' -∗ Q) ioP P ioQ Q where
+instance intoWand_wand (p q : Bool) [BI PROP] (P Q P' : PROP) [h : FromAssumption q m.argIO P P'] :
+    IntoWand p q iprop(P' -∗ Q) m P Q where
   into_wand := (intuitionisticallyIf_mono <| wand_mono_left h.1).trans intuitionisticallyIf_elim
 
 -- TODO: compare this with into_wand_impl_false_false, into_wand_impl_false_true, ... in Rocq
 instance intoWand_imp_false [BI PROP] (P Q P' : PROP) [Absorbing P'] [Absorbing iprop(P' → Q)]
-    [h : FromAssumption b ioP P P'] : IntoWand false b iprop(P' → Q) ioP P ioQ Q where
+    [h : FromAssumption b m.argIO P P'] : IntoWand false b iprop(P' → Q) m P Q where
   into_wand := wand_intro <| (sep_mono_right h.1).trans <| by dsimp; exact sep_and.trans imp_elim_left
 
 instance intoWand_imp_true [BI PROP] (P Q P' : PROP) [Affine P']
-    [h : FromAssumption b ioP P P'] : IntoWand true b iprop(P' → Q) ioP P ioQ Q where
+    [h : FromAssumption b m.argIO P P'] : IntoWand true b iprop(P' → Q) m P Q where
   into_wand := wand_intro <| (sep_mono_right h.1).trans <| by
     dsimp; exact sep_and.trans <| imp_elim intuitionistically_elim
 
 @[ipm_backtrack, rocq_alias into_wand_and_l]
 instance intoWand_and_l (p q : Bool) [BI PROP] (R1 R2 P' Q' : PROP)
-    [h : IntoWand p q R1 ioP P' ioQ Q'] : IntoWand p q iprop(R1 ∧ R2) ioP P' ioQ Q' where
+    [h : IntoWand p q R1 m P' Q'] : IntoWand p q iprop(R1 ∧ R2) m P' Q' where
   into_wand := (intuitionisticallyIf_mono and_elim_l).trans h.1
 
 @[ipm_backtrack, rocq_alias into_wand_and_r]
 instance intoWand_and_r (p q : Bool) [BI PROP] (R1 R2 P' Q' : PROP)
-    [h : IntoWand p q R2 ioP P' ioQ Q'] : IntoWand p q iprop(R1 ∧ R2) ioP P' ioQ Q' where
+    [h : IntoWand p q R2 m P' Q'] : IntoWand p q iprop(R1 ∧ R2) m P' Q' where
   into_wand := (intuitionisticallyIf_mono and_elim_r).trans h.1
 
 instance intoWand_wandIff (p q : Bool) [BI PROP] (R1 R2 P' Q' : PROP)
-    [h : IntoWand p q iprop((R1 -∗ R2) ∧ (R2 -∗ R1)) ioP P' ioQ Q'] : IntoWand p q iprop(R1 ∗-∗ R2) ioP P' ioQ Q' := h
+    [h : IntoWand p q iprop((R1 -∗ R2) ∧ (R2 -∗ R1)) m P' Q'] : IntoWand p q iprop(R1 ∗-∗ R2) m P' Q' := h
 
 @[rocq_alias into_wand_wandM]
 instance intoWand_wandM (p q : Bool) [BI PROP] (mP' : Option PROP) (P Q : PROP)
-    [h : FromAssumption q ioP P (mP'.getD emp)] :
-    IntoWand p q iprop(mP' -∗? Q) ioP P ioQ Q where
+    [h : FromAssumption q m.argIO P (mP'.getD emp)] :
+    IntoWand p q iprop(mP' -∗? Q) m P Q where
   into_wand := (intuitionisticallyIf_mono wandM_sound.mp).trans <|
     (intuitionisticallyIf_mono <| wand_mono_left h.1).trans intuitionisticallyIf_elim
 
@@ -106,29 +109,38 @@ instance intoWand_wandM (p q : Bool) [BI PROP] (mP' : Option PROP) (P Q : PROP)
 set_option synthInstance.checkSynthOrder false in
 @[rocq_alias into_wand_forall]
 instance intoWand_forall (p q : Bool) [BI PROP] (Φ : α → PROP) (P Q : PROP) (x : α)
-    [h : IntoWand p q (Φ x) ioP P ioQ Q] : IntoWand p q iprop(∀ x, Φ x) ioP P ioQ Q where
+    [h : IntoWand p q (Φ x) m P Q] : IntoWand p q iprop(∀ x, Φ x) m P Q where
   into_wand := (intuitionisticallyIf_mono <| BI.forall_elim x).trans h.1
 
 @[rocq_alias into_wand_affine]
-instance intoWand_affinely (p q : Bool) [BI PROP] (R P Q : PROP) [h : IntoWand p q R ioP P ioQ Q] :
-    IntoWand p q iprop(<affine> R) ioP iprop(<affine> P) ioQ iprop(<affine> Q) where
+instance intoWand_affinely (p q : Bool) [BI PROP] (R P Q : PROP) [h : IntoWand p q R m P Q] :
+    IntoWand p q iprop(<affine> R) m iprop(<affine> P) iprop(<affine> Q) where
   into_wand := wand_intro <|
     (sep_congr intuitionisticallyIf_affinely intuitionisticallyIf_affinely).1.trans <|
     affinely_sep_mpr.trans <| affinely_mono <| wand_elim h.1
 
+@[rocq_alias into_wand_affine_args]
+instance (priority := low) intoWand_affinely_args (q : Bool) [BI PROP]
+    (s : WandMode.Side) (R P Q : PROP) [h : IntoWand true q R (.balancing s) P Q] :
+    IntoWand true q R (.balancing s) iprop(<affine> P) iprop(<affine> Q) where
+  into_wand := wand_intro <|
+    (sep_mono_left <| (affine_affinely _).2.trans <| affinely_mono h.1).trans <|
+    (sep_mono_right <| (intuitionisticallyIf_affinely (p := q)).1).trans <|
+    affinely_sep_mpr.trans <| affinely_mono wand_elim_left
+
 @[rocq_alias into_wand_intuitionistically]
 instance intoWand_intuitionistically (p q : Bool) [BI PROP] (R P Q : PROP)
-    [h : IntoWand true q R ioP P ioQ Q] : IntoWand p q iprop(□ R) ioP P ioQ Q where
+    [h : IntoWand true q R m P Q] : IntoWand p q iprop(□ R) m P Q where
   into_wand := (intuitionisticallyIf_mono h.1).trans intuitionisticallyIf_elim
 
 @[rocq_alias into_wand_persistently_true]
 instance intoWand_persistently_true (q : Bool) [BI PROP] (R P Q : PROP)
-    [h : IntoWand true q R ioP P ioQ Q] : IntoWand true q iprop(<pers> R) ioP P ioQ Q where
+    [h : IntoWand true q R m P Q] : IntoWand true q iprop(<pers> R) m P Q where
   into_wand := intuitionistically_persistently.1.trans h.1
 
 @[rocq_alias into_wand_persistently_false]
 instance intoWand_persistently_false (q : Bool) [BI PROP] (R P Q : PROP) [Absorbing R]
-    [h : IntoWand false q R ioP P ioQ Q] : IntoWand false q iprop(<pers> R) ioP P ioQ Q where
+    [h : IntoWand false q R m P Q] : IntoWand false q iprop(<pers> R) m P Q where
   into_wand := persistently_elim.trans h.1
 
 -- FromForall

--- a/Iris/Iris/ProofMode/InstancesLater.lean
+++ b/Iris/Iris/ProofMode/InstancesLater.lean
@@ -61,8 +61,8 @@ instance intoWand_later [BI PROP] (p q : Bool) (R P Q : PROP)
 
 @[rocq_alias into_wand_later_args]
 instance (priority := low) intoWand_later_args [BI PROP] (p q : Bool) (s : WandMode.Side)
-    (R P Q : PROP) [h : IntoWand p q R (.balancing s) P Q] :
-    IntoWand p q R (.balancing s) iprop(▷ P) iprop(▷ Q) where
+    (R P Q : PROP) [h : IntoWand p q R (.matching s) P Q] :
+    IntoWand p q R (.matching s) iprop(▷ P) iprop(▷ Q) where
   into_wand := (intuitionisticallyIf_mono later_intro).trans <| later_intuitionisticallyIf_2.trans <|
     (later_mono h.1).trans <| later_wand.trans <| wand_mono later_intuitionisticallyIf_2 .rfl
 
@@ -75,8 +75,8 @@ instance intoWand_laterN [BI PROP] (n : Nat) (p q : Bool) (R P Q : PROP)
 set_option synthInstance.checkSynthOrder false in
 @[rocq_alias into_wand_laterN_args]
 instance (priority := low) intoWand_laterN_args [BI PROP] (n : Nat) (p q : Bool)
-    (s : WandMode.Side) (R P Q : PROP) [h : IntoWand p q R (.balancing s) P Q] :
-    IntoWand p q R (.balancing s) iprop(▷^[n] P) iprop(▷^[n] Q) where
+    (s : WandMode.Side) (R P Q : PROP) [h : IntoWand p q R (.matching s) P Q] :
+    IntoWand p q R (.matching s) iprop(▷^[n] P) iprop(▷^[n] Q) where
   into_wand := (intuitionisticallyIf_mono (laterN_intro n)).trans <| (laterN_intuitionisticallyIf n).trans <|
     (laterN_mono n h.1).trans <| (laterN_wand n).trans <| wand_mono (laterN_intuitionisticallyIf n) .rfl
 

--- a/Iris/Iris/ProofMode/InstancesLater.lean
+++ b/Iris/Iris/ProofMode/InstancesLater.lean
@@ -55,29 +55,30 @@ instance fromPure_except0 [BI PROP] (a : Bool) (P : PROP) (φ : Prop)
 
 @[rocq_alias into_wand_later]
 instance intoWand_later [BI PROP] (p q : Bool) (R P Q : PROP)
-    [h : IntoWand p q R ioP P ioQ Q] : IntoWand p q iprop(▷ R) ioP iprop(▷ P) ioQ iprop(▷ Q) where
+    [h : IntoWand p q R m P Q] : IntoWand p q iprop(▷ R) m iprop(▷ P) iprop(▷ Q) where
   into_wand := later_intuitionisticallyIf_2.trans <|
     (later_mono h.1).trans <| later_wand.trans <| wand_mono later_intuitionisticallyIf_2 .rfl
 
-#rocq_ignore into_wand_later_args "IntoWand' is not used in Lean"
--- TODO: see if this is necessary. It is an instance for IntoWand' in Rocq
--- instance intoWand_later_args [BI PROP] (p q : Bool) (R P Q : PROP)
---     [h : IntoWand p q R ioP P ioQ Q] : IntoWand p q R ioP iprop(▷ P) ioQ iprop(▷ Q) where
---   into_wand := (intuitionisticallyIf_mono later_intro).trans <| later_intuitionisticallyIf_2.trans <|
---     (later_mono h.1).trans <| later_wand.trans <| wand_mono later_intuitionisticallyIf_2 .rfl
+@[rocq_alias into_wand_later_args]
+instance (priority := low) intoWand_later_args [BI PROP] (p q : Bool) (s : WandMode.Side)
+    (R P Q : PROP) [h : IntoWand p q R (.balancing s) P Q] :
+    IntoWand p q R (.balancing s) iprop(▷ P) iprop(▷ Q) where
+  into_wand := (intuitionisticallyIf_mono later_intro).trans <| later_intuitionisticallyIf_2.trans <|
+    (later_mono h.1).trans <| later_wand.trans <| wand_mono later_intuitionisticallyIf_2 .rfl
 
 @[rocq_alias into_wand_laterN]
 instance intoWand_laterN [BI PROP] (n : Nat) (p q : Bool) (R P Q : PROP)
-    [h : IntoWand p q R ioP P ioQ Q] : IntoWand p q iprop(▷^[n] R) ioP iprop(▷^[n] P) ioQ iprop(▷^[n] Q) where
+    [h : IntoWand p q R m P Q] : IntoWand p q iprop(▷^[n] R) m iprop(▷^[n] P) iprop(▷^[n] Q) where
   into_wand := (laterN_intuitionisticallyIf n).trans <|
     (laterN_mono n h.1).trans <| (laterN_wand n).trans <| wand_mono (laterN_intuitionisticallyIf n) .rfl
 
-#rocq_ignore into_wand_laterN_args "IntoWand' is not used in Lean"
--- TODO: see if this is necessary. It is an instance for IntoWand' in Rocq
--- instance intoWand_laterN_args [BI PROP] (n : Nat) (p q : Bool) (R P Q : PROP)
---     [h : IntoWand p q R ioP P ioQ Q] : IntoWand p q R ioP iprop(▷^[n] P) ioQ iprop(▷^[n] Q) where
---   into_wand := (intuitionisticallyIf_mono (laterN_intro n)).trans <| (laterN_intuitionisticallyIf n).trans <|
---     (laterN_mono n h.1).trans <| (laterN_wand n).trans <| wand_mono (laterN_intuitionisticallyIf n) .rfl
+set_option synthInstance.checkSynthOrder false in
+@[rocq_alias into_wand_laterN_args]
+instance (priority := low) intoWand_laterN_args [BI PROP] (n : Nat) (p q : Bool)
+    (s : WandMode.Side) (R P Q : PROP) [h : IntoWand p q R (.balancing s) P Q] :
+    IntoWand p q R (.balancing s) iprop(▷^[n] P) iprop(▷^[n] Q) where
+  into_wand := (intuitionisticallyIf_mono (laterN_intro n)).trans <| (laterN_intuitionisticallyIf n).trans <|
+    (laterN_mono n h.1).trans <| (laterN_wand n).trans <| wand_mono (laterN_intuitionisticallyIf n) .rfl
 
 /-- FromAnd -/
 

--- a/Iris/Iris/ProofMode/InstancesPlainly.lean
+++ b/Iris/Iris/ProofMode/InstancesPlainly.lean
@@ -45,14 +45,14 @@ instance intoPure_plainly [Sbi PROP] (P : PROP) (φ : Prop)
 /-- IntoWand -/
 
 @[rocq_alias into_wand_plainly_true]
-instance intoWand_plainly_true [Sbi PROP] (q : Bool) ioP ioQ (R P Q : PROP)
-    [h : IntoWand true q R ioP P ioQ Q] : IntoWand true q iprop(■ R) ioP P ioQ Q where
+instance intoWand_plainly_true [Sbi PROP] (q : Bool) m (R P Q : PROP)
+    [h : IntoWand true q R m P Q] : IntoWand true q iprop(■ R) m P Q where
   into_wand := intuitionistically_plainly_elim.trans h.1
 
 @[rocq_alias into_wand_plainly_false]
-instance intoWand_plainly_false [Sbi PROP] (q : Bool) ioP ioQ (R P Q : PROP)
-    [Absorbing R] [h : IntoWand false q R ioP P ioQ Q] :
-    IntoWand false q iprop(■ R) ioP P ioQ Q where
+instance intoWand_plainly_false [Sbi PROP] (q : Bool) m (R P Q : PROP)
+    [Absorbing R] [h : IntoWand false q R m P Q] :
+    IntoWand false q iprop(■ R) m P Q where
   into_wand := plainly_elim.trans h.1
 
 /-- FromAnd -/

--- a/Iris/Iris/ProofMode/InstancesUpdates.lean
+++ b/Iris/Iris/ProofMode/InstancesUpdates.lean
@@ -33,25 +33,32 @@ instance fromPure_bupd (a : Bool) (P : PROP) (φ : Prop)
   from_pure := h.1.trans BIUpdate.intro
 
 @[rocq_alias into_wand_bupd]
-instance intoWand_bupd (p q : Bool) ioP ioQ (R P Q : PROP)
-    [h : IntoWand false false R ioP P ioQ Q] :
-    IntoWand p q iprop(|==> R) ioP iprop(|==> P) ioQ iprop(|==> Q) where
+instance intoWand_bupd (p q : Bool) m (R P Q : PROP)
+    [h : IntoWand false false R m P Q] :
+    IntoWand p q iprop(|==> R) m iprop(|==> P) iprop(|==> Q) where
   into_wand := intuitionisticallyIf_elim.trans <|
     wand_intro <| (sep_mono (BIUpdate.mono h.1) intuitionisticallyIf_elim).trans <|
     bupd_sep.trans <| BIUpdate.mono wand_elim_left
 
-set_option synthInstance.checkSynthOrder false in
+/-- Balances the argument and the result of `R` against the goal's modality.
+Since `R` is left untouched, this only terminates when one of the two slots is an
+input, so it is stated as `balancing _` and never at `unknown`. The `Side` is left a
+variable, so this single instance covers both `argument` and `result`.
+
+The priority must stay below that of every instance which strips structure off
+`R` (such as `intoWand_bupd`), so that this is only reached once `R` has bottomed
+out. This mirrors the priority `100` on Rocq's `into_wand_wand'` bridge. -/
 @[rocq_alias into_wand_bupd_args]
-instance intoWand_bupd_args (p q : Bool) ioP ioQ (R P Q : PROP)
-    [h : IntoWand p false R ioP P ioQ Q] :
-    IntoWand p q R ioP iprop(|==> P) ioQ iprop(|==> Q) where
+instance (priority := low) intoWand_bupd_args (p q : Bool) (s : WandMode.Side) (R P Q : PROP)
+    [h : IntoWand p false R (.balancing s) P Q] :
+    IntoWand p q R (.balancing s) iprop(|==> P) iprop(|==> Q) where
   into_wand := wand_intro_left <|
     (sep_mono intuitionisticallyIf_elim h.into_wand).trans bupd_wand_right
 
 @[rocq_alias into_wand_bupd_persistent]
-instance intoWand_bupd_persistent (p q : Bool) ioP ioQ (R P Q : PROP)
-    [h : IntoWand false q R ioP P ioQ Q] :
-    IntoWand p q iprop(|==> R) ioP P ioQ iprop(|==> Q) where
+instance intoWand_bupd_persistent (p q : Bool) m (R P Q : PROP)
+    [h : IntoWand false q R m P Q] :
+    IntoWand p q iprop(|==> R) m P iprop(|==> Q) where
   into_wand := intuitionisticallyIf_elim.trans <|
     wand_intro <| (sep_mono (BIUpdate.mono h.1) .rfl).trans <|
     bupd_frame_right.trans <| BIUpdate.mono wand_elim_left
@@ -131,26 +138,29 @@ instance fromPure_fupd E a (P : PROP) (φ : Prop)
   from_pure := h.from_pure.trans <| fupd_intro
 
 @[rocq_alias into_wand_fupd]
-instance intoWand_fupd E (p q : Bool) ioP ioQ (R P Q : PROP)
-    [h : IntoWand false false R ioP P ioQ Q] :
-    IntoWand p q iprop(|={E}=> R) ioP iprop(|={E}=> P) ioQ iprop(|={E}=> Q) where
+instance intoWand_fupd E (p q : Bool) m (R P Q : PROP)
+    [h : IntoWand false false R m P Q] :
+    IntoWand p q iprop(|={E}=> R) m iprop(|={E}=> P) iprop(|={E}=> Q) where
   into_wand := intuitionisticallyIf_elim.trans <|
     wand_intro <| (sep_mono (BIFUpdate.mono h.into_wand) intuitionisticallyIf_elim).trans <|
     fupd_sep.trans <| BIFUpdate.mono wand_elim_left
 
 @[rocq_alias into_wand_fupd_persistent]
-instance intoWand_fupd_persistent E1 E2 (p q : Bool) ioP ioQ (R P Q : PROP)
-    [h : IntoWand false q R ioP P ioQ Q] :
-    IntoWand p q iprop(|={E1,E2}=> R) ioP P ioQ iprop(|={E1,E2}=> Q) where
+instance intoWand_fupd_persistent E1 E2 (p q : Bool) m (R P Q : PROP)
+    [h : IntoWand false q R m P Q] :
+    IntoWand p q iprop(|={E1,E2}=> R) m P iprop(|={E1,E2}=> Q) where
   into_wand := intuitionisticallyIf_elim.trans <|
     wand_intro <| (sep_mono (BIFUpdate.mono h.into_wand) .rfl).trans <|
     fupd_frame_right.trans <| BIFUpdate.mono wand_elim_left
 
+-- See `intoWand_bupd_args` for why this is stated as `balancing _` only and why the
+-- priority is `low`. The `set_option` is needed because the masks `E1`/`E2` are
+-- not determined by the argument and result slots.
 set_option synthInstance.checkSynthOrder false in
 @[rocq_alias into_wand_fupd_args]
-instance intoWand_fupd_args E1 E2 (p q : Bool) ioP ioQ (R P Q : PROP)
-    [h : IntoWand p false R ioP P ioQ Q] :
-    IntoWand p q R ioP iprop(|={E1,E2}=> P) ioQ iprop(|={E1,E2}=> Q) where
+instance (priority := low) intoWand_fupd_args E1 E2 (p q : Bool) (s : WandMode.Side)
+    (R P Q : PROP) [h : IntoWand p false R (.balancing s) P Q] :
+    IntoWand p q R (.balancing s) iprop(|={E1,E2}=> P) iprop(|={E1,E2}=> Q) where
   into_wand := wand_intro_left <|
     (sep_mono intuitionisticallyIf_elim h.into_wand).trans fupd_wand_right
 

--- a/Iris/Iris/ProofMode/InstancesUpdates.lean
+++ b/Iris/Iris/ProofMode/InstancesUpdates.lean
@@ -40,18 +40,10 @@ instance intoWand_bupd (p q : Bool) m (R P Q : PROP)
     wand_intro <| (sep_mono (BIUpdate.mono h.1) intuitionisticallyIf_elim).trans <|
     bupd_sep.trans <| BIUpdate.mono wand_elim_left
 
-/-- Balances the argument and the result of `R` against the goal's modality.
-Since `R` is left untouched, this only terminates when one of the two slots is an
-input, so it is stated as `balancing _` and never at `unknown`. The `Side` is left a
-variable, so this single instance covers both `argument` and `result`.
-
-The priority must stay below that of every instance which strips structure off
-`R` (such as `intoWand_bupd`), so that this is only reached once `R` has bottomed
-out. This mirrors the priority `100` on Rocq's `into_wand_wand'` bridge. -/
 @[rocq_alias into_wand_bupd_args]
 instance (priority := low) intoWand_bupd_args (p q : Bool) (s : WandMode.Side) (R P Q : PROP)
-    [h : IntoWand p false R (.balancing s) P Q] :
-    IntoWand p q R (.balancing s) iprop(|==> P) iprop(|==> Q) where
+    [h : IntoWand p false R (.matching s) P Q] :
+    IntoWand p q R (.matching s) iprop(|==> P) iprop(|==> Q) where
   into_wand := wand_intro_left <|
     (sep_mono intuitionisticallyIf_elim h.into_wand).trans bupd_wand_right
 
@@ -153,14 +145,13 @@ instance intoWand_fupd_persistent E1 E2 (p q : Bool) m (R P Q : PROP)
     wand_intro <| (sep_mono (BIFUpdate.mono h.into_wand) .rfl).trans <|
     fupd_frame_right.trans <| BIFUpdate.mono wand_elim_left
 
--- See `intoWand_bupd_args` for why this is stated as `balancing _` only and why the
--- priority is `low`. The `set_option` is needed because the masks `E1`/`E2` are
--- not determined by the argument and result slots.
+-- The `set_option` is needed because the masks `E1`/`E2` are not determined by the argument
+-- and result slots.
 set_option synthInstance.checkSynthOrder false in
 @[rocq_alias into_wand_fupd_args]
 instance (priority := low) intoWand_fupd_args E1 E2 (p q : Bool) (s : WandMode.Side)
-    (R P Q : PROP) [h : IntoWand p false R (.balancing s) P Q] :
-    IntoWand p q R (.balancing s) iprop(|={E1,E2}=> P) iprop(|={E1,E2}=> Q) where
+    (R P Q : PROP) [h : IntoWand p false R (.matching s) P Q] :
+    IntoWand p q R (.matching s) iprop(|={E1,E2}=> P) iprop(|={E1,E2}=> Q) where
   into_wand := wand_intro_left <|
     (sep_mono intuitionisticallyIf_elim h.into_wand).trans fupd_wand_right
 

--- a/Iris/Iris/ProofMode/InstancesUpdates.lean
+++ b/Iris/Iris/ProofMode/InstancesUpdates.lean
@@ -40,7 +40,13 @@ instance intoWand_bupd (p q : Bool) ioP ioQ (R P Q : PROP)
     wand_intro <| (sep_mono (BIUpdate.mono h.1) intuitionisticallyIf_elim).trans <|
     bupd_sep.trans <| BIUpdate.mono wand_elim_left
 
-#rocq_ignore into_wand_bupd_args "IntoWand' is not used in Lean"
+set_option synthInstance.checkSynthOrder false in
+@[rocq_alias into_wand_bupd_args]
+instance intoWand_bupd_args (p q : Bool) ioP ioQ (R P Q : PROP)
+    [h : IntoWand p false R ioP P ioQ Q] :
+    IntoWand p q R ioP iprop(|==> P) ioQ iprop(|==> Q) where
+  into_wand := wand_intro_left <|
+    (sep_mono intuitionisticallyIf_elim h.into_wand).trans bupd_wand_right
 
 @[rocq_alias into_wand_bupd_persistent]
 instance intoWand_bupd_persistent (p q : Bool) ioP ioQ (R P Q : PROP)
@@ -140,7 +146,13 @@ instance intoWand_fupd_persistent E1 E2 (p q : Bool) ioP ioQ (R P Q : PROP)
     wand_intro <| (sep_mono (BIFUpdate.mono h.into_wand) .rfl).trans <|
     fupd_frame_right.trans <| BIFUpdate.mono wand_elim_left
 
-#rocq_ignore into_wand_fupd_args "IntoWand' is not used in Lean"
+set_option synthInstance.checkSynthOrder false in
+@[rocq_alias into_wand_fupd_args]
+instance intoWand_fupd_args E1 E2 (p q : Bool) ioP ioQ (R P Q : PROP)
+    [h : IntoWand p false R ioP P ioQ Q] :
+    IntoWand p q R ioP iprop(|={E1,E2}=> P) ioQ iprop(|={E1,E2}=> Q) where
+  into_wand := wand_intro_left <|
+    (sep_mono intuitionisticallyIf_elim h.into_wand).trans fupd_wand_right
 
 @[rocq_alias from_sep_fupd]
 instance fromSep_fupd E (P Q1 Q2 : PROP)

--- a/Iris/Iris/ProofMode/Tactics/Apply.lean
+++ b/Iris/Iris/ProofMode/Tactics/Apply.lean
@@ -18,7 +18,7 @@ open BI
 
 theorem apply [BI PROP] {p} {P Q Q1 R : PROP}
     (h1 : P ⊢ Q1)
-    [h2 : IntoWand p false Q (.balancing .result) Q1 R] : P ∗ □?p Q ⊢ R :=
+    [h2 : IntoWand p false Q (.matching .result) Q1 R] : P ∗ □?p Q ⊢ R :=
       (Entails.trans (sep_mono_left h1) (wand_elim_swap h2.1))
 
 public meta section
@@ -43,7 +43,7 @@ The proof of `hyps ∗ □?p A ⊢ goal`
 private partial def iApplyCore {prop : Q(Type u)} {bi : Q(BI $prop)} {e} (hyps : Hyps bi e) (p : Q(Bool)) (A : Q($prop)) (goal : Q($prop)) : ProofModeM Q($e ∗ □?$p $A ⊢ $goal) := do
   let B ← mkFreshExprMVarQ q($prop)
   -- if `A := ?B -∗ goal`, add `B` as a new subgoal and conclude `goal`
-  if let some _ ← ProofModeM.trySynthInstanceQ q(IntoWand $p false $A (.balancing .result) $B $goal) then
+  if let some _ ← ProofModeM.trySynthInstanceQ q(IntoWand $p false $A (.matching .result) $B $goal) then
      let pf ← addBIGoal hyps B
      return q(apply $pf)
 

--- a/Iris/Iris/ProofMode/Tactics/Apply.lean
+++ b/Iris/Iris/ProofMode/Tactics/Apply.lean
@@ -18,7 +18,7 @@ open BI
 
 theorem apply [BI PROP] {p} {P Q Q1 R : PROP}
     (h1 : P ⊢ Q1)
-    [h2 : IntoWand p false Q .out Q1 .in R] : P ∗ □?p Q ⊢ R :=
+    [h2 : IntoWand p false Q (.balancing .result) Q1 R] : P ∗ □?p Q ⊢ R :=
       (Entails.trans (sep_mono_left h1) (wand_elim_swap h2.1))
 
 public meta section
@@ -43,7 +43,7 @@ The proof of `hyps ∗ □?p A ⊢ goal`
 private partial def iApplyCore {prop : Q(Type u)} {bi : Q(BI $prop)} {e} (hyps : Hyps bi e) (p : Q(Bool)) (A : Q($prop)) (goal : Q($prop)) : ProofModeM Q($e ∗ □?$p $A ⊢ $goal) := do
   let B ← mkFreshExprMVarQ q($prop)
   -- if `A := ?B -∗ goal`, add `B` as a new subgoal and conclude `goal`
-  if let some _ ← ProofModeM.trySynthInstanceQ q(IntoWand $p false $A .out $B .in $goal) then
+  if let some _ ← ProofModeM.trySynthInstanceQ q(IntoWand $p false $A (.balancing .result) $B $goal) then
      let pf ← addBIGoal hyps B
      return q(apply $pf)
 

--- a/Iris/Iris/ProofMode/Tactics/Specialize.lean
+++ b/Iris/Iris/ProofMode/Tactics/Specialize.lean
@@ -18,7 +18,7 @@ open BI
 
 theorem specialize_wand [BI PROP] {q p : Bool} {A1 A2 A3 Q P1 P2 : PROP}
     (h1 : A1 ⊢ A2 ∗ □?q Q) (h2 : A2 ⊣⊢ A3 ∗ □?p P1)
-    [h3 : IntoWand q p Q .in P1 .out P2] :
+    [h3 : IntoWand q p Q (.balancing .argument) P1 P2] :
     A1 ⊢ A3 ∗ □?(p && q) P2 := by
   refine h1.trans <| (sep_mono_left h2.1).trans <| sep_assoc.1.trans (sep_mono_right ?_)
   cases p with
@@ -31,13 +31,13 @@ theorem specialize_wand [BI PROP] {q p : Bool} {A1 A2 A3 Q P1 P2 : PROP}
 -- see https://gitlab.mpi-sws.org/iris/iris/-/blob/846ed45bed6951035c6204fef365d9a344022ae6/iris/proofmode/coq_tactics.v#L336
 theorem specialize_wand_subgoal [BI PROP] {q : Bool} {A1 A2 A3 A4 Q P1 : PROP} P2
     (h1 : A1 ⊢ A2 ∗ □?q Q) (h2 : A2 ⊣⊢ A3 ∗ A4) (h3 : A4 ⊢ P1)
-    [inst : IntoWand q false Q .out P1 .out P2] : A1 ⊢ A3 ∗ P2 := by
+    [inst : IntoWand q false Q .unknown P1 P2] : A1 ⊢ A3 ∗ P2 := by
   refine h1.trans <| (sep_mono_left h2.1).trans <| sep_assoc.1.trans (sep_mono_right ((sep_mono_left h3).trans ?_))
   exact (sep_mono_right inst.1).trans wand_elim_right
 
 theorem specialize_wand_autoframe [BI PROP] {q : Bool} {A1 A2 A3 Q P1 : PROP} P2
      (h1 : A1 ⊢ A2 ∗ □?q Q) (h2 : A2 ⊢ A3 ∗ P1)
-     [inst : IntoWand q false Q .out P1 .out P2] : A1 ⊢ A3 ∗ P2 :=
+     [inst : IntoWand q false Q .unknown P1 P2] : A1 ⊢ A3 ∗ P2 :=
   h1.trans <| (sep_mono_left h2).trans <| sep_assoc.1.trans
     (sep_mono_right ((sep_mono_right inst.into_wand).trans wand_elim_right))
 
@@ -72,7 +72,7 @@ private def processWand :
     have : $p2 =Q ($p1 && $p) := ⟨⟩
 
     let out₂ ← mkFreshExprMVarQ prop
-    let some _ ← ProofModeM.trySynthInstanceQ q(IntoWand $p $p1 $out .in $out₁' .out $out₂) |
+    let some _ ← ProofModeM.trySynthInstanceQ q(IntoWand $p $p1 $out (.balancing .argument) $out₁' $out₂) |
       throwError m!"ispecialize: cannot instantiate {out} with {out₁'}"
     let pf := q(specialize_wand $pf $pf')
     return { e := e', hyps := hyps', p := p2, out := out₂, pf }
@@ -106,7 +106,7 @@ private def processWand :
       (λ _ ivar => (negate ^^ ivars.contains ivar) || frameIVars.contains ivar) hyps
     let out₁ ← mkFreshExprMVarQ prop
     let out₂ ← mkFreshExprMVarQ prop
-    let some _ ← ProofModeM.trySynthInstanceQ q(IntoWand $p false $out .out $out₁ .out $out₂)
+    let some _ ← ProofModeM.trySynthInstanceQ q(IntoWand $p false $out .unknown $out₁ $out₂)
       | throwError m!"ispecialize: {out} is not a wand"
     let res ← iFrame hypsr' out₁ (frameIVars.map (⟨.ipm ·, true⟩))
     let pf'' ← res.finish λ hyps goal => do
@@ -125,7 +125,7 @@ private def processWand :
       throwError "ispecialize: only spatial kind is supported at the moment"
     let out₁ ← mkFreshExprMVarQ prop
     let out₂ ← mkFreshExprMVarQ prop
-    let some _ ← ProofModeM.trySynthInstanceQ q(IntoWand $p false $out .out $out₁ .out $out₂)
+    let some _ ← ProofModeM.trySynthInstanceQ q(IntoWand $p false $out .unknown $out₁ $out₂)
       | throwError m!"ispecialize: {out} is not a wand"
     let res ← iFrame hyps out₁ (← SelPat.resolve hyps [.spatial, .intuitionistic])
     let ⟨_, hyps', pf'⟩ ← res.finishClose

--- a/Iris/Iris/ProofMode/Tactics/Specialize.lean
+++ b/Iris/Iris/ProofMode/Tactics/Specialize.lean
@@ -18,7 +18,7 @@ open BI
 
 theorem specialize_wand [BI PROP] {q p : Bool} {A1 A2 A3 Q P1 P2 : PROP}
     (h1 : A1 ⊢ A2 ∗ □?q Q) (h2 : A2 ⊣⊢ A3 ∗ □?p P1)
-    [h3 : IntoWand q p Q (.balancing .argument) P1 P2] :
+    [h3 : IntoWand q p Q (.matching .argument) P1 P2] :
     A1 ⊢ A3 ∗ □?(p && q) P2 := by
   refine h1.trans <| (sep_mono_left h2.1).trans <| sep_assoc.1.trans (sep_mono_right ?_)
   cases p with
@@ -72,7 +72,7 @@ private def processWand :
     have : $p2 =Q ($p1 && $p) := ⟨⟩
 
     let out₂ ← mkFreshExprMVarQ prop
-    let some _ ← ProofModeM.trySynthInstanceQ q(IntoWand $p $p1 $out (.balancing .argument) $out₁' $out₂) |
+    let some _ ← ProofModeM.trySynthInstanceQ q(IntoWand $p $p1 $out (.matching .argument) $out₁' $out₂) |
       throwError m!"ispecialize: cannot instantiate {out} with {out₁'}"
     let pf := q(specialize_wand $pf $pf')
     return { e := e', hyps := hyps', p := p2, out := out₂, pf }

--- a/Iris/Iris/Tests/Instances.lean
+++ b/Iris/Iris/Tests/Instances.lean
@@ -73,18 +73,19 @@ section mvars
 variable [BI PROP] (P1 P2 : Nat → PROP)
 
 /- Test creation of mvars -/
-/-- info: solution: IntoWand false false iprop(∀ x, P1 x -∗ P2 x) WandMode.unknown (P1 ?m.23) (P2 ?m.23), new goals: [?m.23: Nat] -/
+set_option pp.mvars false in
+/-- info: solution: IntoWand false false iprop(∀ x, P1 x -∗ P2 x) WandMode.unknown (P1 ?_) (P2 ?_), new goals: [?_: Nat] -/
 #guard_msgs in #ipm_synth (IntoWand false false iprop(∀ a, P1 a -∗ P2 a) .unknown _ _)
 
 /- Test instantiation of forall quantifier -/
-/-- info: solution: IntoWand false false iprop(∀ x, P1 x -∗ P2 x) (WandMode.balancing WandMode.Side.argument) (P1 1)
+/-- info: solution: IntoWand false false iprop(∀ x, P1 x -∗ P2 x) (WandMode.matching WandMode.Side.argument) (P1 1)
   (P2 1), new goals: [] -/
-#guard_msgs in #ipm_synth (IntoWand false false iprop(∀ a, P1 a -∗ P2 a) (.balancing .argument) (P1 1) _)
+#guard_msgs in #ipm_synth (IntoWand false false iprop(∀ a, P1 a -∗ P2 a) (.matching .argument) (P1 1) _)
 
 /- Test instantiation of mvar created outside ipm_synth -/
-/-- info: solution: IntoWand false false iprop(P1 1 -∗ P2 1) (WandMode.balancing WandMode.Side.argument) (P1 1)
+/-- info: solution: IntoWand false false iprop(P1 1 -∗ P2 1) (WandMode.matching WandMode.Side.argument) (P1 1)
   (P2 1), new goals: [] -/
-#guard_msgs in #ipm_synth (IntoWand false false iprop(P1 _ -∗ P2 1) (.balancing .argument) (P1 1) _)
+#guard_msgs in #ipm_synth (IntoWand false false iprop(P1 _ -∗ P2 1) (.matching .argument) (P1 1) _)
 
 end mvars
 

--- a/Iris/Iris/Tests/Instances.lean
+++ b/Iris/Iris/Tests/Instances.lean
@@ -73,17 +73,18 @@ section mvars
 variable [BI PROP] (P1 P2 : Nat → PROP)
 
 /- Test creation of mvars -/
-/-- info: solution: IntoWand false false iprop(∀ x, P1 x -∗ P2 x) InOut.out (P1 ?m.24) InOut.out
-  (P2 ?m.24), new goals: [?m.24: Nat] -/
-#guard_msgs in #ipm_synth (IntoWand false false iprop(∀ a, P1 a -∗ P2 a) .out _ .out _)
+/-- info: solution: IntoWand false false iprop(∀ x, P1 x -∗ P2 x) WandMode.unknown (P1 ?m.23) (P2 ?m.23), new goals: [?m.23: Nat] -/
+#guard_msgs in #ipm_synth (IntoWand false false iprop(∀ a, P1 a -∗ P2 a) .unknown _ _)
 
 /- Test instantiation of forall quantifier -/
-/-- info: solution: IntoWand false false iprop(∀ x, P1 x -∗ P2 x) InOut.in (P1 1) InOut.out (P2 1), new goals: [] -/
-#guard_msgs in #ipm_synth (IntoWand false false iprop(∀ a, P1 a -∗ P2 a) .in (P1 1) .out _)
+/-- info: solution: IntoWand false false iprop(∀ x, P1 x -∗ P2 x) (WandMode.balancing WandMode.Side.argument) (P1 1)
+  (P2 1), new goals: [] -/
+#guard_msgs in #ipm_synth (IntoWand false false iprop(∀ a, P1 a -∗ P2 a) (.balancing .argument) (P1 1) _)
 
 /- Test instantiation of mvar created outside ipm_synth -/
-/-- info: solution: IntoWand false false iprop(P1 1 -∗ P2 1) InOut.in (P1 1) InOut.out (P2 1), new goals: [] -/
-#guard_msgs in #ipm_synth (IntoWand false false iprop(P1 _ -∗ P2 1) .in (P1 1) .out _)
+/-- info: solution: IntoWand false false iprop(P1 1 -∗ P2 1) (WandMode.balancing WandMode.Side.argument) (P1 1)
+  (P2 1), new goals: [] -/
+#guard_msgs in #ipm_synth (IntoWand false false iprop(P1 _ -∗ P2 1) (.balancing .argument) (P1 1) _)
 
 end mvars
 

--- a/Iris/Iris/Tests/Tactics.lean
+++ b/Iris/Iris/Tests/Tactics.lean
@@ -916,6 +916,22 @@ example [BI PROP] (P Q : PROP) : Q ⊢ P -∗ Q := by
   iintro H HP
   iapply H
 
+/-- Tests `iapply` of a plain wand under a basic update, using `intoWand_bupd_args` to balance the
+argument and the result of the wand against the goal's modality. -/
+example [BI PROP] [BIUpdate PROP] (P Q : PROP) :
+    (P -∗ Q) ⊢ (|==> P) -∗ |==> Q := by
+  iintro Hwand HP
+  iapply Hwand
+  iexact HP
+
+/-- Tests `iapply` of a plain wand under a fancy update, using `intoWand_fupd_args` to balance the
+argument and the result of the wand against the goal's modality. -/
+example [BI PROP] [BIFUpdate PROP] (E1 E2 : CoPset) (P Q : PROP) :
+    (P -∗ Q) ⊢ (|={E1,E2}=> P) -∗ |={E1,E2}=> Q := by
+  iintro Hwand HP
+  iapply Hwand
+  iexact HP
+
 end apply
 
 -- have

--- a/Iris/Iris/Tests/Tactics.lean
+++ b/Iris/Iris/Tests/Tactics.lean
@@ -924,10 +924,53 @@ example [BI PROP] [BIUpdate PROP] (P Q : PROP) :
   iapply Hwand
   iexact HP
 
+
 /-- Tests `iapply` of a plain wand under a fancy update, using `intoWand_fupd_args` to balance the
 argument and the result of the wand against the goal's modality. -/
 example [BI PROP] [BIFUpdate PROP] (E1 E2 : CoPset) (P Q : PROP) :
     (P -∗ Q) ⊢ (|={E1,E2}=> P) -∗ |={E1,E2}=> Q := by
+  iintro Hwand HP
+  iapply Hwand
+  iexact HP
+
+/-- Tests `iapply` of a plain wand under a later, using `intoWand_later_args` to balance the
+argument and the result of the wand against the goal's modality. -/
+example [BI PROP] (P Q : PROP) : (P -∗ Q) ⊢ (▷ P) -∗ ▷ Q := by
+  iintro Hwand HP
+  iapply Hwand
+  iexact HP
+
+/-- Tests `iapply` of a plain wand under `▷^[n]`, using `intoWand_laterN_args` to balance the
+argument and the result of the wand against the goal's modality. -/
+example [BI PROP] (n : Nat) (P Q : PROP) : (P -∗ Q) ⊢ (▷^[n] P) -∗ ▷^[n] Q := by
+  iintro Hwand HP
+  iapply Hwand
+  iexact HP
+
+-- `intoWand_later_args` is reached only once `R` has bottomed out: with a `▷` on
+-- `R` itself, both instances match, and the `low` priority of the args instance
+-- means the structure-stripping `intoWand_later` is tried first and wins.
+/--
+[Meta.synthInstance.instances] #[@ProofMode.intoWand_later_args, @ProofMode.intoWand_later]
+[Meta.synthInstance] ✅️ apply @ProofMode.intoWand_later to ProofMode.IntoWand false false iprop(▷ (P -∗ Q))
+-/
+#guard_msgs (whitespace := lax, substring := true) in
+example [BI PROP] (P Q : PROP) : (▷ (P -∗ Q)) ⊢ (▷ P) -∗ ▷ Q := by
+  iintro Hwand HP
+  (set_option trace.Meta.synthInstance true in iapply Hwand)
+  iexact HP
+
+/-- Tests `iapply` of an intuitionistic wand under an `<affine>`, using
+`intoWand_affine_args` to balance the argument and the result of the wand against
+the goal's modality. -/
+example [BI PROP] (P Q : PROP) : □ (P -∗ Q) ⊢ (<affine> P) -∗ <affine> Q := by
+  iintro #Hwand HP
+  iapply Hwand
+  iexact HP
+
+/-- `intoWand_affine_args` is reached only once `R` has bottomed out: with an
+`<affine>` on `R` itself, the structure-stripping `intoWand_affine` wins instead. -/
+example [BI PROP] (P Q : PROP) : (<affine> (P -∗ Q)) ⊢ (<affine> P) -∗ <affine> Q := by
   iintro Hwand HP
   iapply Hwand
   iexact HP
@@ -1497,6 +1540,23 @@ example [BI PROP] (P Q : PROP) :
   · rfl
   iexact H
 
+-- `Q` is not a wand, so no `IntoWand` instance applies. This fails immediately instead of looping by
+-- wrapping the two output slots in ever more modalities.
+/-- error: ispecialize: Q is not a wand
+---
+trace: [Meta.synthInstance] ❌️ IPM: ProofMode.IntoWand false false Q ProofMode.WandMode.unknown ?m.36 ?m.37
+  [Meta.synthInstance] ❌️ IPM: new goal ProofMode.IntoWand false false Q ProofMode.WandMode.unknown ?m.36
+        ?m.37 => ProofMode.IntoWand false false Q ProofMode.WandMode.unknown ?m.36 ?m.37
+    [Meta.synthInstance.tactics] []
+    [Meta.synthInstance.instances] #[]
+  [Meta.synthInstance] result <not-available>
+-/
+#guard_msgs in
+example [BI PROP] [BIUpdate PROP] (P Q: PROP) : Q ⊢ P -∗ Q := by
+  iintro HQ
+  set_option trace.Meta.synthInstance true in
+  ispecialize HQ $$ [$]
+
 end specialize
 
 -- split
@@ -1655,12 +1715,12 @@ PROP : Type u_1
 inst✝¹ : BI PROP
 inst✝ : BIAffine PROP
 P Q : PROP
-⊢ 
+⊢
   ∗x✝ : P
   ∗HQ : <pers> Q
   ⊢ Q
 -/
-#guard_msgs in
+#guard_msgs (whitespace := lax) in
 example [BI PROP] [BIAffine PROP] (P Q : PROP) :
   P ∧ <pers> Q ⊢ Q := by
   iintro H

--- a/Iris/Iris/Tests/Tactics.lean
+++ b/Iris/Iris/Tests/Tactics.lean
@@ -1540,18 +1540,15 @@ example [BI PROP] (P Q : PROP) :
   · rfl
   iexact H
 
--- `Q` is not a wand, so no `IntoWand` instance applies. This fails immediately instead of looping by
--- wrapping the two output slots in ever more modalities.
-/-- error: ispecialize: Q is not a wand
----
-trace: [Meta.synthInstance] ❌️ IPM: ProofMode.IntoWand false false Q ProofMode.WandMode.unknown ?m.36 ?m.37
-  [Meta.synthInstance] ❌️ IPM: new goal ProofMode.IntoWand false false Q ProofMode.WandMode.unknown ?m.36
-        ?m.37 => ProofMode.IntoWand false false Q ProofMode.WandMode.unknown ?m.36 ?m.37
+-- `Q` is not a wand, so no `IntoWand` instance applies. This fails immediately instead of looping with
+-- `into_wand_bupd_args` because the mode does not match.
+set_option pp.mvars false in
+/-- [Meta.synthInstance] ❌️ IPM: new goal ProofMode.IntoWand false false Q ProofMode.WandMode.unknown ?_
+        ?_ => ProofMode.IntoWand false false Q ProofMode.WandMode.unknown ?_ ?_
     [Meta.synthInstance.tactics] []
     [Meta.synthInstance.instances] #[]
-  [Meta.synthInstance] result <not-available>
 -/
-#guard_msgs in
+#guard_msgs (substring := true) in
 example [BI PROP] [BIUpdate PROP] (P Q: PROP) : Q ⊢ P -∗ Q := by
   iintro HQ
   set_option trace.Meta.synthInstance true in


### PR DESCRIPTION
## Description

Two of the `rocq_ignore`d `IntoWand'` instances seem necessary for `iapply` under update modalities.
Why were they ignored?

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
