### PR TITLE
fix: make `instMaxNatAdd` a `local` instance

### DIFF
--- a/Iris/Iris/Algebra/Lib/MonoNat.lean
+++ b/Iris/Iris/Algebra/Lib/MonoNat.lean
@@ -18,7 +18,7 @@ section MaxNat
 
 abbrev MaxNat := Nat
 
-scoped instance : Add MaxNat := ⟨max⟩
+local instance : Add MaxNat := ⟨max⟩
 scoped instance : Associative (Add.add (α := MaxNat)) where
   assoc := Nat.max_assoc
 scoped instance : Commutative (Add.add (α := MaxNat)) where


### PR DESCRIPTION
## Description
Makes `instMaxNatAdd` a `local` instance.

Fixes #562.
Alternative to #563.

## Checklist
* [X] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [X] I have added my name to the `authors` section of any appropriate files