### PR TITLE
feat: finish reservation map

### DIFF
--- a/Iris/Iris/Algebra/DynReservationMap.lean
+++ b/Iris/Iris/Algebra/DynReservationMap.lean
@@ -205,8 +205,9 @@ theorem valid_infinite {x : DynReservationMap A H} (h : x.Valid) :
 theorem valid_disj {x : DynReservationMap A H} (h : x.Valid) (i : Pos) :
     get? x.data i = none ∨ i ∉ x.token := (valid_iff.mp h).right.right.right i
 
-@[rocq_alias dyn_reservation_map_pcore_instance]
 def core (x : DynReservationMap A H) : DynReservationMap A H := mk (CMRA.core x.data) ∅
+
+#rocq_ignore dyn_reservation_map_pcore_instance "Use CMRA core instead"
 
 @[simp]
 theorem core_data (x : DynReservationMap A H) : x.core.data = CMRA.core x.data := rfl
@@ -242,7 +243,7 @@ theorem infinite_op_left {x y : DynReservationMap A H} (vt : ✓{n} (x.token •
 #rocq_ignore dyn_reservation_map_cmra_mixin "Not needed"
 #rocq_ignore dyn_reservation_map_ucmra_mixin "Not needed"
 #rocq_ignore dyn_reservation_mapR "Derivable using UCMRA"
-#rocq_ignore dyn_reservation_map_empty_instance "Part of UCMRA instance (unit field)"
+#rocq_ignore dyn_reservation_map_empty_instance "Part of UCMRA instance"
 
 @[rocq_alias dyn_reservation_mapUR]
 instance instUCMRADynReservationMap : UCMRA (DynReservationMap A H) where

--- a/Iris/Iris/Algebra/DynReservationMap.lean
+++ b/Iris/Iris/Algebra/DynReservationMap.lean
@@ -55,6 +55,8 @@ open OFE
 variable [LawfulPartialMap H Pos] [OFE A]
 
 #rocq_ignore dyn_reservation_map_ofe_mixin "Not needed"
+#rocq_ignore dyn_reservation_map_equiv "Part of OFE instance"
+#rocq_ignore dyn_reservation_map_dist "Part of OFE instance"
 
 @[rocq_alias dyn_reservation_mapO]
 instance : OFE (DynReservationMap A H) where
@@ -77,6 +79,18 @@ instance instDiscreteDynReservationMap [Discrete A] : Discrete (DynReservationMa
     intro n
     exact ⟨(discrete_0 h.left).dist, (discrete_0 h.right).dist⟩
 
+@[rocq_alias DynReservationMap_ne]
+instance instNonExpansive₂DynReservationMapMk :
+    NonExpansive₂ (DynReservationMap.mk (H := H) (A := A)) where
+  ne _ _ _ hd _ _ ht := ⟨hd, ht⟩
+
+@[rocq_alias dyn_reservation_map_data_proj_ne]
+instance instNonExpansiveDynReservationMapDataProj :
+    NonExpansive (DynReservationMap.data (H := H) (A := A)) where
+  ne _ _ _ h := h.left
+
+#rocq_ignore DynReservationMap_proper "Derivable using NonExpansive.eqv"
+#rocq_ignore dyn_reservation_map_data_proj_proper "Derivable using NonExpansive.eqv"
 #rocq_ignore dyn_reservation_map_data_proper "Derivable using NonExpansive.eqv"
 
 @[rocq_alias dyn_reservation_map_data_ne]
@@ -113,15 +127,20 @@ section
 
 variable [LawfulPartialMap H Pos] [CMRA A]
 
+@[rocq_alias dyn_reservation_map_validN_instance]
 def ValidN (n : Nat) (x : DynReservationMap A H) : Prop :=
   match x.token with
   | .valid e => ✓{n} x.data ∧ setInfinite (⊤ \ e) ∧ ∀ i, get? x.data i = none ∨ i ∉ e
   | .error => False
 
+@[rocq_alias dyn_reservation_map_valid_instance]
 def Valid (x : DynReservationMap A H) : Prop :=
   match x.token with
   | .valid e => ✓ x.data ∧ setInfinite (⊤ \ e) ∧ ∀ i, get? x.data i = none ∨ i ∉ e
   | .error => False
+
+#rocq_ignore dyn_reservation_map_valid_eq "Definitional unfolding of Valid"
+#rocq_ignore dyn_reservation_map_validN_eq "Definitional unfolding of ValidN"
 
 /-- The complement of the token's mask `e` is infinite, i.e. there are always infinitely many keys
 still available to reserve. This is a validity requirement of `DynReservationMap`. -/
@@ -186,6 +205,7 @@ theorem valid_infinite {x : DynReservationMap A H} (h : x.Valid) :
 theorem valid_disj {x : DynReservationMap A H} (h : x.Valid) (i : Pos) :
     get? x.data i = none ∨ i ∉ x.token := (valid_iff.mp h).right.right.right i
 
+@[rocq_alias dyn_reservation_map_pcore_instance]
 def core (x : DynReservationMap A H) : DynReservationMap A H := mk (CMRA.core x.data) ∅
 
 @[simp]
@@ -194,6 +214,7 @@ theorem core_data (x : DynReservationMap A H) : x.core.data = CMRA.core x.data :
 @[simp]
 theorem core_token (x : DynReservationMap A H) : x.core.token = CMRA.core x.token := rfl
 
+@[rocq_alias dyn_reservation_map_op_instance]
 def op (x y : DynReservationMap A H) : DynReservationMap A H :=
   mk (x.data • y.data) (x.token • y.token)
 
@@ -221,6 +242,7 @@ theorem infinite_op_left {x y : DynReservationMap A H} (vt : ✓{n} (x.token •
 #rocq_ignore dyn_reservation_map_cmra_mixin "Not needed"
 #rocq_ignore dyn_reservation_map_ucmra_mixin "Not needed"
 #rocq_ignore dyn_reservation_mapR "Derivable using UCMRA"
+#rocq_ignore dyn_reservation_map_empty_instance "Part of UCMRA instance (unit field)"
 
 @[rocq_alias dyn_reservation_mapUR]
 instance instUCMRADynReservationMap : UCMRA (DynReservationMap A H) where

--- a/Iris/Iris/Algebra/ReservationMap.lean
+++ b/Iris/Iris/Algebra/ReservationMap.lean
@@ -308,13 +308,10 @@ theorem op_token (x y : ReservationMap A H): (x • y).token = x.token • y.tok
 theorem included_iff {x y : ReservationMap A H} :
     x ≼ y ↔ x.data ≼ y.data ∧ x.token ≼ y.token := by
   constructor
-  · rintro ⟨z, rfl⟩
-    exact ⟨⟨z.data, rfl⟩, ⟨z.token, rfl⟩⟩
-  · rintro ⟨⟨z₁, hz₁⟩, ⟨z₂, hz₂⟩⟩
-    refine ⟨mk z₁ z₂, ?_⟩
-    obtain ⟨yd, yt⟩ := y
-    subst hz₁ hz₂
-    rfl
+  · exact fun ⟨z, H⟩ => ⟨⟨z.data, H ▸ rfl⟩, ⟨z.token, H ▸ rfl⟩⟩
+  · obtain ⟨yd, yt⟩ := y
+    rintro ⟨⟨z₁, rfl⟩, ⟨z₂, rfl⟩⟩
+    exact ⟨mk z₁ z₂, rfl⟩
 
 @[rocq_alias reservation_map_cmra_discrete]
 instance [CMRA.Discrete A] : CMRA.Discrete (ReservationMap A H) where
@@ -324,7 +321,7 @@ instance [CMRA.Discrete A] : CMRA.Discrete (ReservationMap A H) where
     · exact validN_token_of_validN v
     · exact validN_disj v
 
-#rocq_ignore reservation_map_empty_instance "Part of UCMRA instance (unit field)"
+#rocq_ignore reservation_map_empty_instance "Part of UCMRA instance"
 
 @[rocq_alias reservation_map_data_core_id]
 instance instCoreIdSingleton {a : A} [CoreId a] : CoreId (singleton (H := H) k a) where

--- a/Iris/Iris/Algebra/ReservationMap.lean
+++ b/Iris/Iris/Algebra/ReservationMap.lean
@@ -59,6 +59,8 @@ open OFE
 variable [LawfulPartialMap H Pos] [OFE A]
 
 #rocq_ignore reservation_map_ofe_mixin "Not needed"
+#rocq_ignore reservation_map_equiv "Part of OFE instance"
+#rocq_ignore reservation_map_dist "Part of OFE instance"
 
 @[rocq_alias reservation_mapO]
 instance : OFE (ReservationMap A H) where
@@ -84,6 +86,19 @@ instance instDiscreteReservationMap [Discrete A] : Discrete (ReservationMap A H)
 instance instNonExpansiveReservationMapData :
     NonExpansive (ReservationMap.mkData (H := H) (A := A)) where
   ne _ _ _ h := ⟨h, rfl⟩
+
+@[rocq_alias ReservationMap_ne]
+instance instNonExpansive₂ReservationMapMk :
+    NonExpansive₂ (ReservationMap.mk (H := H) (A := A)) where
+  ne _ _ _ hd _ _ ht := ⟨hd, ht⟩
+
+@[rocq_alias reservation_map_data_proj_ne]
+instance instNonExpansiveReservationMapDataProj :
+    NonExpansive (ReservationMap.data (H := H) (A := A)) where
+  ne _ _ _ h := h.left
+
+#rocq_ignore ReservationMap_proper "Derivable using NonExpansive.eqv"
+#rocq_ignore reservation_map_data_proj_proper "Derivable using NonExpansive.eqv"
 
 #rocq_ignore reservation_map_data_proper "Derivable using NonExpansive.eqv"
 
@@ -119,15 +134,20 @@ namespace ReservationMap
 
 variable [LawfulPartialMap H Pos] [CMRA A]
 
+@[rocq_alias reservation_map_validN_instance]
 def ValidN (n : Nat) (x : ReservationMap A H) : Prop :=
   match x.token with
   | .valid e => ✓{n} x.data ∧ ∀i, get? x.data i = none ∨ i ∉ e
   | .error => False
 
+@[rocq_alias reservation_map_valid_instance]
 def Valid (x : ReservationMap A H) : Prop :=
   match x.token with
   | .valid e => ✓ x.data ∧ ∀i, get? x.data i = none ∨ i ∉ e
   | .error => False
+
+#rocq_ignore reservation_map_valid_eq "Definitional unfolding of Valid"
+#rocq_ignore reservation_map_validN_eq "Definitional unfolding of ValidN"
 
 theorem validN_iff {n : Nat} {x : ReservationMap A H} :
     x.ValidN n ↔ ✓{n} x.data ∧ ✓{n} x.token ∧ ∀ i, get? x.data i = none ∨ i ∉ x.token := by
@@ -155,9 +175,11 @@ theorem valid_iff {x : ReservationMap A H} :
       exact ⟨vd, disj⟩
     · exact ((h ▸ not_valid_invalid (S := CoPset)) vt)
 
+@[rocq_alias reservation_map_data_proj_validN]
 theorem validN_data_of_validN {n : Nat} {x : ReservationMap A H} (h : x.ValidN n) :
     ✓{n} x.data := (validN_iff.mp h).left
 
+@[rocq_alias reservation_map_token_proj_validN]
 theorem validN_token_of_validN {n : Nat} {x : ReservationMap A H} (h : x.ValidN n) :
     ✓{n} x.token := (validN_iff.mp h).right.left
 
@@ -173,6 +195,7 @@ theorem valid_token_of_valid {x : ReservationMap A H} (h : x.Valid) :
 theorem valid_disj {x : ReservationMap A H} (h : x.Valid) (i : Pos):
     get? x.data i = none ∨ i ∉ x.token := (valid_iff.mp h).right.right i
 
+@[rocq_alias reservation_map_pcore_instance]
 def core (x : ReservationMap A H) : ReservationMap A H := mk (CMRA.core x.data) ∅
 
 @[simp]
@@ -181,6 +204,7 @@ theorem core_data (x : ReservationMap A H) : x.core.data = CMRA.core x.data := r
 @[simp]
 theorem core_token (x : ReservationMap A H) : x.core.token = CMRA.core x.token := rfl
 
+@[rocq_alias reservation_map_op_instance]
 def op (x y : ReservationMap A H) : ReservationMap A H := mk (x.data • y.data) (x.token • y.token)
 
 @[simp]
@@ -280,6 +304,18 @@ theorem op_data (x y : ReservationMap A H): (x • y).data = x.data • y.data :
 @[simp]
 theorem op_token (x y : ReservationMap A H): (x • y).token = x.token • y.token := rfl
 
+@[rocq_alias reservation_map_included]
+theorem included_iff {x y : ReservationMap A H} :
+    x ≼ y ↔ x.data ≼ y.data ∧ x.token ≼ y.token := by
+  constructor
+  · rintro ⟨z, rfl⟩
+    exact ⟨⟨z.data, rfl⟩, ⟨z.token, rfl⟩⟩
+  · rintro ⟨⟨z₁, hz₁⟩, ⟨z₂, hz₂⟩⟩
+    refine ⟨mk z₁ z₂, ?_⟩
+    obtain ⟨yd, yt⟩ := y
+    subst hz₁ hz₂
+    rfl
+
 @[rocq_alias reservation_map_cmra_discrete]
 instance [CMRA.Discrete A] : CMRA.Discrete (ReservationMap A H) where
   discrete_valid {_} v := by
@@ -288,6 +324,9 @@ instance [CMRA.Discrete A] : CMRA.Discrete (ReservationMap A H) where
     · exact validN_token_of_validN v
     · exact validN_disj v
 
+#rocq_ignore reservation_map_empty_instance "Part of UCMRA instance (unit field)"
+
+@[rocq_alias reservation_map_data_core_id]
 instance instCoreIdSingleton {a : A} [CoreId a] : CoreId (singleton (H := H) k a) where
   core_id := OFE.eq_dist.mpr <| by
     refine fun n => OFE.some_dist_some.mpr ⟨?_, .rfl⟩


### PR DESCRIPTION
## Description
Brings `reservation_map.v` and `dyn_reservation_map.v` to 100%

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
