### PR TITLE
feat: improve proof state display within IPM

### DIFF
--- a/Iris/Iris/ProofMode/Display.lean
+++ b/Iris/Iris/ProofMode/Display.lean
@@ -7,7 +7,6 @@ module
 
 public meta import Iris.BI.Notation
 public meta import Iris.ProofMode.Expr
-
 public meta import Lean.PrettyPrinter.Delaborator
 
 public meta section

--- a/Iris/Iris/ProofMode/Display.lean
+++ b/Iris/Iris/ProofMode/Display.lean
@@ -39,12 +39,20 @@ def withHypType {α} [Inhabited α] (persistent : Bool) (d : DelabM α) : DelabM
   let d := withMDataExpr <| withAppArg d
   if persistent then withNaryArg 2 d else d
 
+@[delab app.Iris.ProofMode.IrisHyp]
+def delabIrisHyp : Delab := withAppArg delab
+
 @[delab app.Iris.ProofMode.Entails']
 def delabIrisGoal : Delab := do
-  let some { hyps, .. } := parseIrisGoal? (← instantiateMVars (← getExpr)) | failure
-  let (_, hypStxs) ← withNaryArg 2 <| delabHypotheses hyps ({}, #[])
+  let some { hyps, goal, .. } := parseIrisGoal? (← instantiateMVars (← getExpr)) | failure
+  -- Delaboration for the hypotheses
+  let ⟨_, hypStxs⟩ ← withNaryArg 2 <| delabHypotheses hyps ({}, #[])
+  -- Delaboration for the proof goal
   let goalStx ← withNaryArg 3 delabIProp
-  return ⟨← `(irisGoalStx| $hypStxs.reverse* ⊢ $goalStx:term)⟩
+  -- Conceal internal machinery (`Entails'`, `IrisHyp`) from user's view
+  let stx ← annotateCurPos ⟨← `(irisGoalStx| $hypStxs.reverse* ⊢ $goalStx:term)⟩
+  addTermInfo (← getPos) stx q(Entails $(clean hyps) $goal)
+  return stx
 where
   delabHypotheses {u prop bi s} (hyps : @Hyps u prop bi s)
       (acc : NameMap Nat × Array (TSyntax ``irisHyp)) :
@@ -56,23 +64,31 @@ where
       withNaryArg 2 <| delabHypotheses lhs acc
     | .hyp _ name ivar p ty _ =>
       let (map, acc) := acc
+      -- For printing the name of the hypothesis, `✝` if anonymous
       let (idx, name') := match map.find? name with
         | some idx =>
           (idx + 1, name.appendAfter <|
             if idx == 0 then "✝" else "✝" ++ idx.toSuperscriptString)
         | none => (0, name)
       let pos ← getPos
+      -- Delaboration of the proposition itself
       let tyStx ← withHypType (isTrue p) delabIProp
       let nameStx : Ident :=
         ⟨(mkIdent name').raw.setInfo (.synthetic ⟨pos.asNat⟩ ⟨pos.asNat⟩)⟩
       withLCtx ((← getLCtx).mkLocalDecl ⟨ivar.name⟩ name' q(HypMarker $ty))
           (← getLocalInstances) do
         addTermInfo pos nameStx (.fvar ⟨ivar.name⟩) (isBinder := true)
+      -- Determine the prefix based on whether it is in the spatial or intuitionistic context
       let stx ← if isTrue p then
         `(irisHyp| □$nameStx : $tyStx)
       else
         `(irisHyp| ∗$nameStx : $tyStx)
       pure (map.insert name idx, acc.push stx)
+  clean {u prop bi s} (hyps : @Hyps u prop bi s) : Q($prop) :=
+    match hyps with
+    | .emp _ => q(emp)
+    | .sep _ _ _ _ lhs rhs => q(iprop($(clean lhs) ∗ $(clean rhs)))
+    | .hyp _ _ _ p ty _ => (mkIntuitionisticIf bi p ty).val
 
 @[delab app.Iris.ProofMode.HypMarker]
 def delabHypMarker : Delab := do unpackIprop (← withAppArg delab)

--- a/Iris/Iris/ProofMode/Display.lean
+++ b/Iris/Iris/ProofMode/Display.lean
@@ -29,39 +29,50 @@ syntax irisHyp := ("□" <|> "∗") ident " : " term
 
 syntax irisGoalStx := ppDedent(ppLine irisHyp)* ppDedent(ppLine "⊢ " term)
 
-open Lean.PrettyPrinter
+open Lean.PrettyPrinter.Delaborator SubExpr
+
+def delabIProp : Delab := do
+  annotateCurPos (← unpackIprop (← delab))
+
+/-- Move from the position of a hypothesis node `□?p (IrisHyp ty)` to the position of `ty`. -/
+def withHypType {α} [Inhabited α] (persistent : Bool) (d : DelabM α) : DelabM α :=
+  let d := withMDataExpr <| withAppArg d
+  if persistent then withNaryArg 2 d else d
 
 @[delab app.Iris.ProofMode.Entails']
 def delabIrisGoal : Delab := do
-  let expr ← instantiateMVars <| ← getExpr
-
-  -- extract environment
-  let some { hyps, goal, .. } := parseIrisGoal? expr | failure
-
-  -- delaborate
-  let (_, hyps) ← delabHypotheses hyps ({}, #[])
-  let goal ← unpackIprop (← delab goal)
-
-  -- build syntax
-  return ⟨← `(irisGoalStx| $hyps.reverse* ⊢ $goal:term)⟩
+  let some { hyps, .. } := parseIrisGoal? (← instantiateMVars (← getExpr)) | failure
+  let (_, hypStxs) ← withNaryArg 2 <| delabHypotheses hyps ({}, #[])
+  let goalStx ← withNaryArg 3 delabIProp
+  return ⟨← `(irisGoalStx| $hypStxs.reverse* ⊢ $goalStx:term)⟩
 where
   delabHypotheses {u prop bi s} (hyps : @Hyps u prop bi s)
       (acc : NameMap Nat × Array (TSyntax ``irisHyp)) :
       DelabM (NameMap Nat × Array (TSyntax ``irisHyp)) := do
     match hyps with
     | .emp _ => pure acc
-    | .hyp _ name _ p ty _ =>
-      let mut (map, acc) := acc
-      let (idx, name') ← if let some idx := map.find? name then
-        pure (idx + 1, name.appendAfter <| if idx == 0 then "✝" else "✝" ++ idx.toSuperscriptString)
-      else
-        pure (0, name)
+    | .sep _ _ _ _ lhs rhs =>
+      let acc ← withNaryArg 3 <| delabHypotheses rhs acc
+      withNaryArg 2 <| delabHypotheses lhs acc
+    | .hyp _ name ivar p ty _ =>
+      let (map, acc) := acc
+      let (idx, name') := match map.find? name with
+        | some idx =>
+          (idx + 1, name.appendAfter <|
+            if idx == 0 then "✝" else "✝" ++ idx.toSuperscriptString)
+        | none => (0, name)
+      let pos ← getPos
+      let tyStx ← withHypType (isTrue p) delabIProp
+      let nameStx : Ident :=
+        ⟨(mkIdent name').raw.setInfo (.synthetic ⟨pos.asNat⟩ ⟨pos.asNat⟩)⟩
+      withLCtx ((← getLCtx).mkLocalDecl ⟨ivar.name⟩ name' q(HypMarker $ty))
+          (← getLocalInstances) do
+        addTermInfo pos nameStx (.fvar ⟨ivar.name⟩) (isBinder := true)
       let stx ← if isTrue p then
-        `(irisHyp| □$(mkIdent name') : $(← unpackIprop (← delab ty)))
+        `(irisHyp| □$nameStx : $tyStx)
       else
-        `(irisHyp| ∗$(mkIdent name') : $(← unpackIprop (← delab ty)))
+        `(irisHyp| ∗$nameStx : $tyStx)
       pure (map.insert name idx, acc.push stx)
-    | .sep _ _ _ _ lhs rhs => delabHypotheses lhs (← delabHypotheses rhs acc)
 
 @[delab app.Iris.ProofMode.HypMarker]
 def delabHypMarker : Delab := do unpackIprop (← withAppArg delab)

--- a/Iris/Iris/Tests.lean
+++ b/Iris/Iris/Tests.lean
@@ -1,5 +1,6 @@
 module
 
+public import Iris.Tests.Display
 public import Iris.Tests.HeapLang
 public import Iris.Tests.Instances
 public import Iris.Tests.InstancesImport

--- a/Iris/Iris/Tests/Display.lean
+++ b/Iris/Iris/Tests/Display.lean
@@ -22,31 +22,26 @@ partial def collectTags {α} (t : Widget.TaggedText α)
   | .append ts => ts.foldl (init := acc) fun acc t => collectTags t acc
   | .tag a t'  => collectTags t' (acc.push (t'.stripTags, a))
 
-/--
-  Report, for each hoverable region of the pretty-printed `e`,
-  the text and the type its popup would show.
--/
-def hoverReport (e : Expr) : MetaM MessageData := do
-  let ⟨fmt, infos⟩ ← PrettyPrinter.ppExprWithInfos e
-  let mut lines : Array MessageData := #[]
-  for (txt, tag) in collectTags (Widget.TaggedText.prettyTagged fmt) do
-    let some info := infos.get? tag.fst | continue
-    -- Delaboration info in `ofTermInfo`/`ofDelabTermInfo`
-    let ti := match info with
-    | .ofTermInfo ti      => some ti
-    | .ofDelabTermInfo ti => some ti.toTermInfo
-    | _                   => none
-    let some ti := ti | continue
-    let ty ← withLCtx ti.lctx (← getLocalInstances) do
-      try ppExpr (← inferType ti.expr)
-      catch _ => pure "<not typable>"
-    lines := lines.push
-      m!"⋆ {txt.trimAscii}{if ti.isBinder then " (binder)" else ""} : {ty}"
-  return MessageData.joinSep lines.toList "\n"
-
-elab "trace_iris_delab" : tactic => do
+/-- Traverse the delaborated syntax and print the type signature information. -/
+elab "trace_delab" : tactic => do
   let g ← Tactic.getMainGoal
-  g.withContext do logInfo (← hoverReport (← g.getType))
+  g.withContext do
+    let ⟨fmt, infos⟩ ← g.getType >>= (PrettyPrinter.ppExprWithInfos ·)
+    let mut lines : Array MessageData := #[]
+    for (txt, tag) in collectTags (Widget.TaggedText.prettyTagged fmt) do
+      let some info := infos.get? tag.fst | continue
+      -- Delaboration info in `ofTermInfo`/`ofDelabTermInfo`
+      let ti := match info with
+      | .ofTermInfo ti      => some ti
+      | .ofDelabTermInfo ti => some ti.toTermInfo
+      | _                   => none
+      let some ti := ti | continue
+      let ty ← withLCtx ti.lctx (← getLocalInstances) do
+        try ppExpr (← inferType ti.expr)
+        catch _ => pure "<not typable>"
+      lines := lines.push
+        m!"⋆ {txt.trimAscii}{if ti.isBinder then " (binder)" else ""} : {ty}"
+    logInfo <| MessageData.joinSep lines.toList "\n"
 
 end
 
@@ -80,7 +75,7 @@ info:
 #guard_msgs (whitespace := lax) in
 example [BI PROP] (P Q R : PROP) : P ⊢ P -∗ R -∗ (P ∗ P -∗ R -∗ Q) -∗ Q := by
   iintro HP1 HP2 HR HPQ
-  trace_iris_delab
+  trace_delab
   ispecialize HPQ $$ [$HP1 HP2] [-]
   . iexact HP2
   . iexact HR
@@ -123,7 +118,7 @@ example [BI PROP] {P1 P2 Q : PROP} :
     ⊢ <absorb> P1 -∗ <absorb> P2 -∗ <absorb> <affine> P3 -∗ <absorb> <affine> P4 -∗
       (<absorb> (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) -∗ Q) -∗ Q := by
   iintro HP1 HP2 HP3 HP4 H
-  trace_iris_delab
+  trace_delab
   icombine HP1 HP2 HP3 HP4 as HNew
   iapply H
   iexact HNew
@@ -170,7 +165,7 @@ info:
 example [BI PROP] (m n : Nat) (a b c : Prop) :
     ⊢@{PROP} ⌜m = 2⌝ -∗ ⌜3 = n⌝ -∗ ⌜a = b⌝ -∗ ⌜b = c⌝ -∗ ⌜m.succ = n ∧ a = c⌝ := by
   iintro #H1 H2 #H3 H4
-  trace_iris_delab
+  trace_delab
   icases H1 with %rfl
   icases H2 with %rfl
   icases H3 with %rfl
@@ -199,7 +194,7 @@ info:
 example [BI PROP] (Q : PROP) (n : Nat) :
   □ (∀ x, Q -∗ ⌜x = n⌝) ⊢ Q -∗ False := by
   iintro #Hwand HQ
-  trace_iris_delab
+  trace_delab
   icases Hwand $$ %1 HQ with %_
   icases Hwand $$ %2 HQ with %_
   grind

--- a/Iris/Iris/Tests/Display.lean
+++ b/Iris/Iris/Tests/Display.lean
@@ -23,15 +23,6 @@ partial def collectTags {α} (t : Widget.TaggedText α)
   | .tag a t'  => collectTags t' (acc.push (t'.stripTags, a))
 
 /--
-  Delaborators record their info as `ofDelabTermInfo`; hand-rolled
-  `Elab.withInfoContext'` sites record `ofTermInfo`. Accept either.
--/
-def asTermInfo? : Info → Option TermInfo
-  | .ofTermInfo ti      => some ti
-  | .ofDelabTermInfo ti => some ti.toTermInfo
-  | _                   => none
-
-/--
   Report, for each hoverable region of the pretty-printed `e`,
   the text and the type its popup would show.
 -/
@@ -40,7 +31,12 @@ def hoverReport (e : Expr) : MetaM MessageData := do
   let mut lines : Array MessageData := #[]
   for (txt, tag) in collectTags (Widget.TaggedText.prettyTagged fmt) do
     let some info := infos.get? tag.fst | continue
-    let some ti := asTermInfo? info | continue
+    -- Delaboration info in `ofTermInfo`/`ofDelabTermInfo`
+    let ti := match info with
+    | .ofTermInfo ti      => some ti
+    | .ofDelabTermInfo ti => some ti.toTermInfo
+    | _                   => none
+    let some ti := ti | continue
     let ty ← withLCtx ti.lctx (← getLocalInstances) do
       try ppExpr (← inferType ti.expr)
       catch _ => pure "<not typable>"

--- a/Iris/Iris/Tests/Display.lean
+++ b/Iris/Iris/Tests/Display.lean
@@ -52,6 +52,10 @@ end
 
 section
 
+/-
+  Tests delaboration of an IPM goal with only separating conjunctions and
+  separating implications involved.
+-/
 /--
 info:
 ⋆ ∗HP1 : P
@@ -82,6 +86,7 @@ example [BI PROP] (P Q R : PROP) : P ⊢ P -∗ R -∗ (P ∗ P -∗ R -∗ Q) -
   . iexact HR
   iexact HPQ
 
+/- Tests delaboration of an IPM goal with modalities involved. -/
 /--
 info:
 ⋆ ∗HP1 : <absorb> P1
@@ -89,7 +94,7 @@ info:
   ∗HP3 : <absorb> <affine> P3
   ∗HP4 : <absorb> <affine> P4
   ∗H : <absorb> (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) -∗ Q
-⊢ Q : Prop
+  ⊢ Q : Prop
 ⋆ HP1 (binder) : <absorb> P1
   ⋆ <absorb> P1 : PROP
     ⋆ P1 : PROP
@@ -123,6 +128,7 @@ example [BI PROP] {P1 P2 Q : PROP} :
   iapply H
   iexact HNew
 
+/- Tests delaboration of an IPM goal with pure hypotheses involved. -/
 /--
 info:
 ⋆ □H1 : ⌜m = 2⌝
@@ -172,6 +178,7 @@ example [BI PROP] (m n : Nat) (a b c : Prop) :
   ipureintro
   and_intros <;> rfl
 
+/- Tests delaboration of an IPM goal with universal quantifier involved. -/
 /--
 info:
 ⋆ □Hwand : ∀ x, Q -∗ ⌜x = n⌝

--- a/Iris/Iris/Tests/Display.lean
+++ b/Iris/Iris/Tests/Display.lean
@@ -22,15 +22,19 @@ partial def collectTags {α} (t : Widget.TaggedText α)
   | .append ts => ts.foldl (init := acc) fun acc t => collectTags t acc
   | .tag a t'  => collectTags t' (acc.push (t'.stripTags, a))
 
-/-- Delaborators record their info as `ofDelabTermInfo`; hand-rolled
-`Elab.withInfoContext'` sites record `ofTermInfo`. Accept either. -/
+/--
+  Delaborators record their info as `ofDelabTermInfo`; hand-rolled
+  `Elab.withInfoContext'` sites record `ofTermInfo`. Accept either.
+-/
 def asTermInfo? : Info → Option TermInfo
   | .ofTermInfo ti      => some ti
   | .ofDelabTermInfo ti => some ti.toTermInfo
   | _                   => none
 
-/-- Report, for each hoverable region of the pretty-printed `e`,
-the text and the type its popup would show. -/
+/--
+  Report, for each hoverable region of the pretty-printed `e`,
+  the text and the type its popup would show.
+-/
 def hoverReport (e : Expr) : MetaM MessageData := do
   let ⟨fmt, infos⟩ ← PrettyPrinter.ppExprWithInfos e
   let mut lines : Array MessageData := #[]
@@ -44,7 +48,7 @@ def hoverReport (e : Expr) : MetaM MessageData := do
       m!"⋆ {txt.trimAscii}{if ti.isBinder then " (binder)" else ""} : {ty}"
   return MessageData.joinSep lines.toList "\n"
 
-elab "print_iris_delab" : tactic => do
+elab "trace_iris_delab" : tactic => do
   let g ← Tactic.getMainGoal
   g.withContext do logInfo (← hoverReport (← g.getType))
 
@@ -55,28 +59,28 @@ section
 /--
 info:
 ⋆ ∗HP1 : P
-∗HP2 : P
-∗HR : R
-∗HPQ : P ∗ P -∗ R -∗ Q
-⊢ Q : Prop
+  ∗HP2 : P
+  ∗HR : R
+  ∗HPQ : P ∗ P -∗ R -∗ Q
+  ⊢ Q : Prop
 ⋆ HP1 (binder) : P
-⋆ P : PROP
+  ⋆ P : PROP
 ⋆ HP2 (binder) : P
-⋆ P : PROP
+  ⋆ P : PROP
 ⋆ HR (binder) : R
-⋆ R : PROP
+  ⋆ R : PROP
 ⋆ HPQ (binder) : P ∗ P -∗ R -∗ Q
-⋆ P ∗ P -∗ R -∗ Q : PROP
-⋆ P : PROP
-⋆ P : PROP
-⋆ R : PROP
-⋆ Q : PROP
+  ⋆ P ∗ P -∗ R -∗ Q : PROP
+    ⋆ P : PROP
+    ⋆ P : PROP
+    ⋆ R : PROP
+    ⋆ Q : PROP
 ⋆ Q : PROP
 -/
-#guard_msgs in
+#guard_msgs (whitespace := lax) in
 example [BI PROP] (P Q R : PROP) : P ⊢ P -∗ R -∗ (P ∗ P -∗ R -∗ Q) -∗ Q := by
   iintro HP1 HP2 HR HPQ
-  print_iris_delab
+  trace_iris_delab
   ispecialize HPQ $$ [$HP1 HP2] [-]
   . iexact HP2
   . iexact HR
@@ -85,42 +89,116 @@ example [BI PROP] (P Q R : PROP) : P ⊢ P -∗ R -∗ (P ∗ P -∗ R -∗ Q) -
 /--
 info:
 ⋆ ∗HP1 : <absorb> P1
-∗HP2 : <absorb> P2
-∗HP3 : <absorb> <affine> P3
-∗HP4 : <absorb> <affine> P4
-∗H : <absorb> (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) -∗ Q
+  ∗HP2 : <absorb> P2
+  ∗HP3 : <absorb> <affine> P3
+  ∗HP4 : <absorb> <affine> P4
+  ∗H : <absorb> (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) -∗ Q
 ⊢ Q : Prop
 ⋆ HP1 (binder) : <absorb> P1
-⋆ <absorb> P1 : PROP
-⋆ P1 : PROP
+  ⋆ <absorb> P1 : PROP
+    ⋆ P1 : PROP
 ⋆ HP2 (binder) : <absorb> P2
-⋆ <absorb> P2 : PROP
-⋆ P2 : PROP
+  ⋆ <absorb> P2 : PROP
+    ⋆ P2 : PROP
 ⋆ HP3 (binder) : <absorb> <affine> P3
-⋆ <absorb> <affine> P3 : PROP
-⋆ P3 : PROP
+  ⋆ <absorb> <affine> P3 : PROP
+    ⋆ P3 : PROP
 ⋆ HP4 (binder) : <absorb> <affine> P4
-⋆ <absorb> <affine> P4 : PROP
-⋆ P4 : PROP
+  ⋆ <absorb> <affine> P4 : PROP
+    ⋆ P4 : PROP
 ⋆ H (binder) : <absorb> (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) -∗ Q
-⋆ <absorb> (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) -∗ Q : PROP
-⋆ (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) : PROP
-⋆ P1 : PROP
-⋆ P2 : PROP
-⋆ (P3 ∗ P4) : PROP
-⋆ P3 : PROP
-⋆ P4 : PROP
-⋆ Q : PROP
+  ⋆ <absorb> (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) -∗ Q : PROP
+    ⋆ (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) : PROP
+      ⋆ P1 : PROP
+      ⋆ P2 : PROP
+      ⋆ (P3 ∗ P4) : PROP
+        ⋆ P3 : PROP
+        ⋆ P4 : PROP
+  ⋆ Q : PROP
 ⋆ Q : PROP
 -/
-#guard_msgs in
+#guard_msgs (whitespace := lax) in
 example [BI PROP] {P1 P2 Q : PROP} :
     ⊢ <absorb> P1 -∗ <absorb> P2 -∗ <absorb> <affine> P3 -∗ <absorb> <affine> P4 -∗
       (<absorb> (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) -∗ Q) -∗ Q := by
   iintro HP1 HP2 HP3 HP4 H
-  print_iris_delab
+  trace_iris_delab
   icombine HP1 HP2 HP3 HP4 as HNew
   iapply H
   iexact HNew
+
+/--
+info:
+⋆ □H1 : ⌜m = 2⌝
+  ∗H2 : ⌜3 = n⌝
+  □H3 : ⌜a = b⌝
+  ∗H4 : ⌜b = c⌝
+  ⊢ ⌜m.succ = n ∧ a = c⌝ : Prop
+⋆ H1 (binder) : ⌜m = 2⌝
+  ⋆ ⌜m = 2⌝ : PROP
+    ⋆ m = 2 : Prop
+      ⋆ m : Nat
+      ⋆ 2 : Nat
+⋆ H2 (binder) : ⌜3 = n⌝
+  ⋆ ⌜3 = n⌝ : PROP
+    ⋆ 3 = n : Prop
+      ⋆ 3 : Nat
+      ⋆ n : Nat
+⋆ H3 (binder) : ⌜a = b⌝
+  ⋆ ⌜a = b⌝ : PROP
+    ⋆ a = b : Prop
+      ⋆ a : Prop
+      ⋆ b : Prop
+⋆ H4 (binder) : ⌜b = c⌝
+  ⋆ ⌜b = c⌝ : PROP
+    ⋆ b = c : Prop
+      ⋆ b : Prop
+      ⋆ c : Prop
+⋆ ⌜m.succ = n ∧ a = c⌝ : PROP
+  ⋆ m.succ = n ∧ a = c : Prop
+    ⋆ m.succ = n : Prop
+    ⋆ m.succ : Nat
+    ⋆ m : Nat
+    ⋆ n : Nat
+    ⋆ a = c : Prop
+      ⋆ a : Prop
+      ⋆ c : Prop
+-/
+#guard_msgs (whitespace := lax) in
+example [BI PROP] (m n : Nat) (a b c : Prop) :
+    ⊢@{PROP} ⌜m = 2⌝ -∗ ⌜3 = n⌝ -∗ ⌜a = b⌝ -∗ ⌜b = c⌝ -∗ ⌜m.succ = n ∧ a = c⌝ := by
+  iintro #H1 H2 #H3 H4
+  trace_iris_delab
+  icases H1 with %rfl
+  icases H2 with %rfl
+  icases H3 with %rfl
+  icases H4 with %rfl
+  ipureintro
+  and_intros <;> rfl
+
+/--
+info:
+⋆ □Hwand : ∀ x, Q -∗ ⌜x = n⌝
+  ∗HQ : Q
+  ⊢ False : Prop
+⋆ Hwand (binder) : ∀ x, Q -∗ ⌜x = n⌝
+  ⋆ ∀ x, Q -∗ ⌜x = n⌝ : PROP
+    ⋆ x : Nat
+    ⋆ Q : PROP
+    ⋆ x = n : Prop
+      ⋆ x : Nat
+      ⋆ n : Nat
+⋆ HQ (binder) : Q
+  ⋆ Q : PROP
+⋆ False : PROP
+-/
+#guard_msgs (whitespace := lax) in
+example [BI PROP] (Q : PROP) (n : Nat) :
+  □ (∀ x, Q -∗ ⌜x = n⌝) ⊢ Q -∗ False := by
+  iintro #Hwand HQ
+  trace_iris_delab
+  icases Hwand $$ %1 HQ with %_
+  icases Hwand $$ %2 HQ with %_
+  grind
 
 end

--- a/Iris/Iris/Tests/Display.lean
+++ b/Iris/Iris/Tests/Display.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2026 Alvin Tang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alvin Tang
+-/
+
+module
+
+import Lean
+public import Iris.ProofMode
+
+open Lean Elab Meta
+
+namespace Iris.Tests
+
+meta section
+
+partial def collectTags {α} (t : Widget.TaggedText α)
+    (acc : Array (String × α) := #[]) : Array (String × α) :=
+  match t with
+  | .text _    => acc
+  | .append ts => ts.foldl (init := acc) fun acc t => collectTags t acc
+  | .tag a t'  => collectTags t' (acc.push (t'.stripTags, a))
+
+/-- Delaborators record their info as `ofDelabTermInfo`; hand-rolled
+`Elab.withInfoContext'` sites record `ofTermInfo`. Accept either. -/
+def asTermInfo? : Info → Option TermInfo
+  | .ofTermInfo ti      => some ti
+  | .ofDelabTermInfo ti => some ti.toTermInfo
+  | _                   => none
+
+/-- Report, for each hoverable region of the pretty-printed `e`,
+the text and the type its popup would show. -/
+def hoverReport (e : Expr) : MetaM MessageData := do
+  let ⟨fmt, infos⟩ ← PrettyPrinter.ppExprWithInfos e
+  let mut lines : Array MessageData := #[]
+  for (txt, tag) in collectTags (Widget.TaggedText.prettyTagged fmt) do
+    let some info := infos.get? tag.fst | continue
+    let some ti := asTermInfo? info | continue
+    let ty ← withLCtx ti.lctx (← getLocalInstances) do
+      try ppExpr (← inferType ti.expr)
+      catch _ => pure "<not typable>"
+    lines := lines.push
+      m!"⋆ {txt.trimAscii}{if ti.isBinder then " (binder)" else ""} : {ty}"
+  return MessageData.joinSep lines.toList "\n"
+
+elab "print_iris_delab" : tactic => do
+  let g ← Tactic.getMainGoal
+  g.withContext do logInfo (← hoverReport (← g.getType))
+
+end
+
+section
+
+/--
+info:
+⋆ ∗HP1 : P
+∗HP2 : P
+∗HR : R
+∗HPQ : P ∗ P -∗ R -∗ Q
+⊢ Q : Prop
+⋆ HP1 (binder) : P
+⋆ P : PROP
+⋆ HP2 (binder) : P
+⋆ P : PROP
+⋆ HR (binder) : R
+⋆ R : PROP
+⋆ HPQ (binder) : P ∗ P -∗ R -∗ Q
+⋆ P ∗ P -∗ R -∗ Q : PROP
+⋆ P : PROP
+⋆ P : PROP
+⋆ R : PROP
+⋆ Q : PROP
+⋆ Q : PROP
+-/
+#guard_msgs in
+example [BI PROP] (P Q R : PROP) : P ⊢ P -∗ R -∗ (P ∗ P -∗ R -∗ Q) -∗ Q := by
+  iintro HP1 HP2 HR HPQ
+  print_iris_delab
+  ispecialize HPQ $$ [$HP1 HP2] [-]
+  . iexact HP2
+  . iexact HR
+  iexact HPQ
+
+/--
+info:
+⋆ ∗HP1 : <absorb> P1
+∗HP2 : <absorb> P2
+∗HP3 : <absorb> <affine> P3
+∗HP4 : <absorb> <affine> P4
+∗H : <absorb> (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) -∗ Q
+⊢ Q : Prop
+⋆ HP1 (binder) : <absorb> P1
+⋆ <absorb> P1 : PROP
+⋆ P1 : PROP
+⋆ HP2 (binder) : <absorb> P2
+⋆ <absorb> P2 : PROP
+⋆ P2 : PROP
+⋆ HP3 (binder) : <absorb> <affine> P3
+⋆ <absorb> <affine> P3 : PROP
+⋆ P3 : PROP
+⋆ HP4 (binder) : <absorb> <affine> P4
+⋆ <absorb> <affine> P4 : PROP
+⋆ P4 : PROP
+⋆ H (binder) : <absorb> (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) -∗ Q
+⋆ <absorb> (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) -∗ Q : PROP
+⋆ (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) : PROP
+⋆ P1 : PROP
+⋆ P2 : PROP
+⋆ (P3 ∗ P4) : PROP
+⋆ P3 : PROP
+⋆ P4 : PROP
+⋆ Q : PROP
+⋆ Q : PROP
+-/
+#guard_msgs in
+example [BI PROP] {P1 P2 Q : PROP} :
+    ⊢ <absorb> P1 -∗ <absorb> P2 -∗ <absorb> <affine> P3 -∗ <absorb> <affine> P4 -∗
+      (<absorb> (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) -∗ Q) -∗ Q := by
+  iintro HP1 HP2 HP3 HP4 H
+  print_iris_delab
+  icombine HP1 HP2 HP3 HP4 as HNew
+  iapply H
+  iexact HNew
+
+end


### PR DESCRIPTION
## Description

Addresses the Zulip discussion thread [#iris-lean > Porting iris-tutorial @ 💬](https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/Porting.20iris-tutorial/near/615480790).

This involves some improvements to the IPM goal delaborator so that the type signature of an item is shown in a pop-up message upon hovering instead of having the entire entailment as a single item.

<img width="467" height="212" alt="Pop-up message showing the type signature of an item in the Iris Proof Mode" src="https://github.com/user-attachments/assets/ab2652db-3f29-40fd-baff-3d997c72a6f8" />

The proof mode will be even more usable when more syntax definitions are annotated with docstrings.

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files
