### PR TITLE
fix: `@[expose] public section` in FracAuth 

### DIFF
--- a/Iris/Iris/Algebra/Lib/FracAuth.lean
+++ b/Iris/Iris/Algebra/Lib/FracAuth.lean
@@ -19,6 +19,8 @@ fraction) and `◯F{q} a` (fragment with fraction). Splitting works differently 
 - `◯F{q1 + q2} (a1 • a2) = ◯F{q1} a1 • ◯F{q2} a2` (splits the lower bound)
 -/
 
+@[expose] public section
+
 open Iris OFE CMRA UCMRA Auth Option
 
 /-! ## Definitions -/


### PR DESCRIPTION
## Description
Ensures that clients can import and use `FracAuth`. 

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
