### PR TITLE
chore: `rocq_alias` annotations for `bi/interface.v`

### DIFF
--- a/Iris/Iris/BI/BI.lean
+++ b/Iris/Iris/BI/BI.lean
@@ -166,13 +166,13 @@ attribute [rocq_alias bi.persistently_and_sep_elim] BI.persistently_and_l
 attribute [rocq_alias bi.later_mono] BI.later_mono
 attribute [rocq_alias bi.later_intro] BI.later_intro
 
-attribute [rocq_alias bi.later_sep_1, rocq_alias later_sep_2] BI.later_sep
+attribute [rocq_alias bi.later_sep_1, rocq_alias bi.later_sep_2] BI.later_sep
 attribute [rocq_alias bi.later_persistently_1,
            rocq_alias bi.later_persistently_2] BI.later_persistently
 attribute [rocq_alias bi.later_false_em] BI.later_false_em
 
 attribute [rocq_alias bi_cofe] BI.toCOFE
 
-#rocq_ignore bi.ofeO "No coercion required in Lean, use BI.toCOFE.toOFE instead"
+#rocq_ignore bi_ofeO "No coercion required in Lean, use BI.toCOFE.toOFE instead"
 #rocq_ignore bi.pure_ne "No Proper type class in Lean"
 #rocq_ignore bi_rewrite_relation "Rocq-specific setoid-rewriting infrastructure"

--- a/Iris/Iris/BI/BI.lean
+++ b/Iris/Iris/BI/BI.lean
@@ -125,9 +125,6 @@ export BIBase (
   intuitionistically later persistentlyIf affinelyIf absorbinglyIf
   intuitionisticallyIf bigAnd bigOr bigSep Entails.trans BiEntails.trans BiEntails.of_eq BiEntails.to_eq)
 
-attribute [rw_mono_rule] BI.sep_mono
-attribute [rw_mono_rule] BI.persistently_mono
-
 attribute [rocq_alias bi.equiv_entails] BI.equiv_iff
 attribute [rocq_alias bi.and_ne] BI.and_ne
 attribute [rocq_alias bi.or_ne] BI.or_ne
@@ -136,32 +133,46 @@ attribute [rocq_alias bi.sep_ne] BI.sep_ne
 attribute [rocq_alias bi.wand_ne] BI.wand_ne
 attribute [rocq_alias bi.persistently_ne] BI.persistently_ne
 attribute [rocq_alias bi.later_ne] BI.later_ne
