### PR TITLE
fix: `AsFractional` synthesis direction and priorities for `AsFractional` instances

### DIFF
--- a/Iris/Iris/BI/Lib/Fractional.lean
+++ b/Iris/Iris/BI/Lib/Fractional.lean
@@ -19,7 +19,9 @@ class Fractional [BI PROP] (Φ : Qp → PROP) where
   fractional p q : Φ (p + q) ⊣⊢ Φ p ∗ Φ q
 
 @[ipm_class, rocq_alias AsFractional]
-class AsFractional {PROP : Type u} [BI PROP] (P : PROP) (Φ : outParam <| Qp → PROP) (q : outParam Qp) where
+class AsFractional {PROP : Type u} [BI PROP] (P : PROP) (ioΦ : InOut)
+    (Φ : semiOutParamIPM ioΦ (Qp → PROP)) (ioq : InOut)
+    (q : semiOutParamIPM ioq Qp) where
   as_fractional : P ⊣⊢ Φ q
   as_fractional_fractional : Fractional Φ
 
@@ -34,48 +36,48 @@ unify against any `IProp`.  -/
 
 @[rocq_alias fractional_as_fractional]
 instance (priority := low) fractional_as_fractional [h : Fractional Φ] (q : Qp) :
-    AsFractional (Φ q) Φ q where
+    AsFractional (Φ q) ioΦ Φ ioq q where
   as_fractional := .rfl
   as_fractional_fractional := h
 
 @[rocq_alias fractional_split]
-theorem fractional_split [hP : AsFractional P Φ (q1 + q2)]
-    [hP1 : AsFractional P1 Φ q1] [hP2 : AsFractional P2 Φ q2] : P ⊣⊢ P1 ∗ P2 :=
+theorem fractional_split [hP : AsFractional P ioΦ Φ ioq (q1 + q2)]
+    [hP1 : AsFractional P1 ioΦ Φ ioq q1] [hP2 : AsFractional P2 ioΦ Φ ioq q2] : P ⊣⊢ P1 ∗ P2 :=
   hP.as_fractional.trans <|
   (hP.as_fractional_fractional.fractional q1 q2).trans <|
   sep_congr hP1.as_fractional.symm hP2.as_fractional.symm
 
 @[rocq_alias fractional_half]
-theorem fractional_half [hP : AsFractional P Φ q] [hP12 : AsFractional P1 Φ q.half] :
+theorem fractional_half [hP : AsFractional P ioΦ Φ ioq q] [hP12 : AsFractional P1 ioΦ Φ ioq q.half] :
     P ⊣⊢ P1 ∗ P1 :=
   hP.as_fractional.trans <|
   (Qp.half_add_half q ▸ hP.as_fractional_fractional.fractional q.half q.half).trans <|
   sep_congr hP12.as_fractional.symm hP12.as_fractional.symm
 
 @[rocq_alias fractional_merge]
-theorem fractional_merge [Fractional Φ] [hP1 : AsFractional P1 Φ q1] [hP2 : AsFractional P2 Φ q2] :
+theorem fractional_merge [Fractional Φ] [hP1 : AsFractional P1 ioΦ Φ ioq q1] [hP2 : AsFractional P2 ioΦ Φ ioq q2] :
     P1 ∗ P2 ⊢ Φ (q1 + q2) :=
   (sep_mono hP1.as_fractional.1 hP2.as_fractional.1).trans (Fractional.fractional q1 q2).2
 
-@[rocq_alias from_sep_fractional]
-instance (priority := default - 10) fromSepFractional [hP : AsFractional P Φ (q1 + q2)] :
+@[ipm_backtrack, rocq_alias from_sep_fractional]
+instance (priority := default - 10) fromSepFractional [hP : AsFractional P .out Φ .in (q1 + q2)] :
     FromSep P (Φ q1) (Φ q2) where
   from_sep := (hP.as_fractional_fractional.fractional q1 q2).2.trans hP.as_fractional.2
 
