### PR TITLE
refactor: `throwIPMError` for error messages by IPM tactics

### DIFF
--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -180,14 +180,14 @@ public meta def ProofModeM.runTacticWp {α} (tacName : Name) (k : MVarId → WpG
   : TacticM α := do
   ProofModeM.runTactic tacName fun mvar {u, prop, bi, hyps, goal, ..} => do
     let .defEq _ ← isLevelDefEqQ u 0
-      | throwError "The goal {goal} must be an `IProp` at universe level 0"
+      | throwIPMError "The goal {goal} must be an `IProp` at universe level 0"
     let ~q(IProp $GF) := prop
-      | throwError "The goal {goal} must be an `IProp`"
+      | throwIPMError "The goal {goal} must be an `IProp`"
     let ~q(UPred.instBIUPred) := bi
-      | throwError "Expected the BI implementation of `IProp` to be `UPred.instBIUPred`"
+      | throwIPMError "Expected the BI implementation of `IProp` to be `UPred.instBIUPred`"
 
     let ~q(Wp.wp (A := Stuckness) (Expr := Exp) (self := wp.def (ι := $ι)) $s $E $e $Φ) := goal
-      | throwError "The goal {goal} must be a WP"
+      | throwIPMError "The goal {goal} must be a WP"
     k mvar {hyps, ι, s, E, e, Φ, hu:=⟨⟩, hprop:=⟨⟩, hbi:=⟨⟩ }
 
 public theorem tac_wp_value [ι : IrisGS_gen hlc Exp GF] {Δ} {s : Stuckness} {E : CoPset} {v : Val} {Φ : Val → IProp GF}
@@ -242,15 +242,15 @@ elab "wp_value_head" : tactic =>
   ProofModeM.runTacticWp `wp_value_head fun mvar {bi, hyps, ι, s, E, e, Φ, hbi, ..} => do
     have : $bi =Q UPred.instBIUPred := hbi
     let some pf ← iWpValueHead hyps ι s E e Φ
-      | throwTacticEx `wp_value_head mvar s!"{e} is not a value"
+      | throwIPMError s!"{e} is not a value"
     mvar.assign pf
 
 public meta def iWpExprSimp (e : Q(Exp)) :
     ProofModeM ((e' : Q(Exp)) × Q($e = $e')) := do
   let some ext ← getSimpExtension? `wp_expr_simp
-    | throwError "Cannot find `wp_expr_simp` attribute"
+    | throwIPMError "Cannot find `wp_expr_simp` attribute"
   let some procext ← Simp.getSimprocExtension? `wp_expr_simp
-    | throwError "Cannot find `wp_expr_simp` attribute"
+    | throwIPMError "Cannot find `wp_expr_simp` attribute"
 
   let theorems ← ext.getTheorems
   let procs ← procext.getSimprocs
@@ -313,7 +313,7 @@ elab "wp_bind" colGt ppSpace focus:hl_exp:10 : tactic =>
       trace[wp_bind] s!"trying to unify {←ppExpr e} with {←ppExpr focus}"
       guard <| ← isDefEq e focus)
     -- TODO: add a throwProofModeEx for throwing errors consistently across all tactics
-      | throwTacticEx `wp_bind mvar s!"Cannot unify {←ppExpr focus} with any possible evaluation context"
+      | throwIPMError s!"Cannot unify {←ppExpr focus} with any possible evaluation context"
     trace[wp_bind] s!"Found context {←ppExpr K} with expression {←ppExpr e'} matching our focus"
 
     match K with
@@ -357,7 +357,7 @@ elab "wp_pure " colGt ppSpace focus:hl_exp:10 : tactic =>
       let e₂ ← mkFreshExprMVarQ q(Exp)
       let some inst ← ProofModeM.trySynthInstanceQ q(ProgramLogic.Language.PureExec $φ $n $e₁ $e₂) | failure
       return (φ, n, e₂, inst)
-      | throwTacticEx `wp_pure mvar "Cannot find expression to evaluate"
+      | throwIPMError "Cannot find expression to evaluate"
     have inst : Q(ProgramLogic.Language.PureExec $φ $n $e₁ $e₂) := inst
 
     let ⟨_, hyps', pf⟩ ← iModAction hyps q(modality_laterN $n)
