### PR TITLE
fix: auto-sequence in wp_store and wp_xchg tactics

### DIFF
--- a/Iris/Iris/HeapLang/Lib/LazyCoin.lean
+++ b/Iris/Iris/HeapLang/Lib/LazyCoin.lean
@@ -95,7 +95,6 @@ theorem readCoin.spec (cp : Val) (b : Bool) :
     wp_pures
     wp_bind &nondetBool _; iapply nondetBool.spec $$ [//]; iintro !> %b -
     wp_store
-    wp_pure; wp_pure
     wp_bind resolveProph(_, _); iapply wp_resolve_proph $$ proph
     iintro %pvs' %pvs_eq proph
     subst pvs_eq

--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -646,7 +646,7 @@ elab "wp_load" : tactic =>
 
     mvar.assign q(tac_wp_load (ι := $hgs) (Δ' := $eΔ') $pfLater $pfSplit $pfCont)
 
-elab "wp_store" : tactic =>
+elab "wp_store" : tactic => do
   runTacticHeapWp `wp_store fun mvar {bi, s, E, e, Φ, hgs, eΔ', hyps', pfLater, ..} => do
     let some {result := (l, v'), K, ..} ← findECtx e fun e' => do
         let ~q(Exp.store (Exp.ofVal (Val.lit (BaseLit.loc $l))) (Exp.ofVal $v')) := e' | failure
@@ -663,8 +663,11 @@ elab "wp_store" : tactic =>
     let pfCont ← finishHeapOp hyps''' hgs s E K q(hl_val(#())) Φ
 
     mvar.assign q(tac_wp_store (ι := $hgs) (Δ' := $eΔ') $pfLater $pfSplit <| $(pf''').mp.trans $pfCont)
+  -- a store's result is often discarded by a `;`, so try stepping through the
+  -- sequencing redex using `wp_seq`
+  evalTactic (← `(tactic| try wp_seq))
 
-elab "wp_xchg" : tactic =>
+elab "wp_xchg" : tactic => do
   runTacticHeapWp `wp_xchg fun mvar {bi, s, E, e, Φ, hgs, eΔ', hyps', pfLater, ..} => do
     let some {result := (l, v'), K, ..} ← findECtx e fun e' => do
         let ~q(Exp.xchg (Exp.ofVal (Val.lit (BaseLit.loc $l))) (Exp.ofVal $v')) := e' | failure
@@ -681,6 +684,8 @@ elab "wp_xchg" : tactic =>
     let pfCont ← finishHeapOp hyps''' hgs s E K v Φ
 
     mvar.assign q(tac_wp_xchg (ι := $hgs) (Δ' := $eΔ') $pfLater $pfSplit <| $(pf''').mp.trans $pfCont)
+  -- like in `wp_store`, an `xchg` often discards its result, so try `wp_seq`
+  evalTactic (← `(tactic| try wp_seq))
 
 elab "wp_faa" : tactic =>
   runTacticHeapWp `wp_faa fun mvar {bi, s, E, e, Φ, hgs, eΔ', hyps', pfLater, ..} => do

--- a/Iris/Iris/Tests/HeapLang/HeapTactics.lean
+++ b/Iris/Iris/Tests/HeapLang/HeapTactics.lean
@@ -113,6 +113,51 @@ example {l : Loc} {v v' v'' : Val} :
   imodintro
   iframe
 
+-- Rocq parity (`first [wp_seq|wp_finish]`): a store in sequencing position discards its
+-- `#()` result, so `wp_store` steps through the `;` instead of leaving a pure redex behind
+/--
+error: unsolved goals
+hlc : HasLC
+GF : BundledGFunctors
+ι : HeapLangGS hlc GF
+s : Stuckness
+E : CoPset
+Φ : Val → IProp GF
+l : Loc
+v v' : Val
+⊢
+  ∗Hpt : l ↦ some v'
+  ⊢ WP hl(!#l) @ s ; E {{ w, ⌜w = v'⌝ ∗ l ↦ some v' }}
+-/
+#guard_msgs (whitespace := lax) in
+example {l : Loc} {v v' : Val} :
+    (l ↦ some v) ⊢
+      WP hl(v(#l) ← &v'; !v(#l)) @ s ; E {{ w, ⌜w = v'⌝ ∗ l ↦ some v' }} := by
+  iintro Hpt
+  wp_store
+
+-- the fast-forward is *only* for the sequencing redex: a `let` binding the result stays
+/--
+error: unsolved goals
+hlc : HasLC
+GF : BundledGFunctors
+ι : HeapLangGS hlc GF
+s : Stuckness
+E : CoPset
+Φ : Val → IProp GF
+l : Loc
+v v' : Val
+⊢
+  ∗Hpt : l ↦ some v'
+  ⊢ WP hl(let x := #(); !#l) @ s ; E {{ _r, l ↦ some v' }}
+-/
+#guard_msgs (whitespace := lax) in
+example {l : Loc} {v v' : Val} :
+    (l ↦ some v) ⊢
+      WP hl(let x := v(#l) ← &v'; !v(#l)) @ s ; E {{ _r, l ↦ some v' }} := by
+  iintro Hpt
+  wp_store
+
 /-- error: wp_store: cannot find a points-to hypothesis for l ↦{DFrac.own 1} _ -/
 #guard_msgs (whitespace := lax) in
 example {l : Loc} {dq : DFrac} {v v' : Val} :
@@ -180,6 +225,28 @@ example {l : Loc} {v v' : Val} :
   imodintro
   iframe
   itrivial
+
+-- Rocq parity: like `wp_store`, an `xchg` in sequencing position discards its result
+/--
+error: unsolved goals
+hlc : HasLC
+GF : BundledGFunctors
+ι : HeapLangGS hlc GF
+s : Stuckness
+E : CoPset
+Φ : Val → IProp GF
+l : Loc
+v v' : Val
+⊢
+  ∗Hpt : l ↦ some v'
+  ⊢ WP hl(!#l) @ s ; E {{ w, ⌜w = v'⌝ ∗ l ↦ some v' }}
+-/
+#guard_msgs (whitespace := lax) in
+example {l : Loc} {v v' : Val} :
+    (l ↦ some v) ⊢
+      WP hl(xchg(#l, &v'); !v(#l)) @ s ; E {{ w, ⌜w = v'⌝ ∗ l ↦ some v' }} := by
+  iintro Hpt
+  wp_xchg
 
 -- `wp_xchg` failing: writes need full ownership, fractional is rejected
 /-- error: wp_xchg: cannot find a points-to hypothesis for l ↦{DFrac.own 1} _ -/


### PR DESCRIPTION
## Description

In Iris Rocq, `wp_store` and `wp_xchg` call `try wp_seq` to step over a discarded result of these two operations, which saves a manual `wp_pure`/`wp_seq` in many proofs. This PR implements the same behavior in iris-lean, removes such a call to `wp_pure` from `LazyCoin.v`, and adds tests asserting the desired behavior in the discarded and non-discarded cases.

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
