### PR TITLE
feat: Bring Several more Algebra files to 100% 

### DIFF
--- a/Iris/Iris/Algebra/Agree.lean
+++ b/Iris/Iris/Algebra/Agree.lean
@@ -35,6 +35,8 @@ structure Agree.Raw α where
   not_nil : car ≠ []
 attribute [simp] Agree.Raw.not_nil
 
+#rocq_ignore agree_eq "Use Agree.Raw.ext"
+
 namespace Agree.Raw
 
 def toAgree (a : α) : Raw α := ⟨[a], by simp⟩
@@ -471,8 +473,8 @@ theorem idemp {x : Agree α} : x • x = x := op_idemp
 
 #rocq_ignore agree_validN_proper "Derivable from Agree.validN_ne using NonExpansive.eqv"
 #rocq_ignore agree_op_proper "Derivable from Agree.op_ne₂ using NonExpansive₂.eqv"
-#rocq_ignore to_agree_op_inv "Use the general op_invN theorem."
-#rocq_ignore to_agree_op_invN "Use the general op_inv theorem."
+#rocq_ignore to_agree_op_invN "Use the general Agree.op_invN theorem"
+#rocq_ignore to_agree_op_inv "Use the general Agree.op_inv theorem"
 
 @[rocq_alias agree_cmra_discrete]
 instance instCMRADiscrete [OFE.Discrete α] : CMRA.Discrete (Agree α) where

--- a/Iris/Iris/Algebra/Auth.lean
+++ b/Iris/Iris/Algebra/Auth.lean
@@ -186,14 +186,32 @@ instance {a b1 b2 : A} [h : IsOp d a b1 b2] :
     IsOp d (◯ a : Auth A) (◯ b1) (◯ b2) where
   is_op := (congrArg frag h.is_op).trans frag_op
 
--- TODO: auth_frag_sep_homomorphism
+#rocq_ignore auth_frag_sep_homomorphism "Found by typeclass inference from the View.Frag instance"
 
-/- TODO: BigOPs
-    big_opL_auth_frag
-    big_opM_auth_frag
-    big_opS_auth_frag
-    big_opMS_auth_frag
--/
+section BigOp
+open Algebra Std
+
+@[rocq_alias big_opL_auth_frag]
+theorem bigOpL_frag (g : Nat → C → A) (l : List C) :
+    (◯ ([^ CMRA.op list] k ↦ x ∈ l, g k x) : Auth A) = [^ CMRA.op list] k ↦ x ∈ l, ◯ (g k x) :=
+  View.bigOpL_frag _ _
+
+@[rocq_alias big_opM_auth_frag]
+theorem bigOpM_frag [LawfulFiniteMap M' K] (g : K → C → A) (m : M' C) :
+    (◯ ([^ CMRA.op map] k ↦ x ∈ m, g k x) : Auth A) = [^ CMRA.op map] k ↦ x ∈ m, ◯ (g k x) :=
+  View.bigOpM_frag _ _
+
+@[rocq_alias big_opS_auth_frag]
+theorem bigOpS_frag [LawfulFiniteSet S' C] (g : C → A) (X : S') :
+    (◯ ([^ CMRA.op set] x ∈ X, g x) : Auth A) = [^ CMRA.op set] x ∈ X, ◯ (g x) :=
+  View.bigOpS_frag _ _
+
+@[rocq_alias big_opMS_auth_frag]
+theorem bigOpMS_frag [LawfulFiniteMultiSet MS' C] (g : C → A) (X : MS') :
+    (◯ ([^ CMRA.op mset] x ∈ X, g x) : Auth A) = [^ CMRA.op mset] x ∈ X, ◯ (g x) :=
+  View.bigOpMS_frag _ _
+
+end BigOp
 
 /-! ## Validity -/
 

--- a/Iris/Iris/Algebra/COFESolver.lean
+++ b/Iris/Iris/Algebra/COFESolver.lean
@@ -10,7 +10,7 @@ meta import Iris.Std.RocqPorting
 
 @[expose] public section
 