-@[rocq_alias into_sep_fractional]
-instance (priority := default - 10) intoSepFractional [hP : AsFractional P Φ (q1 + q2)] :
+@[ipm_backtrack, rocq_alias into_sep_fractional]
+instance (priority := default - 10) intoSepFractional [hP : AsFractional P .out Φ .in (q1 + q2)] :
     IntoSep P (Φ q1) (Φ q2) where
   into_sep := hP.as_fractional.1.trans (hP.as_fractional_fractional.fractional q1 q2).1
 
 @[rocq_alias from_sep_fractional_half]
-instance (priority := default - 10) fromSepFractionalHalf [hP : AsFractional P Φ q] :
+instance (priority := default - 30) fromSepFractionalHalf [hP : AsFractional P .out Φ .out q] :
     FromSep P (Φ q.half) (Φ q.half) where
   from_sep :=
     (Qp.half_add_half q ▸ hP.as_fractional_fractional.fractional q.half q.half).2.trans
     hP.as_fractional.2
 
 @[rocq_alias into_sep_fractional_half]
-instance (priority := default - 10) intoSepFractionalHalf [hP : AsFractional P Φ q] :
+instance (priority := default - 30) intoSepFractionalHalf [hP : AsFractional P .out Φ .out q] :
     IntoSep P (Φ q.half) (Φ q.half) where
   into_sep :=
     hP.as_fractional.1.trans

--- a/Iris/Iris/BI/Lib/Fractional.lean
+++ b/Iris/Iris/BI/Lib/Fractional.lean
@@ -14,12 +14,12 @@ public import Iris.ProofMode
 namespace Iris
 open Iris.Std BI OFE ProofMode
 
-@[rocq_alias Fractional]
+@[ipm_class, rocq_alias Fractional]
 class Fractional [BI PROP] (Φ : Qp → PROP) where
   fractional p q : Φ (p + q) ⊣⊢ Φ p ∗ Φ q
 
-@[rocq_alias AsFractional]
-class AsFractional {PROP : Type u} [BI PROP] (P : PROP) (Φ : Qp → PROP) (q : Qp) where
+@[ipm_class, rocq_alias AsFractional]
+class AsFractional {PROP : Type u} [BI PROP] (P : PROP) (Φ : outParam <| Qp → PROP) (q : outParam Qp) where
   as_fractional : P ⊣⊢ Φ q
   as_fractional_fractional : Fractional Φ
 
