### PR TITLE
fix: correct parallel composition syntax and add test for `par`

### DIFF
--- a/Iris/Iris/HeapLang/Lib/Par.lean
+++ b/Iris/Iris/HeapLang/Lib/Par.lean
@@ -31,7 +31,7 @@ def par : Val := hl_val%
 syntax:55 hl_exp:56 " ‖ " hl_exp:55 : hl_exp
 
 macro_rules
-  | `(hl($e1 ‖ $e2)) => `(hl(&par v(λ _, $e1) v(λ _, $e2)))
+  | `(hl($e1 ‖ $e2)) => `(hl(&par (λ _, $e1) (λ _, $e2)))
 
 section Specs
 
@@ -64,7 +64,7 @@ theorem wp_par (Ψ1 Ψ2 : Val → IProp GF) (e1 e2 : Exp) (Φ : Val → IProp GF
     ⊢ WP hl(&e1) {{ Ψ1 }} -∗
       WP hl(&e2) {{ Ψ2 }} -∗
       (∀ (v1 v2 : Val), Ψ1 v1 ∗ Ψ2 v2 -∗ ▷ Φ hl_val((&v1, &v2))) -∗
-      WP hl(&e1 ‖ &e2) {{ Φ }} := by
+      WP hl(&par v(λ _, &e1) v(λ _, &e2)) {{ Φ }} := by
   iintro H1 H2 H
   iapply par_spec Ψ1 Ψ2 $$ [H1] [H2] [$]
   · wp_pures; iexact H1

--- a/Iris/Iris/Tests/HeapLang.lean
+++ b/Iris/Iris/Tests/HeapLang.lean
@@ -5,3 +5,4 @@ public import Iris.Tests.HeapLang.Notation
 public import Iris.Tests.HeapLang.WeakestPre
 public import Iris.Tests.HeapLang.HeapTactics
 public import Iris.Tests.HeapLang.Linter
+public import Iris.Tests.HeapLang.Par

--- a/Iris/Iris/Tests/HeapLang/Par.lean
+++ b/Iris/Iris/Tests/HeapLang/Par.lean
@@ -12,11 +12,18 @@ namespace Iris.Tests.HeapLang.Par
 
 open Iris.HeapLang BI Iris ProgramLogic Spawn Iris.HeapLang.Par
 
+-- Regression test for
+-- https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/Porting.20iris-tutorial/near/613886178
+-- testing substitution into `par`
+section
+-- `l` is deliberately a free HeapLang variable so we can test that substitution works as intended
 set_option linter.heapLang.freeVars false
 
 example (v : Val) :
     Exp.substStr "l" v hl((l ← #21) ‖ (l ← #2))
       = hl(&par (λ _, v(&v) ← #21) (λ _, v(&v) ← #2)) := rfl
+
+end
 
 def par_client : Exp := hl%
   let l1 := ref(#0);

--- a/Iris/Iris/Tests/HeapLang/Par.lean
+++ b/Iris/Iris/Tests/HeapLang/Par.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2026. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Klaus Kraßnitzer
+-/
+module
+
+public import Iris.HeapLang.Lib.Par
+
+@[expose] public section
+namespace Iris.Tests.HeapLang.Par
+
+open Iris.HeapLang BI Iris ProgramLogic Spawn Iris.HeapLang.Par
+
+set_option linter.heapLang.freeVars false
+
+example (v : Val) :
+    Exp.substStr "l" v hl((l ← #21) ‖ (l ← #2))
+      = hl(&par (λ _, v(&v) ← #21) (λ _, v(&v) ← #2)) := rfl
+
+def par_client : Exp := hl%
+  let l1 := ref(#0);
+  let l2 := ref(#0);
+  ((l1 ← #21) ‖ (l2 ← #2));
+  let life := !l1 * !l2;
+  (l1, l2, life)
+
+example {hlc} {GF : BundledGFunctors} [HeapLangGS hlc GF] [SpawnG GF] :
+    ⊢ {{ True }} hl(&par_client)
+      {{ (l1 l2 : Loc) (life : Int), RET hl_val((#l1, #l2, #life));
+         l1 ↦ some hl_val(#21) ∗ l2 ↦ some hl_val(#2) ∗ ⌜life = 42⌝ }} := by
+  iintro %Φ - K
+  unfold par_client
+  wp_alloc l1 with Hl1
+  wp_pures
+  wp_alloc l2 with Hl2
+  wp_pures
+  wp_bind &par _ _
+  iapply wp_par (fun _ => l1 ↦ some hl_val(#21)) (fun _ => l2 ↦ some hl_val(#2))
+    $$ [Hl1] [Hl2] [K]
+  · wp_store; imodintro; iexact Hl1
+  · wp_store; imodintro; iexact Hl2
+  · iintro %r1 %r2 ⟨Hl1, Hl2⟩
+    inext
+    wp_pures
+    wp_load
+    wp_load
+    wp_pures
+    iintro !>
+    iapply K
+    iframe
+    itrivial
+
+end Iris.Tests.HeapLang.Par
+end


### PR DESCRIPTION
## Description
As @suhr pointed out in [this Zulip message](https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/Porting.20iris-tutorial/near/613886178), substitution currently does not descend into `‖` expressions because the notation wraps its thunks in value lambdas.

This PR changes `hl($e1 ‖ $e2)` to use expression lambdas (c.f. [Iris-Rocq’s expression-scope `|||` notation)](https://gitlab.mpi-sws.org/iris/iris/-/blob/master/iris_heap_lang/lib/par.v?ref_type=heads#L13). `wp_par` retains the value-lambda form, matching its `%V` use in Iris-Rocq.

The PR also adds @suhr’s example as a regression test.

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