-#rocq_ignore solution "Use OFE.iso + Inhabited + COFE."
+#rocq_ignore solution "Use OFE.iso + Inhabited + COFE"
 
 namespace Iris.COFE.OFunctor
 open OFE
@@ -47,7 +47,7 @@ variable (F) in
 def up (k : Nat) : A F k -n> A F (k+1) := (updown F k).1
 
 variable (F) in
--- rocq_alias solver.g
+@[rocq_alias solver.g]
 def down (k : Nat) : A F (k+1) -n> A F k := (updown F k).2
 
 #rocq_ignore solver.f_S "Not needed"
@@ -168,6 +168,8 @@ def embed : A F k -n> A F i :=
 #rocq_ignore solver.coerce_id "Not needed"
 #rocq_ignore solver.coerce_proper "Inlined in embed"
 #rocq_ignore solver.embed_ne "Implicit in embed"
+#rocq_ignore solver.gg_gg "Inlined in Tower.embed"
+#rocq_ignore solver.ff_ff "Inlined in Tower.embed_up"
 
 @[rocq_alias solver.embed]
 protected def Tower.embed (k) : A F k -n> Tower F := by
@@ -197,6 +199,9 @@ protected def Tower.embed (k) : A F k -n> Tower F := by
       dsimp [downN, Hom.comp]
       rw [down_eqToHom (Nat.add_right_comm i a 1)]
       apply ih
+
+#rocq_ignore solver.embed' "Lean's Tower.embed is already a bundled non-expansive map"
+#rocq_ignore solver.g_embed_coerce "Inlined in Tower.embed, as its well-definedness obligation"
 
 @[rocq_alias solver.embed_f]
 theorem Tower.embed_up (x : A F k) :

--- a/Iris/Iris/Algebra/Csum.lean
+++ b/Iris/Iris/Algebra/Csum.lean
@@ -20,6 +20,9 @@ inductive Csum (α β : Type _) where
   | inr : β → Csum α β
   | invalid : Csum α β
 
+#rocq_ignore maybe_Cinl "std++ `Maybe` class; pattern match instead"
+#rocq_ignore maybe_Cinr "std++ `Maybe` class; pattern match instead"
+
 open Csum OFE CMRA
 
 namespace Csum
