### PR TITLE
doc: Finish annotating the `si_logic` folder

### DIFF
--- a/Iris/Iris/BI/SIProp.lean
+++ b/Iris/Iris/BI/SIProp.lean
@@ -109,6 +109,7 @@ def later (P : SiProp) : SiProp where
 @[rocq_alias siProp_entails]
 def entails (P Q : SiProp) : Prop := ∀ n, P.holds n → Q.holds n
 
+@[rocq_alias siPropO]
 instance : OFE SiProp where
   Dist n P Q := ∀ {m}, m ≤ n → (P.holds m ↔ Q.holds m)
   dist_eqv.refl _ _ _ := Iff.rfl
@@ -122,6 +123,10 @@ instance : OFE SiProp where
       subst this; rfl
   dist_lt h _ _ _ := h (by omega)
 
+#rocq_ignore siProp_equiv' "OFE is Leibniz; use equality."
+#rocq_ignore siProp_equiv "OFE is Leibniz; use equality."
+#rocq_ignore siProp_dist' "Inlined in the `OFE` construction."
+#rocq_ignore siProp_dist "Inlined in the `OFE` construction."
 #rocq_ignore siProp_ofe_mixin "Not needed in Lean."
 
 @[rocq_alias siProp_cofe]
@@ -153,6 +158,7 @@ instance : BIBase SiProp where
 #rocq_ignore siProp_wand "Included in BIBase instance."
 #rocq_ignore siProp_persistently "Included in BIBase instance."
 
+@[rocq_alias siProp_primitive.entails_po]
 instance siPropPreorder : Std.IsPreorder SiProp where
   le_refl _ _ := id
   le_trans _ _ _ h₁ h₂ n h := h₂ n (h₁ n h)
@@ -244,7 +250,45 @@ instance instBI : BI SiProp where
 @[rocq_alias siProp_primitive.pure_ne]
 theorem pure_dist_of_iff {Φ Ψ : Prop} (H : Φ ↔ Ψ) : pure Φ ≡{n}≡ pure Ψ := fun _ => iff_comm.mp H.symm
 
+/-! The primitive laws of `siProp` are the fields of the `siPropI` instance above; each one
+is named in Lean by the corresponding `BI` field, so the Rocq names alias those. -/
+
+attribute [rocq_alias siProp_primitive.equiv_entails,
+           rocq_alias siProp_primitive.entails_anti_symm] BI.equiv_iff
+
+attribute [rocq_alias siProp_primitive.pure_intro] BI.pure_intro
+attribute [rocq_alias siProp_primitive.pure_elim'] BI.pure_elim'
+
+attribute [rocq_alias siProp_primitive.and_ne] BI.and_ne
+attribute [rocq_alias siProp_primitive.and_elim_l] BI.and_elim_l
+attribute [rocq_alias siProp_primitive.and_elim_r] BI.and_elim_r
+attribute [rocq_alias siProp_primitive.and_intro] BI.and_intro
+
+attribute [rocq_alias siProp_primitive.or_ne] BI.or_ne
+attribute [rocq_alias siProp_primitive.or_intro_l] BI.or_intro_l
+attribute [rocq_alias siProp_primitive.or_intro_r] BI.or_intro_r
+attribute [rocq_alias siProp_primitive.or_elim] BI.or_elim
+
+attribute [rocq_alias siProp_primitive.impl_ne] BI.imp_ne
+attribute [rocq_alias siProp_primitive.impl_intro_r] BI.imp_intro
+attribute [rocq_alias siProp_primitive.impl_elim_l'] BI.imp_elim
+
+attribute [rocq_alias siProp_primitive.forall_ne] BI.sForall_ne
+attribute [rocq_alias siProp_primitive.forall_intro] BI.sForall_intro
+attribute [rocq_alias siProp_primitive.forall_elim] BI.sForall_elim
+
+attribute [rocq_alias siProp_primitive.exist_ne] BI.sExists_ne
+attribute [rocq_alias siProp_primitive.exist_intro] BI.sExists_intro
+attribute [rocq_alias siProp_primitive.exist_elim] BI.sExists_elim
+
+attribute [rocq_alias siProp_primitive.later_mono] BI.later_mono
+attribute [rocq_alias siProp_primitive.later_intro] BI.later_intro
+attribute [rocq_alias siProp_primitive.later_forall_2] BI.later_sForall_2
+attribute [rocq_alias siProp_primitive.later_exist_false] BI.later_sExists_false
+attribute [rocq_alias siProp_primitive.later_false_em] BI.later_false_em
+
 #rocq_ignore siProp_pure_forall "BiPureForall is not ported."
+#rocq_ignore siProp_primitive.pure_forall_2 "BiPureForall is not ported."
 
 #rocq_ignore siProp_bi_later_mixin "Not needed in Lean."
 #rocq_ignore siProp_bi_mixin "Not needed in Lean."
@@ -271,7 +315,7 @@ theorem pure_dist_of_iff {Φ Ψ : Prop} (H : Φ ↔ Ψ) : pure Φ ≡{n}≡ pure
 instance instBIAffine : BIAffine SiProp where
   affine _ := { affine := fun _ _ => trivial }
 
-@[rocq_alias siProp_later_contractive]
+@[rocq_alias siProp_later_contractive, rocq_alias siProp_primitive.later_contractive]
 instance instBILaterContractive : BILaterContractive SiProp where
   distLater_dist h m hle := match m with | .zero => .rfl | .succ k => h k (by omega) .refl
 

--- a/Iris/Iris/BI/SIProp.lean
+++ b/Iris/Iris/BI/SIProp.lean
@@ -287,8 +287,8 @@ attribute [rocq_alias siProp_primitive.later_forall_2] BI.later_sForall_2
 attribute [rocq_alias siProp_primitive.later_exist_false] BI.later_sExists_false
 attribute [rocq_alias siProp_primitive.later_false_em] BI.later_false_em
 
-#rocq_ignore siProp_pure_forall "BiPureForall is not ported."
-#rocq_ignore siProp_primitive.pure_forall_2 "BiPureForall is not ported."
+#rocq_ignore siProp_pure_forall "Not necessary due to classical logic, see BiPureForall."
+#rocq_ignore siProp_primitive.pure_forall_2 "Not necessary due to classical logic, see BiPureForall."
 
 #rocq_ignore siProp_bi_later_mixin "Not needed in Lean."
 #rocq_ignore siProp_bi_mixin "Not needed in Lean."


### PR DESCRIPTION
## Description
This should bring `si_logic` to 100% ported. 

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