+
 attribute [rocq_alias bi.pure_intro] BI.pure_intro
 attribute [rocq_alias bi.pure_elim'] BI.pure_elim'
+
 attribute [rocq_alias bi.and_elim_l] BI.and_elim_l
 attribute [rocq_alias bi.and_elim_r] BI.and_elim_r
 attribute [rocq_alias bi.and_intro] BI.and_intro
+
 attribute [rocq_alias bi.or_intro_l] BI.or_intro_l
 attribute [rocq_alias bi.or_intro_r] BI.or_intro_r
 attribute [rocq_alias bi.or_elim] BI.or_elim
+
 attribute [rocq_alias bi.impl_intro_r] BI.imp_intro
 attribute [rocq_alias bi.impl_elim_l'] BI.imp_elim
-attribute [rocq_alias bi.sep_mono] BI.sep_mono
+
+attribute [rw_mono_rule, rocq_alias bi.sep_mono] BI.sep_mono
 attribute [rocq_alias bi.emp_sep_1, rocq_alias bi.emp_sep_2] BI.emp_sep
 attribute [rocq_alias bi.sep_comm'] BI.sep_symm
 attribute [rocq_alias bi.sep_assoc'] BI.sep_assoc_l
+
 attribute [rocq_alias bi.wand_intro_r] BI.wand_intro
 attribute [rocq_alias bi.wand_elim_l'] BI.wand_elim
-attribute [rocq_alias bi.persistently_mono] BI.persistently_mono
+
+attribute [rw_mono_rule, rocq_alias bi.persistently_mono] BI.persistently_mono
 attribute [rocq_alias bi.persistently_idemp_2] BI.persistently_idem_2
 attribute [rocq_alias bi.persistently_and_2] BI.persistently_and_2
 attribute [rocq_alias bi.persistently_emp_2] BI.persistently_emp_2
 attribute [rocq_alias bi.persistently_exist_1] BI.persistently_sExists_1
 attribute [rocq_alias bi.persistently_and_sep_elim] BI.persistently_and_l
+
 attribute [rocq_alias bi.later_mono] BI.later_mono
 attribute [rocq_alias bi.later_intro] BI.later_intro
+
 attribute [rocq_alias bi.later_sep_1, rocq_alias later_sep_2] BI.later_sep
 attribute [rocq_alias bi.later_persistently_1,
            rocq_alias bi.later_persistently_2] BI.later_persistently
 attribute [rocq_alias bi.later_false_em] BI.later_false_em
+
 attribute [rocq_alias bi_cofe] BI.toCOFE
+
+#rocq_ignore bi.ofeO "No coercion required in Lean, use BI.toCOFE.toOFE instead"
+#rocq_ignore bi.pure_ne "No Proper type class in Lean"
+#rocq_ignore bi_rewrite_relation "Rocq-specific setoid-rewriting infrastructure"

--- a/Iris/Iris/BI/BI.lean
+++ b/Iris/Iris/BI/BI.lean
@@ -21,6 +21,8 @@ theorem liftRel_eq : liftRel (@Eq α) A B ↔ A = B := by
   simp [liftRel, forall_and, iff_def, funext_iff]
 
 /-- Require that a separation logic with carrier type `PROP` fulfills all necessary axioms. -/
+@[rocq_alias bi, rocq_alias BiMixin,
+  rocq_alias BiPersistentlyMixin, rocq_alias BiLaterMixin]
 class BI (PROP : Type _) extends COFE PROP, BI.BIBase PROP where
   entails_refl {P : PROP} : P ⊢ P
   entails_trans {P Q R : PROP} : (P ⊢ Q) → (Q ⊢ R) → P ⊢ R
@@ -85,7 +87,8 @@ namespace BI
 instance [BIBase PROP] : LE PROP where
   le := BIBase.Entails
 
-instance BI.entails_preorder [BI PROP] : Std.IsPreorder PROP where
+@[rocq_alias bi.entails_po]
+instance entails_preorder [BI PROP] : Std.IsPreorder PROP where
   le_refl _ := BI.entails_refl
   le_trans _ _ _ := BI.entails_trans
 
@@ -124,3 +127,41 @@ export BIBase (
 
 attribute [rw_mono_rule] BI.sep_mono
 attribute [rw_mono_rule] BI.persistently_mono
+
+attribute [rocq_alias bi.equiv_entails] BI.equiv_iff
+attribute [rocq_alias bi.and_ne] BI.and_ne
+attribute [rocq_alias bi.or_ne] BI.or_ne
+attribute [rocq_alias bi.impl_ne] BI.imp_ne
+attribute [rocq_alias bi.sep_ne] BI.sep_ne
+attribute [rocq_alias bi.wand_ne] BI.wand_ne
+attribute [rocq_alias bi.persistently_ne] BI.persistently_ne
+attribute [rocq_alias bi.later_ne] BI.later_ne
+attribute [rocq_alias bi.pure_intro] BI.pure_intro
+attribute [rocq_alias bi.pure_elim'] BI.pure_elim'
+attribute [rocq_alias bi.and_elim_l] BI.and_elim_l
+attribute [rocq_alias bi.and_elim_r] BI.and_elim_r
+attribute [rocq_alias bi.and_intro] BI.and_intro
+attribute [rocq_alias bi.or_intro_l] BI.or_intro_l
+attribute [rocq_alias bi.or_intro_r] BI.or_intro_r
+attribute [rocq_alias bi.or_elim] BI.or_elim
+attribute [rocq_alias bi.impl_intro_r] BI.imp_intro
+attribute [rocq_alias bi.impl_elim_l'] BI.imp_elim
+attribute [rocq_alias bi.sep_mono] BI.sep_mono
+attribute [rocq_alias bi.emp_sep_1, rocq_alias bi.emp_sep_2] BI.emp_sep
+attribute [rocq_alias bi.sep_comm'] BI.sep_symm
+attribute [rocq_alias bi.sep_assoc'] BI.sep_assoc_l
+attribute [rocq_alias bi.wand_intro_r] BI.wand_intro
+attribute [rocq_alias bi.wand_elim_l'] BI.wand_elim
+attribute [rocq_alias bi.persistently_mono] BI.persistently_mono
+attribute [rocq_alias bi.persistently_idemp_2] BI.persistently_idem_2
+attribute [rocq_alias bi.persistently_and_2] BI.persistently_and_2
+attribute [rocq_alias bi.persistently_emp_2] BI.persistently_emp_2
+attribute [rocq_alias bi.persistently_exist_1] BI.persistently_sExists_1
+attribute [rocq_alias bi.persistently_and_sep_elim] BI.persistently_and_l
+attribute [rocq_alias bi.later_mono] BI.later_mono
+attribute [rocq_alias bi.later_intro] BI.later_intro
+attribute [rocq_alias bi.later_sep_1, rocq_alias later_sep_2] BI.later_sep
+attribute [rocq_alias bi.later_persistently_1,
+           rocq_alias bi.later_persistently_2] BI.later_persistently
+attribute [rocq_alias bi.later_false_em] BI.later_false_em
+attribute [rocq_alias bi_cofe] BI.toCOFE

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -78,8 +78,6 @@ theorem imp_elim_left [BI PROP] {P Q : PROP} : (P → Q) ∧ P ⊢ Q := imp_elim
 @[rocq_alias bi.impl_elim_r]
 theorem imp_elim_right [BI PROP] {P Q : PROP} : P ∧ (P → Q) ⊢ Q := imp_elim_swap .rfl
 
-theorem imp_elim_alt [BI PROP] {P Q R : PROP} (h : P ⊢ Q → R) : P ∧ Q ⊢ R := imp_elim h
-
 @[rocq_alias bi.False_elim]
 theorem false_elim [BI PROP] {P : PROP} : False ⊢ P := pure_elim' False.elim
 
@@ -1038,6 +1036,7 @@ instance sep_affine [BI PROP] (P Q : PROP) [Affine P] [Affine Q] : Affine iprop(
 instance affinely_affine [BI PROP] (P : PROP) : Affine iprop(<affine> P) where
   affine := affinely_elim_emp
 
+@[rocq_alias bi_inhabited]
 instance [BIBase PROP] : Inhabited PROP where
   default := emp
 

--- a/Iris/Iris/BI/DerivedLawsLater.lean
+++ b/Iris/Iris/BI/DerivedLawsLater.lean
@@ -60,7 +60,7 @@ theorem later_exists_mp {Φ : α → PROP} :
     (∃ a, ▷ Φ a) ⊢ ▷ (∃ a, Φ a) :=
   exists_elim (later_mono <| exists_intro ·)
 
-@[rocq_alias later_exists_false]
+@[rocq_alias bi.later_exists_false]
 theorem later_exists_false {Φ : α → PROP} :
     (▷ ∃ a, Φ a) ⊢ ▷ False ∨ ∃ a, ▷ Φ a := by
   apply later_sExists_false.trans

--- a/Iris/Iris/BI/DerivedLawsLater.lean
+++ b/Iris/Iris/BI/DerivedLawsLater.lean
@@ -60,7 +60,7 @@ theorem later_exists_mp {Φ : α → PROP} :
     (∃ a, ▷ Φ a) ⊢ ▷ (∃ a, Φ a) :=
   exists_elim (later_mono <| exists_intro ·)
 
-@[rocq_alias bi.later_exists_false]
+@[rocq_alias bi.later_exist_false]
 theorem later_exists_false {Φ : α → PROP} :
     (▷ ∃ a, Φ a) ⊢ ▷ False ∨ ∃ a, ▷ Φ a := by
   apply later_sExists_false.trans

--- a/Iris/Iris/BI/DerivedLawsLater.lean
+++ b/Iris/Iris/BI/DerivedLawsLater.lean
@@ -40,6 +40,7 @@ theorem later_emp [BIAffine PROP] : ▷ emp ⊣⊢ (emp : PROP) :=
 @[rocq_alias bi.later_emp_2]
 theorem later_emp_2 : emp ⊢@{PROP} ▷ emp := later_intro
 
+@[rocq_alias bi.later_forall_2]
 theorem later_forall_2 {α} {Φ : α → PROP} : (∀ a, ▷ Φ a) ⊢ ▷ ∀ a, Φ a := by
   refine (forall_intro ?_).trans later_sForall_2
   intro P
@@ -59,6 +60,7 @@ theorem later_exists_mp {Φ : α → PROP} :
     (∃ a, ▷ Φ a) ⊢ ▷ (∃ a, Φ a) :=
   exists_elim (later_mono <| exists_intro ·)
 
+@[rocq_alias later_exists_false]
 theorem later_exists_false {Φ : α → PROP} :
     (▷ ∃ a, Φ a) ⊢ ▷ False ∨ ∃ a, ▷ Φ a := by
   apply later_sExists_false.trans

--- a/Iris/Iris/ProofMode/Tactics/Combine.lean
+++ b/Iris/Iris/ProofMode/Tactics/Combine.lean
@@ -89,6 +89,7 @@ theorem combine_gives_step_conj [BI PROP] {p1 p2 : Bool}
         persistently_and_intuitionistically_sep_right.mp
     _ ⊢ e ∗ □ outGivesCombined                                  := sep_mono_left sep_elim_left
 
+@[rocq_alias tac_combine_as_gives]
 theorem combine_as_gives [BI PROP] {p : Bool} {newE e outAs outGives goal : PROP}
     (pfAs : e ⊢ newE ∗ □?p outAs)
     (pfGives : e ⊢ e ∗ □ outGives)


### PR DESCRIPTION
## Description

Adds missing `rocq_alias` and `rocq_ignore` annotations for [`bi/interface.v`](https://gitlab.mpi-sws.org/iris/iris/-/blob/fc4ada8c680cfca3a48ad0a1aaff073c7b28e2db/iris/bi/interface.v).

Annotations for `bi_later_mixin_id` and `bi_persistently_mixin_discrete` have not been added yet. Since the items in `BiMixin`, `BiLaterMixin` and `BiPersistentlyMixin` are all combined into the same type class `BI` in Lean, do we ignore the two lemmas, or will these two "smart constructors" be useful at some point when, for example, non-step-indexed BIs are supported?

As a side note, there are two items named `persistently_absorbing` in Iris-Rocq: one as [a lemma in `bi/interface.v`](https://gitlab.mpi-sws.org/iris/iris/-/blob/fc4ada8c680cfca3a48ad0a1aaff073c7b28e2db/iris/bi/interface.v#L478-L481) and another as [an instance of `Absorbing` in `bi/derived_laws.v`](https://gitlab.mpi-sws.org/iris/iris/-/blob/fc4ada8c680cfca3a48ad0a1aaff073c7b28e2db/iris/bi/derived_laws.v#L934-L935). For the latter, the [corresponding instance in `BI/DerivedLawsLater.lean`](https://github.com/leanprover-community/iris-lean/blob/8ebd8c1/Iris/Iris/BI/DerivedLaws.lean#L1350-L1352) is already annotated. The entry shows up only once on the porting status website, so I have left the annotation for the lemma out.

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files