@@ -88,6 +91,8 @@ instance [OFE α] [OFE β] [OFE.Discrete α] [OFE.Discrete β] : OFE.Discrete (C
       | exact congrArg inl (discrete_0 (α := α) h)
       | exact congrArg inr (discrete_0 (α := β) h)
       | exact h.elim | trivial
+
+#rocq_ignore csum_leibniz "Not needed"
 
 @[rocq_alias Cinl_discrete]
 instance [OFE α] [OFE β] {a : α} [DiscreteE a] : DiscreteE (inl (β := β) a) where

--- a/Iris/Iris/Algebra/DFrac.lean
+++ b/Iris/Iris/Algebra/DFrac.lean
@@ -44,8 +44,6 @@ open DFrac OFE.Discrete IsOp
 @[rocq_alias dfrac_inhabited]
 instance : Inhabited DFrac := ⟨discard⟩
 
-#rocq_ignore dfrac_countable "std++ `Countable`; Lean has no `Pos.Countable Qp` and does not need one"
-
 def valid : DFrac → Prop
   | .own f        => f.val ≤ 1
   | .discard      => True

--- a/Iris/Iris/Algebra/DFrac.lean
+++ b/Iris/Iris/Algebra/DFrac.lean
@@ -26,6 +26,9 @@ inductive DFrac where
 | discard : DFrac
 /-- Ownership of `F` plus knowledge that a fraction has been discarded. -/
 | ownDiscard (f : Qp) : DFrac
+deriving DecidableEq
+
+attribute [rocq_alias dfrac_eq_dec] instDecidableEqDFrac
 
 #rocq_ignore DfracOwn_inj "Not needed"
 #rocq_ignore DfracBoth_inj "Not needed"
@@ -40,6 +43,8 @@ open DFrac OFE.Discrete IsOp
 
 @[rocq_alias dfrac_inhabited]
 instance : Inhabited DFrac := ⟨discard⟩
+
+#rocq_ignore dfrac_countable "std++ `Countable`; Lean has no `Pos.Countable Qp` and does not need one"
 
 def valid : DFrac → Prop
   | .own f        => f.val ≤ 1

--- a/Iris/Iris/Algebra/Excl.lean
+++ b/Iris/Iris/Algebra/Excl.lean
@@ -19,6 +19,8 @@ inductive Excl α where
   | excl : α → Excl α
   | invalid : Excl α
 
+#rocq_ignore maybe_Excl "std++ `Maybe` class; pattern match instead"
+
 namespace Excl
 open OFE
 

--- a/Iris/Iris/Algebra/HeapView.lean
+++ b/Iris/Iris/Algebra/HeapView.lean
@@ -592,7 +592,6 @@ theorem update_big_delete (m m' : H V) :
   | hemp =>
     suffices h : (m \ ∅ : H V) = m by
       rw [bigOpM_frag_empty, CMRA.unit_right_id, h]
-      exact Update.id
     exact eqv_of_Equiv fun j => by simp [get?_difference, get?_empty]
   | hins k v m2 Hm2 IH =>
     suffices h : (m \ Std.insert m2 k v) = delete (m \ m2) k by
@@ -671,8 +670,6 @@ theorem update_big_alloc (m1 m2 : H V) dq
       rw [← CMRA.assoc]
       refine Update.op ?_ ?_
       · rw [← union_insert_left]
-        exact Update.id
       · rw [BigOpM.bigOpM_insert_eq _ _ Hm2]
-        exact Update.id
 
 end FiniteHeapView

--- a/Iris/Iris/Algebra/LeibnizSet.lean
+++ b/Iris/Iris/Algebra/LeibnizSet.lean
@@ -5,6 +5,7 @@ Authors: Sergei Stepanenko, Zongyuan Liu
 -/
 module
 
+public import Iris.Algebra.BigOp
 public import Iris.Algebra.CMRA
 public import Iris.Algebra.OFE
 public import Iris.Algebra.LocalUpdates
@@ -28,6 +29,16 @@ open Iris Std CMRA OFE LawfulSet
 inductive DisjointLeibnizSet (S : Type _) where
   | valid : S → DisjointLeibnizSet S
   | error : DisjointLeibnizSet S
+
+#rocq_ignore GSet_inj "Use the constructor injectivity lemma DisjointLeibnizSet.valid.inj"
+
+#rocq_ignore set_unfold_gset_eq "std++ `SetUnfold` instance for `set_solver`; no counterpart in Lean"
+#rocq_ignore set_unfold_gset_included
+  "std++ `SetUnfold` instance for `set_solver`; use LeibnizSet.included_iff_subset"
+#rocq_ignore set_unfold_gset_disj_included
+  "std++ `SetUnfold` instance for `set_solver`; use DisjointLeibnizSet.included_iff_subset"
+#rocq_ignore set_unfold_gset_disj_valid_op
+  "std++ `SetUnfold` instance for `set_solver`; use DisjointLeibnizSet.valid_op_iff_disj"
 
 instance : COFE (DisjointLeibnizSet S) := COFE.ofDiscrete _
 
@@ -378,6 +389,20 @@ theorem localUpdate (X Y X' : S) (H : X ⊆ X') :
     simp only [op?, op] at e ⊢
     have hZ : Z ⊆ X' := subset_trans union_subset_right (valid.inj e ▸ H)
     rw [union_comm, union_subset_absorption hZ]
+
+end LeibnizSet
+
+namespace LeibnizSet
+open Algebra
+
+variable {S : Type _} [LawfulFiniteSet S A]
+
+@[rocq_alias big_opS_singletons]
+theorem bigOpS_singletons (X : S) :
+    ([^ CMRA.op set] x ∈ X, (valid {x} : LeibnizSet S)) = .valid X := by
+  induction X using FiniteSet.set_ind with
+  | hemp => exact BigOpS.bigOpS_empty
+  | hadd x X hx ih => rw [insert_union, BigOpS.bigOpS_insert hx, ih, op_union]
 
 end LeibnizSet
 

--- a/Iris/Iris/Algebra/Lib/DFracAgree.lean
+++ b/Iris/Iris/Algebra/Lib/DFracAgree.lean
@@ -175,6 +175,8 @@ end Frac
 abbrev DFracAgreeRF (T : COFE.OFunctorPre) [COFE.OFunctor T] : COFE.OFunctorPre :=
   ProdOF (constOF DFrac) (AgreeRF T)
 
+#rocq_ignore dfrac_agreeRF_contractive "Found by typeclass inference"
+
 end DFracAgree
 
 end Iris

--- a/Iris/Iris/Algebra/Lib/ExclAuth.lean
+++ b/Iris/Iris/Algebra/Lib/ExclAuth.lean
@@ -110,9 +110,13 @@ theorem update {a b a' : A} : ((●E a) • ◯E b) ~~> ((●E a') • ◯E a') 
 abbrev ExclAuthURF (T : COFE.OFunctorPre) [URFunctor T] : COFE.OFunctorPre :=
   AuthURF (OptionOF (ExclOF T))
 
+#rocq_ignore excl_authURF_contractive "Found by typeclass inference"
+
 @[rocq_alias excl_authRF]
 abbrev ExclAuthRF (T : COFE.OFunctorPre) [URFunctor T] : COFE.OFunctorPre :=
   AuthRF (OptionOF (ExclOF T))
+
+#rocq_ignore excl_authRF_contractive "Found by typeclass inference"
 
 end ExclAuth
 end Iris

--- a/Iris/Iris/Algebra/Lib/ExclAuth.lean
+++ b/Iris/Iris/Algebra/Lib/ExclAuth.lean
@@ -107,13 +107,13 @@ theorem update {a b a' : A} : ((●E a) • ◯E b) ~~> ((●E a') • ◯E a') 
 /-! ## Functors -/
 
 @[rocq_alias excl_authURF]
-abbrev ExclAuthURF (T : COFE.OFunctorPre) [URFunctor T] : COFE.OFunctorPre :=
+abbrev ExclAuthURF (T : COFE.OFunctorPre) [COFE.OFunctor T] : COFE.OFunctorPre :=
   AuthURF (OptionOF (ExclOF T))
 
 #rocq_ignore excl_authURF_contractive "Found by typeclass inference"
 
 @[rocq_alias excl_authRF]
-abbrev ExclAuthRF (T : COFE.OFunctorPre) [URFunctor T] : COFE.OFunctorPre :=
+abbrev ExclAuthRF (T : COFE.OFunctorPre) [COFE.OFunctor T] : COFE.OFunctorPre :=
   AuthRF (OptionOF (ExclOF T))
 
 #rocq_ignore excl_authRF_contractive "Found by typeclass inference"

--- a/Iris/Iris/Algebra/Lib/FracAuth.lean
+++ b/Iris/Iris/Algebra/Lib/FracAuth.lean
@@ -276,8 +276,12 @@ theorem updateP_both_unpersist {q : Qp} {a b : A} :
 abbrev FracAuthURF (T : COFE.OFunctorPre) [RFunctor T] : COFE.OFunctorPre :=
   AuthURF (OptionOF (ProdOF (constOF (Qp)) T))
 
+#rocq_ignore frac_authURF_contractive "Found by typeclass inference"
+
 @[rocq_alias frac_authRF]
-abbrev FracAuthF (T : COFE.OFunctorPre) [RFunctor T] : COFE.OFunctorPre :=
+abbrev FracAuthRF (T : COFE.OFunctorPre) [RFunctor T] : COFE.OFunctorPre :=
   AuthRF (OptionOF (ProdOF (constOF (Qp)) T))
+
+#rocq_ignore frac_authRF_contractive "Found by typeclass inference"
 
 end FracAuth

--- a/Iris/Iris/Algebra/Lib/MonoNat.lean
+++ b/Iris/Iris/Algebra/Lib/MonoNat.lean
@@ -36,7 +36,11 @@ scoped instance : CMRA.CoreId (a : MaxNat) := OrdCommMonoidLike.instCoreId _
 
 end MaxNat
 
+@[rocq_alias mono_nat]
 abbrev MonoNat := Auth MaxNat
+
+#rocq_ignore mono_natR "Use the MonoNat type and View.instCMRA typeclass"
+#rocq_ignore mono_natUR "Use the MonoNat type and View.instUCMRA typeclass"
 
 namespace MonoNat
 

--- a/Iris/Iris/Algebra/Lib/UFracAuth.lean
+++ b/Iris/Iris/Algebra/Lib/UFracAuth.lean
@@ -216,13 +216,13 @@ theorem update_surplus_cancel {p q : Qp} {a b : A} [CMRA.Cancelable b] :
 abbrev UFracAuthURF (T : COFE.OFunctorPre) [RFunctor T] : COFE.OFunctorPre :=
   AuthURF (OptionOF (ProdOF (constOF UFrac) T))
 
-#rocq_ignore ufrac_authURF_contractive "Contractiveness is bundled into Lean's RFunctor class"
+#rocq_ignore ufrac_authURF_contractive "Found by typeclass inference"
 
 @[rocq_alias ufrac_authRF]
 abbrev UFracAuthRF (T : COFE.OFunctorPre) [RFunctor T] : COFE.OFunctorPre :=
   AuthRF (OptionOF (ProdOF (constOF UFrac) T))
 
-#rocq_ignore ufrac_authRF_contractive "Contractiveness is bundled into Lean's RFunctor class"
+#rocq_ignore ufrac_authRF_contractive "Found by typeclass inference"
 
 end UFracAuth
 

--- a/Iris/Iris/Algebra/LocalUpdates.lean
+++ b/Iris/Iris/Algebra/LocalUpdates.lean
@@ -26,6 +26,13 @@ variable [CMRA α]
 
 theorem LocalUpdate.id (x : α × α) : x ~l~> x := fun _ _ vx e => ⟨vx, e⟩
 
+theorem LocalUpdate.trans {x y z : α × α} (uxy : x ~l~> y) (uyz : y ~l~> z) : x ~l~> z :=
+  fun n mz vx e => (uxy n mz vx e).elim (uyz n mz)
+
+instance : Trans LocalUpdate LocalUpdate LocalUpdate (α := α × α) where
+  trans := LocalUpdate.trans
+
+#rocq_ignore local_update_preorder "Use LocalUpdate.id and LocalUpdate.trans"
 #rocq_ignore local_update_proper "OFE is Leibniz; use equality"
 
 @[rocq_alias exclusive_local_update]

--- a/Iris/Iris/Algebra/StepIndex.lean
+++ b/Iris/Iris/Algebra/StepIndex.lean
@@ -27,6 +27,7 @@ class SIdx (I : Type u) extends LT I, LE I, Zero I where
 /-- The step-indexing successor operator. -/
 scoped prefix:max "succᵢ" => SIdx.succ
 
+@[rocq_alias SIdxFinite]
 class SIdxFinite (I : Type u) [SIdx I] where
   finite_index : ∀ n : I, n = 0 ∨ ∃ m, n = succᵢ m
 

--- a/Iris/Iris/Algebra/UFrac.lean
+++ b/Iris/Iris/Algebra/UFrac.lean
@@ -41,6 +41,8 @@ instance : OFE.Discrete UFrac := ⟨fun h => h⟩
 
 @[simp] theorem dist_iff {n} {x y : UFrac} : x ≡{n}≡ y ↔ x = y := Iff.rfl
 
+#rocq_ignore ufrac_ra_mixin "Use CMRA instance"
+
 @[rocq_alias ufracR]
 instance : CMRA UFrac where
   pcore _ := none

--- a/Iris/Iris/Algebra/Updates.lean
+++ b/Iris/Iris/Algebra/Updates.lean
@@ -69,6 +69,10 @@ instance [CMRA α] : Trans Update Update Update (α := α) where
 instance [CMRA α] : Trans Update UpdateP UpdateP (α := α) where
   trans := Update.transP
 
+#rocq_ignore cmra_update_preorder "Use Update.id and Update.trans"
+#rocq_ignore cmra_update_proper_update "Rocq setoid-rewriting instance; use Update.trans"
+#rocq_ignore cmra_update_flip_proper_update "Rocq setoid-rewriting instance; use Update.trans"
+
 @[rocq_alias cmra_updateP_op]
 theorem UpdateP.op {P Q R : α → Prop} {x y}
     (uxp : x ~~>: P) (uyq : y ~~>: Q) (pqr : ∀z w, P z → Q w → R (z • w)) : x • y ~~>: R := by
@@ -91,6 +95,9 @@ theorem UpdateP.op' {P Q : α → Prop} {x y : α} (uxp : x ~~>: P) (uyq : y ~~>
 @[rocq_alias cmra_update_op]
 theorem Update.op {x₁ x₂ y₁ y₂ : α} (xy₁ : x₁ ~~> y₁) (xy₂ : x₂ ~~> y₂) : x₁ • x₂ ~~> y₁ • y₂ :=
   .of_updateP <| .op (.of_update xy₁) (.of_update xy₂) fun _ _ ez ew => ez ▸ ew ▸ rfl
+
+#rocq_ignore cmra_update_op_proper "Rocq setoid-rewriting instance; use Update.op"
+#rocq_ignore cmra_update_op_flip_proper "Rocq setoid-rewriting instance; use Update.op"
 
 @[rocq_alias cmra_update_op_l]
 theorem Update.op_l {x y : α} : x • y ~~> x := fun _ _ => CMRA.validN_op_opM_left

--- a/Iris/Iris/Algebra/Updates.lean
+++ b/Iris/Iris/Algebra/Updates.lean
@@ -42,6 +42,7 @@ theorem UpdateP.of_update {x y : α} (h : x ~~> y) : x ~~>: (y = ·) :=
 theorem UpdateP.id {P : α → Prop} {x} (h : P x) : x ~~>: P :=
   fun _ _ v => ⟨x, h, v⟩
 
+@[refl]
 theorem Update.id {x : α} : x ~~> x := fun _ _ h => h
 
 theorem Update.trans {x y z : α} (uxy : x ~~> y) (uyz : y ~~> z) : x ~~> z :=
@@ -63,13 +64,16 @@ theorem UpdateP.weaken {x : α} (uxp : x ~~>: P) (pq : ∀ y, P y → Q y) : x ~
 theorem Update.exclusive {x y : α} [CMRA.Exclusive x] (vy : ✓ y) : x ~~> y :=
   fun _ _ P => CMRA.none_of_excl_valid_op P ▸ vy.validN
 
+instance [CMRA α] : Std.Refl (Update (α := α)) where
+  refl _ := Update.id
+
 instance [CMRA α] : Trans Update Update Update (α := α) where
   trans := Update.trans
 
 instance [CMRA α] : Trans Update UpdateP UpdateP (α := α) where
   trans := Update.transP
 
-#rocq_ignore cmra_update_preorder "Use Update.id and Update.trans"
+#rocq_ignore cmra_update_preorder "Split into the Std.Refl and Trans instances above"
 #rocq_ignore cmra_update_proper_update "Rocq setoid-rewriting instance; use Update.trans"
 #rocq_ignore cmra_update_flip_proper_update "Rocq setoid-rewriting instance; use Update.trans"
 

--- a/Iris/Iris/Algebra/View.lean
+++ b/Iris/Iris/Algebra/View.lean
@@ -10,6 +10,7 @@ public import Iris.Algebra.OFE
 public import Iris.Algebra.Frac
 public import Iris.Algebra.DFrac
 public import Iris.Algebra.Agree
+public import Iris.Algebra.BigOp
 public import Iris.Algebra.Updates
 public import Iris.Algebra.LocalUpdates
 meta import Iris.Std.RocqPorting
@@ -387,6 +388,41 @@ instance [CMRA.CoreId b] : CMRA.CoreId ((●V{.discard} a : View R) • ◯V b) 
 instance {b b1 b2 : B} [h : IsOp d b b1 b2] :
     IsOp d (◯V b : View R) (◯V b1) (◯V b2) where
   is_op := by rw [h.is_op]; exact frag_op_eq
+
+section BigOp
+open Algebra Std
+
+@[rocq_alias view_frag_sep_homomorphism]
+instance : MonoidHomomorphism CMRA.op CMRA.op UCMRA.unit UCMRA.unit (· = ·)
+    (Frag : B → View R) where
+  rel_refl := rfl
+  rel_trans := Eq.trans
+  op_proper h₁ h₂ := h₁ ▸ h₂ ▸ rfl
+  map_ne := frag_ne
+  map_op := frag_op_eq
+  map_unit := rfl
+
+@[rocq_alias big_opL_view_frag]
+theorem bigOpL_frag (g : Nat → C → B) (l : List C) :
+    (◯V ([^ CMRA.op list] k ↦ x ∈ l, g k x) : View R) = [^ CMRA.op list] k ↦ x ∈ l, ◯V (g k x) :=
+  BigOpL.bigOpL_hom _ _
+
+@[rocq_alias big_opM_view_frag]
+theorem bigOpM_frag [LawfulFiniteMap M' K] (g : K → C → B) (m : M' C) :
+    (◯V ([^ CMRA.op map] k ↦ x ∈ m, g k x) : View R) = [^ CMRA.op map] k ↦ x ∈ m, ◯V (g k x) :=
+  BigOpM.bigOpM_hom _ _
+
+@[rocq_alias big_opS_view_frag]
+theorem bigOpS_frag [LawfulFiniteSet S' C] (g : C → B) (X : S') :
+    (◯V ([^ CMRA.op set] x ∈ X, g x) : View R) = [^ CMRA.op set] x ∈ X, ◯V (g x) :=
+  BigOpS.hom inferInstance _ _
+
+@[rocq_alias big_opMS_view_frag]
+theorem bigOpMS_frag [LawfulFiniteMultiSet MS' C] (g : C → B) (X : MS') :
+    (◯V ([^ CMRA.op mset] x ∈ X, g x) : View R) = [^ CMRA.op mset] x ∈ X, ◯V (g x) :=
+  BigOpMS.hom inferInstance _ _
+
+end BigOp
 
 @[rocq_alias view_auth_dfrac_op_invN]
 theorem dist_of_validN_auth (H : ✓{n} ((●V{dq1} a1 : View R) • ●V{dq2} a2)) : a1 ≡{n}≡ a2 := by
@@ -855,6 +891,10 @@ instance (f : A → A') (g : B → B') [OFE.NonExpansive f] [hne : OFE.NonExpans
 def mapO (f : A -n> A') (g : B -n> B') : View R -n> View R' where
   f := View.map R' f g
   ne := inferInstance
+
+@[rocq_alias viewO_map_ne]
+instance mapO_ne : OFE.NonExpansive₂ (mapO (R := R) (R' := R')) where
+  ne _ _ _ hf _ _ hg v := map_ne v (hf ·) (hg ·)
 
 end mapO
 


### PR DESCRIPTION
## Description
Brings the following files to 100% ported

- Agree
- Auth
- BigOp
- COFESolver
- ~~DFrac~~
- DFracAgree
- Excl
- ExclAuth
- Frac
- FracAuth
- Functions
- IsOp
- LeibnizSet
- LocalUpdates
- MonoNat
- Monoid
- StepIndex
- UFrac
- UFracAuth
- View

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