@@ -57,19 +57,16 @@ theorem fractional_merge [Fractional Φ] [hP1 : AsFractional P1 Φ q1] [hP2 : As
     P1 ∗ P2 ⊢ Φ (q1 + q2) :=
   (sep_mono hP1.as_fractional.1 hP2.as_fractional.1).trans (Fractional.fractional q1 q2).2
 
-set_option synthInstance.checkSynthOrder false in
 @[rocq_alias from_sep_fractional]
 instance (priority := default - 10) fromSepFractional [hP : AsFractional P Φ (q1 + q2)] :
     FromSep P (Φ q1) (Φ q2) where
   from_sep := (hP.as_fractional_fractional.fractional q1 q2).2.trans hP.as_fractional.2
 
-set_option synthInstance.checkSynthOrder false in
 @[rocq_alias into_sep_fractional]
 instance (priority := default - 10) intoSepFractional [hP : AsFractional P Φ (q1 + q2)] :
     IntoSep P (Φ q1) (Φ q2) where
   into_sep := hP.as_fractional.1.trans (hP.as_fractional_fractional.fractional q1 q2).1
 
-set_option synthInstance.checkSynthOrder false in
 @[rocq_alias from_sep_fractional_half]
 instance (priority := default - 10) fromSepFractionalHalf [hP : AsFractional P Φ q] :
     FromSep P (Φ q.half) (Φ q.half) where
@@ -77,7 +74,6 @@ instance (priority := default - 10) fromSepFractionalHalf [hP : AsFractional P �
     (Qp.half_add_half q ▸ hP.as_fractional_fractional.fractional q.half q.half).2.trans
     hP.as_fractional.2
 
-set_option synthInstance.checkSynthOrder false in
 @[rocq_alias into_sep_fractional_half]
 instance (priority := default - 10) intoSepFractionalHalf [hP : AsFractional P Φ q] :
     IntoSep P (Φ q.half) (Φ q.half) where

--- a/Iris/Iris/BI/Lib/Fractional.lean
+++ b/Iris/Iris/BI/Lib/Fractional.lean
@@ -83,6 +83,23 @@ instance (priority := default - 30) intoSepFractionalHalf [hP : AsFractional P .
     hP.as_fractional.1.trans
     (Qp.half_add_half q ▸ hP.as_fractional_fractional.fractional q.half q.half).1
 
+@[ipm_backtrack, rocq_alias combine_sep_as_fractional]
+instance (priority := default - 10) combineSepAsFractional
+    [hP1 : AsFractional P1 .out Φ .out q1] [hP2 : AsFractional P2 .in Φ .out q2] :
+    CombineSepAs P1 P2 (Φ (q1 + q2)) where
+  combine_sep_as :=
+    (sep_mono hP1.as_fractional.mp hP2.as_fractional.mp).trans
+    (hP1.as_fractional_fractional.fractional q1 q2).mpr
+
+@[ipm_backtrack, rocq_alias combine_sep_as_fractional_half]
+instance (priority := default - 10) combineSepAsFractionalHalf
+    [hP : AsFractional P .out Φ .in q.half] :
+    CombineSepAs P P (Φ q) where
+  combine_sep_as := calc
+    _ ⊢ Φ q.half ∗ Φ q.half := sep_mono hP.as_fractional.mp hP.as_fractional.mp
+    _ ⊢ Φ (q.half + q.half) := (hP.as_fractional_fractional.fractional q.half q.half).mpr
+    _ ⊢ Φ q                 := Qp.half_add_half _ ▸ .rfl
+
 end Lemmas
 
 section Divide

--- a/Iris/Iris/BI/Lib/Fractional.lean
+++ b/Iris/Iris/BI/Lib/Fractional.lean
@@ -14,7 +14,7 @@ public import Iris.ProofMode
 namespace Iris
 open Iris.Std BI OFE ProofMode
 
-@[ipm_class, rocq_alias Fractional]
+@[rocq_alias Fractional]
 class Fractional [BI PROP] (Φ : Qp → PROP) where
   fractional p q : Φ (p + q) ⊣⊢ Φ p ∗ Φ q
 

--- a/Iris/Iris/BI/Lib/GenHeap.lean
+++ b/Iris/Iris/BI/Lib/GenHeap.lean
@@ -121,9 +121,9 @@ instance instFractionalPointsTo : Fractional (l ↦{.own ·} v) :=
   inferInstanceAs (Fractional (heapName ↪◯MAP[l]{.own ·} v))
 
 @[rocq_alias pointsto_as_fractional]
-instance instAsFractionalPointsTo : AsFractional (l ↦{.own q} v) (l ↦{.own ·} v) q :=
+instance instAsFractionalPointsTo : AsFractional (l ↦{.own q} v) ioΦ (l ↦{.own ·} v) ioq q :=
   inferInstanceAs
-    (AsFractional (heapName ↪◯MAP[l]{.own q} v) (heapName ↪◯MAP[l]{.own ·} v) q)
+    (AsFractional (heapName ↪◯MAP[l]{.own q} v) ioΦ (heapName ↪◯MAP[l]{.own ·} v) ioq q)
 
 @[rocq_alias pointsto_valid]
 theorem pointsTo_cmraValid : l ↦{dq} v ⊢@{IProp GF} ⌜✓ dq⌝ := by

--- a/Iris/Iris/Instances/Lib/CInvariants.lean
+++ b/Iris/Iris/Instances/Lib/CInvariants.lean
@@ -96,7 +96,7 @@ instance instFractionalOwn (γ : GName) :
 
 @[rocq_alias cinv_own_as_fractional]
 instance instAsFractionalOwn (γ : GName) (q : Qp) :
-    AsFractional (own (GF := GF) γ q) (fun p : Qp => own γ p) q where
+    AsFractional (own (GF := GF) γ q) ioΦ (fun p : Qp => own γ p) ioq q where
   as_fractional := .rfl
   as_fractional_fractional := instFractionalOwn γ
 

--- a/Iris/Iris/Instances/Lib/GhostMap.lean
+++ b/Iris/Iris/Instances/Lib/GhostMap.lean
@@ -85,7 +85,7 @@ instance ghost_map_elem_fractional (γ : GName) (k : K) (v : V) :
 
 @[rocq_alias ghost_map_elem_as_fractional]
 instance (γ : GName) (k : K) (v : V) : AsFractional (PROP := IProp GF) (γ ↪◯MAP[k]{.own q} v)
-    (fun q => γ ↪◯MAP[k]{.own q} v) q where
+    ioΦ (fun q => γ ↪◯MAP[k]{.own q} v) ioq q where
   as_fractional := .rfl
   as_fractional_fractional := ghost_map_elem_fractional γ k v
 
@@ -261,7 +261,7 @@ instance ghost_map_auth_fractional (m : H V) :
 
 @[rocq_alias ghost_map_auth_as_fractional]
 instance (γ : GName) (m : H V) (q : Qp) :
-    AsFractional (PROP := IProp GF) (γ ↪●MAP{.own q} m) (fun q => γ ↪●MAP{.own q} m) q where
+    AsFractional (PROP := IProp GF) (γ ↪●MAP{.own q} m) ioΦ (fun q => γ ↪●MAP{.own q} m) ioq q where
   as_fractional := .rfl
   as_fractional_fractional := ghost_map_auth_fractional m
 

--- a/Iris/Iris/Instances/Lib/SavedProp.lean
+++ b/Iris/Iris/Instances/Lib/SavedProp.lean
@@ -62,7 +62,7 @@ instance saved_anything_fractional (γ : GName) (x : F.ap (IProp GF)) :
 @[rocq_alias saved_anything_as_fractional]
 instance saved_anything_as_fractional (γ : GName) (x : F.ap (IProp GF)) (q : Qp) :
     AsFractional (saved_anything_own γ (.own q) x)
-      (fun q => saved_anything_own γ (.own q) x) q where
+      ioΦ (fun q => saved_anything_own γ (.own q) x) ioq q where
   as_fractional := .rfl
   as_fractional_fractional := saved_anything_fractional γ x
 
@@ -208,7 +208,7 @@ instance saved_prop_fractional (γ : GName) (P : IProp GF) :
 
 @[rocq_alias saved_prop_as_fractional]
 instance saved_prop_as_fractional (γ : GName) (P : IProp GF) (q : Qp) :
-    AsFractional (saved_prop_own γ (.own q) P) (fun q => saved_prop_own γ (.own q) P) q where
+    AsFractional (saved_prop_own γ (.own q) P) ioΦ (fun q => saved_prop_own γ (.own q) P) ioq q where
   as_fractional := .rfl
   as_fractional_fractional := saved_prop_fractional γ P
 
@@ -311,7 +311,7 @@ instance saved_pred_fractional (γ : GName) (Φ : A → IProp GF) :
 
 @[rocq_alias saved_pred_as_fractional]
 instance saved_pred_as_fractional (γ : GName) (Φ : A → IProp GF) (q : Qp) :
-    AsFractional (saved_pred_own γ (.own q) Φ) (fun q => saved_pred_own γ (.own q) Φ) q where
+    AsFractional (saved_pred_own γ (.own q) Φ) ioΦ (fun q => saved_pred_own γ (.own q) Φ) ioq q where
   as_fractional := .rfl
   as_fractional_fractional := saved_pred_fractional γ Φ
 

--- a/Iris/Iris/Tests/HeapLang.lean
+++ b/Iris/Iris/Tests/HeapLang.lean
@@ -6,3 +6,4 @@ public import Iris.Tests.HeapLang.WeakestPre
 public import Iris.Tests.HeapLang.HeapTactics
 public import Iris.Tests.HeapLang.Linter
 public import Iris.Tests.HeapLang.Par
+public import Iris.Tests.HeapLang.Tactics

--- a/Iris/Iris/Tests/HeapLang/Tactics.lean
+++ b/Iris/Iris/Tests/HeapLang/Tactics.lean
@@ -1,0 +1,51 @@
+/-
+Copyright (c) 2026 Alvin Tang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alvin Tang
+-/
+module
+
+public import Iris.ProofMode
+public import Iris.HeapLang
+
+namespace Iris.HeapLang
+
+section Fractional
+
+variable {hlc : HasLC} {GF : BundledGFunctors} [ι : HeapLangGS hlc GF]
+
+/--
+  Tests `icases` with the use of `intoSepFractionalHalf` after backtracking
+  from `intoSepFractional`.
+-/
+example (l : Loc) (v : Val) :
+    l ↦ v ⊢ l ↦{.own (.half 1)} v ∗ l ↦{.own (.half 1)} v := by
+  iintro Hl
+  icases Hl with ⟨H1, H2⟩
+  iframe
+
+/--
+  Tests `icases` with the use of `intoSepFractional`, which has higher
+  priority than `intoSepFractionalHalf`.
+-/
+example (l : Loc) (v : Val) :
+    l ↦{.own (q1 + q2)} v ⊢ l ↦{.own q1} v ∗ l ↦{.own q2} v := by
+  iintro Hl
+  icases Hl with ⟨H1, H2⟩
+  iframe
+
+/-- Tests `icombine` with the use of `combineSepAsFractionalHalf`. -/
+example (l : Loc) (v : Val) :
+    l ↦{.own (.half 1)} v ∗ l ↦{.own (.half 1)} v ⊢ l ↦ v := by
+  iintro ⟨H1, H2⟩
+  icombine H1 H2 as Hl
+  iassumption
+
+/-- Tests `icombine` with the use of `combineSepAsFractional`. -/
+example (l : Loc) (v : Val) :
+    l ↦{.own q1} v ∗ l ↦{.own q2} v ⊢ l ↦{.own (q1 + q2)} v := by
+  iintro ⟨H1, H2⟩
+  icombine H1 H2 as Hl
+  iassumption
+
+end Fractional

--- a/Iris/Iris/Tests/Tactics.lean
+++ b/Iris/Iris/Tests/Tactics.lean
@@ -18,11 +18,12 @@ public import Iris.Instances.Lib.CInvariants
 public import Iris.Instances.Lib.NaInvariants
 public import Iris.ProgramLogic.Language
 public import Iris.ProgramLogic.WeakestPre
+public import Iris.HeapLang
 
 @[expose] public section
 
 namespace Iris.Tests
-open BI CMRA DFrac CancelableInvariant NonAtomicInvariant ProgramLogic
+open BI CMRA DFrac CancelableInvariant NonAtomicInvariant ProgramLogic HeapLang
 
 /- This file contains tests with various scenarios for all available tactics. -/
 
@@ -2276,6 +2277,28 @@ example [BI PROP] (a b c1 c2 c3 : Prop) (P : Prop → Prop) :
   icases Hpure with %⟨⟨rfl, ((hb : a) | ⟨hc, _, -⟩)⟩, @⟨d : Prop, hd⟩⟩
   · ipureintro <;> grind
   · ipureintro <;> grind
+
+variable {hlc : HasLC} {GF : BundledGFunctors} [ι : HeapLangGS hlc GF]
+
+/--
+  Tests `icases` with the use of `intoSepFractionalHalf` after backtracking
+  from `intoSepFractional`.
+-/
+example (l : Loc) (v : Val) :
+    l ↦ v ⊢ l ↦{.own (.half 1)} v ∗ l ↦{.own (.half 1)} v := by
+  iintro Hl
+  icases Hl with ⟨H1, H2⟩
+  iframe
+
+/--
+  Tests `icases` with the use of `intoSepFractional`, which has higher
+  priority than `intoSepFractionalHalf`.
+-/
+example (l : Loc) (v : Val) :
+    l ↦{.own (q1 + q2)} v ⊢ l ↦{.own q1} v ∗ l ↦{.own q2} v := by
+  iintro Hl
+  icases Hl with ⟨H1, H2⟩
+  iframe
 
 end cases
 

--- a/Iris/Iris/Tests/Tactics.lean
+++ b/Iris/Iris/Tests/Tactics.lean
@@ -2277,6 +2277,8 @@ example [BI PROP] (a b c1 c2 c3 : Prop) (P : Prop → Prop) :
   · ipureintro <;> grind
   · ipureintro <;> grind
 
+end cases
+
 section imodintro
 
 /-- Tests `imodintro` for absorbing (intuitionistic: id, spatial: id) -/
@@ -3363,6 +3365,8 @@ example [BI PROP] {P Q R : PROP} [CombineSepGives P Q R] :
     ⊢ <absorb> <affine> P -∗ <absorb> <affine> Q -∗ <absorb> <affine> (P ∗ Q) ∗ <pers> R := by
   iintro HP HQ
   icombine HP HQ as ⟨HNew1, _⟩ gives HNew2
+
+end icombine
 
 section iloeb
 

--- a/Iris/Iris/Tests/Tactics.lean
+++ b/Iris/Iris/Tests/Tactics.lean
@@ -18,12 +18,11 @@ public import Iris.Instances.Lib.CInvariants
 public import Iris.Instances.Lib.NaInvariants
 public import Iris.ProgramLogic.Language
 public import Iris.ProgramLogic.WeakestPre
-public import Iris.HeapLang
 
 @[expose] public section
 
 namespace Iris.Tests
-open BI CMRA DFrac CancelableInvariant NonAtomicInvariant ProgramLogic HeapLang
+open BI CMRA DFrac CancelableInvariant NonAtomicInvariant ProgramLogic
 
 /- This file contains tests with various scenarios for all available tactics. -/
 
@@ -2278,30 +2277,6 @@ example [BI PROP] (a b c1 c2 c3 : Prop) (P : Prop → Prop) :
   · ipureintro <;> grind
   · ipureintro <;> grind
 
-variable {hlc : HasLC} {GF : BundledGFunctors} [ι : HeapLangGS hlc GF]
-
-/--
-  Tests `icases` with the use of `intoSepFractionalHalf` after backtracking
-  from `intoSepFractional`.
--/
-example (l : Loc) (v : Val) :
-    l ↦ v ⊢ l ↦{.own (.half 1)} v ∗ l ↦{.own (.half 1)} v := by
-  iintro Hl
-  icases Hl with ⟨H1, H2⟩
-  iframe
-
-/--
-  Tests `icases` with the use of `intoSepFractional`, which has higher
-  priority than `intoSepFractionalHalf`.
--/
-example (l : Loc) (v : Val) :
-    l ↦{.own (q1 + q2)} v ⊢ l ↦{.own q1} v ∗ l ↦{.own q2} v := by
-  iintro Hl
-  icases Hl with ⟨H1, H2⟩
-  iframe
-
-end cases
-
 section imodintro
 
 /-- Tests `imodintro` for absorbing (intuitionistic: id, spatial: id) -/
@@ -3388,24 +3363,6 @@ example [BI PROP] {P Q R : PROP} [CombineSepGives P Q R] :
     ⊢ <absorb> <affine> P -∗ <absorb> <affine> Q -∗ <absorb> <affine> (P ∗ Q) ∗ <pers> R := by
   iintro HP HQ
   icombine HP HQ as ⟨HNew1, _⟩ gives HNew2
-
-variable {hlc : HasLC} {GF : BundledGFunctors} [ι : HeapLangGS hlc GF]
-
-/-- Tests `icombine` with the use of `combineSepAsFractionalHalf`. -/
-example (l : Loc) (v : Val) :
-    l ↦{.own (.half 1)} v ∗ l ↦{.own (.half 1)} v ⊢ l ↦ v := by
-  iintro ⟨H1, H2⟩
-  icombine H1 H2 as Hl
-  iassumption
-
-/-- Tests `icombine` with the use of `combineSepAsFractional`. -/
-example (l : Loc) (v : Val) :
-    l ↦{.own q1} v ∗ l ↦{.own q2} v ⊢ l ↦{.own (q1 + q2)} v := by
-  iintro ⟨H1, H2⟩
-  icombine H1 H2 as Hl
-  iassumption
-
-end icombine
 
 section iloeb
 

--- a/Iris/Iris/Tests/Tactics.lean
+++ b/Iris/Iris/Tests/Tactics.lean
@@ -3389,6 +3389,22 @@ example [BI PROP] {P Q R : PROP} [CombineSepGives P Q R] :
   iintro HP HQ
   icombine HP HQ as ⟨HNew1, _⟩ gives HNew2
 
+variable {hlc : HasLC} {GF : BundledGFunctors} [ι : HeapLangGS hlc GF]
+
+/-- Tests `icombine` with the use of `combineSepAsFractionalHalf`. -/
+example (l : Loc) (v : Val) :
+    l ↦{.own (.half 1)} v ∗ l ↦{.own (.half 1)} v ⊢ l ↦ v := by
+  iintro ⟨H1, H2⟩
+  icombine H1 H2 as Hl
+  iassumption
+
+/-- Tests `icombine` with the use of `combineSepAsFractional`. -/
+example (l : Loc) (v : Val) :
+    l ↦{.own q1} v ∗ l ↦{.own q2} v ⊢ l ↦{.own (q1 + q2)} v := by
+  iintro ⟨H1, H2⟩
+  icombine H1 H2 as Hl
+  iassumption
+
 end icombine
 
 section iloeb


### PR DESCRIPTION
## Description

Addresses the bugs noted in the discussion thread [#iris-lean > Porting iris-tutorial @ 💬](https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/Porting.20iris-tutorial/near/615060705).

Consider the following example.

```lean4
variable [ι : HeapLangGS hlc GF]

example (l : Loc) (v : Val) :
    l ↦ v ⊢ l ↦{.own (.half 1)} v ∗ l ↦{.own (.half 1)} v := by
  iintro Hl
  icases Hl with ⟨H1, H2⟩
  iframe
```

The line `icases Hl with ⟨H1, H2⟩` throws an error about being unable to split `l ↦ v` into halves. This is due to `Φ` and `q` not being set as output parameters of the type class `AsFractional`.

Upon fixing this bug, we get the following proof state as expected:

```
∗H1 : l ↦{DFrac.own (Qp.half 1)} some v
∗H2 : l ↦{DFrac.own (Qp.half 1)} some v
⊢ l ↦{DFrac.own (Qp.half 1)} some v ∗ l ↦{DFrac.own (Qp.half 1)} some v
```

Also, the instances are set with incorrect priorities. Consider the following example:

```lean4
example (l : Loc) (v : Val) :
    l ↦{.own (q1 + q2)} v ⊢ l ↦{.own q1} v ∗ l ↦{.own q2} v := by
  iintro Hl
  icases Hl with ⟨H1, H2⟩
  iframe
```

Currently, the use of `icases Hl with ⟨H1, H2⟩` incorrectly gives the following proof state:

```
∗H1 : l ↦{DFrac.own (q1 + q2).half} some v
∗H2 : l ↦{DFrac.own (q1 + q2).half} some v
⊢ l ↦{DFrac.own q1} some v ∗ l ↦{DFrac.own q2} some v
```

We expect:

```
∗H1 : l ↦{DFrac.own q1} some v
∗H2 : l ↦{DFrac.own q2} some v
⊢ l ↦{DFrac.own q1} some v ∗ l ↦{DFrac.own q2} some v
```

The instances `fromSepFractional` and `intoSepFractional` should have higher priorities than `fromSepFractionalHalf` and `intoSepFractionalHalf`, respectively. Backtracking should be enabled for the former two instances.

For `fromSepFractional` and `intoSepFractional`, it is worth noting that the parameter `p` is an *input* parameter for `AsFractional`, as `q1 + q2` is already known. On the contrary, `p` is an *output* parameter for `fromSepFractionalHalf` and `intoSepFractionalHalf` as `(q1 + q2).half` obtained during the synthesis. Therefore, it is defined as a *semi-output* parameter of the type class.

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files