@@ -578,7 +578,7 @@ structure PointsToLookup {u : Level} {GF : Q(BundledGFunctors.{0, 0, 0})}
 Throws if no matching hypothesis exists. -/
 meta def lookupPointsTo {u} {GF : Q(BundledGFunctors.{0, 0, 0})} {hlc : Q(HasLC)}
     {prop : Q(Type u)} {bi : Q(BI $prop)} {eΔ' : Q($prop)}
-    (tacName : Name) (mvar : MVarId) (hgs : Q(HeapLangGS $hlc $GF))
+    (hgs : Q(HeapLangGS $hlc $GF))
     (hyps' : Hyps bi eΔ') (l : Q(Loc)) (dq : Q(DFrac)) (p : Q(Bool))
     (hu : QuotedLevelDefEq u 0 := ⟨⟩)
     (hprop : $prop =Q IProp $GF := ⟨⟩) :
@@ -593,7 +593,7 @@ meta def lookupPointsTo {u} {GF : Q(BundledGFunctors.{0, 0, 0})} {hlc : Q(HasLC)
         unless ← isDefEq dq' dq do return none
         unless ← isDefEq p' p do return none
         return some ((v : Q(Val)), name, vid)
-    | throwTacticEx tacName mvar
+    | throwIPMError
         m!"cannot find a points-to hypothesis for {l} ↦\{{dq}} _"
   trace[wp_heap.lookup] "found {name} : □?{p} (pointsTo {l} ({dq}) (some {v}))"
   let pfSplit : Q($eΔ' ⊣⊢ $eΔ'' ∗ □?$p (pointsTo $l $dq (some $v))) := pf
@@ -619,7 +619,7 @@ meta def runTacticHeapWp {α} (tacName : Name)
   ProofModeM.runTacticWp tacName fun mvar {hyps, GF, hlc, ι, s, E, e, Φ, hu, hprop, hbi, ..} => do
     have ιQ : Q(IrisGS_gen $hlc Exp $GF) := ι
     let ~q(@HeapLang _ _ $hgs) := ιQ
-      | throwTacticEx tacName mvar "the goal is not a HeapLang WP"
+      | throwIPMError "the goal is not a HeapLang WP"
     trace[wp_heap] "{tacName}: e = {e}"
     -- currently specialized to later (no twp exists yet)
     let ⟨_, hyps', pfLater⟩ ← iModAction hyps q(modality_laterN 1)
@@ -632,13 +632,13 @@ elab "wp_load" : tactic =>
     let some {result := l, K, ..} ← findECtx e fun e' => do
         let ~q(Exp.load (Exp.ofVal (Val.lit (BaseLit.loc $l)))) := e' | failure
         return l
-      | throwTacticEx `wp_load mvar "cannot find a `load` redex"
+      | throwIPMError "cannot find a `load` redex"
     trace[wp_heap.redex] "load {l}; K = {K}"
 
     -- find `l ↦{dq} some v` in the spatial context and extract `dq`
     let dq ← mkFreshExprMVarQ q(DFrac)
     let p ← mkFreshExprMVarQ q(Bool)
-    let ⟨v, _, _, _, _, pfSplit⟩ ← lookupPointsTo `wp_load mvar hgs hyps' l dq p
+    let ⟨v, _, _, _, _, pfSplit⟩ ← lookupPointsTo hgs hyps' l dq p
 
     -- fill the loaded value back into `K` and finish the continuation
     -- (over `hyps'`: the points-to hypothesis is kept)
@@ -651,12 +651,12 @@ elab "wp_store" : tactic =>
     let some {result := (l, v'), K, ..} ← findECtx e fun e' => do
         let ~q(Exp.store (Exp.ofVal (Val.lit (BaseLit.loc $l))) (Exp.ofVal $v')) := e' | failure
         return (l, v')
-      | throwTacticEx `wp_store mvar "cannot find a `store` redex"
+      | throwIPMError "cannot find a `store` redex"
     trace[wp_heap.redex] "store {l} ← {v'}; K = {K}"
 
     -- find and remove `l ↦ some v` (stores need full ownership)
     let ⟨_, name, vid, _, hyps'', pfSplit⟩ ←
-      lookupPointsTo `wp_store mvar hgs hyps' l q(DFrac.own 1) q(false)
+      lookupPointsTo hgs hyps' l q(DFrac.own 1) q(false)
 
     let ⟨_, hyps''', pf'''⟩ := hyps''.add bi name vid q(false) q(pointsTo $l (DFrac.own 1) (some $v'))
 
@@ -669,12 +669,12 @@ elab "wp_xchg" : tactic =>
     let some {result := (l, v'), K, ..} ← findECtx e fun e' => do
         let ~q(Exp.xchg (Exp.ofVal (Val.lit (BaseLit.loc $l))) (Exp.ofVal $v')) := e' | failure
         return (l, v')
-      | throwTacticEx `wp_xchg mvar "cannot find an `xchg` redex"
+      | throwIPMError "cannot find an `xchg` redex"
     trace[wp_heap.redex] "xchg {l} ← {v'}; K = {K}"
 
     -- find and remove `l ↦ some v` (xchg writes, so it needs full ownership)
     let ⟨v, name, vid, _, hyps'', pfSplit⟩ ←
-      lookupPointsTo `wp_xchg mvar hgs hyps' l q(DFrac.own 1) q(false)
+      lookupPointsTo hgs hyps' l q(DFrac.own 1) q(false)
 
     let ⟨_, hyps''', pf'''⟩ := hyps''.add bi name vid q(false) q(pointsTo $l (DFrac.own 1) (some $v'))
 
@@ -689,16 +689,16 @@ elab "wp_faa" : tactic =>
         let ~q(Exp.faa (Exp.ofVal (Val.lit (BaseLit.loc $l)))
             (Exp.ofVal (Val.lit (BaseLit.int $z2)))) := e' | failure
         return (l, z2)
-      | throwTacticEx `wp_faa mvar "cannot find a `faa` redex"
+      | throwIPMError "cannot find a `faa` redex"
     trace[wp_heap.redex] "faa {l} += {z2}; K = {K}"
 
     -- find and remove `l ↦ some v` (faa writes, so it needs full ownership)
     let ⟨v, name, vid, eΔ'', hyps'', pfSplit⟩ ←
-      lookupPointsTo `wp_faa mvar hgs hyps' l q(DFrac.own 1) q(false)
+      lookupPointsTo hgs hyps' l q(DFrac.own 1) q(false)
 
     -- check that the points-to value is an integer (FAA requirement)
     let ~q(Val.lit (BaseLit.int $z1)) := v
-      | throwTacticEx `wp_faa mvar
+      | throwIPMError
           m!"the points-to hypothesis for location {l} does not store an integer"
     have pfSplit : Q($eΔ' ⊣⊢ $eΔ'' ∗
       pointsTo $l (DFrac.own 1) (some (Val.lit (BaseLit.int $z1)))) := pfSplit
@@ -716,12 +716,12 @@ elab "wp_cmpxchg_suc" : tactic =>
         let ~q(Exp.cmpXchg (Exp.ofVal (Val.lit (BaseLit.loc $l)))
             (Exp.ofVal $v1) (Exp.ofVal $v2)) := e' | failure
         return (l, v1, v2)
-      | throwTacticEx `wp_cmpxchg_suc mvar "cannot find a `cmpXchg` redex"
+      | throwIPMError "cannot find a `cmpXchg` redex"
     trace[wp_heap.redex] "cmpXchg {l}: {v1} → {v2}; K = {K}"
 
     -- find and remove `l ↦ some v` (a successful cmpXchg writes, so full ownership)
     let ⟨v, name, vid, _, hyps'', pfSplit⟩ ←
-      lookupPointsTo `wp_cmpxchg_suc mvar hgs hyps' l q(DFrac.own 1) q(false)
+      lookupPointsTo hgs hyps' l q(DFrac.own 1) q(false)
 
     -- check safety, don't throw hard error to match Rocq behavior
     let pfSafe ← iSolveSidecondition q(($v).compareSafe $v1 = true) (failOnUnsolved := false)
@@ -744,13 +744,13 @@ elab "wp_cmpxchg_fail" : tactic =>
         let ~q(Exp.cmpXchg (Exp.ofVal (Val.lit (BaseLit.loc $l)))
             (Exp.ofVal $v1) (Exp.ofVal $v2)) := e' | failure
         return (l, v1, v2)
-      | throwTacticEx `wp_cmpxchg_fail mvar "cannot find a `cmpXchg` redex"
+      | throwIPMError "cannot find a `cmpXchg` redex"
     trace[wp_heap.redex] "cmpXchg {l}: {v1} → {v2}; K = {K}"
 
     -- any fraction suffices for a failing compare (the points-to is only read)
     let dq ← mkFreshExprMVarQ q(DFrac)
     let p ← mkFreshExprMVarQ q(Bool)
-    let ⟨v, _, _, _, _, pfSplit⟩ ← lookupPointsTo `wp_cmpxchg_fail mvar hgs hyps' l dq p
+    let ⟨v, _, _, _, _, pfSplit⟩ ← lookupPointsTo hgs hyps' l dq p
 
     -- check safety, don't throw hard error to match Rocq behavior
     let pfSafe ← iSolveSidecondition q(($v).compareSafe $v1 = true) (failOnUnsolved := false)
@@ -772,12 +772,12 @@ elab "wp_cmpxchg" " with" colGt ppSpace h1:binderIdent colGt ppSpace h2:binderId
         let ~q(Exp.cmpXchg (Exp.ofVal (Val.lit (BaseLit.loc $l)))
             (Exp.ofVal $v1) (Exp.ofVal $v2)) := e' | failure
         return (l, v1, v2)
-      | throwTacticEx `wp_cmpxchg mvar "cannot find a `cmpXchg` redex"
+      | throwIPMError "cannot find a `cmpXchg` redex"
     trace[wp_heap.redex] "cmpXchg {l}: {v1} → {v2}; K = {K}"
 
     -- find and remove `l ↦ some v` (the success branch writes, so full ownership)
     let ⟨v, name, vid, eΔ'', hyps'', pfSplit⟩ ←
-      lookupPointsTo `wp_cmpxchg mvar hgs hyps' l q(DFrac.own 1) q(false)
+      lookupPointsTo hgs hyps' l q(DFrac.own 1) q(false)
 
     let ⟨_, hypsSuc, pfEq⟩ := hyps''.add bi name vid q(false)
       q(pointsTo $l (DFrac.own 1) (some $v2))
@@ -814,13 +814,13 @@ elab "wp_free" : tactic =>
     let some {result := l, K, ..} ← findECtx e fun e' => do
         let ~q(Exp.free (Exp.ofVal (Val.lit (BaseLit.loc $l)))) := e' | failure
         return l
-      | throwTacticEx `wp_free mvar "cannot find a `free` redex"
+      | throwIPMError "cannot find a `free` redex"
     trace[wp_heap.redex] "free {l}; K = {K}"
 
     -- find and remove `l ↦ some v` (freeing needs full ownership); the continuation
     -- runs over the pruned context `hyps''` since the points-to is consumed
     let ⟨_, _, _, _, hyps'', pfSplit⟩ ←
-      lookupPointsTo `wp_free mvar hgs hyps' l q(DFrac.own 1) q(false)
+      lookupPointsTo hgs hyps' l q(DFrac.own 1) q(false)
 
     let pfCont ← finishHeapOp hyps'' hgs s E K q(hl_val(#())) Φ
 
@@ -833,7 +833,7 @@ elab "wp_alloc" colGt ppSpace loc:binderIdent " with" colGt ppSpace hyp:binderId
         let ~q(Exp.allocN (Exp.ofVal (Val.lit (BaseLit.int 1)))
             (Exp.ofVal $v)) := e' | failure
         return v
-      | throwTacticEx `wp_alloc mvar "cannot find a `ref` alloc"
+      | throwIPMError "cannot find a `ref` alloc"
     trace[wp_heap.redex] "ref {v}; K = {K}"
 
     -- get location name from tactic call

--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -176,9 +176,9 @@ public structure WpGoal where
   hprop : $prop =Q IProp $GF
   hbi : $bi =Q UPred.instBIUPred
 
-public meta def ProofModeM.runTacticWp {α} (k : MVarId → WpGoal → ProofModeM α)
+public meta def ProofModeM.runTacticWp {α} (tacName : Name) (k : MVarId → WpGoal → ProofModeM α)
   : TacticM α := do
-  ProofModeM.runTactic fun mvar {u, prop, bi, hyps, goal, ..} => do
+  ProofModeM.runTactic tacName fun mvar {u, prop, bi, hyps, goal, ..} => do
     let .defEq _ ← isLevelDefEqQ u 0
       | throwError "The goal {goal} must be an `IProp` at universe level 0"
     let ~q(IProp $GF) := prop
@@ -239,7 +239,7 @@ public meta def iWpValueHead {u}
   return some q(tac_wp_value (s:=$s) $pf)
 
 elab "wp_value_head" : tactic =>
-  ProofModeM.runTacticWp fun mvar {bi, hyps, ι, s, E, e, Φ, hbi, ..} => do
+  ProofModeM.runTacticWp `wp_value_head fun mvar {bi, hyps, ι, s, E, e, Φ, hbi, ..} => do
     have : $bi =Q UPred.instBIUPred := hbi
     let some pf ← iWpValueHead hyps ι s E e Φ
       | throwTacticEx `wp_value_head mvar s!"{e} is not a value"
@@ -264,7 +264,7 @@ public theorem tac_wp_expr_simp [ι : IrisGS_gen hlc Exp GF] {Δ} {s : Stuckness
   (Δ ⊢ WP e @ s ; E {{ Φ }}) := by simp [*]
 
 elab "wp_expr_simp" : tactic =>
-  ProofModeM.runTacticWp fun mvar {hyps, s, E, e, Φ, ..} => do
+  ProofModeM.runTacticWp `wp_expr_simp fun mvar {hyps, s, E, e, Φ, ..} => do
     let ⟨e', pfeq⟩ ← iWpExprSimp e
     let pf ← addBIGoal hyps q(Wp.wp $s $E $e' $Φ)
     mvar.assign q(tac_wp_expr_simp $pf $pfeq)
@@ -294,7 +294,7 @@ public meta def iWpFinish {u}
   return q(tac_wp_expr_simp $nextPf $pfeq)
 
 elab "wp_finish" : tactic =>
-  ProofModeM.runTacticWp fun mvar {hyps, ι, s, E, e, Φ, ..} => do
+  ProofModeM.runTacticWp `wp_finish fun mvar {hyps, ι, s, E, e, Φ, ..} => do
     let pf ← iWpFinish hyps ι s E e Φ
     mvar.assign pf
 
@@ -305,7 +305,7 @@ public theorem tac_wp_bind [ι : IrisGS_gen hlc Exp GF] {Δ} {s : Stuckness} {E 
 
 -- level of hl_exp should be above the level of ; in the heaplang notation to make `wp_bind _ _; wp_rec` work
 elab "wp_bind" colGt ppSpace focus:hl_exp:10 : tactic =>
-  ProofModeM.runTacticWp fun mvar {GF, hyps, s, E, e, Φ, ..} => do
+  ProofModeM.runTacticWp `wp_bind fun mvar {GF, hyps, s, E, e, Φ, ..} => do
     let focus ← elabTermEnsuringTypeQ (←`(hl($focus))) q(HeapLang.Exp)
     trace[wp_bind] s!"Context to bind over: {←ppExpr focus}"
 
@@ -346,7 +346,7 @@ public theorem tac_wp_pure [ι : IrisGS_gen hlc Exp GF] {Δ Δ'} {s : Stuckness}
   iintro $ !> -; itrivial
 
 elab "wp_pure " colGt ppSpace focus:hl_exp:10 : tactic =>
-  ProofModeM.runTacticWp fun mvar {hyps, ι, s, E, e, Φ, ..} => do
+  ProofModeM.runTacticWp `wp_pure fun mvar {hyps, ι, s, E, e, Φ, ..} => do
     let focus ← elabTermEnsuringTypeQ (← `(hl($focus))) q(HeapLang.Exp)
     trace[wp_pure] m!"Focusing with {focus}"
 
@@ -616,7 +616,7 @@ meta def runTacticHeapWp {α} (tacName : Name)
     (k : MVarId → HeapWpGoal → ProofModeM α) : TacticM α := do
   -- Rocq parity: every heap tactic first normalizes pure redexes
   evalTactic (← `(tactic| wp_pures))
-  ProofModeM.runTacticWp fun mvar {hyps, GF, hlc, ι, s, E, e, Φ, hu, hprop, hbi, ..} => do
+  ProofModeM.runTacticWp tacName fun mvar {hyps, GF, hlc, ι, s, E, e, Φ, hu, hprop, hbi, ..} => do
     have ιQ : Q(IrisGS_gen $hlc Exp $GF) := ι
     let ~q(@HeapLang _ _ $hgs) := ιQ
       | throwTacticEx tacName mvar "the goal is not a HeapLang WP"

--- a/Iris/Iris/ProofMode/ProofModeM.lean
+++ b/Iris/Iris/ProofMode/ProofModeM.lean
@@ -13,10 +13,13 @@ public meta section
 namespace Iris.ProofMode
 open Lean Elab Tactic Meta Qq BI Std
 
+structure ProofModeM.Context where
+  tacName : Name := .anonymous
+
 structure ProofModeM.State where
   goals : Array MVarId := #[]
 
-abbrev ProofModeM := StateRefT ProofModeM.State TacticM
+abbrev ProofModeM := ReaderT ProofModeM.Context <| StateRefT ProofModeM.State TacticM
 
 structure ProofModeM.SavedState where
   tactic : Tactic.SavedState
@@ -32,6 +35,36 @@ protected def ProofModeM.saveState : ProofModeM SavedState :=
 instance : MonadBacktrack ProofModeM.SavedState ProofModeM where
   saveState := ProofModeM.saveState
   restoreState b := b.restore
+
+/-- Name of the tactic currently being run; prefixes IPM error messages. -/
+def ProofModeM.getTacticName : ProofModeM Name :=
+  return (← readThe ProofModeM.Context).tacName
+
+/-- Run `k` attributing its errors to `n` instead of the ambient tactic name. -/
+def ProofModeM.withTacticName (n : Name) (k : ProofModeM α) : ProofModeM α :=
+  withTheReader ProofModeM.Context ({ · with tacName := n }) k
+
+@[inline] protected def ProofModeM.throwError (msg : MessageData) : ProofModeM α := do
+  let n ← ProofModeM.getTacticName
+  if n.isAnonymous then
+    Lean.throwError msg
+  else
+    Lean.throwError m!"{n}: {msg}"
+
+@[inline] protected def ProofModeM.throwErrorAt (ref : Syntax) (msg : MessageData) :
+    ProofModeM α :=
+  withRef ref <| ProofModeM.throwError msg
+
+syntax:max "throwIPMError "   (interpolatedStr(term) <|> term) : term
+syntax:max "throwIPMErrorAt " term:max (interpolatedStr(term) <|> term) : term
+
+macro_rules
+  | `(throwIPMError $msg:interpolatedStr) => `(ProofModeM.throwError (m! $msg))
+  | `(throwIPMError $msg:term)            => `(ProofModeM.throwError $msg)
+
+macro_rules
+  | `(throwIPMErrorAt $ref $msg:interpolatedStr) => `(ProofModeM.throwErrorAt $ref (m! $msg))
+  | `(throwIPMErrorAt $ref $msg:term)            => `(ProofModeM.throwErrorAt $ref $msg)
 
 /-
 Make the compiler generate specialized `pure`/`bind` so we do not have to optimize through the
@@ -140,8 +173,8 @@ def ProofModeM.synthInstanceQ (α : Q(Sort v)) : ProofModeM Q($α) := do
   return e
 
 /-- Initialize proof mode for a metavariable, converting it to an Iris goal. -/
-def startProofMode (mvar : MVarId) (customProp : Option Expr := none) :
-    MetaM (MVarId × IrisGoal) := mvar.withContext do
+def startProofMode (mvar : MVarId) (customProp : Option Expr := none)
+    (tacName : Name := `istart): MetaM (MVarId × IrisGoal) := mvar.withContext do
   -- parse goal
   let goal ← instantiateMVars <| ← mvar.getType
 
@@ -149,7 +182,7 @@ def startProofMode (mvar : MVarId) (customProp : Option Expr := none) :
   if let some irisGoal := parseIrisGoal? goal then
     if let some customProp := customProp then
       unless ← isDefEq irisGoal.prop customProp do
-        throwError m!"istart: currently in the Iris Proof Mode with \
+        throwError m!"{tacName}: currently in the Iris Proof Mode with \
           {irisGoal.prop} rather than {customProp}"
     return (mvar, irisGoal)
 
@@ -160,7 +193,7 @@ def startProofMode (mvar : MVarId) (customProp : Option Expr := none) :
 
   if let some customProp := customProp then
     unless ← isDefEq prop customProp do
-      throwError "istart: {customProp} is not a valid BI instance type"
+      throwError "{tacName}: {customProp} is not a valid BI instance type"
 
   let P ← mkFreshExprMVarQ q($prop)
   let bi ← mkFreshExprMVarQ q(BI $prop)
@@ -169,27 +202,27 @@ def startProofMode (mvar : MVarId) (customProp : Option Expr := none) :
 
   match synthResult, customProp with
   | .some (inst, mvars), _ =>
-    if !mvars.isEmpty then throwError "istart does not support creating mvars"
+    if !mvars.isEmpty then throwError "{tacName} does not support creating mvars"
     let irisGoal := { u, prop, bi, hyps := .mkEmp bi, goal := P, .. }
     let subgoal : Quoted q(⊢ $P) ←
       mkFreshExprSyntheticOpaqueMVar (IrisGoal.toExpr irisGoal) (← mvar.getTag)
     mvar.assign q(asEmpValid_2 $goal $inst $subgoal)
     pure (subgoal.mvarId!, irisGoal)
   | _, none =>
-    throwError "istart: {goal} is not an emp valid"
+    throwError "{tacName}: {goal} is not an emp valid"
   | _, some _ =>
-    throwError "istart: {goal} is not an emp valid in {customProp}"
+    throwError "{tacName}: {goal} is not an emp valid in {customProp}"
 
 /--
   Run a ProofModeM computation on the main goal, ordering resulting goals with
   dependencies last.
 -/
-def ProofModeM.runTactic (x : MVarId → IrisGoal → ProofModeM α)
+def ProofModeM.runTactic (tacName : Name) (x : MVarId → IrisGoal → ProofModeM α)
     (s : ProofModeM.State := {}) : TacticM α := do
   let (mvar, g) ← startProofMode (← getMainGoal)
   mvar.withContext do
 
-  let (res, {goals}) ← StateRefT'.run (x mvar g) s
+  let (res, {goals}) ← StateRefT'.run ((x mvar g).run { tacName }) s
 
   -- make sure to synthesize everything postponed
   Term.synthesizeSyntheticMVarsNoPostponing (ignoreStuckTC := true)

--- a/Iris/Iris/ProofMode/Tactics/Accu.lean
+++ b/Iris/Iris/ProofMode/Tactics/Accu.lean
@@ -18,15 +18,15 @@ open Lean Elab Tactic Meta Qq
   goal by unifying the metavariable with the combined proposition.
 -/
 elab "iaccu" : tactic => do
-  ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
+  ProofModeM.runTactic `iaccu λ mvar { hyps, goal, .. } => do
     unless goal.isMVar do
-      throwError m!"iaccu: {goal} is not a metavariable"
+      throwIPMError "{goal} is not a metavariable"
 
     let ⟨spatial, pf⟩ := hyps.buildAccuProof
 
     -- Assign and unify the metavariable
     unless ← isDefEq goal spatial do
-      throwError "iaccu: could not assign goal metavariable to {spatial}"
+      throwIPMError "could not assign goal metavariable to {spatial}"
 
     mvar.assign pf
 

--- a/Iris/Iris/ProofMode/Tactics/Apply.lean
+++ b/Iris/Iris/ProofMode/Tactics/Apply.lean
@@ -53,7 +53,7 @@ private partial def iApplyCore {prop : Q(Type u)} {bi : Q(BI $prop)} {e}
   -- otherwise, if `A` has the form `?P -∗ ?B`, create a subgoal for `P` and continue with `?B`
   let some ⟨_, hyps', pb, B, pf⟩ ← try? <| iSpecializeCore hyps p A goal
     [⟨← getRef, .goal {kind := .spatial, negate := false, trivial := false, frame := [], hyps := []} .anonymous⟩]
-    | throwError m!"iapply: cannot apply {A} to {goal}"
+    | throwIPMError "cannot apply {A} to {goal}"
   let pf' ← iApplyCore hyps' pb B goal
   return q($pf $pf')
 
@@ -71,14 +71,14 @@ private partial def iApplyCore {prop : Q(Type u)} {bi : Q(BI $prop)} {e}
 -/
 elab "iapply " colGt pmt:pmTerm : tactic => do
   let pmt ← liftMacroM <| PMTerm.parse pmt
-  ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
+  ProofModeM.runTactic `iapply λ mvar { hyps, goal, .. } => do
   -- elaborate the proof mode term `pmt` to the hypothesis `out`
   let ⟨e, hyps', p, out, pf⟩ ← iHave hyps goal pmt true
   -- if `□?p out` directly matches goal, behave like `iexact`
   if let some _ ← ProofModeM.trySynthInstanceQ q(FromAssumption $p .in $out $goal) then
     -- ensure the context can be discarded
     let .some _ ← trySynthInstanceQ q(TCOr (Affine $e) (Absorbing $goal))
-      | throwError "iapply: the context {e} is not affine and goal not absorbing"
+      | throwIPMError "the context {e} is not affine and goal not absorbing"
     mvar.assign q($pf apply_assumption)
     return
   -- otherwise, `out` should be a wand, handled by `iApplyCore`

--- a/Iris/Iris/ProofMode/Tactics/Assumption.lean
+++ b/Iris/Iris/ProofMode/Tactics/Assumption.lean
@@ -30,19 +30,19 @@ open Lean Elab Tactic Meta Qq
   intuitionistic or spatial context.
 -/
 elab "iassumption" : tactic => do
-  ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
+  ProofModeM.runTactic `iassumption λ mvar { hyps, goal, .. } => do
 
   if goal.isMVar then
-    throwError "iassumption: goal is a mvar, use iaccu instead"
+    throwIPMError "goal is a mvar, use iaccu instead"
 
   let some ⟨inst, e', _, out, ty, b, _, pf⟩ ←
     hyps.removeG true fun _ _ b ty => do
       ProofModeM.trySynthInstanceQ q(FromAssumption $b .in $ty $goal)
-    | throwError "iassumption: no matching assumption"
+    | throwIPMError "no matching assumption"
   let _ : Q(FromAssumption $b .in $ty $goal) := inst
   have : $out =Q iprop(□?$b $ty) := ⟨⟩
   let .some _ ← trySynthInstanceQ q(TCOr (Affine $e') (Absorbing $goal))
-    | throwError "iassumption: context is not affine or goal is not absorbing"
+    | throwIPMError "context is not affine or goal is not absorbing"
   mvar.assign q(assumption (Q := $goal) $pf)
 
 macro_rules | `(tactic| itrivial) => `(tactic| (try iassumption) <;> done)

--- a/Iris/Iris/ProofMode/Tactics/Cases.lean
+++ b/Iris/Iris/ProofMode/Tactics/Cases.lean
@@ -89,7 +89,7 @@ private def iCasesEmptyConj {prop : Q(Type u)} (bi : Q(BI $prop))
   if let .defEq _ ← isDefEqQ A q(iprop(False)) then
     return q(false_elim')
   else
-    throwError "icases: cannot destruct {A} as an empty conjunct"
+    throwIPMError "cannot destruct {A} as an empty conjunct"
 
 /--
   Destruct an existential hypothesis `A` by introducing its witness and
@@ -103,13 +103,13 @@ private def iCasesExists {prop : Q(Type u)} {bi : Q(BI $prop)} (pat : TSyntax `r
   let α : Q(Sort v) ← mkFreshExprMVarQ q(Sort v)
   let Φ : Q($α → $prop) ← mkFreshExprMVarQ q($α → $prop)
   let .some _ ← ProofModeM.trySynthInstanceQ q(IntoExists $A $Φ)
-  | throwError "icases: {A} is not an existential quantifier"
+  | throwIPMError "{A} is not an existential quantifier"
   let pf : Q(∀ x, $P ∗ □?$p $Φ x ⊢ $goal) ←
     iPureCases q(∀ x, $P ∗ □?$p $Φ x ⊢ $goal) pat fun g => do
       let B : Q($prop) ← mkFreshExprMVarQ q($prop)
       -- TODO: Is this the right way to check this?
       unless ← withTransparency .none <| isDefEq (← g.getType) q($P ∗ □?$p $B ⊢ $goal) do
-        throwError "icases: unexpected goal {goal} after intro pattern"
+        throwIPMError "unexpected goal {goal} after intro pattern"
       k (Expr.headBeta (← instantiateMVars B))
   return q(exists_elim' $pf)
 
@@ -141,23 +141,23 @@ private def iCasesSep {prop : Q(Type u)} {bi : Q(BI $prop)}
   match matchBool p with
   | .inl _ =>
     let .some _ ← ProofModeM.trySynthInstanceQ q(IntoAnd $p $A $A1 $A2)
-      | throwError "icases: cannot destruct {A}"
+      | throwIPMError "cannot destruct {A}"
     let goal' := q(iprop(□ $A2 -∗ $goal))
     let pf ← k1 hyps goal' A1 fun hyps goal' => do
       let goal'' ← mkFreshExprMVarQ q($prop)
       let .some inst ← ProofModeM.trySynthInstanceQ q(FromWand $goal' .in iprop(□ $A2) $goal'')
-        | throwError "icases: internal error: {goal'} is not a wand"
+        | throwIPMError "internal error: {goal'} is not a wand"
       let pf ← k2 hyps goal'' A2 k
       return q((wand_intro $pf).trans $(inst).from_wand)
     return q(and_elim_intuitionistic $pf)
   | .inr _ =>
     let .some _ ← ProofModeM.trySynthInstanceQ q(IntoSep $A $A1 $A2)
-      | throwError "icases: cannot destruct {A}"
+      | throwIPMError "cannot destruct {A}"
     let goal' := q(iprop($A2 -∗ $goal))
     let pf ← k1 hyps goal' A1 fun hyps goal' => do
       let goal'' ← mkFreshExprMVarQ q($prop)
       let .some inst ← ProofModeM.trySynthInstanceQ q(FromWand $goal' .in $A2 $goal'')
-        | throwError "icases: internal error: {goal'} is not a wand"
+        | throwIPMError "internal error: {goal'} is not a wand"
       let pf ← k2 hyps goal'' A2 k
       return q((wand_intro $pf).trans $(inst).from_wand)
     return q(sep_elim_spatial (A := $A) $pf)
@@ -170,7 +170,7 @@ private def iCasesOr {prop : Q(Type u)} {bi : Q(BI $prop)}
   let A1 ← mkFreshExprMVarQ q($prop)
   let A2 ← mkFreshExprMVarQ q($prop)
   let .some _ ← ProofModeM.trySynthInstanceQ q(IntoOr $A $A1 $A2)
-    | throwError "icases: {A} is not a disjunction"
+    | throwIPMError "{A} is not a disjunction"
   return q(or_elim' $(← k1 A1) $(← k2 A2))
 
 /--
@@ -183,13 +183,13 @@ private def iCasesIntuitionistic {prop : Q(Type u)} {bi : Q(BI $prop)}
     ProofModeM (Q($P ∗ □?$p $A ⊢ $goal)) := do
   let B ← mkFreshExprMVarQ q($prop)
   let .some _ ← ProofModeM.trySynthInstanceQ q(IntoPersistently $p $A $B)
-    | throwError "icases: {A} not persistent"
+    | throwIPMError "{A} not persistent"
   match matchBool p with
   | .inl _ =>
     return q(intuitionistic_elim_intuitionistic $(← k B))
   | .inr _ =>
     let .some _ ← trySynthInstanceQ q(TCOr (Affine $A) (Absorbing $goal))
-      | throwError "icases: {A} not affine and the goal not absorbing"
+      | throwIPMError "{A} not affine and the goal not absorbing"
     return q(intuitionistic_elim_spatial (A := $A) $(← k B))
 
 /--
@@ -306,7 +306,7 @@ elab "icases" keep:("+keep ")? colGt pmt:pmTerm " with " colGt pat:icasesPat : t
   -- parse syntax
   let pmt ← liftMacroM <| PMTerm.parse pmt
   let pat ← liftMacroM <| iCasesPat.parse pat
-  ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
+  ProofModeM.runTactic `icases λ mvar { hyps, goal, .. } => do
 
   /-
     We keep the persistent hypothesis if it is required by the user (`+keep` is set by `ihave`)

--- a/Iris/Iris/ProofMode/Tactics/Clear.lean
+++ b/Iris/Iris/ProofMode/Tactics/Clear.lean
@@ -36,7 +36,7 @@ def iClearCoreOne {prop : Q(Type u)} (_bi : Q(BI $prop)) (e e' : Q($prop))
     | .inl _ => return q(clear_intuitionistic (Q := $goal) $pf)
     | .inr _ =>
       let .some _ ← trySynthInstanceQ q(TCOr (Affine $out) (Absorbing $goal))
-        | throwError "iclear: {out} is not affine and the goal not absorbing"
+        | throwIPMError "{out} is not affine and the goal not absorbing"
       return q(clear_spatial (A:=$out) $pf)
 
 private structure ClearState {u} {prop : Q(Type u)} {bi : Q(BI $prop)} (origE goal : Q($prop)) where
@@ -81,6 +81,6 @@ def iClearCore {u} {prop : Q(Type u)} {bi : Q(BI $prop)} {e}
 elab "iclear " pats:(colGt ppSpace selPat)+ : tactic => do
   let pats ← liftMacroM <| SelPat.parse pats
 
-  ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
+  ProofModeM.runTactic `iclear λ mvar { hyps, goal, .. } => do
     let pf ← iClearCore hyps goal pats (addBIGoalWithoutFVars · ·)
     mvar.assign pf

--- a/Iris/Iris/ProofMode/Tactics/Combine.lean
+++ b/Iris/Iris/ProofMode/Tactics/Combine.lean
@@ -151,7 +151,7 @@ private def CombineState.combineProofModeHyp {u prop bi origE goal} :
   | { newHyps, p := p1, outAs, pfAs, outGives, pfGives, .. }, ivar => do
     let some (_, ⟨_, hyps2, _, out2, p2, _, pf2⟩) ←
         newHyps.removeG false <| fun _ ivar' _ _ => return guard <| ivar' == ivar
-    | throwError "icombine: propositions in the spatial context cannot be used as arguments multiple times"
+    | throwIPMError "propositions in the spatial context cannot be used as arguments multiple times"
 
     -- Type class instance search for the `as` syntax
     let newOutAs ← mkFreshExprMVarQ q($prop)
@@ -228,10 +228,10 @@ private def iCombineParseSelPats {u} {prop : Q(Type $u)} {bi} {e : Q($prop)}
   targets.mapM fun t =>
     match t.kind with
     | .ipm iVarId => pure iVarId
-    | .pure _      => throwError "icombine: invalid selection pattern with pure propositions"
+    | .pure _      => throwIPMError "invalid selection pattern with pure propositions"
 
 private def throwNoInstanceForGives : ProofModeM Unit := do
-  throwError "icombine: no type class instance to combine propositions"
+  throwIPMError "no type class instance to combine propositions"
 
 /--
   `icombine patSels as patAs` combines the hypotheses specified by the selection
@@ -245,7 +245,7 @@ elab "icombine " patSels:(colGt ppSpace selPat)*
     " as " colGt patAs:icasesPat : tactic => do
   let pat ← liftMacroM <| iCasesPat.parse patAs
 
-  ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
+  ProofModeM.runTactic `icombine λ mvar { hyps, goal, .. } => do
     let hs ← iCombineParseSelPats hyps patSels
     let st ← iCombineCore hs hyps goal
 
@@ -265,7 +265,7 @@ elab "icombine " patSels:(colGt ppSpace selPat)*
     " gives " colGt patGives:icasesPat : tactic => do
   let pat ← liftMacroM <| iCasesPat.parse patGives
 
-  ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
+  ProofModeM.runTactic `icombine λ mvar { hyps, goal, .. } => do
     let hs ← iCombineParseSelPats hyps patSels
     let {outGives, pfGives, ..} ← iCombineCore hs hyps goal
 
@@ -294,7 +294,7 @@ elab "icombine " patSels:(colGt ppSpace selPat)*
   let pat1 ← liftMacroM <| iCasesPat.parse patAs
   let pat2 ← liftMacroM <| iCasesPat.parse patGives
 
-  ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
+  ProofModeM.runTactic `icombine λ mvar { hyps, goal, .. } => do
     let hs ← iCombineParseSelPats hyps patSels
     let st@{outGives, pfGives, ..} ← iCombineCore hs hyps goal
 

--- a/Iris/Iris/ProofMode/Tactics/Eval.lean
+++ b/Iris/Iris/ProofMode/Tactics/Eval.lean
@@ -45,9 +45,9 @@ private def iEvalOne {u} {prop : Q(Type u)} (bi : Q(BI $prop))
   let m : Q($prop) ← mkFreshExprMVar q($prop)
   let pf ← mkFreshExprSyntheticOpaqueMVar <| if isGoal then q($m ⊢ $ty) else q($ty ⊢ $m)
   let [g] ← evalTacticAt tac pf.mvarId!
-    | throwError "ieval: the supplied tactic does not produce exactly one subgoal"
+    | throwIPMError "the supplied tactic does not produce exactly one subgoal"
   let some ⟨_, _, lhs, rhs⟩ := parseEntails? (← g.getType)
-    | throwError "ieval: the goal is not Iris entailment upon applying the supplied tactic"
+    | throwIPMError "the goal is not Iris entailment upon applying the supplied tactic"
   let newTy : Q($prop) := if isGoal then rhs else lhs
   m.mvarId!.assign newTy
   g.assign (q(.rfl) : Q($newTy ⊢ $newTy))
@@ -73,13 +73,13 @@ private def iEvalCore {u} {prop : Q(Type u)} {bi : Q(BI $prop)} {e}
     for selTarget in selTargets do
       evalState ← match selTarget.kind with
       | .pure _ =>
-        throwError "ieval: pure hypotheses in the selection pattern is not supported"
+        throwIPMError "pure hypotheses in the selection pattern is not supported"
       | .ipm ivar =>
         let some ⟨newE, newHyps, pf⟩ ← evalState.newHyps.replace ivar fun _ _ ty => do
           let ⟨newTy, pf⟩ ← iEvalOne (isGoal := false) bi tac ty
           let pf : Q($ty ⊢ $newTy) := pf
           return ⟨newTy, q(hyps_replace_ieval $pf)⟩
-        | throwError m!"ieval: unable to find the hypothesis {ivar.name} in the context"
+        | throwIPMError "unable to find the hypothesis {ivar.name} in the context"
         pure { newE, newHyps, pf := q($(evalState.pf).trans $pf) }
     let pf' ← addBIGoal evalState.newHyps goal
     return q($(evalState.pf).trans $pf')
@@ -88,7 +88,7 @@ private def iEvalCore {u} {prop : Q(Type u)} {bi : Q(BI $prop)} {e}
   `ieval (tac)` applies the tactic sequence `tac` to the proof goal.
 -/
 elab "ieval " "(" tac:tacticSeq ")" : tactic => do
-  ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
+  ProofModeM.runTactic `ieval λ mvar { hyps, goal, .. } => do
     let pf ← iEvalCore hyps goal tac none
     mvar.assign pf
 
@@ -100,7 +100,7 @@ elab "ieval " "(" tac:tacticSeq ")" : tactic => do
 elab "ieval " "(" tacs:tacticSeq ")" " in " spats:(colGt ppSpace selPat)+ : tactic => do
   let selPats ← liftMacroM <| SelPat.parse spats
 
-  ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
+  ProofModeM.runTactic `ieval λ mvar { hyps, goal, .. } => do
     let selTargets ← SelPat.resolve hyps selPats
     let pf ← iEvalCore hyps goal tacs selTargets
     mvar.assign pf

--- a/Iris/Iris/ProofMode/Tactics/ExFalso.lean
+++ b/Iris/Iris/ProofMode/Tactics/ExFalso.lean
@@ -23,6 +23,6 @@ open Lean Elab.Tactic Meta Qq
   `iexfalso` changes the goal to `False`.
 -/
 elab "iexfalso" : tactic => do
-  ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
+  ProofModeM.runTactic `iexfalso λ mvar { hyps, goal, .. } => do
     let m ← addBIGoal hyps q(iprop(False))
     mvar.assign q(exfalso (Q := $goal) $m)

--- a/Iris/Iris/ProofMode/Tactics/Exact.lean
+++ b/Iris/Iris/ProofMode/Tactics/Exact.lean
@@ -16,13 +16,13 @@ open Lean Elab Tactic Meta Qq BI Std
   `iexact H` solves the goal by matching it with the hypothesis `H`.
 -/
 elab "iexact " colGt hyp:ident : tactic => do
-  ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
+  ProofModeM.runTactic `iexact λ mvar { hyps, goal, .. } => do
   let ivar ← hyps.findWithInfo hyp
   let ⟨e', _, _, out, p, _, pf⟩ := hyps.remove true ivar
 
   let some _ ← ProofModeM.trySynthInstanceQ q(FromAssumption $p .in $out $goal)
-    | throwError "iexact: cannot unify {out} and {goal}"
+    | throwIPMError "cannot unify {out} and {goal}"
   let .some _ ← trySynthInstanceQ q(TCOr (Affine $e') (Absorbing $goal))
-    | throwError "iexact: context is not affine or goal is not absorbing"
+    | throwIPMError "context is not affine or goal is not absorbing"
 
   mvar.assign q(assumption (Q := $goal) $pf)

--- a/Iris/Iris/ProofMode/Tactics/Exists.lean
+++ b/Iris/Iris/ProofMode/Tactics/Exists.lean
@@ -31,7 +31,7 @@ open Lean Elab Tactic Meta Qq
 -/
 elab "iexists " xs:term,+ : tactic => do
   -- resolve existential quantifier with the given argument
-  ProofModeM.runTactic λ mvar { prop, e, hyps, goal, .. } => do
+  ProofModeM.runTactic `iexists λ mvar { prop, e, hyps, goal, .. } => do
 
     let mut new_goal_and_pf : ((g : Q($prop)) × Q($g ⊢ $goal)) := ⟨goal, q(.rfl)⟩
 
@@ -42,7 +42,7 @@ elab "iexists " xs:term,+ : tactic => do
       let α ← mkFreshExprMVarQ q(Sort v)
       let Φ ← mkFreshExprMVarQ q($α → $prop)
       let some _ ← ProofModeM.trySynthInstanceQ q(FromExists $(new_goal) $Φ)
-        | throwError "iexists: cannot turn {new_goal} into an existential quantifier"
+        | throwIPMError "cannot turn {new_goal} into an existential quantifier"
       let x ← elabTermEnsuringTypeQ (u := .succ .zero) x α
       let newMVarIds ← getMVarsNoDelayed x
       for mvar in newMVarIds do addMVarGoal mvar

--- a/Iris/Iris/ProofMode/Tactics/Frame.lean
+++ b/Iris/Iris/ProofMode/Tactics/Frame.lean
@@ -89,20 +89,20 @@ private def FrameResult.step {u prop bi origE origGoal} :
     if let .some _ ← ProofModeM.trySynthInstanceQ q(Frame $p $out' $goal $goal') then
       return ⟨true, e', hyps', goal', q(frame_hyp $pf $hrem)⟩
     if explicit then
-      throwError "iframe: cannot frame {out'}"
+      throwIPMError "cannot frame {out'}"
     else
       return st
   | st@{e, hyps, goal, pf, ..}, {explicit, kind := .pure fvar, ..} => do
     let ty ← fvar.getType
     if ! (← Meta.isProp ty) then
-      throwError "iframe: {← fvar.getUserName} is not a Prop"
+      throwIPMError "{← fvar.getUserName} is not a Prop"
     have φ : Q(Prop) := ty
     have t : Q($φ) := Expr.fvar fvar
     let goal' ← mkFreshExprMVarQ q($prop)
     if let .some _ ← ProofModeM.trySynthInstanceQ q(Frame true iprop(⌜$φ⌝) $goal $goal') then
       return ⟨true, e, hyps, goal', q(frame_pure $φ $pf $t)⟩
     if explicit then
-      throwError "iframe: cannot frame ⌜{φ}⌝"
+      throwIPMError "cannot frame ⌜{φ}⌝"
     else
       return st
 
@@ -147,7 +147,7 @@ def FrameResult.finishClose {u prop bi origE origGoal}
     return ⟨e, hyps, q(frame_finish_close_emp $pf)⟩
   | ~q(iprop(True)) =>
     return ⟨e, hyps, q(frame_finish_close_true $pf)⟩
-  | _ => throwError "iframe: cannot solve {origGoal} by framing"
+  | _ => throwIPMError "cannot solve {origGoal} by framing"
 
 /--
   `iframe pats` cancels the hypotheses specified by the selection pattern `pats`
@@ -157,7 +157,7 @@ def FrameResult.finishClose {u prop bi origE origGoal}
 elab "iframe " pats:(colGt ppSpace selPat)+ : tactic => do
   let pats ← liftMacroM <| SelPat.parse pats
 
-  ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
+  ProofModeM.runTactic `iframe λ mvar { hyps, goal, .. } => do
     let pats ← SelPat.resolve hyps pats
 
     let res ← iFrame hyps goal pats

--- a/Iris/Iris/ProofMode/Tactics/Have.lean
+++ b/Iris/Iris/ProofMode/Tactics/Have.lean
@@ -40,7 +40,7 @@ macro "ihave " colGt pat:icasesPat " := " pmt:pmTerm : tactic =>
 elab "ihave " colGt pat:icasesPat " : " P:term " $$ " spat:specPat : tactic => do
   let spat ← liftMacroM <| SpecPat.parse spat
   let pat ← liftMacroM <| iCasesPat.parse pat
-  ProofModeM.runTactic λ mvar { prop, hyps, goal, .. } => do
+  ProofModeM.runTactic `ihave λ mvar { prop, hyps, goal, .. } => do
   let P ← elabTermEnsuringTypeQ (← `(iprop($P))) prop
   -- Establish `P` with `spat`
   let ⟨_, hyps', p, A, pf⟩ ← iSpecializeCore hyps q(true) q(iprop($P -∗ $P))

--- a/Iris/Iris/ProofMode/Tactics/HaveCore.lean
+++ b/Iris/Iris/ProofMode/Tactics/HaveCore.lean
@@ -90,13 +90,13 @@ private def iHaveCore {e} (hyps : @Hyps u prop bi e)
       addMVarGoal mvar
 
     let ty ← instantiateMVars <| ← inferType val
-    if ! (← Meta.isProp ty) then throwError m!"ihave: {val} is not a Prop"
+    if ! (← Meta.isProp ty) then throwIPMError "{val} is not a Prop"
     have ty : Q(Prop) := ty
     have val : Q($ty) := val
 
     let hyp ← mkFreshExprMVarQ q($prop)
     let some _ ← ProofModeM.trySynthInstanceQ q(AsEmpValid .into $ty .in $prop $bi $hyp)
-      | throwError m!"ihave: {ty} is not an entailment"
+      | throwIPMError "{ty} is not an entailment"
 
     return ⟨_, hyps, q(true), hyp, q(have_asEmpValid $val)⟩
 

--- a/Iris/Iris/ProofMode/Tactics/Induction.lean
+++ b/Iris/Iris/ProofMode/Tactics/Induction.lean
@@ -82,7 +82,7 @@ private structure Alts where
   and return an `Alts` instance.
 -/
 private def parseInductionAlts (altsSyntax : TSyntax `Lean.Parser.Tactic.inductionAlts) :
-    TacticM Alts := do
+    ProofModeM Alts := do
   -- For parsing the user-supplied names for variables and induction hypotheses
   let parseVars (vars : Array Syntax) : TacticM (Array (TSyntax `Lean.binderIdent)) := do
     vars.mapM fun v =>
@@ -99,7 +99,7 @@ private def parseInductionAlts (altsSyntax : TSyntax `Lean.Parser.Tactic.inducti
         | `(inductionAlt| $[$lhs:inductionAltLHS]* => $tac:tacticSeq) => pure (lhs, some tac)
         | `(inductionAlt| $[$lhs:inductionAltLHS]* => $_:hole)
         | `(inductionAlt| $[$lhs:inductionAltLHS]* => $_:syntheticHole) => pure (lhs, none)
-        | _ => throwErrorAt alt "iinduction: invalid syntax"
+        | _ => throwIPMErrorAt alt "invalid syntax"
 
       for l in lhs do
         match l with
@@ -108,13 +108,13 @@ private def parseInductionAlts (altsSyntax : TSyntax `Lean.Parser.Tactic.inducti
           parsedAlts := parsedAlts.push ⟨ctor.getId, ← parseVars vars, tacs, alt⟩
         | `(inductionAltLHS| | $_:hole $[$vars]*) =>
           if parsedAlts.size < alts.size - 1 then
-            throwErrorAt alt
-              s!"iinduction: invalid occurrence of the wildcard alternative `| _ => ...`: ".append
-              "It must be the last alternative"
+            throwIPMErrorAt alt
+              s!"invalid occurrence of the wildcard alternative `| _ => ...`: \
+              It must be the last alternative"
           return ⟨tac, parsedAlts, some ⟨.anonymous, ← parseVars vars, tacs, alt⟩, altsSyntax⟩
-        | _ => throwErrorAt l "iinduction: invalid syntax"
+        | _ => throwIPMErrorAt l "invalid syntax"
     return ⟨tac, parsedAlts, none, altsSyntax⟩
-  | _ => throwErrorAt altsSyntax "iinduction: invalid syntax"
+  | _ => throwIPMErrorAt altsSyntax "invalid syntax"
 
 /--
   Designed to be a mutable state such that `newHyps` contains induction
@@ -140,7 +140,7 @@ private def addIHs {u} {prop : Q(Type u)} {bi : Q(BI $prop)} {e : Q($prop)}
     -- Obtain the proposition to be introduced into the intuitionistic context
     let Q ← mkFreshExprMVarQ q($prop)
     let some inst ← ProofModeM.trySynthInstanceQ q(IntoIH $φ $e $Q)
-    | throwError m!"iinduction: unable to perform type class synthesis with \
+    | throwIPMError "unable to perform type class synthesis with \
         IntoIH for the induction hypothesis {φ}"
 
     -- Introduce the induction hypothesis into the intuitionistic context
@@ -154,7 +154,7 @@ private def addIHs {u} {prop : Q(Type u)} {bi : Q(BI $prop)} {e : Q($prop)}
   return st
 
 private def throwMissingAlt {α} (ctor : Name) : ProofModeM α :=
-  throwError "iinduction: alternative `{ctor.getString!}` has not been provided"
+  throwIPMError "alternative `{ctor.getString!}` has not been provided"
 
 /--
   Check that all the alternative names are valid and that there are no duplicates.
@@ -191,8 +191,8 @@ private def iInductionCore {u} {prop : Q(Type u)} {bi : Q(BI $prop)} {e}
       altRecName.elim
         (getCustomEliminator? #[mkFVar fvar] true <&> (·.getD <| mkRecName indName))
         pure
-    | _ => throwError "iinduction: {indName} is not inductive"
-  | _ => throwError "iinduction: unable to determine inductive type"
+    | _ => throwIPMError "{indName} is not inductive"
+  | _ => throwIPMError "unable to determine inductive type"
 
   let matcher := fun ctor alt => alt.ctor != .anonymous && ctor == alt.ctor
 
@@ -384,16 +384,17 @@ elab_rules : tactic
     let fvar ← generalizeTermWithFVar x
     -- Parse the recursor name provided by the user
     let recName := r.map (·.getId)
-    -- Parse the list of alternative names supplied by the user
-    let parsedAlts ← alts.mapM parseInductionAlts
 
-    ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
+    ProofModeM.runTactic `iinduction λ mvar { hyps, goal, .. } => do
+      -- Parse the list of alternative names supplied by the user
+      let parsedAlts ← alts.mapM parseInductionAlts
+
       let genSelTargets ← do
         -- Parse the selection patterns for generalising hypotheses
         let parsedGenSelPats ← liftMacroM <| SelPat.parse genSelPats
         let genSelTargets ← SelPat.resolve hyps parsedGenSelPats
         -- Check for dependencies with the hypotheses in the selection targets
-        checkDependentHyps "iinduction" hyps genSelTargets fvar genSelPats
+        checkDependentHyps hyps genSelTargets fvar genSelPats
           (fun pats => `(tactic| iinduction $x $[using $r]? generalizing $pats* $[$alts]?))
           (fun pats => `(tactic| iinduction $x $[using $r]? generalizing! $pats* $[$alts]?))
         pure genSelTargets
@@ -404,10 +405,11 @@ elab_rules : tactic
     let fvar ← generalizeTermWithFVar x
     -- Parse the recursor name provided by the user
     let recName := r.map (·.getId)
-    -- Parse the list of alternative names supplied by the user
-    let parsedAlts ← alts.mapM parseInductionAlts
 
-    ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
+    ProofModeM.runTactic `iinduction λ mvar { hyps, goal, .. } => do
+      -- Parse the list of alternative names supplied by the user
+      let parsedAlts ← alts.mapM parseInductionAlts
+
       let mkGenSelTargets := fun genSelTargets => do
         let ⟨_, missingIrisHyps, allPureFVarsSorted⟩ ←
           getDependentHyps hyps genSelTargets fvar false

--- a/Iris/Iris/ProofMode/Tactics/Intro.lean
+++ b/Iris/Iris/ProofMode/Tactics/Intro.lean
@@ -94,14 +94,14 @@ private def iIntroCoreForallIntro {u} {prop : Q(Type u)} {bi : Q(BI $prop)}
   let Φ ← mkFreshExprMVarQ q($α → $prop)
   match ← ProofModeM.trySynthInstanceQ q(FromForall $Q $Φ), k' with
   | none, none =>
-    throwError "iintro: {Q} cannot be turned into a universal quantifier or pure hypothesis"
+    throwIPMError "{Q} cannot be turned into a universal quantifier or pure hypothesis"
   | none, some k' => k'
   | some _, _ =>
     let pf : Q(∀ x, $P ⊢ $Φ x) ← iPureCases q(∀ x, $P ⊢ $Φ x) pat fun g => do
       let B : Q($prop) ← mkFreshExprMVarQ q($prop)
       -- TODO: Is this the right way to check this?
       unless ← withTransparency .none <| isDefEq (← g.getType) q($P ⊢ $B) do
-        throwError "iintro: internal error: unexpected goal after intro pattern"
+        throwIPMError "unexpected goal after intro pattern"
       k g (Expr.headBeta (← instantiateMVars B))
     return q(from_forall_intro (Q := $Q) $pf)
 
@@ -204,28 +204,28 @@ partial def iIntroCore {u} {prop : Q(Type u)} {bi : Q(BI $prop)}
       match pat.case, fromImp with
       | .intuitionistic p, some _ =>
         let .some _ ← ProofModeM.trySynthInstanceQ q(IntoPersistently false $A1 $B)
-          | throwError "iintro: {A1} not persistent"
+          | throwIPMError "{A1} not persistent"
         let pf ← iCasesCore hyps A2 p q(true) B (iIntroCore · · pats k)
         return q(imp_intro_intuitionistic (Q := $Q) $pf)
       | .intuitionistic p, none =>
         let .some _ ← ProofModeM.trySynthInstanceQ q(FromWand $Q .out $A1 $A2)
-          | throwError "iintro: {Q} not a wand"
+          | throwIPMError "{Q} not a wand"
         let .some _ ← ProofModeM.trySynthInstanceQ q(IntoPersistently false $A1 $B)
-          | throwError "iintro: {A1} not persistent"
+          | throwIPMError "{A1} not persistent"
         let .some _ ← trySynthInstanceQ q(TCOr (Affine $A1) (Absorbing $A2))
-          | throwError "iintro: {A1} not affine and the goal not absorbing"
+          | throwIPMError "{A1} not affine and the goal not absorbing"
         let pf ← iCasesCore hyps A2 p q(true) B (iIntroCore · · pats k)
         return q(wand_intro_intuitionistic (A1 := $A1) (Q := $Q) $pf)
       | _, some _ =>
         -- should always succeed
         let _ ← ProofModeM.synthInstanceQ q(FromAffinely $B $A1)
         let .some _ ← trySynthInstanceQ q(TCOr (Persistent $A1) (Intuitionistic $P))
-          | throwError "iintro: {A1} is not persistent and spatial context is non-empty"
+          | throwIPMError "{A1} is not persistent and spatial context is non-empty"
         let pf ← iCasesCore hyps A2 pat q(false) B (iIntroCore · · pats k)
         return q(imp_intro_spatial (Q := $Q) $pf)
       | _, none =>
         let .some _ ← ProofModeM.trySynthInstanceQ q(FromWand $Q .out $A1 $A2)
-          | throwError "iintro: {Q} not a wand"
+          | throwIPMError "{Q} not a wand"
         let pf ← iCasesCore hyps A2 pat q(false) A1 (iIntroCore · · pats k)
         return q(wand_intro_spatial (A1 := $A1) (Q := $Q) $pf)
 
@@ -236,7 +236,7 @@ elab "iintro " pats:(colGt ppSpace introPat)* : tactic => do
   -- parse syntax
   let pats ← liftMacroM <| pats.mapM <| IntroPat.parse
 
-  ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
+  ProofModeM.runTactic `iintro λ mvar { hyps, goal, .. } => do
     let pf ← iIntroCore hyps goal pats.toList
 
     mvar.assign pf

--- a/Iris/Iris/ProofMode/Tactics/Inv.lean
+++ b/Iris/Iris/ProofMode/Tactics/Inv.lean
@@ -81,7 +81,7 @@ private def iInvCore {u} {prop : Q(Type u)} {bi} {e}
   let Q' ← mkFreshExprMVarQ q($X → $prop)
   let some inst ← ProofModeM.trySynthInstanceQ
     q(ElimInv $φ $X $Pinv $Pin $Pout $close $mPclose $goal $Q')
-  | throwError "iinv: invalid invariant {Pinv} (ElimInv type class synthesis failed)"
+  | throwIPMError "invalid invariant {Pinv} (ElimInv type class synthesis failed)"
 
   let ⟨e'', hyps'', p'', out'', pfPin⟩ ←
     iSpecializeCoreNoModal hyps' q(false) q(iprop($Pin -∗ $Pin))
@@ -107,7 +107,7 @@ private def iInvCore {u} {prop : Q(Type u)} {bi} {e}
             q(false) q(iprop($Pout' $x ∗ $f' $x))
           mkLambdaFVars #[x] pf'
         -- Throw an error if `hclose` is not given, but `mPclose` is not `none`
-        | none => throwError "iinv: missing cases pattern for the closing hypothesis"
+        | none => throwIPMError "missing cases pattern for the closing hypothesis"
     return q(tac_inv_elim $inst $hφ $pf $pfEq $pfPin)
   | ~q(none) =>
     let pf : Q(∀ x, $e'' ∗ $Pout x ⊢ $Q' x) ←
@@ -145,7 +145,7 @@ elab_rules : tactic
     let casesPat ← liftMacroM <| iCasesPat.parse casesPat
     let closePat ← liftMacroM <| closePat.mapM iCasesPat.parse
 
-    ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
+    ProofModeM.runTactic `iinv λ mvar { hyps, goal, .. } => do
       -- Find the invariant hypothesis
       let ivar ← do match ← try? <| hyps.findWithInfo ⟨t⟩ with
       -- Hypothesis supplied by the user: return the `IVarId` value of the invariant directly
@@ -155,7 +155,7 @@ elab_rules : tactic
         let N ← elabTermEnsuringTypeQ t q(Namespace)
         let some (_, ivar, _, _) ← hyps.findM? fun _ _ _ ty =>
             return (← ProofModeM.trySynthInstanceQ q(IntoInv $ty $N)).isSome
-          | throwError m!"iinv: invariant hypothesis with the namespace {N} not found"
+          | throwIPMError "invariant hypothesis with the namespace {N} not found"
         pure ivar
 
       let pf ← iInvCore hyps goal ivar specPat casesPat closePat

--- a/Iris/Iris/ProofMode/Tactics/LeftRight.lean
+++ b/Iris/Iris/ProofMode/Tactics/LeftRight.lean
@@ -32,12 +32,12 @@ open Lean Elab.Tactic Meta Qq Std
   Given a goal of the form `P ∨ Q`, the new goal is `P`.
 -/
 elab "ileft" : tactic => do
-  ProofModeM.runTactic λ mvar { prop, e, hyps, goal, .. } => do
+  ProofModeM.runTactic `ileft λ mvar { prop, e, hyps, goal, .. } => do
   -- choose left side of disjunction
   let A1 ← mkFreshExprMVarQ prop
   let A2 ← mkFreshExprMVarQ prop
   let some _ ← ProofModeM.trySynthInstanceQ q(FromOr $goal $A1 $A2)
-    | throwError "ileft: {goal} is not a disjunction"
+    | throwIPMError "{goal} is not a disjunction"
 
   let m : Q($e ⊢ $A1) ← addBIGoal hyps A1
   mvar.assign q(from_or_left (Q := $goal) $m)
@@ -47,11 +47,11 @@ elab "ileft" : tactic => do
   Given a goal of the form `P ∨ Q`, the new goal is `Q`.
 -/
 elab "iright" : tactic => do
-  ProofModeM.runTactic λ mvar { prop, e, hyps, goal, .. } => do
+  ProofModeM.runTactic `iright λ mvar { prop, e, hyps, goal, .. } => do
   -- choose right side of disjunction
   let A1 ← mkFreshExprMVarQ prop
   let A2 ← mkFreshExprMVarQ prop
   let some _ ← ProofModeM.trySynthInstanceQ q(FromOr $goal $A1 $A2)
-    | throwError "iright: {goal} is not a disjunction"
+    | throwIPMError "{goal} is not a disjunction"
   let m : Q($e ⊢ $A2) ← addBIGoal hyps A2
   mvar.assign q(from_or_right (Q := $goal) $m)

--- a/Iris/Iris/ProofMode/Tactics/Loeb.lean
+++ b/Iris/Iris/ProofMode/Tactics/Loeb.lean
@@ -25,7 +25,7 @@ private def iLoebCore {u} {prop : Q(Type u)} {bi : Q(BI $prop)} {e}
     (IH : TSyntax `Lean.binderIdent) : ProofModeM Q($e ⊢ $goal) :=
   iRevertIntro hyps goal targets fun {prop _ _} hyps goal k => do
     let some _ ← ProofModeM.trySynthInstanceQ q(BI.BILoeb $prop)
-      | throwError m!"iloeb: no `{←ppExpr q(BI.BILoeb $prop)}` instance found"
+      | throwIPMError "no `{←ppExpr q(BI.BILoeb $prop)}` instance found"
     let pf := q(BI.loeb_wand_intuitionistically (P := $goal))
     let pf' ← do
       -- We have applied `BI.loeb_wand_intuitionistically`
@@ -50,19 +50,19 @@ elab_rules : tactic
   | `(tactic| iloeb as $IH:binderIdent generalizing $hs:selPat*) => do
     let pats ← Elab.liftMacroM <| SelPat.parse hs
 
-    ProofModeM.runTactic fun mvid { hyps, goal, .. } => do
+    ProofModeM.runTactic `iloeb fun mvid { hyps, goal, .. } => do
       -- Parse the selection patterns provided by the tactic user
       let targets : List SelTarget ← SelPat.resolve hyps (pats ++ [.spatial])
 
       -- Check for dependencies with the hypotheses in the selection targets
-      checkDependentHyps "iloeb" hyps targets none hs
+      checkDependentHyps hyps targets none hs
         (fun pats => `(tactic| iloeb as $IH generalizing $pats*))
         (fun pats => `(tactic| iloeb as $IH generalizing! $pats*))
 
       let expr ← iLoebCore hyps goal targets IH
       mvid.assign expr
   | `(tactic| iloeb as $IH:binderIdent $[generalizing! $hs:selPat*]?) => do
-    ProofModeM.runTactic fun mvid { hyps, goal, .. } => do
+    ProofModeM.runTactic `iloeb fun mvid { hyps, goal, .. } => do
       let targets ← do match hs with
       | none =>
         SelPat.resolve hyps [.spatial]

--- a/Iris/Iris/ProofMode/Tactics/Mod.lean
+++ b/Iris/Iris/ProofMode/Tactics/Mod.lean
@@ -47,7 +47,7 @@ def iModCore {prop : Q(Type u)} (_bi : Q(BI $prop))
   let Q' : Q($prop) ← mkFreshExprMVarQ q($prop)
   -- transform `Q` to `Q'` and `A` to `A'`
   let .some _ ← ProofModeM.trySynthInstanceQ q(ElimModal $Φ $p .out $p' $A $A' $Q $Q')
-    | throwError "imod: {A} is not a modality"
+    | throwIPMError "{A} is not a modality"
   let hΦ ← iSolveSidecondition q($Φ)
   let p'' : Q(Bool) ← instantiateMVars p'
   let A'' ← instantiateMVarsQ A'

--- a/Iris/Iris/ProofMode/Tactics/ModIntro.lean
+++ b/Iris/Iris/ProofMode/Tactics/ModIntro.lean
@@ -92,7 +92,7 @@ private def parseModalityActionQ {prop1 prop2 : Q(Type u)}
   | ModalityAction.transform _ _ C => return .transform C
   | ModalityAction.clear _ _ => return .clear
   | ModalityAction.id _ => return .id
-  | _ => throwError "imodintro: unknown modality action {act}"
+  | _ => throwIPMError "unknown modality action {act}"
 
 /--
 Applies modality actions to transform proof mode context.
@@ -125,12 +125,12 @@ where go {e}
     let p' := isTrue p
     let act := if p' then iact else sact
     match act with
-    | .isEmpty => throwError "imodintro: {if p' then "intuitionistic" else "spatial"} context is not empty"
+    | .isEmpty => throwIPMError "{if p' then "intuitionistic" else "spatial"} context is not empty"
     | .forall C => do
       have : $prop1 =Q $prop2 := ⟨⟩
       have : $bi1 =Q $bi2 := ⟨⟩
       let .some hC ← trySynthInstanceQ q($C $ty)
-        | throwError "imodintro: hypothesis {name} : {ty} does not satisfy {C}"
+        | throwIPMError "hypothesis {name}: {ty} does not satisfy {C}"
       -- bridge through defeq since `M.action` cannot unify directly with the pattern (same in other cases)
       have heq : Q(@ModalityAction.forall $prop1 $C = .forall $C) :=
         q(Eq.refl (ModalityAction.forall $C))
@@ -139,7 +139,7 @@ where go {e}
     | .transform C => do
       let ty' ← mkFreshExprMVarQ q($prop1)
       let .some hC ← trySynthInstanceQ q($C $ty $ty')
-        | throwError "imodintro: cannot transform hypothesis {name} : {ty} with {C}"
+        | throwIPMError "cannot transform hypothesis {name}: {ty} with {C}"
       have heq : Q(@ModalityAction.transform $prop1 $prop2 $C = .transform $C) :=
         q(Eq.refl (ModalityAction.transform $C))
       have heq : Q($(M).action $p = .transform $C) := heq
@@ -190,7 +190,7 @@ def iModIntroCore {e} (hyps : @Hyps u prop bi e) (goal : Q($prop))
     -- `M Q ⊢ goal`
     let .some _ ←
       ProofModeM.trySynthInstanceQ q(@FromModal $prop' $prop $α $bi' $bi $Φ $M $sel $goal $Q)
-      | throwError "imodintro: {goal} is not a \
+      | throwIPMError "{goal} is not a \
           modality{if sel.isMVar then m!"" else m!" matching {sel}"}"
     -- show the side condition
     let hΦ ← iSolveSidecondition q($Φ)
@@ -206,7 +206,7 @@ def iModIntroCore {e} (hyps : @Hyps u prop bi e) (goal : Q($prop))
   The tactic succeeds only when the selector term `sel` matches the modality.
 -/
 elab "imodintro " colGt sel:term : tactic => do
-  ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
+  ProofModeM.runTactic `imodintro λ mvar { hyps, goal, .. } => do
     let pf ← iModIntroCore hyps goal sel
 
     mvar.assign pf

--- a/Iris/Iris/ProofMode/Tactics/Pure.lean
+++ b/Iris/Iris/ProofMode/Tactics/Pure.lean
@@ -71,19 +71,19 @@ def iPureCore {prop : Q(Type u)} {bi : Q(BI $prop)}
     ProofModeM Q($P ⊢ $Q) := do
   let φ : Q(Prop) ← mkFreshExprMVarQ q(Prop)
   let some _ ← ProofModeM.trySynthInstanceQ q(IntoPure $A $φ)
-  | throwError "ipure: {A} is not pure"
+  | throwIPMError "{A} is not pure"
   let f ← iPureCases q($φ → ($(hyps'.tm) ⊢ $Q)) purePat <| fun g => do
     let some ⟨_, _, tm, goal'⟩ := parseEntails? (← instantiateMVars (← g.getType))
-      | throwError "ipure: unable to parse the Iris entailment {← g.getType}"
+      | throwIPMError "unable to parse the Iris entailment {← g.getType}"
     let some ⟨_, hyps'⟩ := parseHyps? bi tm
-      | throwError "ipure: unable to parse the Iris context {tm}"
+      | throwIPMError "unable to parse the Iris context {tm}"
     return (← k hyps' goal' : Expr)
   have : $hyps'.tm =Q $P' := ⟨⟩
   match matchBool p with
   | .inl _ => return q(pure_elim_intuitionistic $pf $f)
   | .inr _ =>
     let .some _ ← trySynthInstanceQ q(TCOr (Affine $A) (Absorbing $Q))
-    | throwError "ipure: {A} is not affine and the goal not absorbing"
+    | throwIPMError "{A} is not affine and the goal not absorbing"
     return q(pure_elim_spatial (A := $A) $pf $f)
 
 def iPureIntroCore {u} {prop : Q(Type u)} (_bi : Q(BI $prop))
@@ -92,7 +92,7 @@ def iPureIntroCore {u} {prop : Q(Type u)} (_bi : Q(BI $prop))
   let b : Q(Bool) ← mkFreshExprMVarQ q(Bool)
   let φ : Q(Prop) ← mkFreshExprMVarQ q(Prop)
   let .some h ← ProofModeM.trySynthInstanceQ q(FromPure $b $goal .out $φ)
-  | throwError "ipureintro: {goal} is not pure"
+  | throwIPMError "{goal} is not pure"
   let m : Q($φ) ← mkFreshExprSyntheticOpaqueMVar (← instantiateMVars φ)
 
   let pf : Q($e ⊢ $goal) ← do
@@ -100,13 +100,13 @@ def iPureIntroCore {u} {prop : Q(Type u)} (_bi : Q(BI $prop))
     | .const ``true _ =>
       have : $b =Q true := ⟨⟩
       let .some _ ← trySynthInstanceQ q(Affine $e)
-        | throwError "ipureintro: context is not affine"
+        | throwIPMError "context is not affine"
       pure q(pure_intro_affine (P := $e) (Q := $goal) $h $m)
     | .const ``false _ =>
       have : $b =Q false := ⟨⟩
       pure q(pure_intro_spatial (P := $e) (Q := $goal) $h $m)
     -- the following indicates a bug in the typeclass instances that generate b
-    | _ => throwError "ipureintro: bug in typeclass instances, cannot reduce {b} to true or false"
+    | _ => throwIPMError "bug in typeclass instances, cannot reduce {b} to true or false"
 
   return ⟨pf, m.mvarId!⟩
 
@@ -115,7 +115,7 @@ def iPureIntroCore {u} {prop : Q(Type u)} (_bi : Q(BI $prop))
   Lean context.
 -/
 elab "ipure " colGt hyp:ident : tactic => do
-  ProofModeM.runTactic λ mvar { bi, e, hyps, goal, .. } => do
+  ProofModeM.runTactic `ipure λ mvar { bi, e, hyps, goal, .. } => do
 
   let ivar ← hyps.findWithInfo hyp
   let ⟨_, hyps', _, out', p, _, pf⟩ := hyps.remove true ivar
@@ -129,7 +129,7 @@ elab "ipure " colGt hyp:ident : tactic => do
   regular Lean context and destructs it using the `rcases` destruction pattern.
 -/
 elab "ipure " colGt hyp:ident " with " pat:rcasesPat : tactic => do
-  ProofModeM.runTactic λ mvar { bi, e, hyps, goal, .. } => do
+  ProofModeM.runTactic `ipure λ mvar { bi, e, hyps, goal, .. } => do
 
   let ivar ← hyps.findWithInfo hyp
   let ⟨_, hyps', _, out', p, _, pf⟩ := hyps.remove true ivar
@@ -142,18 +142,18 @@ elab "ipure " colGt hyp:ident " with " pat:rcasesPat : tactic => do
   `iempintro` solves an `emp` goal, provided that the spatial context is affine.
 -/
 elab "iempintro" : tactic => do
-  ProofModeM.runTactic λ mvar { prop, e, goal, .. } => do
+  ProofModeM.runTactic `iempintro λ mvar { prop, e, goal, .. } => do
 
-  let .true ← isDefEq goal q(emp : $prop) | throwError "goal is not `emp`"
+  let .true ← isDefEq goal q(emp : $prop) | throwIPMError "goal is not `emp`"
   let .some _ ← trySynthInstanceQ q(Affine $e)
-    | throwError "iempintro: context is not affine"
+    | throwIPMError "context is not affine"
   mvar.assign q(affine (P := $e))
 
 /--
   `ipureintro` turns a goal of the form `⌜φ⌝` into the Lean goal `φ`.
 -/
 elab "ipureintro" : tactic => do
-  ProofModeM.runTactic λ mvar { bi, e, goal, .. } => do
+  ProofModeM.runTactic `ipureintro λ mvar { bi, e, goal, .. } => do
     let ⟨pf, m⟩ ← iPureIntroCore bi e goal
     addMVarGoal m
     mvar.assign pf

--- a/Iris/Iris/ProofMode/Tactics/Rename.lean
+++ b/Iris/Iris/ProofMode/Tactics/Rename.lean
@@ -20,10 +20,10 @@ open Lean Elab Tactic Qq
   `irename H => H'` renames the hypothesis `H` as `H'`.
 -/
 elab "irename " colGt nameFrom:ident " => " colGt nameTo:ident : tactic => do
-  ProofModeM.runTactic λ mvar { prop, bi, hyps, goal, .. } => do
+  ProofModeM.runTactic `irename λ mvar { prop, bi, hyps, goal, .. } => do
 
   -- find hypothesis index
-  let some (ivar, ty) := hyps.find? nameFrom.getId | throwError "irename: unknown hypothesis"
+  let some (ivar, ty) := hyps.find? nameFrom.getId | throwIPMError "unknown hypothesis"
   addHypInfo nameFrom nameFrom.getId ivar prop ty
   let some hyps' := hyps.rename ivar nameTo.getId | unreachable!
   addHypInfo nameTo nameTo.getId ivar prop ty (isBinder := true)
@@ -40,10 +40,10 @@ elab "irename" " : " colGt ty:term " => " colGt nameTo:ident : tactic => do
     throwUnsupportedSyntax
 
   -- find hypothesis index
-  ProofModeM.runTactic λ mvar { prop, bi, hyps, goal, .. } => do
+  ProofModeM.runTactic `irename λ mvar { prop, bi, hyps, goal, .. } => do
 
   let ty ← elabTerm ty prop
-  let (ivar, _, ty) ← try Hyps.select ty hyps catch _ => throwError "irename: unknown hypothesis"
+  let (ivar, _, ty) ← try Hyps.select ty hyps catch _ => throwIPMError "unknown hypothesis"
   let some hyps' := hyps.rename ivar nameTo.getId | unreachable!
   addHypInfo nameTo nameTo.getId ivar prop ty (isBinder := true)
 

--- a/Iris/Iris/ProofMode/Tactics/Revert.lean
+++ b/Iris/Iris/ProofMode/Tactics/Revert.lean
@@ -76,7 +76,7 @@ private def RevertState.revertLeanPropHyp
   let { e, hyps, goal, reverted, pf } := st
   let P ← mkFreshExprMVarQ prop
   let some _ ← ProofModeM.trySynthInstanceQ q(MakeAffinely iprop(⌜$φ⌝) $P)
-  | throwError m!"irevert: MakeAffinely type class synthesis failed with {φ}"
+  | throwIPMError "MakeAffinely type class synthesis failed with {φ}"
   let hp : Q($φ) := mkFVar f
   let goal' : Q($prop) := q(iprop($P -∗ $goal))
   let pf' : Q(($e ⊢ $goal') → ($origE ⊢ $origGoal)) := q(fun h => $pf (pure_revert h $hp))
@@ -181,7 +181,7 @@ def getCompleteSelTargets (explicitTargets : List SelTarget)
   hypotheses dependent on it should also be generalised.
 -/
 def checkDependentHyps {u} {prop : Q(Type $u)} {bi} {e : Q($prop)}
-    (tacticName : String) (hyps : Hyps bi e)
+    (hyps : Hyps bi e)
     (explicitTargets : List SelTarget)
     (inductionTarget : Option FVarId)
     (selPats : TSyntaxArray `selPat)
@@ -238,7 +238,7 @@ def checkDependentHyps {u} {prop : Q(Type $u)} {bi} {e : Q($prop)}
     Lean.Meta.Tactic.TryThis.addSuggestion oldTactic newTactic
 
     -- Log the error and attach the clickable suggestion
-    throwError m!"{tacticName}: The following hypotheses depend on variables in \
+    throwIPMError "The following hypotheses depend on variables in \
       the `generalizing` clause but are not themselves included:\
       \n{"\n".intercalate (leanLines ++ irisLines)}"
 
@@ -271,12 +271,12 @@ elab_rules : tactic
   | `(tactic| irevert $pats:selPat*) => do
     let parsedPats ← liftMacroM <| SelPat.parse pats
 
-    ProofModeM.runTactic fun mvar { hyps, goal, .. } => do
+    ProofModeM.runTactic `irevert fun mvar { hyps, goal, .. } => do
       -- Parse the selection patterns provided by the tactic user
       let targets ← SelPat.resolve hyps parsedPats
 
       -- Check for dependencies with the hypotheses in the selection targets
-      checkDependentHyps "irevert" hyps targets none pats
+      checkDependentHyps hyps targets none pats
         (fun pats => `(tactic| irevert $pats*))
         (fun pats => `(tactic| irevert! $pats*))
 
@@ -285,7 +285,7 @@ elab_rules : tactic
   | `(tactic| irevert! $pats:selPat*) => do
     let parsedPats ← liftMacroM <| SelPat.parse pats
 
-    ProofModeM.runTactic fun mvar { hyps, goal, .. } => do
+    ProofModeM.runTactic `irevert fun mvar { hyps, goal, .. } => do
       -- Parse the selection patterns provided by the tactic user
       let explicitTargets ← SelPat.resolve hyps parsedPats
       -- Find all dependent hypotheses

--- a/Iris/Iris/ProofMode/Tactics/Rewrite.lean
+++ b/Iris/Iris/ProofMode/Tactics/Rewrite.lean
@@ -68,12 +68,12 @@ inductive Location
   | goal
   | hyp (name : Ident)
 
-def Location.parse (loc : Option (TSyntax `Lean.Parser.Tactic.location)) : MetaM Location := do
+def Location.parse (loc : Option (TSyntax `Lean.Parser.Tactic.location)) : ProofModeM Location := do
   let some loc := loc | return Location.goal
   match loc with
   | `(location| at ⊢) => pure Location.goal
   | `(location| at $hyp:ident) => pure (Location.hyp hyp)
-  | _ => throwError "irewrite: only single location is supported (at ⊢ or at <hyp>)"
+  | _ => throwIPMError "only single location is supported (at ⊢ or at <hyp>)"
 
 end location
 
@@ -115,12 +115,12 @@ private def iRewriteCore {prop : Q(Type u)} {bi : Q(BI $prop)}
   let g : Q($prop) ← mkFreshExprMVarQ q($prop)
   let ⟨e', _, p, eq, pf⟩ ← iHave hyps g rule.term true
   unless ← isDefEq g q(iprop($e' ∗ □?$p $eq)) do
-    throwError "irewrite: could not pin the equality goal"
+    throwIPMError "could not pin the equality goal"
   have : $g =Q iprop($e' ∗ □?$p $eq) := ⟨⟩
   let pf' : Q($e ⊢ $e' ∗ □?$p $eq) := q($pf .rfl)
 
   let .some sbi ← trySynthInstanceQ q(Sbi $prop)
-    | throwError "irewrite: could not synthesize Sbi instance"
+    | throwIPMError "could not synthesize Sbi instance"
 
   -- we assume that the SBI instance has bi as its BI instance
   have : $bi =Q ($sbi).toBI := ⟨⟩
@@ -132,7 +132,7 @@ private def iRewriteCore {prop : Q(Type u)} {bi : Q(BI $prop)}
   let _ofe : Q(OFE $A) ← mkFreshExprMVarQ q(OFE $A)
 
   let .some _ ← ProofModeM.trySynthInstanceQ q(IntoInternalEq (PROP := $prop) $eq $a $b)
-    | throwError "irewrite: {eq} is not an internal equality"
+    | throwIPMError "{eq} is not an internal equality"
 
   let ⟨a, _⟩ ← instantiateMVarsQ' a
   let ⟨b, _⟩ ← instantiateMVarsQ' b
@@ -142,7 +142,7 @@ private def iRewriteCore {prop : Q(Type u)} {bi : Q(BI $prop)}
   let goalAbstracted ← kabstract (occs := occs) target search
   unless goalAbstracted.hasLooseBVars do
     let (tgt, pat) ← addPPExplicitToExposeDiff target search
-    throwError "irewrite: Could not find {indentExpr pat}\nin the target expression{indentExpr tgt}"
+    throwIPMError "Could not find {indentExpr pat}\nin the target expression{indentExpr tgt}"
   have Ψ : Q($A → $prop) := mkLambda `x .default A goalAbstracted
 
   -- add OFE.NonExpansive to be solved by TC synthesis or left as a goal otherwise
@@ -177,7 +177,7 @@ def iRewriteHyp {prop : Q(Type u)} {bi : Q(BI $prop)}
   let some r ← hyps.replace ivar λ _ _ ty => do
     let ⟨ty', pf⟩ ← iRewriteCore hyps rule ty (occs := occs)
     return ⟨ty', q(rewrite_tac_hyp $pf)⟩
-    | throwError "irewrite: cannot find hyp" -- should never happen
+    | throwIPMError "cannot find hyp" -- should never happen
   return r
 
 /--
@@ -192,11 +192,11 @@ def iRewriteHyp {prop : Q(Type u)} {bi : Q(BI $prop)}
 -/
 elab "irewrite " cfg:optConfig " [" rules:(IRewrite.irwRule),* "] " loc:(location)? : tactic => do
   let config ← IRewrite.elabIRewriteConfig cfg
-  let location ← IRewrite.Location.parse loc
   let rules ← liftMacroM <| IRewrite.Rule.parse rules.getElems
 
   for rule in rules do
-    ProofModeM.runTactic λ mvar { hyps, goal, .. } => do
+    ProofModeM.runTactic `irewrite λ mvar { hyps, goal, .. } => do
+      let location ← IRewrite.Location.parse loc
       match location with
       | .goal =>
         let pf ← iRewriteGoal hyps rule goal config.occs

--- a/Iris/Iris/ProofMode/Tactics/Specialize.lean
+++ b/Iris/Iris/ProofMode/Tactics/Specialize.lean
@@ -135,7 +135,7 @@ private def synthIntoWand {u} {prop : Q(Type u)} (bi : Q(BI $prop))
   let out1 ← mkFreshExprMVarQ prop
   let out2 ← mkFreshExprMVarQ prop
   let some inst ← ProofModeM.trySynthInstanceQ q(IntoWand $p $persistent $out .unknown $out1 $out2)
-    | throwError m!"ispecialize: {out} is not a wand"
+    | throwIPMError "{out} is not a wand"
   return ⟨out1, out2, inst⟩
 
 private def finishSubgoal {u} {prop : Q(Type u)} {bi : Q(BI $prop)} {e}
@@ -151,9 +151,9 @@ private def finishSubgoal {u} {prop : Q(Type u)} {bi : Q(BI $prop)} {e}
     for i in frameIdents do
       let ivar ← hyps.findWithInfo i
       if frameIVars.contains ivar then
-        throwError "ispecialize: {i} used twice for framing"
+        throwIPMError "{i} used twice for framing"
       if ivars.contains ivar then
-        throwError "ispecialize: {i} cannot be used for both the subgoal and framing"
+        throwIPMError "{i} cannot be used for both the subgoal and framing"
       frameIVars := ivar :: frameIVars
     frameIVars := frameIVars.reverse
 
@@ -164,7 +164,7 @@ private def finishSubgoal {u} {prop : Q(Type u)} {bi : Q(BI $prop)} {e}
     let pf'' ← res.finish λ hyps goal => do
       if trivial then
         let some r ← iTrivial hyps goal
-          | throwError "ispecialize: itrivial could not solve\
+          | throwIPMError "itrivial could not solve\
               {← ppExpr <| IrisGoal.toExpr {hyps, goal ..}}"
         return r
       else addBIGoal hyps goal name
@@ -195,7 +195,7 @@ private def processSpecGoal {u} {prop : Q(Type u)} {bi : Q(BI $prop)} {orig goal
       | .modal =>
         let out1' ← mkFreshExprMVarQ prop
         let some instModal ← ProofModeM.trySynthInstanceQ q(AddModal $out1' $out1 $goal)
-          | throwError m!"ispecialize: AddModal type class synthesis failed with {out1} and {goal}"
+          | throwIPMError "AddModal type class synthesis failed with {out1} and {goal}"
         pure ⟨out1', instModal⟩
       | _ /- .spatial -/ => pure ⟨out1, q(addModal_id _ _)⟩
 
@@ -206,14 +206,14 @@ private def processSpecGoal {u} {prop : Q(Type u)} {bi : Q(BI $prop)} {orig goal
   | .intuitionistic =>
     let spec : Option (SpecGoal × Name) ← spec.mapM fun ⟨sg, name⟩ => do
       unless sg.hyps.isEmpty do
-        throwError "ispecialize: cannot select hypotheses for intuitionistic premise"
+        throwIPMError "cannot select hypotheses for intuitionistic premise"
       return ({ sg with negate := true }, name)
     let ⟨out1, out2, instWand⟩ ← synthIntoWand bi p out true
     let some instPers ← ProofModeM.trySynthInstanceQ q(Persistent $out1)
-      | throwError m!"ispecialize: {out1} is not persistent"
+      | throwIPMError "{out1} is not persistent"
     let out1' ← mkFreshExprMVarQ prop
     let some instAbsorb ← ProofModeM.trySynthInstanceQ q(IntoAbsorbingly $out1' $out1)
-      | throwError m!"ispecialize: IntoAbsorbingly type class synthesis failed with {out1}"
+      | throwIPMError "IntoAbsorbingly type class synthesis failed with {out1}"
     let ⟨_, _, pf⟩ ← finishSubgoal hyps out1' spec
     let pfStep := q(specialize_wand_intuitionistic $out1 $out2 $instWand $instPers $instAbsorb $pf)
     return specState.update hyps p out2 pfStep
@@ -230,7 +230,7 @@ partial def processWand {u} {prop : Q(Type u)} {bi : Q(BI $prop)} {orig goal : Q
   -- A hypothesis name, possibly with nested specialisation patterns
   | .ident pmt =>
     let some ivar ← try? <| hyps.findWithInfo ⟨pmt.term⟩
-      | throwError "ispecialize: invalid hypothesis {pmt.term}"
+      | throwIPMError "invalid hypothesis {pmt.term}"
     let ⟨_, hyps', _, out1', p1, _, pf'⟩ := hyps.remove false ivar
     let ⟨_, hyps'', pNest, outNest, pfContNest⟩ ←
       iSpecializeCore hyps' p1 out1' q(iprop(□?$p $out -∗ $goal)) pmt.spats
@@ -238,7 +238,7 @@ partial def processWand {u} {prop : Q(Type u)} {bi : Q(BI $prop)} {orig goal : Q
     let out2 ← mkFreshExprMVarQ prop
     let some inst ← ProofModeM.trySynthInstanceQ
         q(IntoWand $p $pNest $out (.matching .argument) $outNest $out2)
-      | throwError m!"ispecialize: IntoWand type class synthesis failed with {out} and {outNest}"
+      | throwIPMError "IntoWand type class synthesis failed with {out} and {outNest}"
     let pfStep := q(specialize_wand_nest $inst $pf' $pfContNest)
     return specState.updateCont hyps'' p2 out2 pfStep
   -- A pure Lean hypothesis
@@ -247,7 +247,7 @@ partial def processWand {u} {prop : Q(Type u)} {bi : Q(BI $prop)} {orig goal : Q
     let α : Q(Sort v) ← mkFreshExprMVarQ q(Sort v)
     let Φ : Q($α → $prop) ← mkFreshExprMVarQ q($α → $prop)
     let some inst ← ProofModeM.trySynthInstanceQ q(IntoForall $out $Φ)
-      | throwError "ispecialize: {out} is not a Lean premise"
+      | throwIPMError "{out} is not a Lean premise"
     let x ← elabTermEnsuringTypeQ t α
     let out' : Q($prop) := Expr.headBeta q($Φ $x)
     let newMVarIds ← getMVarsNoDelayed x
@@ -308,7 +308,7 @@ partial def iSpecializeCoreNoModal {prop : Q(Type u)} {bi : Q(BI $prop)} {e}
   let st ← spats.foldlM processWand
     { hyps, p := pa, out := A, pf := q(id (α := $e ∗ □?$pa $A ⊢ $goal)) }
   unless ← isDefEq goal q(iprop($(st.e) ∗ □?$(st.p) $(st.out))) do
-    throwError "ispecialize: internal error, goal does not match the proof"
+    throwIPMError "internal error, goal does not match the proof"
   let stPf : Q(($(st.e) ∗ □?$(st.p) $(st.out) ⊢ $(st.e) ∗ □?$(st.p) $(st.out)) →
     $e ∗ □?$pa $A ⊢ $(st.e) ∗ □?$(st.p) $(st.out)) := st.pf
   let pf : Q($e ∗ □?$pa $A ⊢ $(st.e) ∗ □?$(st.p) $(st.out)) := q($stPf .rfl)
@@ -346,14 +346,14 @@ partial def iCasesPat.should_try_dup_context (pat : iCasesPat) : Bool :=
 -/
 elab "ispecialize " colGt pmt:pmTerm : tactic => do
   let pmt ← liftMacroM <| PMTerm.parse pmt
-  ProofModeM.runTactic λ mvar { bi, hyps, goal, .. } => do
+  ProofModeM.runTactic `ispecialize λ mvar { bi, hyps, goal, .. } => do
   -- Hypothesis must be in the context, otherwise use `ihave`
   let name := ⟨pmt.term⟩
   let some ivar ← try? <| hyps.findWithInfo name
-    | throwError "ispecialize: {name} should be a hypothesis, use ihave instead"
+    | throwIPMError "{name} should be a hypothesis, use ihave instead"
   let some ⟨name, _, hyps', _, out, p, _, pf⟩ := Id.run <|
     hyps.removeG true λ name ivar' _ _ => if ivar == ivar' then some name else none
-    | throwError "ispecialize: cannot find argument {name}"
+    | throwIPMError "cannot find argument {name}"
 
   let ⟨_, hyps'', pb, B, pf'⟩ ← iSpecializeCore hyps' p out goal pmt.spats
   let ⟨_, hyps''', pfEq⟩ := Hyps.add bi name ivar pb B hyps''

--- a/Iris/Iris/ProofMode/Tactics/Split.lean
+++ b/Iris/Iris/ProofMode/Tactics/Split.lean
@@ -34,12 +34,12 @@ open Lean Elab Tactic Meta Qq
   both keeping the entire context.
 -/
 elab "isplit " : tactic => do
-  ProofModeM.runTactic λ mvar { prop, hyps, goal, .. } => do
+  ProofModeM.runTactic `isplit λ mvar { prop, hyps, goal, .. } => do
 
   let A1 ← mkFreshExprMVarQ prop
   let A2 ← mkFreshExprMVarQ prop
   let some _ ← ProofModeM.trySynthInstanceQ q(FromAnd $goal $A1 $A2)
-    | throwError "isplit: {goal} is not a conjunction"
+    | throwIPMError "{goal} is not a conjunction"
   let m1 ← addBIGoal hyps A1
   let m2 ← addBIGoal hyps A2
   mvar.assign q(from_and_intro (Q := $goal) $m1 $m2)
@@ -53,7 +53,7 @@ private def isplitCore (side : splitSide) (names : Array (TSyntax `ident)) : Tac
     | .splitRight => true
 
   -- extract environment
-  ProofModeM.runTactic λ mvar { prop, bi, hyps, goal, .. } => do
+  ProofModeM.runTactic `isplit λ mvar { prop, bi, hyps, goal, .. } => do
 
   let mut ivars : IVarIdSet := {}
   for name in names do
@@ -62,7 +62,7 @@ private def isplitCore (side : splitSide) (names : Array (TSyntax `ident)) : Tac
   let Q1 ← mkFreshExprMVarQ prop
   let Q2 ← mkFreshExprMVarQ prop
   let some _ ← ProofModeM.trySynthInstanceQ q(FromSep $goal $Q1 $Q2) |
-    throwError "isplit: {goal} is not a separating conjunction"
+    throwIPMError "{goal} is not a separating conjunction"
 
   -- split conjunction
   let ⟨_, _, lhs, rhs, pf⟩ := hyps.split bi (fun _ ivar => ivars.contains ivar == splitRight)

--- a/Iris/Iris/ProofMode/Tactics/Trivial.lean
+++ b/Iris/Iris/ProofMode/Tactics/Trivial.lean
@@ -28,4 +28,4 @@ def iTrivial {prop : Q(Type u)} {bi : Q(BI $prop)} {e} (hyps : Hyps bi e)
     -- itrivial failed, so we fail
     return none
   -- itrivial succeed, but did not fully solve the goal. This should not happen.
-  throwError "itrivial: itrivial should not make partial progress"
+  throwIPMError "itrivial should not make partial progress"

--- a/Iris/Iris/Tests/HeapLang/HeapTactics.lean
+++ b/Iris/Iris/Tests/HeapLang/HeapTactics.lean
@@ -69,21 +69,7 @@ example {l : Loc} {v : Val} :
   imodintro
   iapply HΦ $$ Hl
 
-/--
-error: Tactic `wp_load` failed: cannot find a points-to hypothesis for l ↦{?_} _
-
-hlc : HasLC
-GF : BundledGFunctors
-ι : HeapLangGS hlc GF
-s : Stuckness
-E : CoPset
-Φ : Val → IProp GF
-l l' : Loc
-v : Val
-⊢
-  ∗Hpt : l' ↦ some v
-  ⊢ WP hl(!#l) @ s ; E {{ Φ }}
--/
+/-- error: wp_load: cannot find a points-to hypothesis for l ↦{?_} _ -/
 #guard_msgs (whitespace := lax) in
 set_option pp.mvars false in
 example {l l' : Loc} {v : Val} :
@@ -91,21 +77,7 @@ example {l l' : Loc} {v : Val} :
   iintro Hpt
   wp_load
 
-/--
-error: Tactic `wp_load` failed: cannot find a `load` redex
-
-hlc : HasLC
-GF : BundledGFunctors
-ι : HeapLangGS hlc GF
-s : Stuckness
-E : CoPset
-Φ : Val → IProp GF
-l : Loc
-v v' : Val
-⊢
-  ∗Hpt : l ↦ some v
-  ⊢ WP hl(#l ← v(&v')) @ s ; E {{ Φ }}
--/
+/-- error: wp_load: cannot find a `load` redex -/
 #guard_msgs (whitespace := lax) in
 example {l : Loc} {v v' : Val} :
     (l ↦ some v) ⊢ WP hl(v(#l) ← &v') @ s ; E {{ Φ }} := by
@@ -141,22 +113,7 @@ example {l : Loc} {v v' v'' : Val} :
   imodintro
   iframe
 
-/--
-error: Tactic `wp_store` failed: cannot find a points-to hypothesis for l ↦{DFrac.own 1} _
-
-hlc : HasLC
-GF : BundledGFunctors
-ι : HeapLangGS hlc GF
-s : Stuckness
-E : CoPset
-Φ : Val → IProp GF
-l : Loc
-dq : DFrac
-v v' : Val
-⊢
-  ∗Hpt : l ↦{dq} some v
-  ⊢ WP hl(#l ← v(&v')) @ s ; E {{ Φ }}
--/
+/-- error: wp_store: cannot find a points-to hypothesis for l ↦{DFrac.own 1} _ -/
 #guard_msgs (whitespace := lax) in
 example {l : Loc} {dq : DFrac} {v v' : Val} :
     (l ↦{dq} some v) ⊢ WP hl(v(#l) ← &v') @ s ; E {{ Φ }} := by
@@ -188,22 +145,7 @@ example {l : Loc} {z : Int} :
   itrivial
 
 -- `wp_faa` failing: writes need full ownership, fractional is rejected
-/--
-error: Tactic `wp_faa` failed: cannot find a points-to hypothesis for l ↦{DFrac.own 1} _
-
-hlc : HasLC
-GF : BundledGFunctors
-ι : HeapLangGS hlc GF
-s : Stuckness
-E : CoPset
-Φ : Val → IProp GF
-l : Loc
-dq : DFrac
-z : Int
-⊢
-  ∗Hpt : l ↦{dq} some hl_val(#z)
-  ⊢ WP hl(faa(#l, #1)) @ s ; E {{ Φ }}
--/
+/-- error: wp_faa: cannot find a points-to hypothesis for l ↦{DFrac.own 1} _ -/
 #guard_msgs (whitespace := lax) in
 example {l : Loc} {dq : DFrac} {z : Int} :
     (l ↦{dq} some hl_val(#z)) ⊢ WP hl(faa(#l, #1)) @ s ; E {{ Φ }} := by
@@ -211,21 +153,7 @@ example {l : Loc} {dq : DFrac} {z : Int} :
   wp_faa
 
 -- `wp_faa` failing: the stored value must be an integer literal
-/--
-error: Tactic `wp_faa` failed: the points-to hypothesis for location l does not store an integer
-
-hlc : HasLC
-GF : BundledGFunctors
-ι : HeapLangGS hlc GF
-s : Stuckness
-E : CoPset
-Φ : Val → IProp GF
-l : Loc
-v : Val
-⊢
-  ∗Hpt : l ↦ some v
-  ⊢ WP hl(faa(#l, #1)) @ s ; E {{ Φ }}
--/
+/-- error: wp_faa: the points-to hypothesis for location l does not store an integer -/
 #guard_msgs (whitespace := lax) in
 example {l : Loc} {v : Val} :
     (l ↦ some v) ⊢ WP hl(faa(#l, #1)) @ s ; E {{ Φ }} := by
@@ -254,22 +182,7 @@ example {l : Loc} {v v' : Val} :
   itrivial
 
 -- `wp_xchg` failing: writes need full ownership, fractional is rejected
-/--
-error: Tactic `wp_xchg` failed: cannot find a points-to hypothesis for l ↦{DFrac.own 1} _
-
-hlc : HasLC
-GF : BundledGFunctors
-ι : HeapLangGS hlc GF
-s : Stuckness
-E : CoPset
-Φ : Val → IProp GF
-l : Loc
-dq : DFrac
-v v' : Val
-⊢
-  ∗Hpt : l ↦{dq} some v
-  ⊢ WP hl(xchg(#l, v(&v'))) @ s ; E {{ Φ }}
--/
+/-- error: wp_xchg: cannot find a points-to hypothesis for l ↦{DFrac.own 1} _ -/
 #guard_msgs (whitespace := lax) in
 example {l : Loc} {dq : DFrac} {v v' : Val} :
     (l ↦{dq} some v) ⊢ WP hl(xchg(#l, &v')) @ s ; E {{ Φ }} := by
@@ -298,22 +211,7 @@ example {l l' : Loc} {v w : Val} :
   iframe
 
 -- `wp_free` failing: deallocation needs full ownership, fractional is rejected
-/--
-error: Tactic `wp_free` failed: cannot find a points-to hypothesis for l ↦{DFrac.own 1} _
-
-hlc : HasLC
-GF : BundledGFunctors
-ι : HeapLangGS hlc GF
-s : Stuckness
-E : CoPset
-Φ : Val → IProp GF
-l : Loc
-dq : DFrac
-v : Val
-⊢
-  ∗Hpt : l ↦{dq} some v
-  ⊢ WP hl(free(#l)) @ s ; E {{ Φ }}
--/
+/-- error: wp_free: cannot find a points-to hypothesis for l ↦{DFrac.own 1} _ -/
 #guard_msgs (whitespace := lax) in
 example {l : Loc} {dq : DFrac} {v : Val} :
     (l ↦{dq} some v) ⊢ WP hl(free(#l)) @ s ; E {{ Φ }} := by
@@ -360,22 +258,7 @@ example {l : Loc} {v2 : Val} :
   itrivial
 
 -- `wp_cmpxchg_suc` failing: a successful CAS writes, so fractional is rejected
-/--
-error: Tactic `wp_cmpxchg_suc` failed: cannot find a points-to hypothesis for l ↦{DFrac.own 1} _
-
-hlc : HasLC
-GF : BundledGFunctors
-ι : HeapLangGS hlc GF
-s : Stuckness
-E : CoPset
-Φ : Val → IProp GF
-l : Loc
-dq : DFrac
-v2 : Val
-⊢
-  ∗Hl : l ↦{dq} some hl_val(#1)
-  ⊢ WP hl(cmpXchg(#l, #1, v(&v2))) @ s ; E {{ Φ }}
--/
+/-- error: wp_cmpxchg_suc: cannot find a points-to hypothesis for l ↦{DFrac.own 1} _ -/
 #guard_msgs (whitespace := lax) in
 example {l : Loc} {dq : DFrac} {v2 : Val} :
     (l ↦{dq} some hl_val(#1)) ⊢
@@ -428,23 +311,7 @@ end wp_cmpxchg
 section goal_shape
 
 -- heap tactics reject WPs over a non-HeapLang `IrisGS_gen` instance
-/--
-error: Tactic `wp_load` failed: the goal is not a HeapLang WP
-
-hlc : HasLC
-GF : BundledGFunctors
-ι : HeapLangGS hlc GF
-s : Stuckness
-E : CoPset
-Φ✝ : Val → IProp GF
-hlc' : HasLC
-GF' : BundledGFunctors
-inst✝ : IrisGS_gen hlc' Exp GF'
-e : Exp
-Φ : Val → IProp GF'
-⊢
-  ⊢ WP e @ s ; E {{ Φ }}
--/
+/-- error: wp_load: the goal is not a HeapLang WP -/
 #guard_msgs (whitespace := lax) in
 example {hlc'} {GF' : BundledGFunctors} [IrisGS_gen hlc' Exp GF']
     {e : Exp} {Φ : Val → IProp GF'} :
@@ -452,9 +319,7 @@ example {hlc'} {GF' : BundledGFunctors} [IrisGS_gen hlc' Exp GF']
   wp_load
 
 -- heap tactics reject goals that are not WPs at all
-/--
-error: The goal P must be a WP
--/
+/-- error: wp_load: The goal P must be a WP -/
 #guard_msgs (whitespace := lax) in
 example {P : IProp GF} : P ⊢ P := by
   iintro HP

--- a/Iris/Iris/Tests/HeapLang/WeakestPre.lean
+++ b/Iris/Iris/Tests/HeapLang/WeakestPre.lean
@@ -78,15 +78,7 @@ GF : BundledGFunctors
 example : ⊢@{IProp GF}  WP hl(((#0 + #1) + #2) + #3) {{ v, True }} := by
   wp_bind ((#0 + _) + _)
 
-/--
-error: Tactic `wp_bind` failed: Cannot unify hl((#2 + &?_)) with any possible evaluation context
-
-hlc : HasLC
-GF : BundledGFunctors
-ι : IrisGS_gen hlc Exp GF
-⊢ ⏎
-  ⊢ WP hl((((#0 + #1) + #2) + #3)) {{ v, True }}
--/
+/-- error: wp_bind: Cannot unify hl((#2 + &?_)) with any possible evaluation context -/
 #guard_msgs in
 example : ⊢@{IProp GF}  WP hl(((#0 + #1) + #2) + #3) {{ v, True }} := by
   wp_bind (#2 + _)
@@ -281,17 +273,7 @@ end wp_lam
 
 section wp_let
 
-/--
-error: Tactic `wp_pure` failed: Cannot find expression to evaluate
-
-hlc : HasLC
-GF✝ : BundledGFunctors
-ι : IrisGS_gen hlc Exp GF✝
-GF : BundledGFunctors
-inst✝ : HeapLangGS hlc GF
-⊢ ⏎
-  ⊢ WP hl(#1; #2) {{ v, ⌜v = hl_val(#2)⌝ }}
--/
+/-- error: wp_pure: Cannot find expression to evaluate -/
 #guard_msgs in
 example : ⊢@{IProp GF} WP hl(#1; #2) {{ v, ⌜v = hl_val(#2)⌝ }} := by
   wp_let
@@ -328,17 +310,7 @@ inst✝ : HeapLangGS hlc GF
 example : ⊢@{IProp GF} WP hl(#1; #2) {{ v, ⌜v = hl_val(#2)⌝ }} := by
   wp_seq
 
-/--
-error: Tactic `wp_pure` failed: Cannot find expression to evaluate
-
-hlc : HasLC
-GF✝ : BundledGFunctors
-ι : IrisGS_gen hlc Exp GF✝
-GF : BundledGFunctors
-inst✝ : HeapLangGS hlc GF
-⊢ ⏎
-  ⊢ WP hl(let x := #1; x) {{ v, ⌜v = hl_val(#1)⌝ }}
--/
+/-- error: wp_pure: Cannot find expression to evaluate -/
 #guard_msgs in
 example : ⊢@{IProp GF} WP hl(let x := #1; x) {{ v, ⌜v = hl_val(#1)⌝ }} := by
   wp_seq
@@ -347,17 +319,7 @@ end wp_seq
 
 section wp_closure
 
-/--
-error: Tactic `wp_pure` failed: Cannot find expression to evaluate
-
-hlc : HasLC
-GF✝ : BundledGFunctors
-ι : IrisGS_gen hlc Exp GF✝
-GF : BundledGFunctors
-inst✝ : HeapLangGS hlc GF
-⊢ ⏎
-  ⊢ WP hl((#1 + #1)) {{ v, ⌜v = hl_val(#2)⌝ }}
--/
+/-- error: wp_pure: Cannot find expression to evaluate -/
 #guard_msgs in
 example : ⊢@{IProp GF} WP hl(#1 + #1) {{ v, ⌜v = hl_val(#2)⌝ }} := by
   wp_closure
@@ -394,17 +356,7 @@ inst✝ : HeapLangGS hlc GF
 example : ⊢@{IProp GF} WP hl(if #true then #1 else #2) {{ v, ⌜v = hl_val(#1)⌝ }} := by
   wp_if
 
-/--
-error: Tactic `wp_pure` failed: Cannot find expression to evaluate
-
-hlc : HasLC
-GF✝ : BundledGFunctors
-ι : IrisGS_gen hlc Exp GF✝
-GF : BundledGFunctors
-inst✝ : HeapLangGS hlc GF
-⊢ ⏎
-  ⊢ WP hl((#1 + #2)) {{ v, ⌜v = hl_val(#3)⌝ }}
--/
+/-- error: wp_pure: Cannot find expression to evaluate -/
 #guard_msgs in
 example : ⊢@{IProp GF} WP hl(#1 + #2) {{ v, ⌜v = hl_val(#3)⌝ }} := by
   wp_if
@@ -413,17 +365,7 @@ end wp_if
 
 section wp_if_true
 
-/--
-error: Tactic `wp_pure` failed: Cannot find expression to evaluate
-
-hlc : HasLC
-GF✝ : BundledGFunctors
-ι : IrisGS_gen hlc Exp GF✝
-GF : BundledGFunctors
-inst✝ : HeapLangGS hlc GF
-⊢ ⏎
-  ⊢ WP hl(if #false then #1 else #2) {{ v, ⌜v = hl_val(#2)⌝ }}
--/
+/-- error: wp_pure: Cannot find expression to evaluate -/
 #guard_msgs in
 example : ⊢@{IProp GF} WP hl(if #false then #1 else #2) {{ v, ⌜v = hl_val(#2)⌝ }} := by
   wp_if_true
@@ -460,17 +402,7 @@ inst✝ : HeapLangGS hlc GF
 example : ⊢@{IProp GF} WP hl(if #false then #1 else #2) {{ v, ⌜v = hl_val(#2)⌝ }} := by
   wp_if_false
 
-/--
-error: Tactic `wp_pure` failed: Cannot find expression to evaluate
-
-hlc : HasLC
-GF✝ : BundledGFunctors
-ι : IrisGS_gen hlc Exp GF✝
-GF : BundledGFunctors
-inst✝ : HeapLangGS hlc GF
-⊢ ⏎
-  ⊢ WP hl(if #true then #1 else #2) {{ v, ⌜v = hl_val(#1)⌝ }}
--/
+/-- error: wp_pure: Cannot find expression to evaluate -/
 #guard_msgs in
 example : ⊢@{IProp GF} WP hl(if #true then #1 else #2) {{ v, ⌜v = hl_val(#1)⌝ }} := by
   wp_if_false
@@ -493,17 +425,7 @@ inst✝ : HeapLangGS hlc GF
 example : ⊢@{IProp GF} WP hl(fst(v((#1, #2)))) {{ v, ⌜v = hl_val(#1)⌝ }} := by
   wp_proj
 
-/--
-error: Tactic `wp_pure` failed: Cannot find expression to evaluate
-
-hlc : HasLC
-GF✝ : BundledGFunctors
-ι : IrisGS_gen hlc Exp GF✝
-GF : BundledGFunctors
-inst✝ : HeapLangGS hlc GF
-⊢ ⏎
-  ⊢ WP hl((#1, #2)) {{ v, ⌜v = hl_val((#1, #2))⌝ }}
--/
+/-- error: wp_pure: Cannot find expression to evaluate -/
 #guard_msgs in
 example : ⊢@{IProp GF} WP hl((#1, #2)) {{ v, ⌜v = hl_val((#1, #2))⌝ }} := by
   wp_proj
@@ -526,17 +448,7 @@ end wp_proj
 
 section wp_inj
 
-/--
-error: Tactic `wp_pure` failed: Cannot find expression to evaluate
-
-hlc : HasLC
-GF✝ : BundledGFunctors
-ι : IrisGS_gen hlc Exp GF✝
-GF : BundledGFunctors
-inst✝ : HeapLangGS hlc GF
-⊢ ⏎
-  ⊢ WP hl(injr((#1 + #1))) {{ v, ⌜v = hl_val(injr(#2))⌝ }}
--/
+/-- error: wp_pure: Cannot find expression to evaluate -/
 #guard_msgs in
 example : ⊢@{IProp GF} WP hl(injr(#1 + #1)) {{ v, ⌜v = hl_val(injr(#2))⌝ }} := by
   wp_inj
@@ -587,17 +499,7 @@ inst✝ : HeapLangGS hlc GF
 example : ⊢@{IProp GF} WP hl((#1, #2)) {{ v, ⌜v = hl_val((#1, #2))⌝ }} := by
   wp_pair
 
-/--
-error: Tactic `wp_pure` failed: Cannot find expression to evaluate
-
-hlc : HasLC
-GF✝ : BundledGFunctors
-ι : IrisGS_gen hlc Exp GF✝
-GF : BundledGFunctors
-inst✝ : HeapLangGS hlc GF
-⊢ ⏎
-  ⊢ WP hl(((#1 + #1), #2)) {{ v, ⌜v = hl_val((#2, #2))⌝ }}
--/
+/-- error: wp_pure: Cannot find expression to evaluate -/
 #guard_msgs in
 example : ⊢@{IProp GF} WP hl((#1 + #1, #2)) {{ v, ⌜v = hl_val((#2, #2))⌝ }} := by
   wp_pair
@@ -606,17 +508,7 @@ end wp_pair
 
 section wp_unop
 
-/--
-error: Tactic `wp_pure` failed: Cannot find expression to evaluate
-
-hlc : HasLC
-GF✝ : BundledGFunctors
-ι : IrisGS_gen hlc Exp GF✝
-GF : BundledGFunctors
-inst✝ : HeapLangGS hlc GF
-⊢ ⏎
-  ⊢ WP hl((#1 + #2)) {{ v, ⌜v = hl_val(#3)⌝ }}
--/
+/-- error: wp_pure: Cannot find expression to evaluate -/
 #guard_msgs in
 example : ⊢@{IProp GF} WP hl(#1 + #2) {{ v, ⌜v = hl_val(#3)⌝ }} := by
   wp_unop
@@ -653,17 +545,7 @@ inst✝ : HeapLangGS hlc GF
 example : ⊢@{IProp GF} WP hl(#1 + #2) {{ v, ⌜v = hl_val(#3)⌝ }} := by
   wp_binop
 
-/--
-error: Tactic `wp_pure` failed: Cannot find expression to evaluate
-
-hlc : HasLC
-GF✝ : BundledGFunctors
-ι : IrisGS_gen hlc Exp GF✝
-GF : BundledGFunctors
-inst✝ : HeapLangGS hlc GF
-⊢ ⏎
-  ⊢ WP hl((~#true)) {{ v, ⌜v = hl_val(#false)⌝ }}
--/
+/-- error: wp_pure: Cannot find expression to evaluate -/
 #guard_msgs in
 example : ⊢@{IProp GF} WP hl(~#true) {{ v, ⌜v = hl_val(#false)⌝ }} := by
   wp_binop
@@ -686,17 +568,7 @@ inst✝ : HeapLangGS hlc GF
 example : ⊢@{IProp GF} WP hl(~#true) {{ v, ⌜v = hl_val(#false)⌝ }} := by
   wp_op
 
-/--
-error: Tactic `wp_pure` failed: Cannot find expression to evaluate
-
-hlc : HasLC
-GF✝ : BundledGFunctors
-ι : IrisGS_gen hlc Exp GF✝
-GF : BundledGFunctors
-inst✝ : HeapLangGS hlc GF
-⊢ ⏎
-  ⊢ WP hl(if #true then #1 else #2) {{ v, ⌜v = hl_val(#1)⌝ }}
--/
+/-- error: wp_pure: Cannot find expression to evaluate -/
 #guard_msgs in
 example : ⊢@{IProp GF} WP hl(if #true then #1 else #2) {{ v, ⌜v = hl_val(#1)⌝ }} := by
   wp_op
@@ -719,17 +591,7 @@ end wp_op
 
 section wp_case
 
-/--
-error: Tactic `wp_pure` failed: Cannot find expression to evaluate
-
-hlc : HasLC
-GF✝ : BundledGFunctors
-ι : IrisGS_gen hlc Exp GF✝
-GF : BundledGFunctors
-inst✝ : HeapLangGS hlc GF
-⊢ ⏎
-  ⊢ WP hl(match injl(#1) with | injl(x) => (x + #1) | injr(y) => y) {{ v, ⌜v = hl_val(#2)⌝ }}
--/
+/-- error: wp_pure: Cannot find expression to evaluate -/
 #guard_msgs in
 example : ⊢@{IProp GF}
     WP hl(match injl(#1) with | injl(x) => x + #1 | injr(y) => y)
@@ -772,17 +634,7 @@ example : ⊢@{IProp GF}
       {{ v, ⌜v = hl_val(#2)⌝ }} := by
   wp_match
 
-/--
-error: Tactic `wp_pure` failed: Cannot find expression to evaluate
-
-hlc : HasLC
-GF✝ : BundledGFunctors
-ι : IrisGS_gen hlc Exp GF✝
-GF : BundledGFunctors
-inst✝ : HeapLangGS hlc GF
-⊢ ⏎
-  ⊢ WP hl(if #true then #1 else #2) {{ v, ⌜v = hl_val(#1)⌝ }}
--/
+/-- error: wp_pure: Cannot find expression to evaluate -/
 #guard_msgs in
 example : ⊢@{IProp GF} WP hl(if #true then #1 else #2) {{ v, ⌜v = hl_val(#1)⌝ }} := by
   wp_match

--- a/Iris/Iris/Tests/Tactics.lean
+++ b/Iris/Iris/Tests/Tactics.lean
@@ -387,7 +387,7 @@ example [BI PROP] (n : Nat) (P Q : PROP) : ⊢ □ P -∗ □ Q -∗ ⌜n = n⌝
   rfl
 
 /- Tests `iintro` with pure introduction failure. -/
-/-- error: ipureintro: Q is not pure -/
+/-- error: iintro: Q is not pure -/
 #guard_msgs in
 example [BI PROP] (P Q : PROP) : P ⊢ Q := by
   iintro HP !%
@@ -839,7 +839,7 @@ example [BI PROP] {α} (Q : α → PROP) (a b : α) : (∀ x, ∀ y, ⌜x = a⌝
   iintro H
   iapply H $$ %_ %b %rfl
 
-/-- error: ispecialize: iprop(P a -∗ Q b) is not a Lean premise -/
+/-- error: iapply: iprop(P a -∗ Q b) is not a Lean premise -/
 #guard_msgs in
 example [BI PROP] {α} (P Q : α → PROP) (a b : α) : (∀ x, ∀ y, P x -∗ Q y) ⊢ P a -∗ Q b := by
   iintro H HP
@@ -2241,7 +2241,7 @@ example [BI PROP] (P : Prop) : ⊢@{PROP} ⌜P⌝ -∗ True := by
   Tests `icases` with a case destruction pattern for rewriting but the
   hypothesis is not a pure hypothesis.
 -/
-/-- error: ipure: P is not pure -/
+/-- error: icases: P is not pure -/
 #guard_msgs in
 example [BI PROP] (P : PROP) : ⊢@{PROP} P -∗ True := by
   iintro HP
@@ -2283,7 +2283,7 @@ example [BI PROP] (P : PROP) : □ P ∗ <affine> P ⊢ <affine> P := by
   iexact HP2
 
 /- Tests `imodintro` for affinely (intuitionistic: id, spatial: forall Affine) failing. -/
-/-- error: imodintro: hypothesis HP2 : P does not satisfy Affine -/
+/-- error: imodintro: hypothesis HP2: P does not satisfy Affine -/
 #guard_msgs in
 example [BI PROP] (P : PROP) : □ P ∗ P ⊢ <affine> P := by
   iintro ⟨#HP1, HP2⟩
@@ -2479,7 +2479,7 @@ example {PROP1 PROP2 : Type u} [BI PROP1] [BI PROP2] [BIUpdate PROP1] [BIUpdate 
   iassumption
 
 /- Tests `imodintro` where `intoEmbed_embed` does not apply. -/
-/-- error: imodintro: cannot transform hypothesis HQ : Q with ProofMode.IntoEmbed -/
+/-- error: imodintro: cannot transform hypothesis HQ: Q with ProofMode.IntoEmbed -/
 #guard_msgs in
 example {PROP1 PROP2 : Type u} [BI PROP1] [BI PROP2] [BiEmbed PROP1 PROP2]
     (P : PROP1) (Q : PROP2) : ⎡P⎤ ∗ Q ⊢@{PROP2} ⎡P⎤ := by
@@ -2563,7 +2563,7 @@ example [BI PROP] [BIFUpdate PROP]
   iexact HP
 
 /- Tests `imod` for no modality. -/
-/-- error: imod: P is not a modality -/
+/-- error: icases: P is not a modality -/
 #guard_msgs in
 example [BI PROP] (P : PROP) : P ⊢ P := by
   iintro HP
@@ -3338,7 +3338,7 @@ example {GF} [TokenG GF] {γ} :
   iexact H
 
 /- Tests `icombine` with an invalid destruction pattern. -/
-/-- error: icases: cannot destruct iprop(<absorb> <affine> (P ∗ Q)) -/
+/-- error: icombine: cannot destruct iprop(<absorb> <affine> (P ∗ Q)) -/
 #guard_msgs in
 example [BI PROP] {P Q R : PROP} [CombineSepGives P Q R] :
     ⊢ <absorb> <affine> P -∗ <absorb> <affine> Q -∗ <absorb> <affine> (P ∗ Q) ∗ <pers> R := by


### PR DESCRIPTION
## Description

Addresses the discussions in https://github.com/leanprover-community/iris-lean/pull/516#issuecomment-4980039789.

There have been discussions about whether having the tactic name in the error message is actually useful at all. In my opinion, there is not much difference from the user's perspective, given that there is already error highlighting in the IDE, and the use of `withRef` enables the highlighting to be more precise (e.g. in `iinduction`, introduction patterns). Nonetheless, there are some minor benefits, such as avoiding repeated threading of tactic names in function calls (e.g. with `throwTacticEx`) and a more consistent error message format amongst HeapLang tactics and other tactics.

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files
