### PR TITLE
fix: Do not throw isDefEqStuck in IPM TC synth

### DIFF
--- a/Iris/Iris/ProofMode/SynthInstance.lean
+++ b/Iris/Iris/ProofMode/SynthInstance.lean
@@ -187,11 +187,14 @@ def synthInstanceCore? (type : Expr) (maxResultSize? : Option Nat := none) :
   let maxResultSize := maxResultSize?.getD (synthInstance.maxSize.get opts)
   withTraceNode `Meta.synthInstance
     (λ _ => return m!"IPM: {← instantiateMVars type}") do
-  withConfig (fun config =>
-                { config with isDefEqStuckEx := true,
-                              transparency := TransparencyMode.instances,
-                              foApprox := true, ctxApprox := true, constApprox := false,
-                              univApprox := false }) do
+  withConfig (fun config => { config with
+    -- The following options match standard Lean TC synthesis, except that
+    -- we set `isDefEqStuckEx` to false since we want to treat stuck defeq
+    -- as a normal failure and continue instead of aborting everything
+    isDefEqStuckEx := false,
+    transparency := TransparencyMode.instances,
+    foApprox := true, ctxApprox := true, constApprox := false,
+    univApprox := false }) do
   withInTypeClassResolution do
     let type ← instantiateMVars type
     -- TODO: if it becomes necessary, run whnf under the ∀ quantifiers of type
@@ -214,19 +217,15 @@ protected def synthInstance? (type : Expr) (maxResultSize? : Option Nat := none)
 
 protected def trySynthInstance (type : Expr) (maxResultSize? : Option Nat := none)
 : MetaM (LOption (Expr × Std.HashSet MVarId)) := do
-  catchInternalId isDefEqStuckExceptionId
-    (toLOptionM <| ProofMode.synthInstance? type maxResultSize?)
-    (fun _ => pure LOption.undef)
+   toLOptionM <| ProofMode.synthInstance? type maxResultSize?
+
 
 protected def synthInstance (type : Expr) (maxResultSize? : Option Nat := none) :
-    MetaM (Expr × Std.HashSet MVarId) :=
-  catchInternalId isDefEqStuckExceptionId
-    (do
+    MetaM (Expr × Std.HashSet MVarId) := do
       let result? ← ProofMode.synthInstance? type maxResultSize?
       match result? with
       | some result => pure result
-      | none        => do _ ← throwFailedToSynthesize type; unreachable!)
-    (fun _ => do _ ← throwFailedToSynthesize type; unreachable!)
+      | none        => do _ ← throwFailedToSynthesize type; unreachable!
 
 /- It is recommended to use ProofModeM.trySynthInstanceQ and ProofModeM.synthInstanceQ that
 automatically handle the newly spawned goals. -/

--- a/Iris/Iris/Tests/Tactics.lean
+++ b/Iris/Iris/Tests/Tactics.lean
@@ -970,6 +970,33 @@ example [BI PROP] (P Q : PROP) : (<affine> (P -∗ Q)) ⊢ (<affine> P) -∗ <af
   iapply Hwand
   iexact HP
 
+inductive R where
+  | R_Constr (n : Int) (r : R)
+/-- Test `iapply` with a `match` in a hypothesis, regression test for
+https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/iapply.20doesn.27t.20work.20with.20matches.3F/near/615255205 -/
+example [BI PROP] (P : PROP) :
+    (∀ t,
+      (match t with
+      | R.R_Constr _ _ => True) -∗ P) -∗
+    (match t with
+    | R.R_Constr _ _ => True) -∗ P := by
+  iintro Hwand Ht
+  iapply Hwand
+  iapply Ht
+
+/-- Test `iapply` with other match, regression test for
+https://github.com/leanprover-community/iris-lean/issues/145 -/
+example [BI PROP] (Q : PROP) : Q ⊢ Q := by
+  iintro HQ
+  have H: (∀ b (Q: PROP),
+    (match b with
+     | true => iprop(Q)
+     | false => iprop(Q))
+    ⊢ Q) := by rintro ⟨⟩ <;> simp
+  iapply H
+  case b => exact true
+  itrivial
+
 end iapply
 
 section ihave


### PR DESCRIPTION
## Description
The IPM TC synth used the same defeq config as the standard Lean TC synth, which includes setting the flag for the isDefEqStuck exception. However, the IPM TC synth does not handle this exception, and thus the IPM TC synth can unexpectedly abort. This commit fixes this by disabling the isDefEqStuck exception.

Fixes [#iris-lean > iapply doesn't work with matches? @ 💬](https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/iapply.20doesn.27t.20work.20with.20matches.3F/near/615255205) and #145 

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files
