### PR TITLE
feat: Deal with numbers 

### DIFF
--- a/Iris/Iris/Algebra/Lib.lean
+++ b/Iris/Iris/Algebra/Lib.lean
@@ -4,4 +4,5 @@ public import Iris.Algebra.Lib.DFracAgree
 public import Iris.Algebra.Lib.ExclAuth
 public import Iris.Algebra.Lib.FracAuth
 public import Iris.Algebra.Lib.MonoNat
+public import Iris.Algebra.Lib.MonoZ
 public import Iris.Algebra.Lib.UFracAuth

--- a/Iris/Iris/Algebra/Lib/MonoNat.lean
+++ b/Iris/Iris/Algebra/Lib/MonoNat.lean
@@ -12,61 +12,6 @@ public import Iris.Algebra.Numbers
 
 namespace Iris
 
-open _root_.Std (Associative Commutative LeftIdentity LawfulLeftIdentity)
-
-section MaxNat
-
-@[grind cases]
-structure MaxNat where
-  ofNat ::
-  toNat : Nat
-
-instance : OfNat MaxNat n where ofNat := .ofNat n
-
-@[grind]
-def MaxNat.max (a b : MaxNat) : MaxNat where
-  toNat := a.toNat.max b.toNat
-
-scoped instance : Add MaxNat where add := .max
--- scoped instance : Max MaxNat where max := .max
-scoped instance : LE MaxNat where le a b := a.toNat ≤ b.toNat
-
-@[simp, grind =]
-theorem MaxNat.le_toNat (a b : MaxNat) : a ≤ b ↔ a.toNat ≤ b.toNat := by rfl
-
-@[simp, grind =]
-theorem MaxNat.toNat_add (a b : MaxNat) : (a + b).toNat = a.toNat.max b.toNat := rfl
-
-@[simp, grind =]
-theorem MaxNat.add_ofNat (a b : Nat) : (MaxNat.ofNat a + MaxNat.ofNat b) = MaxNat.ofNat (a.max b) := rfl
-
-@[grind =_]
-theorem MaxNat.toNat_zero : (0 : MaxNat).toNat = 0 := rfl
-
-@[grind =]
-theorem MaxNat.zero_ofNat : (0 : MaxNat) = .ofNat 0 := rfl
-
-theorem MaxNat.eq_toNat (a b : MaxNat) : a = b ↔ a.toNat = b.toNat := by
-  constructor
-  · rintro rfl; rfl
-  · cases a; cases b; rintro rfl; rfl
-
-scoped instance : Associative (α := MaxNat) (· + ·) where
-  assoc := by grind
-scoped instance : Commutative (α := MaxNat) (· + ·) where
-  comm := by grind
-scoped instance : LawfulLeftIdentity (α := MaxNat) (· + ·) (0 : MaxNat) where
-  left_id a := by grind
-scoped instance : Std.IdempotentOp (α := MaxNat) (· + ·) where
-  idempotent x := by grind
-scoped instance : COFE MaxNat := COFE.ofDiscrete _
-scoped instance : OFE.Discrete MaxNat := ⟨fun h => h⟩
-scoped instance : UCMRA MaxNat := OrdCommMonoidLike.instUCMRAOfLawfulLeftIdentityHAddZero
-scoped instance : CMRA.Discrete MaxNat := OrdCommMonoidLike.instDiscrete
-scoped instance : CMRA.CoreId (a : MaxNat) := OrdCommMonoidLike.instCoreId _
-
-end MaxNat
-
 @[rocq_alias mono_nat]
 abbrev MonoNat := Auth MaxNat
 

--- a/Iris/Iris/Algebra/Lib/MonoNat.lean
+++ b/Iris/Iris/Algebra/Lib/MonoNat.lean
@@ -34,8 +34,8 @@ scoped instance : OFE.DiscreteE (◯MN n : MonoNat) := Auth.frag_discrete
 scoped instance : OFE.DiscreteE (●MN{dq} n : MonoNat) :=
   ⟨fun h => OFE.discrete h⟩
 scoped instance : IsUnit (◯MN 0 : MonoNat) where
-  unit_valid := by simp only [lb, Auth.frag_valid]; exact True.intro
-  unit_left_id {x} := rfl
+  unit_valid := Auth.frag_valid.mpr trivial
+  unit_left_id := rfl
   pcore_unit := rfl
 
 @[rocq_alias mono_nat_lb_core_id]
@@ -50,16 +50,10 @@ instance {l : MaxNat} : CMRA.CoreId (●MN□ l : MonoNat) := by
 
 @[rocq_alias mono_nat_auth_dfrac_op]
 theorem auth_dfrac_op (dq1 dq2 : DFrac) (n : MaxNat) :
-  (●MN{dq1 • dq2} n : MonoNat) = (●MN{dq1} n) • (●MN{dq2} n) :=
-  CMRA.comm'.trans <|
-  (congrArg ((◯ n) • ·) Auth.auth_dfrac_op).trans <|
-  CMRA.comm'.trans <|
-  CMRA.assoc'.symm.trans <|
-  (congrArg ((●{dq1} n) • ·) CMRA.comm').trans <|
-  (congrArg ((●{dq1} n) • ·) (congrArg (· • ●{dq2} n) (CMRA.op_self (◯ n)).symm)).trans <|
-  (congrArg ((●{dq1} n) • ·) CMRA.assoc'.symm).trans <|
-  CMRA.assoc'.trans <|
-  congrArg (((●{dq1} n) • ◯ n) • ·) CMRA.comm'
+  (●MN{dq1 • dq2} n : MonoNat) = (●MN{dq1} n) • (●MN{dq2} n) := by
+  unfold auth
+  rw [← CMRA.assoc', CMRA.op_core_right_of_inc (CMRA.inc_op_right ..), CMRA.assoc',
+    ← Auth.auth_dfrac_op]
 
 @[rocq_alias mono_nat_lb_op]
 theorem lb_op (n1 n2 : MaxNat) :
@@ -68,23 +62,18 @@ theorem lb_op (n1 n2 : MaxNat) :
 
 @[rocq_alias mono_nat_auth_lb_op]
 theorem auth_lb_op (dq : DFrac) (n : MaxNat) :
-  (●MN{dq} n : MonoNat) = (●MN{dq} n) • (◯MN n) := by
-  refine .trans ?_ CMRA.assoc'
-  simp only [lb, ←Auth.frag_op]
-  refine congrArg ((●{dq} n) • ·) ?_
-  simp [CMRA.op, Add.add, MaxNat.max]
+  (●MN{dq} n : MonoNat) = (●MN{dq} n) • (◯MN n) :=
+  (CMRA.op_core_left_of_inc (CMRA.inc_op_right ..)).symm
 
 @[rocq_alias mono_nat_lb_op_le_l]
 theorem lb_op_le_l (n n' : MaxNat) (h : n' ≤ n) :
-  (◯MN n : MonoNat) = ((◯MN n') • (◯MN n) : MonoNat) := by
-  rw [←lb_op]
-  grind
+  (◯MN n : MonoNat) = ((◯MN n') • (◯MN n) : MonoNat) :=
+  (congrArg lb (by grind)).trans (lb_op n' n)
 
 @[rocq_alias mono_nat_auth_dfrac_valid]
 theorem auth_dfrac_valid (dq : DFrac) (n : MaxNat) :
-  (✓ (●MN{dq} n : MonoNat)) ↔ ✓ dq := by
-  refine Auth.both_dfrac_valid_discrete.trans ?_
-  simpa only [CMRA.inc_refl, true_and] using ⟨fun ⟨h, _⟩ => h, fun h => ⟨h, True.intro⟩⟩
+  (✓ (●MN{dq} n : MonoNat)) ↔ ✓ dq :=
+  Auth.both_dfrac_valid_discrete.trans ⟨And.left, fun h => ⟨h, CMRA.inc_refl _, trivial⟩⟩
 
 @[rocq_alias mono_nat_auth_valid]
 theorem auth_valid (n : MaxNat) :
@@ -97,71 +86,44 @@ theorem auth_dfrac_op_valid (dq1 dq2 : DFrac) (n1 n2 : MaxNat) :
   constructor
   · intro h
     unfold auth at h
-    replace h := (CMRA.assoc'.symm.trans <|
-      (congrArg (CMRA.op (●{dq1} n1)) <|
-        CMRA.assoc'.trans <|
-          (congrArg (CMRA.op · (◯ n2)) CMRA.comm').trans CMRA.assoc'.symm).trans
-      CMRA.assoc') ▸ h
-    have ⟨hdq, heq, _⟩ := Auth.auth_dfrac_op_valid.mp (CMRA.valid_op_left h)
+    have ⟨hdq, heq, _⟩ := Auth.auth_dfrac_op_valid.mp <|
+      CMRA.valid_of_inc (CMRA.op_mono (CMRA.inc_op_left ..) (CMRA.inc_op_left ..)) h
     exact ⟨hdq, heq⟩
   · rintro ⟨hdq, rfl⟩
-    exact auth_dfrac_op dq1 dq2 n1 ▸
-      Auth.both_dfrac_valid_discrete.mpr ⟨hdq, CMRA.inc_refl n1, trivial⟩
+    exact auth_dfrac_op dq1 dq2 n1 ▸ (auth_dfrac_valid _ n1).mpr hdq
 
 @[rocq_alias mono_nat_auth_op_valid]
 theorem auth_op_valid (n1 n2 : MaxNat) :
-  (✓ ((●MN n1) • (●MN n2) : MonoNat)) ↔ False := by
-  refine (auth_dfrac_op_valid _ _ n1 n2).trans ?_
-  refine ⟨fun ⟨h, _⟩ => ?_, False.elim⟩
-  exact DFrac.own_whole_exclusive |>.exclusive0_l _ h.validN
+  (✓ ((●MN n1) • (●MN n2) : MonoNat)) ↔ False :=
+  (auth_dfrac_op_valid ..).trans
+    ⟨fun ⟨h, _⟩ => DFrac.own_whole_exclusive.exclusive0_l _ h.validN, False.elim⟩
 
 @[rocq_alias mono_nat_both_dfrac_valid]
 theorem both_dfrac_valid (dq : DFrac) (n m : MaxNat) :
   (✓ ((●MN{dq} n) • (◯MN m) : MonoNat)) ↔ ✓ dq ∧ m ≤ n := by
   unfold auth lb
-  rw [CMRA.assoc'.symm, ←Auth.frag_op, Auth.both_dfrac_valid_discrete]
-  constructor
-  · intro ⟨hdq, ⟨k, hk⟩, _⟩; refine ⟨hdq, ?_⟩
-    simp only [CMRA.op, Add.add] at hk
-    grind
-  · intro ⟨hdq, hle⟩
-    refine ⟨hdq, ⟨0, ?_⟩, trivial⟩
-    dsimp only [CMRA.op, Add.add]
-    grind
+  rw [CMRA.assoc'.symm, ← Auth.frag_op, Auth.both_dfrac_valid_discrete, MaxNat.inc_iff]
+  exact ⟨fun ⟨hdq, hle, _⟩ => ⟨hdq, by grind⟩, fun ⟨hdq, hle⟩ => ⟨hdq, by grind, trivial⟩⟩
 
 @[rocq_alias mono_nat_both_valid]
 theorem both_valid (n m : MaxNat) :
-  (✓ ((●MN n) • (◯MN m) : MonoNat)) ↔ m ≤ n := by
-  rw [both_dfrac_valid]
-  exact ⟨fun h => h.2, fun h => ⟨DFrac.valid_own_one, h⟩⟩
+  (✓ ((●MN n) • (◯MN m) : MonoNat)) ↔ m ≤ n :=
+  (both_dfrac_valid ..).trans ⟨And.right, fun h => ⟨DFrac.valid_own_one, h⟩⟩
 
 @[rocq_alias mono_nat_lb_mono]
 theorem lb_mono (n1 n2 : MaxNat) (h : n1 ≤ n2) :
-  (◯MN n1 : MonoNat) ≼ ◯MN n2 := by
-  refine Auth.frag_inc_of_inc ?_
-  exists n2
-  simp only [CMRA.op, Add.add]
-  grind
+  (◯MN n1 : MonoNat) ≼ ◯MN n2 :=
+  Auth.frag_inc_of_inc (MaxNat.inc_iff.mpr h)
 
 @[rocq_alias mono_nat_included]
 theorem included (dq : DFrac) (n : MaxNat) :
   (◯MN n : MonoNat) ≼ ●MN{dq} n :=
-  CMRA.inc_op_right _ _
+  CMRA.inc_op_right ..
 
 @[rocq_alias mono_nat_update]
 theorem update {n : MaxNat} (n' : MaxNat) (h : n ≤ n') :
-  (●MN n : MonoNat) ~~> ●MN n' := by
-  refine Auth.auth_update (fun _ mz _ hn => ?_)
-  refine ⟨trivial, ?_⟩
-  cases mz with | none => rfl | some z =>
-  simp only [CMRA.op?, CMRA.op, Add.add] at hn ⊢
-  refine OFE.Dist.of_eq ?_
-  simp only [MaxNat.eq_toNat, MaxNat.max]
-  refine Nat.max_eq_left ?_ |>.symm
-  refine Nat.le_trans ?_ h
-  refine hn ▸ ?_
-  simp only [MaxNat.max]
-  apply Nat.le_max_right
+  (●MN n : MonoNat) ~~> ●MN n' :=
+  Auth.auth_update (MaxNat.local_update h)
 
 @[rocq_alias mono_nat_auth_persist]
 theorem auth_persist (n : MaxNat) (dq : DFrac) :
@@ -178,7 +140,7 @@ set_option synthInstance.checkSynthOrder false in
 instance {dq dq1 dq2 : DFrac} {n : MaxNat}
     [h : IsOp d dq dq1 dq2] :
     IsOp d (●MN{dq} n) (●MN{dq1} n) (●MN{dq2} n) where
-  is_op := by rw [h.is_op]; apply auth_dfrac_op
+  is_op := by rw [h.is_op]; exact auth_dfrac_op ..
 
 @[rocq_alias mono_nat_lb_max_is_op]
 instance {n n1 n2 : MaxNat}

--- a/Iris/Iris/Algebra/Lib/MonoZ.lean
+++ b/Iris/Iris/Algebra/Lib/MonoZ.lean
@@ -64,6 +64,21 @@ scoped instance : CMRA.Discrete MaxZ := OrdCommMonoidLike.instDiscrete
 scoped instance : CMRA.IsTotal MaxZ := OrdCommMonoidLike.instIsTotal
 scoped instance : CMRA.CoreId (a : MaxZ) := OrdCommMonoidLike.instCoreId _
 
+@[simp, grind =]
+theorem MaxZ.toInt_op (a b : MaxZ) : (a • b).toInt = Max.max a.toInt b.toInt := rfl
+
+@[rocq_alias max_Z_included]
+theorem MaxZ.inc_iff {a b : MaxZ} : a ≼ b ↔ a ≤ b :=
+  ⟨fun ⟨_, hz⟩ => by grind, fun h => ⟨b, (eq_toInt ..).mpr (by grind)⟩⟩
+
+@[rocq_alias max_Z_local_update]
+theorem MaxZ.local_update {a b a' : MaxZ} (h : a ≤ a') : (a, b) ~l~> (a', a') := by
+  refine fun _ mz _ hn => ⟨trivial, OFE.Dist.of_eq ?_⟩
+  cases mz with | none => rfl | some z =>
+  replace hn : a = b • z := hn
+  simp only [CMRA.op?, eq_toInt]
+  grind
+
 end MaxZ
 
 @[rocq_alias mono_Z]
@@ -99,35 +114,24 @@ instance {l : MaxZ} : CMRA.CoreId (●MZ□ l : MonoZ) := by
 
 @[rocq_alias mono_Z_auth_dfrac_op]
 theorem auth_dfrac_op (dq1 dq2 : DFrac) (n : MaxZ) :
-    (●MZ{dq1 • dq2} n : MonoZ) = (●MZ{dq1} n) • (●MZ{dq2} n) :=
-  CMRA.comm'.trans <|
-  (congrArg ((◯ some n) • ·) Auth.auth_dfrac_op).trans <|
-  CMRA.comm'.trans <|
-  CMRA.assoc'.symm.trans <|
-  (congrArg ((●{dq1} some n) • ·) CMRA.comm').trans <|
-  (congrArg ((●{dq1} some n) • ·)
-    (congrArg (· • ●{dq2} some n) (CMRA.op_self (◯ some n)).symm)).trans <|
-  (congrArg ((●{dq1} some n) • ·) CMRA.assoc'.symm).trans <|
-  CMRA.assoc'.trans <|
-  congrArg (((●{dq1} some n) • ◯ some n) • ·) CMRA.comm'
+    (●MZ{dq1 • dq2} n : MonoZ) = (●MZ{dq1} n) • (●MZ{dq2} n) := by
+  unfold auth
+  rw [← CMRA.assoc', CMRA.op_core_right_of_inc (CMRA.inc_op_right ..), CMRA.assoc',
+    ← Auth.auth_dfrac_op]
 
 @[rocq_alias mono_Z_lb_op]
 theorem lb_op (n1 n2 : MaxZ) : (◯MZ (n1 + n2) : MonoZ) = ((◯MZ n1) • (◯MZ n2) : MonoZ) :=
   Auth.frag_op (b1 := some n1) (b2 := some n2)
 
 @[rocq_alias mono_Z_auth_lb_op]
-theorem auth_lb_op (dq : DFrac) (n : MaxZ) : (●MZ{dq} n : MonoZ) = (●MZ{dq} n) • (◯MZ n) := by
-  refine .trans ?_ CMRA.assoc'
-  simp only [lb, ← Auth.frag_op]
-  refine congrArg ((●{dq} some n) • ·) ?_
-  simp [CMRA.op, Add.add, MaxZ.max]
+theorem auth_lb_op (dq : DFrac) (n : MaxZ) : (●MZ{dq} n : MonoZ) = (●MZ{dq} n) • (◯MZ n) :=
+  (CMRA.op_core_left_of_inc (CMRA.inc_op_right ..)).symm
 
 /-- Rephrasing of `MonoZ.lb_op`, useful for weakening a fragment to a smaller lower bound. -/
 @[rocq_alias mono_Z_lb_op_le_l]
 theorem lb_op_le_l (n n' : MaxZ) (h : n' ≤ n) :
-    (◯MZ n : MonoZ) = ((◯MZ n') • (◯MZ n) : MonoZ) := by
-  rw [← lb_op]
-  grind
+    (◯MZ n : MonoZ) = ((◯MZ n') • (◯MZ n) : MonoZ) :=
+  (congrArg lb (by grind)).trans (lb_op n' n)
 
 @[rocq_alias mono_Z_auth_dfrac_valid]
 theorem auth_dfrac_valid (dq : DFrac) (n : MaxZ) : (✓ (●MZ{dq} n : MonoZ)) ↔ ✓ dq :=
@@ -143,66 +147,40 @@ theorem auth_dfrac_op_valid (dq1 dq2 : DFrac) (n1 n2 : MaxZ) :
   constructor
   · intro h
     unfold auth at h
-    replace h := (CMRA.assoc'.symm.trans <|
-      (congrArg (CMRA.op (●{dq1} some n1)) <|
-        CMRA.assoc'.trans <|
-          (congrArg (CMRA.op · (◯ some n2)) CMRA.comm').trans CMRA.assoc'.symm).trans
-      CMRA.assoc') ▸ h
-    have ⟨hdq, heq, _⟩ := Auth.auth_dfrac_op_valid.mp (CMRA.valid_op_left h)
+    have ⟨hdq, heq, _⟩ := Auth.auth_dfrac_op_valid.mp <|
+      CMRA.valid_of_inc (CMRA.op_mono (CMRA.inc_op_left ..) (CMRA.inc_op_left ..)) h
     exact ⟨hdq, Option.some_inj.mp heq⟩
   · rintro ⟨hdq, rfl⟩
-    exact auth_dfrac_op dq1 dq2 n1 ▸
-      Auth.both_dfrac_valid_discrete.mpr ⟨hdq, CMRA.inc_refl (some n1), trivial⟩
+    exact auth_dfrac_op dq1 dq2 n1 ▸ (auth_dfrac_valid _ n1).mpr hdq
 
 @[rocq_alias mono_Z_auth_op_valid]
-theorem auth_op_valid (n1 n2 : MaxZ) : (✓ ((●MZ n1) • (●MZ n2) : MonoZ)) ↔ False := by
-  refine (auth_dfrac_op_valid _ _ n1 n2).trans ?_
-  refine ⟨fun ⟨h, _⟩ => ?_, False.elim⟩
-  exact DFrac.own_whole_exclusive |>.exclusive0_l _ h.validN
+theorem auth_op_valid (n1 n2 : MaxZ) : (✓ ((●MZ n1) • (●MZ n2) : MonoZ)) ↔ False :=
+  (auth_dfrac_op_valid ..).trans
+    ⟨fun ⟨h, _⟩ => DFrac.own_whole_exclusive.exclusive0_l _ h.validN, False.elim⟩
 
 @[rocq_alias mono_Z_both_dfrac_valid]
 theorem both_dfrac_valid (dq : DFrac) (n m : MaxZ) :
     (✓ ((●MZ{dq} n) • (◯MZ m) : MonoZ)) ↔ ✓ dq ∧ m ≤ n := by
   unfold auth lb
   rw [CMRA.assoc'.symm, ← Auth.frag_op, Auth.both_dfrac_valid_discrete, ← Option.some_op,
-    Option.some_inc_some_iff_is_total]
-  constructor
-  · intro ⟨hdq, ⟨k, hk⟩, _⟩; refine ⟨hdq, ?_⟩
-    simp only [CMRA.op, Add.add] at hk
-    grind
-  · intro ⟨hdq, hle⟩
-    refine ⟨hdq, ⟨n, ?_⟩, trivial⟩
-    dsimp only [CMRA.op, Add.add]
-    grind
+    Option.some_inc_some_iff_is_total, MaxZ.inc_iff]
+  exact ⟨fun ⟨hdq, hle, _⟩ => ⟨hdq, by grind⟩, fun ⟨hdq, hle⟩ => ⟨hdq, by grind, trivial⟩⟩
 
 @[rocq_alias mono_Z_both_valid]
-theorem both_valid (n m : MaxZ) : (✓ ((●MZ n) • (◯MZ m) : MonoZ)) ↔ m ≤ n := by
-  rw [both_dfrac_valid]
-  exact ⟨fun h => h.2, fun h => ⟨DFrac.valid_own_one, h⟩⟩
+theorem both_valid (n m : MaxZ) : (✓ ((●MZ n) • (◯MZ m) : MonoZ)) ↔ m ≤ n :=
+  (both_dfrac_valid ..).trans ⟨And.right, fun h => ⟨DFrac.valid_own_one, h⟩⟩
 
 @[rocq_alias mono_Z_lb_mono]
-theorem lb_mono (n1 n2 : MaxZ) (h : n1 ≤ n2) : (◯MZ n1 : MonoZ) ≼ ◯MZ n2 := by
-  refine Auth.frag_inc_of_inc (Option.some_inc_some_iff_is_total.mpr ?_)
-  exists n2
-  simp only [CMRA.op, Add.add]
-  grind
+theorem lb_mono (n1 n2 : MaxZ) (h : n1 ≤ n2) : (◯MZ n1 : MonoZ) ≼ ◯MZ n2 :=
+  Auth.frag_inc_of_inc <| Option.some_inc_some_iff_is_total.mpr <| MaxZ.inc_iff.mpr h
 
 @[rocq_alias mono_Z_included]
 theorem included (dq : DFrac) (n : MaxZ) : (◯MZ n : MonoZ) ≼ ●MZ{dq} n :=
-  CMRA.inc_op_right _ _
+  CMRA.inc_op_right ..
 
 @[rocq_alias mono_Z_update]
-theorem update {n : MaxZ} (n' : MaxZ) (h : n ≤ n') : (●MZ n : MonoZ) ~~> ●MZ n' := by
-  refine Auth.auth_update (LocalUpdate.option fun _ mz _ hn => ⟨trivial, ?_⟩)
-  cases mz with | none => rfl | some z =>
-  simp only [CMRA.op?, CMRA.op, Add.add] at hn ⊢
-  refine OFE.Dist.of_eq ?_
-  simp only [MaxZ.eq_toInt, MaxZ.max]
-  refine Int.max_eq_left ?_ |>.symm
-  refine Int.le_trans ?_ h
-  refine hn ▸ ?_
-  simp only [MaxZ.max]
-  apply Int.le_max_right
+theorem update {n : MaxZ} (n' : MaxZ) (h : n ≤ n') : (●MZ n : MonoZ) ~~> ●MZ n' :=
+  Auth.auth_update (LocalUpdate.option (MaxZ.local_update h))
 
 @[rocq_alias mono_Z_auth_persist]
 theorem auth_persist (n : MaxZ) (dq : DFrac) : (●MZ{dq} n : MonoZ) ~~> ●MZ□ n :=

--- a/Iris/Iris/Algebra/Lib/MonoZ.lean
+++ b/Iris/Iris/Algebra/Lib/MonoZ.lean
@@ -14,9 +14,6 @@ meta import Iris.Std.RocqPorting
 
 /-!
 # Authoritative CMRA over `MaxZ`
-
-The authoritative element is a monotonically increasing `Int`, while a fragment is a lower
-bound. Unlike `MaxNat`, `MaxZ` has no unit, so the underlying UCMRA is `Option MaxZ`.
 -/
 
 namespace Iris
@@ -89,9 +86,6 @@ abbrev MonoZ := Auth (Option MaxZ)
 
 namespace MonoZ
 
-/-- The authoritative element. The definition includes the fragment at the same value so that
-`MonoZ.included` holds; without this trick a frame-preserving update lemma would be required
-instead. -/
 @[rocq_alias mono_Z_auth]
 def auth (dq : DFrac) (n : MaxZ) : MonoZ := (●{dq} some n) • (◯ some n)
 @[rocq_alias mono_Z_lb]
@@ -127,7 +121,6 @@ theorem lb_op (n1 n2 : MaxZ) : (◯MZ (n1 + n2) : MonoZ) = ((◯MZ n1) • (◯M
 theorem auth_lb_op (dq : DFrac) (n : MaxZ) : (●MZ{dq} n : MonoZ) = (●MZ{dq} n) • (◯MZ n) :=
   (CMRA.op_core_left_of_inc (CMRA.inc_op_right ..)).symm
 
-/-- Rephrasing of `MonoZ.lb_op`, useful for weakening a fragment to a smaller lower bound. -/
 @[rocq_alias mono_Z_lb_op_le_l]
 theorem lb_op_le_l (n n' : MaxZ) (h : n' ≤ n) :
     (◯MZ n : MonoZ) = ((◯MZ n') • (◯MZ n) : MonoZ) :=

--- a/Iris/Iris/Algebra/Lib/MonoZ.lean
+++ b/Iris/Iris/Algebra/Lib/MonoZ.lean
@@ -25,15 +25,38 @@ open _root_.Std (Associative Commutative IdempotentOp)
 
 section MaxZ
 
-abbrev MaxZ := Int
+@[grind cases]
+structure MaxZ where
+  ofInt ::
+  toInt : Int
 
-scoped instance : Add MaxZ := ⟨max⟩
-scoped instance : Associative (Add.add (α := MaxZ)) where
-  assoc := Int.max_assoc
-scoped instance : Commutative (Add.add (α := MaxZ)) where
-  comm := Int.max_comm
-scoped instance : IdempotentOp (Add.add (α := MaxZ)) where
-  idempotent x := by simp [Add.add]
+@[grind]
+def MaxZ.max (a b : MaxZ) : MaxZ where
+  toInt := Max.max a.toInt b.toInt
+
+scoped instance : Add MaxZ where add := .max
+scoped instance : LE MaxZ where le a b := a.toInt ≤ b.toInt
+
+@[simp, grind =]
+theorem MaxZ.le_toInt (a b : MaxZ) : a ≤ b ↔ a.toInt ≤ b.toInt := by rfl
+
+@[simp, grind =]
+theorem MaxZ.toInt_add (a b : MaxZ) : (a + b).toInt = Max.max a.toInt b.toInt := rfl
+
+@[simp, grind =]
+theorem MaxZ.add_ofInt (a b : Int) : (MaxZ.ofInt a + MaxZ.ofInt b) = MaxZ.ofInt (Max.max a b) := rfl
+
+theorem MaxZ.eq_toInt (a b : MaxZ) : a = b ↔ a.toInt = b.toInt := by
+  constructor
+  · rintro rfl; rfl
+  · cases a; cases b; rintro rfl; rfl
+
+scoped instance : Associative (α := MaxZ) (· + ·) where
+  assoc := by grind
+scoped instance : Commutative (α := MaxZ) (· + ·) where
+  comm := by grind
+scoped instance : IdempotentOp (α := MaxZ) (· + ·) where
+  idempotent x := by grind
 scoped instance : COFE MaxZ := COFE.ofDiscrete _
 scoped instance : OFE.Discrete MaxZ := ⟨fun h => h⟩
 scoped instance : CMRA MaxZ := OrdCommMonoidLike.instCMRA
@@ -89,7 +112,7 @@ theorem auth_dfrac_op (dq1 dq2 : DFrac) (n : MaxZ) :
   congrArg (((●{dq1} some n) • ◯ some n) • ·) CMRA.comm'
 
 @[rocq_alias mono_Z_lb_op]
-theorem lb_op (n1 n2 : MaxZ) : (◯MZ (max n1 n2) : MonoZ) = ((◯MZ n1) • (◯MZ n2) : MonoZ) :=
+theorem lb_op (n1 n2 : MaxZ) : (◯MZ (n1 + n2) : MonoZ) = ((◯MZ n1) • (◯MZ n2) : MonoZ) :=
   Auth.frag_op (b1 := some n1) (b2 := some n2)
 
 @[rocq_alias mono_Z_auth_lb_op]
@@ -97,13 +120,14 @@ theorem auth_lb_op (dq : DFrac) (n : MaxZ) : (●MZ{dq} n : MonoZ) = (●MZ{dq} 
   refine .trans ?_ CMRA.assoc'
   simp only [lb, ← Auth.frag_op]
   refine congrArg ((●{dq} some n) • ·) ?_
-  simp [CMRA.op, Add.add]
+  simp [CMRA.op, Add.add, MaxZ.max]
 
 /-- Rephrasing of `MonoZ.lb_op`, useful for weakening a fragment to a smaller lower bound. -/
 @[rocq_alias mono_Z_lb_op_le_l]
 theorem lb_op_le_l (n n' : MaxZ) (h : n' ≤ n) :
     (◯MZ n : MonoZ) = ((◯MZ n') • (◯MZ n) : MonoZ) := by
-  rw [← lb_op, Int.max_eq_right h]
+  rw [← lb_op]
+  grind
 
 @[rocq_alias mono_Z_auth_dfrac_valid]
 theorem auth_dfrac_valid (dq : DFrac) (n : MaxZ) : (✓ (●MZ{dq} n : MonoZ)) ↔ ✓ dq :=
@@ -146,8 +170,10 @@ theorem both_dfrac_valid (dq : DFrac) (n m : MaxZ) :
   · intro ⟨hdq, ⟨k, hk⟩, _⟩; refine ⟨hdq, ?_⟩
     simp only [CMRA.op, Add.add] at hk
     grind
-  · intro ⟨hdq, hle⟩; refine ⟨hdq, ⟨n, ?_⟩, trivial⟩
-    simp [CMRA.op, Add.add, Int.max_eq_left hle]
+  · intro ⟨hdq, hle⟩
+    refine ⟨hdq, ⟨n, ?_⟩, trivial⟩
+    dsimp only [CMRA.op, Add.add]
+    grind
 
 @[rocq_alias mono_Z_both_valid]
 theorem both_valid (n m : MaxZ) : (✓ ((●MZ n) • (◯MZ m) : MonoZ)) ↔ m ≤ n := by
@@ -155,8 +181,11 @@ theorem both_valid (n m : MaxZ) : (✓ ((●MZ n) • (◯MZ m) : MonoZ)) ↔ m 
   exact ⟨fun h => h.2, fun h => ⟨DFrac.valid_own_one, h⟩⟩
 
 @[rocq_alias mono_Z_lb_mono]
-theorem lb_mono (n1 n2 : MaxZ) (h : n1 ≤ n2) : (◯MZ n1 : MonoZ) ≼ ◯MZ n2 :=
-  Auth.frag_inc_of_inc <| Option.some_inc_some_iff_is_total.mpr ⟨n2, (Int.max_eq_right h).symm⟩
+theorem lb_mono (n1 n2 : MaxZ) (h : n1 ≤ n2) : (◯MZ n1 : MonoZ) ≼ ◯MZ n2 := by
+  refine Auth.frag_inc_of_inc (Option.some_inc_some_iff_is_total.mpr ?_)
+  exists n2
+  simp only [CMRA.op, Add.add]
+  grind
 
 @[rocq_alias mono_Z_included]
 theorem included (dq : DFrac) (n : MaxZ) : (◯MZ n : MonoZ) ≼ ●MZ{dq} n :=
@@ -167,7 +196,13 @@ theorem update {n : MaxZ} (n' : MaxZ) (h : n ≤ n') : (●MZ n : MonoZ) ~~> ●
   refine Auth.auth_update (LocalUpdate.option fun _ mz _ hn => ⟨trivial, ?_⟩)
   cases mz with | none => rfl | some z =>
   simp only [CMRA.op?, CMRA.op, Add.add] at hn ⊢
-  exact OFE.Dist.of_eq (Int.max_eq_left (Int.le_trans (hn ▸ Int.le_max_right n z) h)).symm
+  refine OFE.Dist.of_eq ?_
+  simp only [MaxZ.eq_toInt, MaxZ.max]
+  refine Int.max_eq_left ?_ |>.symm
+  refine Int.le_trans ?_ h
+  refine hn ▸ ?_
+  simp only [MaxZ.max]
+  apply Int.le_max_right
 
 @[rocq_alias mono_Z_auth_persist]
 theorem auth_persist (n : MaxZ) (dq : DFrac) : (●MZ{dq} n : MonoZ) ~~> ●MZ□ n :=

--- a/Iris/Iris/Algebra/Lib/MonoZ.lean
+++ b/Iris/Iris/Algebra/Lib/MonoZ.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
+Authors: Markus de Medeiros
 -/
 module
 
@@ -13,13 +13,13 @@ meta import Iris.Std.RocqPorting
 @[expose] public section
 
 /-!
-# Authoritative CMRA over `MaxZ`
+# Authoritative CMRA over `MaxInt`
 -/
 
 namespace Iris
 
 @[rocq_alias mono_Z]
-abbrev MonoZ := Auth (Option MaxZ)
+abbrev MonoZ := Auth (Option MaxInt)
 
 #rocq_ignore mono_ZR "Use the MonoZ type and View.instCMRA typeclass"
 #rocq_ignore mono_ZUR "Use the MonoZ type and View.instUCMRA typeclass"
@@ -27,9 +27,9 @@ abbrev MonoZ := Auth (Option MaxZ)
 namespace MonoZ
 
 @[rocq_alias mono_Z_auth]
-def auth (dq : DFrac) (n : MaxZ) : MonoZ := (●{dq} some n) • (◯ some n)
+def auth (dq : DFrac) (n : MaxInt) : MonoZ := (●{dq} some n) • (◯ some n)
 @[rocq_alias mono_Z_lb]
-def lb (n : MaxZ) : MonoZ := ◯ some n
+def lb (n : MaxInt) : MonoZ := ◯ some n
 
 notation "●MZ{" dq "} " n => auth dq n
 notation "●MZ " n => auth (DFrac.own 1) n
@@ -37,45 +37,45 @@ notation "●MZ□ " n => auth DFrac.discard n
 notation "◯MZ " n => lb n
 
 @[rocq_alias mono_Z_lb_core_id]
-instance {n : MaxZ} : CMRA.CoreId (◯MZ n : MonoZ) := by
+instance {n : MaxInt} : CMRA.CoreId (◯MZ n : MonoZ) := by
   unfold lb
   infer_instance
 
 @[rocq_alias mono_Z_auth_core_id]
-instance {l : MaxZ} : CMRA.CoreId (●MZ□ l : MonoZ) := by
+instance {l : MaxInt} : CMRA.CoreId (●MZ□ l : MonoZ) := by
   unfold auth
   infer_instance
 
 @[rocq_alias mono_Z_auth_dfrac_op]
-theorem auth_dfrac_op (dq1 dq2 : DFrac) (n : MaxZ) :
+theorem auth_dfrac_op (dq1 dq2 : DFrac) (n : MaxInt) :
     (●MZ{dq1 • dq2} n : MonoZ) = (●MZ{dq1} n) • (●MZ{dq2} n) := by
   unfold auth
   rw [← CMRA.assoc', CMRA.op_core_right_of_inc (CMRA.inc_op_right ..), CMRA.assoc',
     ← Auth.auth_dfrac_op]
 
 @[rocq_alias mono_Z_lb_op]
-theorem lb_op (n1 n2 : MaxZ) : (◯MZ (n1 + n2) : MonoZ) = ((◯MZ n1) • (◯MZ n2) : MonoZ) :=
+theorem lb_op (n1 n2 : MaxInt) : (◯MZ (n1 + n2) : MonoZ) = ((◯MZ n1) • (◯MZ n2) : MonoZ) :=
   Auth.frag_op (b1 := some n1) (b2 := some n2)
 
 @[rocq_alias mono_Z_auth_lb_op]
-theorem auth_lb_op (dq : DFrac) (n : MaxZ) : (●MZ{dq} n : MonoZ) = (●MZ{dq} n) • (◯MZ n) :=
+theorem auth_lb_op (dq : DFrac) (n : MaxInt) : (●MZ{dq} n : MonoZ) = (●MZ{dq} n) • (◯MZ n) :=
   (CMRA.op_core_left_of_inc (CMRA.inc_op_right ..)).symm
 
 @[rocq_alias mono_Z_lb_op_le_l]
-theorem lb_op_le_l (n n' : MaxZ) (h : n' ≤ n) :
+theorem lb_op_le_l (n n' : MaxInt) (h : n' ≤ n) :
     (◯MZ n : MonoZ) = ((◯MZ n') • (◯MZ n) : MonoZ) :=
   (congrArg lb (by grind)).trans (lb_op n' n)
 
 @[rocq_alias mono_Z_auth_dfrac_valid]
-theorem auth_dfrac_valid (dq : DFrac) (n : MaxZ) : (✓ (●MZ{dq} n : MonoZ)) ↔ ✓ dq :=
+theorem auth_dfrac_valid (dq : DFrac) (n : MaxInt) : (✓ (●MZ{dq} n : MonoZ)) ↔ ✓ dq :=
   Auth.both_dfrac_valid_discrete.trans ⟨And.left, fun h => ⟨h, CMRA.inc_refl _, trivial⟩⟩
 
 @[rocq_alias mono_Z_auth_valid]
-theorem auth_valid (n : MaxZ) : ✓ (●MZ n : MonoZ) :=
+theorem auth_valid (n : MaxInt) : ✓ (●MZ n : MonoZ) :=
   auth_dfrac_valid _ _ |>.mpr DFrac.valid_own_one
 
 @[rocq_alias mono_Z_auth_dfrac_op_valid]
-theorem auth_dfrac_op_valid (dq1 dq2 : DFrac) (n1 n2 : MaxZ) :
+theorem auth_dfrac_op_valid (dq1 dq2 : DFrac) (n1 n2 : MaxInt) :
     (✓ ((●MZ{dq1} n1) • (●MZ{dq2} n2) : MonoZ)) ↔ ✓ (dq1 • dq2) ∧ n1 = n2 := by
   constructor
   · intro h
@@ -87,51 +87,51 @@ theorem auth_dfrac_op_valid (dq1 dq2 : DFrac) (n1 n2 : MaxZ) :
     exact auth_dfrac_op dq1 dq2 n1 ▸ (auth_dfrac_valid _ n1).mpr hdq
 
 @[rocq_alias mono_Z_auth_op_valid]
-theorem auth_op_valid (n1 n2 : MaxZ) : (✓ ((●MZ n1) • (●MZ n2) : MonoZ)) ↔ False :=
+theorem auth_op_valid (n1 n2 : MaxInt) : (✓ ((●MZ n1) • (●MZ n2) : MonoZ)) ↔ False :=
   (auth_dfrac_op_valid ..).trans
     ⟨fun ⟨h, _⟩ => DFrac.own_whole_exclusive.exclusive0_l _ h.validN, False.elim⟩
 
 @[rocq_alias mono_Z_both_dfrac_valid]
-theorem both_dfrac_valid (dq : DFrac) (n m : MaxZ) :
+theorem both_dfrac_valid (dq : DFrac) (n m : MaxInt) :
     (✓ ((●MZ{dq} n) • (◯MZ m) : MonoZ)) ↔ ✓ dq ∧ m ≤ n := by
   unfold auth lb
   rw [CMRA.assoc'.symm, ← Auth.frag_op, Auth.both_dfrac_valid_discrete, ← Option.some_op,
-    Option.some_inc_some_iff_is_total, MaxZ.inc_iff]
+    Option.some_inc_some_iff_is_total, MaxInt.inc_iff]
   exact ⟨fun ⟨hdq, hle, _⟩ => ⟨hdq, by grind⟩, fun ⟨hdq, hle⟩ => ⟨hdq, by grind, trivial⟩⟩
 
 @[rocq_alias mono_Z_both_valid]
-theorem both_valid (n m : MaxZ) : (✓ ((●MZ n) • (◯MZ m) : MonoZ)) ↔ m ≤ n :=
+theorem both_valid (n m : MaxInt) : (✓ ((●MZ n) • (◯MZ m) : MonoZ)) ↔ m ≤ n :=
   (both_dfrac_valid ..).trans ⟨And.right, fun h => ⟨DFrac.valid_own_one, h⟩⟩
 
 @[rocq_alias mono_Z_lb_mono]
-theorem lb_mono (n1 n2 : MaxZ) (h : n1 ≤ n2) : (◯MZ n1 : MonoZ) ≼ ◯MZ n2 :=
-  Auth.frag_inc_of_inc <| Option.some_inc_some_iff_is_total.mpr <| MaxZ.inc_iff.mpr h
+theorem lb_mono (n1 n2 : MaxInt) (h : n1 ≤ n2) : (◯MZ n1 : MonoZ) ≼ ◯MZ n2 :=
+  Auth.frag_inc_of_inc <| Option.some_inc_some_iff_is_total.mpr <| MaxInt.inc_iff.mpr h
 
 @[rocq_alias mono_Z_included]
-theorem included (dq : DFrac) (n : MaxZ) : (◯MZ n : MonoZ) ≼ ●MZ{dq} n :=
+theorem included (dq : DFrac) (n : MaxInt) : (◯MZ n : MonoZ) ≼ ●MZ{dq} n :=
   CMRA.inc_op_right ..
 
 @[rocq_alias mono_Z_update]
-theorem update {n : MaxZ} (n' : MaxZ) (h : n ≤ n') : (●MZ n : MonoZ) ~~> ●MZ n' :=
-  Auth.auth_update (LocalUpdate.option (MaxZ.local_update h))
+theorem update {n : MaxInt} (n' : MaxInt) (h : n ≤ n') : (●MZ n : MonoZ) ~~> ●MZ n' :=
+  Auth.auth_update (LocalUpdate.option (MaxInt.local_update h))
 
 @[rocq_alias mono_Z_auth_persist]
-theorem auth_persist (n : MaxZ) (dq : DFrac) : (●MZ{dq} n : MonoZ) ~~> ●MZ□ n :=
+theorem auth_persist (n : MaxInt) (dq : DFrac) : (●MZ{dq} n : MonoZ) ~~> ●MZ□ n :=
   Update.op Auth.auth_update_auth_persist fun _ _ h => h
 
 @[rocq_alias mono_Z_auth_unpersist]
-theorem auth_unpersist (n : MaxZ) :
+theorem auth_unpersist (n : MaxInt) :
     (●MZ□ n : MonoZ) ~~>: (fun k => ∃ q, k = ●MZ{DFrac.own q} n) :=
   Auth.auth_updateP_both_unpersist
 
 set_option synthInstance.checkSynthOrder false in
 @[rocq_alias mono_Z_auth_dfrac_is_op]
-instance {dq dq1 dq2 : DFrac} {n : MaxZ} [h : IsOp d dq dq1 dq2] :
+instance {dq dq1 dq2 : DFrac} {n : MaxInt} [h : IsOp d dq dq1 dq2] :
     IsOp d (●MZ{dq} n) (●MZ{dq1} n) (●MZ{dq2} n) where
   is_op := by rw [h.is_op]; exact auth_dfrac_op ..
 
 @[rocq_alias mono_Z_lb_max_is_op]
-instance {n n1 n2 : MaxZ} [h : IsOp d n n1 n2] :
+instance {n n1 n2 : MaxInt} [h : IsOp d n n1 n2] :
     IsOp d (◯MZ n : MonoZ) (◯MZ n1) (◯MZ n2) where
   is_op := by rw [h.is_op]; exact rfl
 

--- a/Iris/Iris/Algebra/Lib/MonoZ.lean
+++ b/Iris/Iris/Algebra/Lib/MonoZ.lean
@@ -1,0 +1,194 @@
+/-
+Copyright (c) 2026. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
+module
+
+public import Iris.Algebra.Auth
+public import Iris.Algebra.LocalUpdates
+public import Iris.Algebra.Numbers
+meta import Iris.Std.RocqPorting
+
+@[expose] public section
+
+/-!
+# Authoritative CMRA over `MaxZ`
+
+The authoritative element is a monotonically increasing `Int`, while a fragment is a lower
+bound. Unlike `MaxNat`, `MaxZ` has no unit, so the underlying UCMRA is `Option MaxZ`.
+-/
+
+namespace Iris
+
+open _root_.Std (Associative Commutative IdempotentOp)
+
+section MaxZ
+
+abbrev MaxZ := Int
+
+scoped instance : Add MaxZ := ⟨max⟩
+scoped instance : Associative (Add.add (α := MaxZ)) where
+  assoc := Int.max_assoc
+scoped instance : Commutative (Add.add (α := MaxZ)) where
+  comm := Int.max_comm
+scoped instance : IdempotentOp (Add.add (α := MaxZ)) where
+  idempotent x := by simp [Add.add]
+scoped instance : COFE MaxZ := COFE.ofDiscrete _
+scoped instance : OFE.Discrete MaxZ := ⟨fun h => h⟩
+scoped instance : CMRA MaxZ := OrdCommMonoidLike.instCMRA
+scoped instance : CMRA.Discrete MaxZ := OrdCommMonoidLike.instDiscrete
+scoped instance : CMRA.IsTotal MaxZ := OrdCommMonoidLike.instIsTotal
+scoped instance : CMRA.CoreId (a : MaxZ) := OrdCommMonoidLike.instCoreId _
+
+end MaxZ
+
+@[rocq_alias mono_Z]
+abbrev MonoZ := Auth (Option MaxZ)
+
+#rocq_ignore mono_ZR "Use the MonoZ type and View.instCMRA typeclass"
+#rocq_ignore mono_ZUR "Use the MonoZ type and View.instUCMRA typeclass"
+
+namespace MonoZ
+
+/-- The authoritative element. The definition includes the fragment at the same value so that
+`MonoZ.included` holds; without this trick a frame-preserving update lemma would be required
+instead. -/
+@[rocq_alias mono_Z_auth]
+def auth (dq : DFrac) (n : MaxZ) : MonoZ := (●{dq} some n) • (◯ some n)
+@[rocq_alias mono_Z_lb]
+def lb (n : MaxZ) : MonoZ := ◯ some n
+
+notation "●MZ{" dq "} " n => auth dq n
+notation "●MZ " n => auth (DFrac.own 1) n
+notation "●MZ□ " n => auth DFrac.discard n
+notation "◯MZ " n => lb n
+
+@[rocq_alias mono_Z_lb_core_id]
+instance {n : MaxZ} : CMRA.CoreId (◯MZ n : MonoZ) := by
+  unfold lb
+  infer_instance
+
+@[rocq_alias mono_Z_auth_core_id]
+instance {l : MaxZ} : CMRA.CoreId (●MZ□ l : MonoZ) := by
+  unfold auth
+  infer_instance
+
+@[rocq_alias mono_Z_auth_dfrac_op]
+theorem auth_dfrac_op (dq1 dq2 : DFrac) (n : MaxZ) :
+    (●MZ{dq1 • dq2} n : MonoZ) = (●MZ{dq1} n) • (●MZ{dq2} n) :=
+  CMRA.comm'.trans <|
+  (congrArg ((◯ some n) • ·) Auth.auth_dfrac_op).trans <|
+  CMRA.comm'.trans <|
+  CMRA.assoc'.symm.trans <|
+  (congrArg ((●{dq1} some n) • ·) CMRA.comm').trans <|
+  (congrArg ((●{dq1} some n) • ·)
+    (congrArg (· • ●{dq2} some n) (CMRA.op_self (◯ some n)).symm)).trans <|
+  (congrArg ((●{dq1} some n) • ·) CMRA.assoc'.symm).trans <|
+  CMRA.assoc'.trans <|
+  congrArg (((●{dq1} some n) • ◯ some n) • ·) CMRA.comm'
+
+@[rocq_alias mono_Z_lb_op]
+theorem lb_op (n1 n2 : MaxZ) : (◯MZ (max n1 n2) : MonoZ) = ((◯MZ n1) • (◯MZ n2) : MonoZ) :=
+  Auth.frag_op (b1 := some n1) (b2 := some n2)
+
+@[rocq_alias mono_Z_auth_lb_op]
+theorem auth_lb_op (dq : DFrac) (n : MaxZ) : (●MZ{dq} n : MonoZ) = (●MZ{dq} n) • (◯MZ n) := by
+  refine .trans ?_ CMRA.assoc'
+  simp only [lb, ← Auth.frag_op]
+  refine congrArg ((●{dq} some n) • ·) ?_
+  simp [CMRA.op, Add.add]
+
+/-- Rephrasing of `MonoZ.lb_op`, useful for weakening a fragment to a smaller lower bound. -/
+@[rocq_alias mono_Z_lb_op_le_l]
+theorem lb_op_le_l (n n' : MaxZ) (h : n' ≤ n) :
+    (◯MZ n : MonoZ) = ((◯MZ n') • (◯MZ n) : MonoZ) := by
+  rw [← lb_op, Int.max_eq_right h]
+
+@[rocq_alias mono_Z_auth_dfrac_valid]
+theorem auth_dfrac_valid (dq : DFrac) (n : MaxZ) : (✓ (●MZ{dq} n : MonoZ)) ↔ ✓ dq :=
+  Auth.both_dfrac_valid_discrete.trans ⟨And.left, fun h => ⟨h, CMRA.inc_refl _, trivial⟩⟩
+
+@[rocq_alias mono_Z_auth_valid]
+theorem auth_valid (n : MaxZ) : ✓ (●MZ n : MonoZ) :=
+  auth_dfrac_valid _ _ |>.mpr DFrac.valid_own_one
+
+@[rocq_alias mono_Z_auth_dfrac_op_valid]
+theorem auth_dfrac_op_valid (dq1 dq2 : DFrac) (n1 n2 : MaxZ) :
+    (✓ ((●MZ{dq1} n1) • (●MZ{dq2} n2) : MonoZ)) ↔ ✓ (dq1 • dq2) ∧ n1 = n2 := by
+  constructor
+  · intro h
+    unfold auth at h
+    replace h := (CMRA.assoc'.symm.trans <|
+      (congrArg (CMRA.op (●{dq1} some n1)) <|
+        CMRA.assoc'.trans <|
+          (congrArg (CMRA.op · (◯ some n2)) CMRA.comm').trans CMRA.assoc'.symm).trans
+      CMRA.assoc') ▸ h
+    have ⟨hdq, heq, _⟩ := Auth.auth_dfrac_op_valid.mp (CMRA.valid_op_left h)
+    exact ⟨hdq, Option.some_inj.mp heq⟩
+  · rintro ⟨hdq, rfl⟩
+    exact auth_dfrac_op dq1 dq2 n1 ▸
+      Auth.both_dfrac_valid_discrete.mpr ⟨hdq, CMRA.inc_refl (some n1), trivial⟩
+
+@[rocq_alias mono_Z_auth_op_valid]
+theorem auth_op_valid (n1 n2 : MaxZ) : (✓ ((●MZ n1) • (●MZ n2) : MonoZ)) ↔ False := by
+  refine (auth_dfrac_op_valid _ _ n1 n2).trans ?_
+  refine ⟨fun ⟨h, _⟩ => ?_, False.elim⟩
+  exact DFrac.own_whole_exclusive |>.exclusive0_l _ h.validN
+
+@[rocq_alias mono_Z_both_dfrac_valid]
+theorem both_dfrac_valid (dq : DFrac) (n m : MaxZ) :
+    (✓ ((●MZ{dq} n) • (◯MZ m) : MonoZ)) ↔ ✓ dq ∧ m ≤ n := by
+  unfold auth lb
+  rw [CMRA.assoc'.symm, ← Auth.frag_op, Auth.both_dfrac_valid_discrete, ← Option.some_op,
+    Option.some_inc_some_iff_is_total]
+  constructor
+  · intro ⟨hdq, ⟨k, hk⟩, _⟩; refine ⟨hdq, ?_⟩
+    simp only [CMRA.op, Add.add] at hk
+    grind
+  · intro ⟨hdq, hle⟩; refine ⟨hdq, ⟨n, ?_⟩, trivial⟩
+    simp [CMRA.op, Add.add, Int.max_eq_left hle]
+
+@[rocq_alias mono_Z_both_valid]
+theorem both_valid (n m : MaxZ) : (✓ ((●MZ n) • (◯MZ m) : MonoZ)) ↔ m ≤ n := by
+  rw [both_dfrac_valid]
+  exact ⟨fun h => h.2, fun h => ⟨DFrac.valid_own_one, h⟩⟩
+
+@[rocq_alias mono_Z_lb_mono]
+theorem lb_mono (n1 n2 : MaxZ) (h : n1 ≤ n2) : (◯MZ n1 : MonoZ) ≼ ◯MZ n2 :=
+  Auth.frag_inc_of_inc <| Option.some_inc_some_iff_is_total.mpr ⟨n2, (Int.max_eq_right h).symm⟩
+
+@[rocq_alias mono_Z_included]
+theorem included (dq : DFrac) (n : MaxZ) : (◯MZ n : MonoZ) ≼ ●MZ{dq} n :=
+  CMRA.inc_op_right _ _
+
+@[rocq_alias mono_Z_update]
+theorem update {n : MaxZ} (n' : MaxZ) (h : n ≤ n') : (●MZ n : MonoZ) ~~> ●MZ n' := by
+  refine Auth.auth_update (LocalUpdate.option fun _ mz _ hn => ⟨trivial, ?_⟩)
+  cases mz with | none => rfl | some z =>
+  simp only [CMRA.op?, CMRA.op, Add.add] at hn ⊢
+  exact OFE.Dist.of_eq (Int.max_eq_left (Int.le_trans (hn ▸ Int.le_max_right n z) h)).symm
+
+@[rocq_alias mono_Z_auth_persist]
+theorem auth_persist (n : MaxZ) (dq : DFrac) : (●MZ{dq} n : MonoZ) ~~> ●MZ□ n :=
+  Update.op Auth.auth_update_auth_persist fun _ _ h => h
+
+@[rocq_alias mono_Z_auth_unpersist]
+theorem auth_unpersist (n : MaxZ) :
+    (●MZ□ n : MonoZ) ~~>: (fun k => ∃ q, k = ●MZ{DFrac.own q} n) :=
+  Auth.auth_updateP_both_unpersist
+
+set_option synthInstance.checkSynthOrder false in
+@[rocq_alias mono_Z_auth_dfrac_is_op]
+instance {dq dq1 dq2 : DFrac} {n : MaxZ} [h : IsOp d dq dq1 dq2] :
+    IsOp d (●MZ{dq} n) (●MZ{dq1} n) (●MZ{dq2} n) where
+  is_op := by rw [h.is_op]; exact auth_dfrac_op ..
+
+@[rocq_alias mono_Z_lb_max_is_op]
+instance {n n1 n2 : MaxZ} [h : IsOp d n n1 n2] :
+    IsOp d (◯MZ n : MonoZ) (◯MZ n1) (◯MZ n2) where
+  is_op := by rw [h.is_op]; exact rfl
+
+end MonoZ
+
+end Iris

--- a/Iris/Iris/Algebra/Lib/MonoZ.lean
+++ b/Iris/Iris/Algebra/Lib/MonoZ.lean
@@ -18,66 +18,6 @@ meta import Iris.Std.RocqPorting
 
 namespace Iris
 
-open _root_.Std (Associative Commutative IdempotentOp)
-
-section MaxZ
-
-@[grind cases]
-structure MaxZ where
-  ofInt ::
-  toInt : Int
-
-@[grind]
-def MaxZ.max (a b : MaxZ) : MaxZ where
-  toInt := Max.max a.toInt b.toInt
-
-scoped instance : Add MaxZ where add := .max
-scoped instance : LE MaxZ where le a b := a.toInt ≤ b.toInt
-
-@[simp, grind =]
-theorem MaxZ.le_toInt (a b : MaxZ) : a ≤ b ↔ a.toInt ≤ b.toInt := by rfl
-
-@[simp, grind =]
-theorem MaxZ.toInt_add (a b : MaxZ) : (a + b).toInt = Max.max a.toInt b.toInt := rfl
-
-@[simp, grind =]
-theorem MaxZ.add_ofInt (a b : Int) : (MaxZ.ofInt a + MaxZ.ofInt b) = MaxZ.ofInt (Max.max a b) := rfl
-
-theorem MaxZ.eq_toInt (a b : MaxZ) : a = b ↔ a.toInt = b.toInt := by
-  constructor
-  · rintro rfl; rfl
-  · cases a; cases b; rintro rfl; rfl
-
-scoped instance : Associative (α := MaxZ) (· + ·) where
-  assoc := by grind
-scoped instance : Commutative (α := MaxZ) (· + ·) where
-  comm := by grind
-scoped instance : IdempotentOp (α := MaxZ) (· + ·) where
-  idempotent x := by grind
-scoped instance : COFE MaxZ := COFE.ofDiscrete _
-scoped instance : OFE.Discrete MaxZ := ⟨fun h => h⟩
-scoped instance : CMRA MaxZ := OrdCommMonoidLike.instCMRA
-scoped instance : CMRA.Discrete MaxZ := OrdCommMonoidLike.instDiscrete
-scoped instance : CMRA.IsTotal MaxZ := OrdCommMonoidLike.instIsTotal
-scoped instance : CMRA.CoreId (a : MaxZ) := OrdCommMonoidLike.instCoreId _
-
-@[simp, grind =]
-theorem MaxZ.toInt_op (a b : MaxZ) : (a • b).toInt = Max.max a.toInt b.toInt := rfl
-
-@[rocq_alias max_Z_included]
-theorem MaxZ.inc_iff {a b : MaxZ} : a ≼ b ↔ a ≤ b :=
-  ⟨fun ⟨_, hz⟩ => by grind, fun h => ⟨b, (eq_toInt ..).mpr (by grind)⟩⟩
-
-@[rocq_alias max_Z_local_update]
-theorem MaxZ.local_update {a b a' : MaxZ} (h : a ≤ a') : (a, b) ~l~> (a', a') := by
-  refine fun _ mz _ hn => ⟨trivial, OFE.Dist.of_eq ?_⟩
-  cases mz with | none => rfl | some z =>
-  replace hn : a = b • z := hn
-  simp only [CMRA.op?, eq_toInt]
-  grind
-
-end MaxZ
-
 @[rocq_alias mono_Z]
 abbrev MonoZ := Auth (Option MaxZ)
 

--- a/Iris/Iris/Algebra/Numbers.lean
+++ b/Iris/Iris/Algebra/Numbers.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Shreyas Srinivas. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Shreyas Srinivas, Markus de Medeiros
+Authors: Shreyas Srinivas, Markus de Medeiros, Fernando Leal
 -/
 module
 
@@ -11,13 +11,16 @@ public import Iris.Algebra.IsOp
 public import Iris.Algebra.LocalUpdates
 meta import Iris.Std.RocqPorting
 
-/-! ## Numbers CMRA
-Simple CMRA's for commutative monoids.
-
-There are three variants:
+/-! ## Numbers CMRAs
+For simple numerical types which form commutative monoids, there are three classes of CMRA:
 - "Constant core": the core is a fixed value such as 0 (eg. (ℕ, +))
 - "Universal core": every element is a core (eg. (ℕ, max))
 - "No core": there is no core (eg. (PNat, +))
+Depending on your application, you may either want to open these scopeds or declare an alias
+to the scoped instances.
+
+This file also includes some CMRA's for types with nonstandard operations, for example (ℕ, max).
+These are newtyped to avoid clashing with the normal mathematical operations.
 -/
 
 @[expose] public section
@@ -66,23 +69,22 @@ scoped instance : CMRA α where
     exists zero
     rw [left_id (op := add) _]
   extend _ h := ⟨_, _, discrete h, .rfl, .rfl⟩
-#rocq_ignore natR "Use Nat with scoped CMRA instance"
-#rocq_ignore ZR "Use Int with scoped CMRA instance"
-#rocq_ignore nat_ra_mixin "Not needed"
-#rocq_ignore Z_ra_mixin "Not needed"
-#rocq_ignore nat_op_instance "Use CMRA instance"
-#rocq_ignore nat_pcore_instance "Use CMRA instance"
-#rocq_ignore nat_valid_instance "Use CMRA instance"
-#rocq_ignore nat_validN_instance "Use CMRA instance"
-#rocq_ignore Z_op_instance "Use CMRA instance"
-#rocq_ignore Z_pcore_instance "Use CMRA instance"
-#rocq_ignore Z_valid_instance "Use CMRA instance"
-#rocq_ignore Z_validN_instance "Use CMRA instance"
+#rocq_ignore natR "Use the (ℕ, +) Constant Core CMRA."
+#rocq_ignore nat_ra_mixin "Use the (ℕ, +) Constant Core CMRA."
+#rocq_ignore nat_op_instance "Use the (ℕ, +) Constant Core CMRA."
+#rocq_ignore nat_pcore_instance "Use the (ℕ, +) Constant Core CMRA."
+#rocq_ignore nat_valid_instance "Use the (ℕ, +) Constant Core CMRA."
+#rocq_ignore nat_validN_instance "Use the (ℕ, +) Constant Core CMRA."
+#rocq_ignore ZR "Use the (ℤ, +) Constant Core CMRA"
+#rocq_ignore Z_ra_mixin "Use the (ℤ, +) Constant Core CMRA"
+#rocq_ignore Z_op_instance "Use the (ℤ, +) Constant Core CMRA"
+#rocq_ignore Z_pcore_instance "Use the (ℤ, +) Constant Core CMRA"
+#rocq_ignore Z_valid_instance "Use the (ℤ, +) Constant Core CMRA"
+#rocq_ignore Z_validN_instance "Use the (ℤ, +) Constant Core CMRA"
 
-scoped instance : CMRA.Discrete α where
-  discrete_valid := id
-#rocq_ignore nat_cmra_discrete "Use scoped Discrete instance"
-#rocq_ignore Z_cmra_discrete "Use scoped Discrete instance"
+scoped instance : CMRA.Discrete α where discrete_valid := id
+#rocq_ignore nat_cmra_discrete "Use the (ℕ, +) Constant Core instance."
+#rocq_ignore Z_cmra_discrete "Use the (ℤ, +) Constant Core instance."
 
 scoped instance : UCMRA α where
   unit := zero
@@ -90,19 +92,18 @@ scoped instance : UCMRA α where
   unit_left_id := pcore_op_left rfl
   pcore_unit := rfl
 
-#rocq_ignore natUR "Use Nat with scoped UCMRA instance"
-#rocq_ignore ZUR "Use Int with scoped UCMRA instance"
-#rocq_ignore nat_ucmra_mixin "Not needed"
-#rocq_ignore Z_ucmra_mixin "Not needed"
-#rocq_ignore nat_unit_instance "Use UCMRA instance"
-#rocq_ignore Z_unit_instance "Use UCMRA instance"
+#rocq_ignore natUR "Use the (ℕ, +) Constant Core UCMRA."
+#rocq_ignore nat_ucmra_mixin "Use the (ℕ, +) Constant Core UCMRA."
+#rocq_ignore nat_unit_instance "Use the (ℕ, +) Constant Core UCMRA."
+#rocq_ignore ZUR "Use the (ℤ, +) Constant Core UCMRA."
+#rocq_ignore Z_ucmra_mixin "Use the (ℤ, +) Constant Core UCMRA."
+#rocq_ignore Z_unit_instance "Use the (ℤ, +) Constant Core UCMRA."
 
 scoped instance [LeftCancelAdd α] {a : α} : Cancelable a where
   cancelableN {_ _ _} _ := .of_eq ∘ LeftCancelAdd.cancel_left ∘ discrete
-#rocq_ignore nat_cancelable "Use scoped Cancelable instance"
-#rocq_ignore Z_cancelable "Use scoped Cancelable instance"
+#rocq_ignore nat_cancelable "Use the (ℕ, +) Constant Core instance."
+#rocq_ignore Z_cancelable "Use the (ℤ, +) Constant Core instance."
 
-/-- The CMRA operation is `add`. -/
 @[rocq_alias nat_op, rocq_alias Z_op]
 theorem op_eq {x y : α} : x • y = x + y := rfl
 
@@ -163,69 +164,68 @@ scoped instance : CMRA α where
     exists z
   extend _ h := ⟨_, _, discrete h, .rfl, .rfl⟩
 
-#rocq_ignore max_natO "Use scoped COFE instance"
-#rocq_ignore max_ZO "Use scoped COFE instance"
-#rocq_ignore min_natO "Use scoped COFE instance"
-#rocq_ignore max_natR "Use Nat with scoped CMRA instance"
-#rocq_ignore max_ZR "Use Int with scoped CMRA instance"
-#rocq_ignore min_natR "Use scoped CMRA instance"
-#rocq_ignore max_nat_ra_mixin "Not needed"
-#rocq_ignore max_Z_ra_mixin "Not needed"
-#rocq_ignore min_nat_ra_mixin "Not needed"
-#rocq_ignore max_nat_op_instance "Use CMRA instance"
-#rocq_ignore max_nat_pcore_instance "Use CMRA instance"
-#rocq_ignore max_nat_valid_instance "Use CMRA instance"
-#rocq_ignore max_nat_validN_instance "Use CMRA instance"
-#rocq_ignore max_Z_op_instance "Use CMRA instance"
-#rocq_ignore max_Z_pcore_instance "Use CMRA instance"
-#rocq_ignore max_Z_valid_instance "Use CMRA instance"
-#rocq_ignore max_Z_validN_instance "Use CMRA instance"
-#rocq_ignore min_nat_op_instance "Use CMRA instance"
-#rocq_ignore min_nat_pcore_instance "Use CMRA instance"
-#rocq_ignore min_nat_valid_instance "Use CMRA instance"
-#rocq_ignore min_nat_validN_instance "Use CMRA instance"
+#rocq_ignore max_natO "Use the (ℕ, max) Universal Core CMRA."
+#rocq_ignore max_natR "Use the (ℕ, max) Universal Core CMRA."
+#rocq_ignore max_nat_ra_mixin "Use the (ℕ, max) Universal Core CMRA."
+#rocq_ignore max_nat_op_instance "Use the (ℕ, max) Universal Core CMRA."
+#rocq_ignore max_nat_pcore_instance "Use the (ℕ, max) Universal Core CMRA."
+#rocq_ignore max_nat_valid_instance "Use the (ℕ, max) Universal Core CMRA."
+#rocq_ignore max_nat_validN_instance "Use the (ℕ, max) Universal Core CMRA."
+
+#rocq_ignore max_ZO "Use the (ℤ, max) Universal Core CMRA."
+#rocq_ignore max_ZR "Use the (ℤ, max) Universal Core CMRA."
+#rocq_ignore max_Z_ra_mixin "Use the (ℤ, max) Universal Core CMRA."
+#rocq_ignore max_Z_op_instance "Use the (ℤ, max) Universal Core CMRA."
+#rocq_ignore max_Z_pcore_instance "Use the (ℤ, max) Universal Core CMRA."
+#rocq_ignore max_Z_valid_instance "Use the (ℤ, max) Universal Core CMRA."
+#rocq_ignore max_Z_validN_instance "Use the (ℤ, max) Universal Core CMRA."
+
+#rocq_ignore min_natO "Use the (ℕ, max) Universal Core CMRA."
+#rocq_ignore min_natR "Use the (ℕ, max) Universal Core CMRA."
+#rocq_ignore min_nat_ra_mixin "Use the (ℕ, max) Universal Core CMRA."
+#rocq_ignore min_nat_op_instance "Use the (ℕ, max) Universal Core CMRA."
+#rocq_ignore min_nat_pcore_instance "Use the (ℕ, max) Universal Core CMRA."
+#rocq_ignore min_nat_valid_instance "Use the (ℕ, max) Universal Core CMRA."
+#rocq_ignore min_nat_validN_instance "Use the (ℕ, max) Universal Core CMRA."
 
 scoped instance : CMRA.Discrete α where
   discrete_valid := id
-#rocq_ignore max_nat_cmra_discrete "Use scoped Discrete instance"
-#rocq_ignore max_Z_cmra_discrete "Use scoped Discrete instance"
-#rocq_ignore min_nat_cmra_discrete "Use scoped Discrete instance"
+#rocq_ignore max_nat_cmra_discrete "Use the (ℕ, max) Universal Core instance."
+#rocq_ignore max_Z_cmra_discrete "Use the (ℤ, max) Universal Core instance."
+#rocq_ignore min_nat_cmra_discrete "Use the (ℕ, min) Universal Core instance."
 
 scoped instance : CMRA.IsTotal α where
   total x := ⟨x, rfl⟩
-#rocq_ignore max_Z_cmra_total "Use scoped IsTotal instance"
+#rocq_ignore max_Z_cmra_total "Use the (ℤ, max) Universal Core instance."
 
 scoped instance (a : α) : CMRA.CoreId a where
   core_id := by simp [pcore]
-#rocq_ignore max_nat_core_id "Use scoped CoreId instance"
-#rocq_ignore max_Z_core_id "Use scoped CoreId instance"
-#rocq_ignore min_nat_core_id "Use scoped CoreId instance"
+#rocq_ignore max_nat_core_id "Use the (ℕ, max) Universal Core instance."
+#rocq_ignore max_Z_core_id "Use the (ℤ, max) Universal Core instance."
+#rocq_ignore min_nat_core_id "Use the (ℕ, min) Universal Core instance."
 
 scoped instance [LawfulLeftIdentity (α := α) (· + ·) zero] : UCMRA α where
   unit := zero
   unit_valid := trivial
   unit_left_id := left_id _
   pcore_unit := rfl
-#rocq_ignore max_natUR "Use Nat with scoped UCMRA instance"
-#rocq_ignore max_nat_ucmra_mixin "Not needed"
-#rocq_ignore max_nat_unit_instance "Use UCMRA instance"
+#rocq_ignore max_natUR "Use the (ℕ, max) Universal Core instance."
+#rocq_ignore max_nat_ucmra_mixin "Use the (ℕ, max) Universal Core instance."
+#rocq_ignore max_nat_unit_instance "Use the (ℕ, max) Universal Core instance."
 
 scoped instance [LeftCancelAdd α] {a : α} : Cancelable a where
   cancelableN {_ _ _} _ := .of_eq ∘ LeftCancelAdd.cancel_left ∘ discrete
 
 omit [Zero α] in
-/-- The CMRA operation is `add` (which is `max`/`min` for max_nat/min_nat/max_Z). -/
 @[simp, grind =, rocq_alias max_nat_op, rocq_alias max_Z_op, rocq_alias min_nat_op_min]
 theorem op_eq {x y : α} : x • y = x + y := rfl
 
 omit [Zero α] in
-/-- Every element is its own core, so inclusion is absorption. Specialize this to get the
-`≤`-phrased inclusion lemmas for `MaxNat`/`MaxZ`. -/
 theorem inc_iff {x y : α} : x ≼ y ↔ x • y = y :=
   ⟨CMRA.op_core_right_of_inc, fun h => ⟨y, h.symm⟩⟩
 
 omit [Zero α] in
-/-- Sufficient condition for a local update on an idempotent structure, such as (ℕ, max). -/
+/-- Sufficient condition for a local update on an idempotent structure. -/
 theorem idem_local_update {x y x' : α} (h : x ≼ x') : (x, y) ~l~> (x', x') := by
   refine fun _ mz _ hn => ⟨trivial, OFE.Dist.of_eq ?_⟩
   cases mz with | none => rfl | some z =>
@@ -236,11 +236,62 @@ scoped instance {a : α} : DiscreteE a := ⟨fun H => discrete H⟩
 
 end OrdCommMonoidLike
 
-/-! ### Carriers for the universal-core CMRA
+/- NoCore core -/
+namespace PosCommMonoidLike
 
-The three `OrdCommMonoidLike` carriers of `numbers.v`, in Rocq's order. Only `MaxNat` has a
-unit; `min` over `Nat` and `max` over `Int` have none, so `MinNat` and `MaxZ` are CMRAs but
-not UCMRAs — matching Rocq, which has `min_natR`/`max_ZR` but no `min_natUR`/`max_ZUR`. -/
+open Iris Iris.OFE Add Zero One Associative Commutative LawfulLeftIdentity CMRA IdempotentOp
+
+variable [OFE α] [Discrete α]
+variable [Add α] [Associative (α := α) (· + ·)] [Commutative (α := α) (· + ·)]
+variable [IdempotentOp (α := α) (· + ·)]
+
+variable {x y x' y' : α}
+
+scoped instance : CMRA α where
+  pcore _ := none
+  op := add
+  ValidN _ _ := True
+  Valid _ := True
+  op_ne.ne _ _ _ h := by rw [discrete h]
+  pcore_ne _ := by rintro ⟨rfl⟩
+  validN_ne _ _ := .intro
+  valid_iff_validN := .symm <| forall_const Nat
+  validN_succ := (·)
+  validN_op_left := id
+  assoc {_ _ _} := by rw [assoc (op := add)]
+  comm {_ _} := by rw [comm (op := add)]
+  pcore_op_left {_ _} := by rintro ⟨rfl⟩
+  pcore_idem := by simp
+  pcore_op_mono {_ _} := by rintro ⟨rfl⟩
+  extend _ h := ⟨_, _, discrete h, .rfl, .rfl⟩
+#rocq_ignore positiveR "Use (PNat, +) No Core CMRA."
+#rocq_ignore pos_ra_mixin "Use (PNat, +) No Core CMRA."
+#rocq_ignore pos_op_instance "Use (PNat, +) No Core CMRA."
+#rocq_ignore pos_pcore_instance "Use (PNat, +) No Core CMRA."
+#rocq_ignore pos_valid_instance "Use (PNat, +) No Core CMRA."
+#rocq_ignore pos_validN_instance "Use (PNat, +) No Core CMRA."
+
+scoped instance : CMRA.Discrete α where
+  discrete_valid := id
+#rocq_ignore pos_cmra_discrete "Use (PNat, +) No Core instance."
+
+scoped instance [LeftCancelAdd α] {a : α} : Cancelable a where
+  cancelableN {_ _ _} _ := .of_eq ∘ LeftCancelAdd.cancel_left ∘ discrete
+#rocq_ignore pos_cancelable "Use (PNat, +) No Core instance."
+
+scoped instance [IdentityFree α] {a : α} : CMRA.IdFree a where
+  id_free0_r _ _ h := IdentityFree.id_free <| discrete h
+#rocq_ignore pos_id_free "Use (PNat, +) No Core instance."
+
+end PosCommMonoidLike
+
+/-! ### New types for commutative monoids with nonstandard addition
+This section covers the commutative monoids whose addition is not `Add`. As such, they are
+wrapped in custom structures:
+- (ℕ, max): `MaxNat`
+- (ℤ, max): `MaxInt`
+- (ℕ, min): `MinNat`
+-/
 
 namespace Iris
 
@@ -258,7 +309,6 @@ def MaxNat.max (a b : MaxNat) : MaxNat where
   toNat := a.toNat.max b.toNat
 
 scoped instance : Add MaxNat where add := .max
--- scoped instance : Max MaxNat where max := .max
 scoped instance : LE MaxNat where le a b := a.toNat ≤ b.toNat
 
 @[simp, grind =]
@@ -281,14 +331,10 @@ theorem MaxNat.eq_toNat (a b : MaxNat) : a = b ↔ a.toNat = b.toNat := by
   · rintro rfl; rfl
   · cases a; cases b; rintro rfl; rfl
 
-scoped instance : Associative (α := MaxNat) (· + ·) where
-  assoc := by grind
-scoped instance : Commutative (α := MaxNat) (· + ·) where
-  comm := by grind
-scoped instance : LawfulLeftIdentity (α := MaxNat) (· + ·) (0 : MaxNat) where
-  left_id a := by grind
-scoped instance : Std.IdempotentOp (α := MaxNat) (· + ·) where
-  idempotent x := by grind
+scoped instance : Associative (α := MaxNat) (· + ·) where assoc := by grind
+scoped instance : Commutative (α := MaxNat) (· + ·) where comm := by grind
+scoped instance : LawfulLeftIdentity (α := MaxNat) (· + ·) (0 : MaxNat) where left_id a := by grind
+scoped instance : Std.IdempotentOp (α := MaxNat) (· + ·) where idempotent x := by grind
 scoped instance : COFE MaxNat := COFE.ofDiscrete _
 scoped instance : OFE.Discrete MaxNat := ⟨fun h => h⟩
 scoped instance : UCMRA MaxNat := OrdCommMonoidLike.instUCMRAOfLawfulLeftIdentityHAddZero
@@ -297,8 +343,7 @@ scoped instance : CMRA.CoreId (a : MaxNat) := OrdCommMonoidLike.instCoreId _
 
 @[rocq_alias max_nat_included]
 theorem MaxNat.inc_iff {a b : MaxNat} : a ≼ b ↔ a ≤ b := by
-  rw [OrdCommMonoidLike.inc_iff, OrdCommMonoidLike.op_eq, eq_toNat]
-  grind
+  grind [OrdCommMonoidLike.inc_iff, eq_toNat]
 
 @[rocq_alias max_nat_local_update]
 theorem MaxNat.local_update {a b a' : MaxNat} (h : a ≤ a') : (a, b) ~l~> (a', a') :=
@@ -311,6 +356,61 @@ instance {a b : Nat} :
   is_op := rfl
 
 end MaxNat
+
+section MaxInt
+
+@[grind cases, rocq_alias max_Z]
+structure MaxInt where
+  ofInt ::
+  toInt : Int
+
+@[grind]
+def MaxInt.max (a b : MaxInt) : MaxInt where
+  toInt := Max.max a.toInt b.toInt
+
+scoped instance : Add MaxInt where add := .max
+scoped instance : LE MaxInt where le a b := a.toInt ≤ b.toInt
+
+@[simp, grind =]
+theorem MaxInt.le_toInt (a b : MaxInt) : a ≤ b ↔ a.toInt ≤ b.toInt := by rfl
+
+@[simp, grind =]
+theorem MaxInt.toInt_add (a b : MaxInt) : (a + b).toInt = Max.max a.toInt b.toInt := rfl
+
+@[simp, grind =]
+theorem MaxInt.add_ofInt (a b : Int) : (MaxInt.ofInt a + MaxInt.ofInt b) = MaxInt.ofInt (Max.max a b) := rfl
+
+theorem MaxInt.eq_toInt (a b : MaxInt) : a = b ↔ a.toInt = b.toInt := by
+  constructor
+  · rintro rfl; rfl
+  · cases a; cases b; rintro rfl; rfl
+
+scoped instance : Associative (α := MaxInt) (· + ·) where assoc := by grind
+scoped instance : Commutative (α := MaxInt) (· + ·) where comm := by grind
+scoped instance : IdempotentOp (α := MaxInt) (· + ·) where idempotent x := by grind
+scoped instance : COFE MaxInt := COFE.ofDiscrete _
+scoped instance : OFE.Discrete MaxInt := ⟨fun h => h⟩
+scoped instance : CMRA MaxInt := OrdCommMonoidLike.instCMRA
+scoped instance : CMRA.Discrete MaxInt := OrdCommMonoidLike.instDiscrete
+scoped instance : CMRA.IsTotal MaxInt := OrdCommMonoidLike.instIsTotal
+scoped instance : CMRA.CoreId (a : MaxInt) := OrdCommMonoidLike.instCoreId _
+
+@[rocq_alias max_Z_included]
+theorem MaxInt.inc_iff {a b : MaxInt} : a ≼ b ↔ a ≤ b := by
+  rw [OrdCommMonoidLike.inc_iff, OrdCommMonoidLike.op_eq, eq_toInt]
+  grind
+
+@[rocq_alias max_Z_local_update]
+theorem MaxInt.local_update {a b a' : MaxInt} (h : a ≤ a') : (a, b) ~l~> (a', a') :=
+  OrdCommMonoidLike.idem_local_update (inc_iff.mpr h)
+
+set_option synthInstance.checkSynthOrder false in
+@[rocq_alias max_Z_is_op]
+instance {a b : Int} :
+    IsOp d (MaxInt.ofInt (Max.max a b)) (MaxInt.ofInt a) (MaxInt.ofInt b) where
+  is_op := rfl
+
+end MaxInt
 
 section MinNat
 
@@ -343,12 +443,9 @@ theorem MinNat.eq_toNat (a b : MinNat) : a = b ↔ a.toNat = b.toNat := by
   · rintro rfl; rfl
   · cases a; cases b; rintro rfl; rfl
 
-scoped instance : Associative (α := MinNat) (· + ·) where
-  assoc := by grind
-scoped instance : Commutative (α := MinNat) (· + ·) where
-  comm := by grind
-scoped instance : IdempotentOp (α := MinNat) (· + ·) where
-  idempotent _ := by grind
+scoped instance : Associative (α := MinNat) (· + ·) where assoc := by grind
+scoped instance : Commutative (α := MinNat) (· + ·) where comm := by grind
+scoped instance : IdempotentOp (α := MinNat) (· + ·) where idempotent _ := by grind
 scoped instance : COFE MinNat := COFE.ofDiscrete _
 scoped instance : OFE.Discrete MinNat := ⟨fun h => h⟩
 scoped instance : CMRA MinNat := OrdCommMonoidLike.instCMRA
@@ -356,7 +453,6 @@ scoped instance : CMRA.Discrete MinNat := OrdCommMonoidLike.instDiscrete
 scoped instance : CMRA.IsTotal MinNat := OrdCommMonoidLike.instIsTotal
 scoped instance : CMRA.CoreId (a : MinNat) := OrdCommMonoidLike.instCoreId _
 
-/-- Inclusion is the *reverse* of `≤`, since the operation is `min`. -/
 @[rocq_alias min_nat_included]
 theorem MinNat.inc_iff {a b : MinNat} : a ≼ b ↔ b ≤ a := by
   rw [OrdCommMonoidLike.inc_iff, OrdCommMonoidLike.op_eq, eq_toNat]
@@ -374,114 +470,4 @@ instance {a b : Nat} :
 
 end MinNat
 
-section MaxZ
-
-@[grind cases, rocq_alias max_Z]
-structure MaxZ where
-  ofInt ::
-  toInt : Int
-
-@[grind]
-def MaxZ.max (a b : MaxZ) : MaxZ where
-  toInt := Max.max a.toInt b.toInt
-
-scoped instance : Add MaxZ where add := .max
-scoped instance : LE MaxZ where le a b := a.toInt ≤ b.toInt
-
-@[simp, grind =]
-theorem MaxZ.le_toInt (a b : MaxZ) : a ≤ b ↔ a.toInt ≤ b.toInt := by rfl
-
-@[simp, grind =]
-theorem MaxZ.toInt_add (a b : MaxZ) : (a + b).toInt = Max.max a.toInt b.toInt := rfl
-
-@[simp, grind =]
-theorem MaxZ.add_ofInt (a b : Int) : (MaxZ.ofInt a + MaxZ.ofInt b) = MaxZ.ofInt (Max.max a b) := rfl
-
-theorem MaxZ.eq_toInt (a b : MaxZ) : a = b ↔ a.toInt = b.toInt := by
-  constructor
-  · rintro rfl; rfl
-  · cases a; cases b; rintro rfl; rfl
-
-scoped instance : Associative (α := MaxZ) (· + ·) where
-  assoc := by grind
-scoped instance : Commutative (α := MaxZ) (· + ·) where
-  comm := by grind
-scoped instance : IdempotentOp (α := MaxZ) (· + ·) where
-  idempotent x := by grind
-scoped instance : COFE MaxZ := COFE.ofDiscrete _
-scoped instance : OFE.Discrete MaxZ := ⟨fun h => h⟩
-scoped instance : CMRA MaxZ := OrdCommMonoidLike.instCMRA
-scoped instance : CMRA.Discrete MaxZ := OrdCommMonoidLike.instDiscrete
-scoped instance : CMRA.IsTotal MaxZ := OrdCommMonoidLike.instIsTotal
-scoped instance : CMRA.CoreId (a : MaxZ) := OrdCommMonoidLike.instCoreId _
-
-@[rocq_alias max_Z_included]
-theorem MaxZ.inc_iff {a b : MaxZ} : a ≼ b ↔ a ≤ b := by
-  rw [OrdCommMonoidLike.inc_iff, OrdCommMonoidLike.op_eq, eq_toInt]
-  grind
-
-@[rocq_alias max_Z_local_update]
-theorem MaxZ.local_update {a b a' : MaxZ} (h : a ≤ a') : (a, b) ~l~> (a', a') :=
-  OrdCommMonoidLike.idem_local_update (inc_iff.mpr h)
-
-set_option synthInstance.checkSynthOrder false in
-@[rocq_alias max_Z_is_op]
-instance {a b : Int} :
-    IsOp d (MaxZ.ofInt (Max.max a b)) (MaxZ.ofInt a) (MaxZ.ofInt b) where
-  is_op := rfl
-
-end MaxZ
-
 end Iris
-
-
-/- NoCore core -/
-namespace PosCommMonoidLike
-
-open Iris Iris.OFE Add Zero One Associative Commutative LawfulLeftIdentity CMRA IdempotentOp
-
-variable [OFE α] [Discrete α]
-variable [Add α] [Associative (α := α) (· + ·)] [Commutative (α := α) (· + ·)]
-variable [IdempotentOp (α := α) (· + ·)]
-
-variable {x y x' y' : α}
-
-scoped instance : CMRA α where
-  pcore _ := none
-  op := add
-  ValidN _ _ := True
-  Valid _ := True
-  op_ne.ne _ _ _ h := by rw [discrete h]
-  pcore_ne _ := by rintro ⟨rfl⟩
-  validN_ne _ _ := .intro
-  valid_iff_validN := .symm <| forall_const Nat
-  validN_succ := (·)
-  validN_op_left := id
-  assoc {_ _ _} := by rw [assoc (op := add)]
-  comm {_ _} := by rw [comm (op := add)]
-  pcore_op_left {_ _} := by rintro ⟨rfl⟩
-  pcore_idem := by simp
-  pcore_op_mono {_ _} := by rintro ⟨rfl⟩
-  extend _ h := ⟨_, _, discrete h, .rfl, .rfl⟩
-#rocq_ignore positiveR "Use PNat with scoped CMRA instance"
-#rocq_ignore pos_ra_mixin "Not needed"
-#rocq_ignore pos_op_instance "Use CMRA instance"
-#rocq_ignore pos_pcore_instance "Use CMRA instance"
-#rocq_ignore pos_valid_instance "Use CMRA instance"
-#rocq_ignore pos_validN_instance "Use CMRA instance"
-
-scoped instance : CMRA.Discrete α where
-  discrete_valid := id
-#rocq_ignore pos_cmra_discrete "Use Discrete instance"
-
-scoped instance [LeftCancelAdd α] {a : α} : Cancelable a where
-  cancelableN {_ _ _} _ := .of_eq ∘ LeftCancelAdd.cancel_left ∘ discrete
-#rocq_ignore pos_cancelable "Use scoped Cancelable instance"
-
-scoped instance [IdentityFree α] {a : α} : CMRA.IdFree a where
-  id_free0_r _ _ h := IdentityFree.id_free <| discrete h
-#rocq_ignore pos_id_free "Use scoped IdentityFree instance"
-
-#rocq_ignore pos_op_add "Not needed"
-
-end PosCommMonoidLike

--- a/Iris/Iris/Algebra/Numbers.lean
+++ b/Iris/Iris/Algebra/Numbers.lean
@@ -7,6 +7,7 @@ module
 
 public import Iris.Algebra.CMRA
 public import Iris.Algebra.OFE
+public import Iris.Algebra.IsOp
 public import Iris.Algebra.LocalUpdates
 meta import Iris.Std.RocqPorting
 
@@ -162,15 +163,12 @@ scoped instance : CMRA α where
     exists z
   extend _ h := ⟨_, _, discrete h, .rfl, .rfl⟩
 
-#rocq_ignore max_nat "Use Nat with IdempotentOp max"
-#rocq_ignore min_nat "Uses Nat with IdempotentOp min"
-#rocq_ignore max_Z "Uses Int with IdempotentOp max"
-#rocq_ignore max_natO "Use LeibnizO Nat"
-#rocq_ignore max_ZO "Use LeibnizO Int"
-#rocq_ignore min_natO "Use LeibnizO Nat"
+#rocq_ignore max_natO "Use scoped COFE instance"
+#rocq_ignore max_ZO "Use scoped COFE instance"
+#rocq_ignore min_natO "Use scoped COFE instance"
 #rocq_ignore max_natR "Use Nat with scoped CMRA instance"
 #rocq_ignore max_ZR "Use Int with scoped CMRA instance"
-#rocq_ignore min_natR "Use Nat with scoped CMRA instance"
+#rocq_ignore min_natR "Use scoped CMRA instance"
 #rocq_ignore max_nat_ra_mixin "Not needed"
 #rocq_ignore max_Z_ra_mixin "Not needed"
 #rocq_ignore min_nat_ra_mixin "Not needed"
@@ -211,19 +209,231 @@ scoped instance [LawfulLeftIdentity (α := α) (· + ·) zero] : UCMRA α where
 #rocq_ignore max_natUR "Use Nat with scoped UCMRA instance"
 #rocq_ignore max_nat_ucmra_mixin "Not needed"
 #rocq_ignore max_nat_unit_instance "Use UCMRA instance"
-#rocq_ignore max_Z_unit_instance "Not needed: MaxZ has no unit, see MonoZ"
 
 scoped instance [LeftCancelAdd α] {a : α} : Cancelable a where
   cancelableN {_ _ _} _ := .of_eq ∘ LeftCancelAdd.cancel_left ∘ discrete
 
 omit [Zero α] in
 /-- The CMRA operation is `add` (which is `max`/`min` for max_nat/min_nat/max_Z). -/
-@[rocq_alias max_nat_op, rocq_alias max_Z_op, rocq_alias min_nat_op_min]
+@[simp, grind =, rocq_alias max_nat_op, rocq_alias max_Z_op, rocq_alias min_nat_op_min]
 theorem op_eq {x y : α} : x • y = x + y := rfl
+
+omit [Zero α] in
+/-- Every element is its own core, so inclusion is absorption. Specialize this to get the
+`≤`-phrased inclusion lemmas for `MaxNat`/`MaxZ`. -/
+theorem inc_iff {x y : α} : x ≼ y ↔ x • y = y :=
+  ⟨CMRA.op_core_right_of_inc, fun h => ⟨y, h.symm⟩⟩
+
+omit [Zero α] in
+/-- Sufficient condition for a local update on an idempotent structure, such as (ℕ, max). -/
+theorem idem_local_update {x y x' : α} (h : x ≼ x') : (x, y) ~l~> (x', x') := by
+  refine fun _ mz _ hn => ⟨trivial, OFE.Dist.of_eq ?_⟩
+  cases mz with | none => rfl | some z =>
+  replace hn : x = y • z := discrete hn
+  exact (CMRA.op_core_left_of_inc <| .trans ⟨y, hn.trans CMRA.comm'⟩ h).symm
 
 scoped instance {a : α} : DiscreteE a := ⟨fun H => discrete H⟩
 
 end OrdCommMonoidLike
+
+/-! ### Carriers for the universal-core CMRA
+
+The three `OrdCommMonoidLike` carriers of `numbers.v`, in Rocq's order. Only `MaxNat` has a
+unit; `min` over `Nat` and `max` over `Int` have none, so `MinNat` and `MaxZ` are CMRAs but
+not UCMRAs — matching Rocq, which has `min_natR`/`max_ZR` but no `min_natUR`/`max_ZUR`. -/
+
+namespace Iris
+
+section MaxNat
+
+@[grind cases, rocq_alias max_nat]
+structure MaxNat where
+  ofNat ::
+  toNat : Nat
+
+instance : OfNat MaxNat n where ofNat := .ofNat n
+
+@[grind]
+def MaxNat.max (a b : MaxNat) : MaxNat where
+  toNat := a.toNat.max b.toNat
+
+scoped instance : Add MaxNat where add := .max
+-- scoped instance : Max MaxNat where max := .max
+scoped instance : LE MaxNat where le a b := a.toNat ≤ b.toNat
+
+@[simp, grind =]
+theorem MaxNat.le_toNat (a b : MaxNat) : a ≤ b ↔ a.toNat ≤ b.toNat := by rfl
+
+@[simp, grind =]
+theorem MaxNat.toNat_add (a b : MaxNat) : (a + b).toNat = a.toNat.max b.toNat := rfl
+
+@[simp, grind =]
+theorem MaxNat.add_ofNat (a b : Nat) : (MaxNat.ofNat a + MaxNat.ofNat b) = MaxNat.ofNat (a.max b) := rfl
+
+@[grind =_]
+theorem MaxNat.toNat_zero : (0 : MaxNat).toNat = 0 := rfl
+
+@[grind =]
+theorem MaxNat.zero_ofNat : (0 : MaxNat) = .ofNat 0 := rfl
+
+theorem MaxNat.eq_toNat (a b : MaxNat) : a = b ↔ a.toNat = b.toNat := by
+  constructor
+  · rintro rfl; rfl
+  · cases a; cases b; rintro rfl; rfl
+
+scoped instance : Associative (α := MaxNat) (· + ·) where
+  assoc := by grind
+scoped instance : Commutative (α := MaxNat) (· + ·) where
+  comm := by grind
+scoped instance : LawfulLeftIdentity (α := MaxNat) (· + ·) (0 : MaxNat) where
+  left_id a := by grind
+scoped instance : Std.IdempotentOp (α := MaxNat) (· + ·) where
+  idempotent x := by grind
+scoped instance : COFE MaxNat := COFE.ofDiscrete _
+scoped instance : OFE.Discrete MaxNat := ⟨fun h => h⟩
+scoped instance : UCMRA MaxNat := OrdCommMonoidLike.instUCMRAOfLawfulLeftIdentityHAddZero
+scoped instance : CMRA.Discrete MaxNat := OrdCommMonoidLike.instDiscrete
+scoped instance : CMRA.CoreId (a : MaxNat) := OrdCommMonoidLike.instCoreId _
+
+@[rocq_alias max_nat_included]
+theorem MaxNat.inc_iff {a b : MaxNat} : a ≼ b ↔ a ≤ b := by
+  rw [OrdCommMonoidLike.inc_iff, OrdCommMonoidLike.op_eq, eq_toNat]
+  grind
+
+@[rocq_alias max_nat_local_update]
+theorem MaxNat.local_update {a b a' : MaxNat} (h : a ≤ a') : (a, b) ~l~> (a', a') :=
+  OrdCommMonoidLike.idem_local_update (inc_iff.mpr h)
+
+set_option synthInstance.checkSynthOrder false in
+@[rocq_alias max_nat_is_op]
+instance {a b : Nat} :
+    IsOp d (MaxNat.ofNat (Nat.max a b)) (MaxNat.ofNat a) (MaxNat.ofNat b) where
+  is_op := rfl
+
+end MaxNat
+
+section MinNat
+
+@[grind cases, rocq_alias min_nat]
+structure MinNat where
+  ofNat ::
+  toNat : Nat
+
+instance : OfNat MinNat n where ofNat := .ofNat n
+
+@[grind]
+def MinNat.min (a b : MinNat) : MinNat where
+  toNat := Nat.min a.toNat b.toNat
+
+scoped instance : Add MinNat where add := .min
+scoped instance : LE MinNat where le a b := a.toNat ≤ b.toNat
+
+@[simp, grind =]
+theorem MinNat.le_toNat (a b : MinNat) : a ≤ b ↔ a.toNat ≤ b.toNat := by rfl
+
+@[simp, grind =]
+theorem MinNat.toNat_add (a b : MinNat) : (a + b).toNat = Nat.min a.toNat b.toNat := rfl
+
+@[simp, grind =]
+theorem MinNat.add_ofNat (a b : Nat) :
+    (MinNat.ofNat a + MinNat.ofNat b) = MinNat.ofNat (Nat.min a b) := rfl
+
+theorem MinNat.eq_toNat (a b : MinNat) : a = b ↔ a.toNat = b.toNat := by
+  constructor
+  · rintro rfl; rfl
+  · cases a; cases b; rintro rfl; rfl
+
+scoped instance : Associative (α := MinNat) (· + ·) where
+  assoc := by grind
+scoped instance : Commutative (α := MinNat) (· + ·) where
+  comm := by grind
+scoped instance : IdempotentOp (α := MinNat) (· + ·) where
+  idempotent _ := by grind
+scoped instance : COFE MinNat := COFE.ofDiscrete _
+scoped instance : OFE.Discrete MinNat := ⟨fun h => h⟩
+scoped instance : CMRA MinNat := OrdCommMonoidLike.instCMRA
+scoped instance : CMRA.Discrete MinNat := OrdCommMonoidLike.instDiscrete
+scoped instance : CMRA.IsTotal MinNat := OrdCommMonoidLike.instIsTotal
+scoped instance : CMRA.CoreId (a : MinNat) := OrdCommMonoidLike.instCoreId _
+
+/-- Inclusion is the *reverse* of `≤`, since the operation is `min`. -/
+@[rocq_alias min_nat_included]
+theorem MinNat.inc_iff {a b : MinNat} : a ≼ b ↔ b ≤ a := by
+  rw [OrdCommMonoidLike.inc_iff, OrdCommMonoidLike.op_eq, eq_toNat]
+  grind
+
+@[rocq_alias min_nat_local_update]
+theorem MinNat.local_update {a b a' : MinNat} (h : a' ≤ a) : (a, b) ~l~> (a', a') :=
+  OrdCommMonoidLike.idem_local_update (inc_iff.mpr h)
+
+set_option synthInstance.checkSynthOrder false in
+@[rocq_alias min_nat_is_op]
+instance {a b : Nat} :
+    IsOp d (MinNat.ofNat (Nat.min a b)) (MinNat.ofNat a) (MinNat.ofNat b) where
+  is_op := rfl
+
+end MinNat
+
+section MaxZ
+
+@[grind cases, rocq_alias max_Z]
+structure MaxZ where
+  ofInt ::
+  toInt : Int
+
+@[grind]
+def MaxZ.max (a b : MaxZ) : MaxZ where
+  toInt := Max.max a.toInt b.toInt
+
+scoped instance : Add MaxZ where add := .max
+scoped instance : LE MaxZ where le a b := a.toInt ≤ b.toInt
+
+@[simp, grind =]
+theorem MaxZ.le_toInt (a b : MaxZ) : a ≤ b ↔ a.toInt ≤ b.toInt := by rfl
+
+@[simp, grind =]
+theorem MaxZ.toInt_add (a b : MaxZ) : (a + b).toInt = Max.max a.toInt b.toInt := rfl
+
+@[simp, grind =]
+theorem MaxZ.add_ofInt (a b : Int) : (MaxZ.ofInt a + MaxZ.ofInt b) = MaxZ.ofInt (Max.max a b) := rfl
+
+theorem MaxZ.eq_toInt (a b : MaxZ) : a = b ↔ a.toInt = b.toInt := by
+  constructor
+  · rintro rfl; rfl
+  · cases a; cases b; rintro rfl; rfl
+
+scoped instance : Associative (α := MaxZ) (· + ·) where
+  assoc := by grind
+scoped instance : Commutative (α := MaxZ) (· + ·) where
+  comm := by grind
+scoped instance : IdempotentOp (α := MaxZ) (· + ·) where
+  idempotent x := by grind
+scoped instance : COFE MaxZ := COFE.ofDiscrete _
+scoped instance : OFE.Discrete MaxZ := ⟨fun h => h⟩
+scoped instance : CMRA MaxZ := OrdCommMonoidLike.instCMRA
+scoped instance : CMRA.Discrete MaxZ := OrdCommMonoidLike.instDiscrete
+scoped instance : CMRA.IsTotal MaxZ := OrdCommMonoidLike.instIsTotal
+scoped instance : CMRA.CoreId (a : MaxZ) := OrdCommMonoidLike.instCoreId _
+
+@[rocq_alias max_Z_included]
+theorem MaxZ.inc_iff {a b : MaxZ} : a ≼ b ↔ a ≤ b := by
+  rw [OrdCommMonoidLike.inc_iff, OrdCommMonoidLike.op_eq, eq_toInt]
+  grind
+
+@[rocq_alias max_Z_local_update]
+theorem MaxZ.local_update {a b a' : MaxZ} (h : a ≤ a') : (a, b) ~l~> (a', a') :=
+  OrdCommMonoidLike.idem_local_update (inc_iff.mpr h)
+
+set_option synthInstance.checkSynthOrder false in
+@[rocq_alias max_Z_is_op]
+instance {a b : Int} :
+    IsOp d (MaxZ.ofInt (Max.max a b)) (MaxZ.ofInt a) (MaxZ.ofInt b) where
+  is_op := rfl
+
+end MaxZ
+
+end Iris
+
 
 /- NoCore core -/
 namespace PosCommMonoidLike

--- a/Iris/Iris/Algebra/Numbers.lean
+++ b/Iris/Iris/Algebra/Numbers.lean
@@ -193,6 +193,10 @@ scoped instance : CMRA.Discrete α where
 #rocq_ignore max_Z_cmra_discrete "Use scoped Discrete instance"
 #rocq_ignore min_nat_cmra_discrete "Use scoped Discrete instance"
 
+scoped instance : CMRA.IsTotal α where
+  total x := ⟨x, rfl⟩
+#rocq_ignore max_Z_cmra_total "Use scoped IsTotal instance"
+
 scoped instance (a : α) : CMRA.CoreId a where
   core_id := by simp [pcore]
 #rocq_ignore max_nat_core_id "Use scoped CoreId instance"
@@ -207,7 +211,7 @@ scoped instance [LawfulLeftIdentity (add (α := α)) zero] : UCMRA α where
 #rocq_ignore max_natUR "Use Nat with scoped UCMRA instance"
 #rocq_ignore max_nat_ucmra_mixin "Not needed"
 #rocq_ignore max_nat_unit_instance "Use UCMRA instance"
-#rocq_ignore max_Z_unit_instance "Use UCMRA instance"
+#rocq_ignore max_Z_unit_instance "Not needed: MaxZ has no unit, see MonoZ"
 
 scoped instance [LeftCancelAdd α] {a : α} : Cancelable a where
   cancelableN {_ _ _} _ := .of_eq ∘ LeftCancelAdd.cancel_left ∘ discrete

--- a/Iris/Iris/Algebra/Numbers.lean
+++ b/Iris/Iris/Algebra/Numbers.lean
@@ -33,6 +33,12 @@ class IdentityFree (α : Type _) [Add α] where
 class LeftCancelAdd (α : Type _) [Add α] where
   cancel_left {x₁ x₂ y : α} : y + x₁ = y + x₂ → x₁ = x₂
 
+class LawfulAddLE (α : Type _) [Add α] [LE α] where
+  le_iff_exists_add {x y : α} : x ≤ y ↔ ∃ z, y = x + z
+
+class LawfulAddLT (α : Type _) [Add α] [LT α] where
+  lt_iff_exists_add {x y : α} : x < y ↔ ∃ z, y = x + z
+
 open Add Commutative in
 theorem LeftCancelAdd.cancel_right {x₁ x₂ y : α} [Add α] [LeftCancelAdd α]
     [Commutative (add (α := α))] (h : add x₁ y = add x₂ y) : x₁ = x₂ := by
@@ -49,7 +55,7 @@ variable [Add α] [Associative (α := α) (· + ·)] [Commutative (α := α) (·
 variable [Zero α] [LawfulLeftIdentity (α := α) (· + ·) zero]
 variable {x y x' y' : α}
 
-scoped instance : CMRA α where
+scoped instance instCMRA : CMRA α where
   pcore _ := some zero
   op := add
   ValidN _ _ := True
@@ -69,6 +75,7 @@ scoped instance : CMRA α where
     exists zero
     rw [left_id (op := add) _]
   extend _ h := ⟨_, _, discrete h, .rfl, .rfl⟩
+
 #rocq_ignore natR "Use the (ℕ, +) Constant Core CMRA."
 #rocq_ignore nat_ra_mixin "Use the (ℕ, +) Constant Core CMRA."
 #rocq_ignore nat_op_instance "Use the (ℕ, +) Constant Core CMRA."
@@ -82,11 +89,11 @@ scoped instance : CMRA α where
 #rocq_ignore Z_valid_instance "Use the (ℤ, +) Constant Core CMRA"
 #rocq_ignore Z_validN_instance "Use the (ℤ, +) Constant Core CMRA"
 
-scoped instance : CMRA.Discrete α where discrete_valid := id
+scoped instance instDiscrete : CMRA.Discrete α where discrete_valid := id
 #rocq_ignore nat_cmra_discrete "Use the (ℕ, +) Constant Core instance."
 #rocq_ignore Z_cmra_discrete "Use the (ℤ, +) Constant Core instance."
 
-scoped instance : UCMRA α where
+scoped instance instUCMRA : UCMRA α where
   unit := zero
   unit_valid := trivial
   unit_left_id := pcore_op_left rfl
@@ -99,7 +106,7 @@ scoped instance : UCMRA α where
 #rocq_ignore Z_ucmra_mixin "Use the (ℤ, +) Constant Core UCMRA."
 #rocq_ignore Z_unit_instance "Use the (ℤ, +) Constant Core UCMRA."
 
-scoped instance [LeftCancelAdd α] {a : α} : Cancelable a where
+scoped instance instCancelable [LeftCancelAdd α] {a : α} : Cancelable a where
   cancelableN {_ _ _} _ := .of_eq ∘ LeftCancelAdd.cancel_left ∘ discrete
 #rocq_ignore nat_cancelable "Use the (ℕ, +) Constant Core instance."
 #rocq_ignore Z_cancelable "Use the (ℤ, +) Constant Core instance."
@@ -107,10 +114,14 @@ scoped instance [LeftCancelAdd α] {a : α} : Cancelable a where
 @[rocq_alias nat_op, rocq_alias Z_op]
 theorem op_eq {x y : α} : x • y = x + y := rfl
 
-theorem included_iff {x y : α} : x ≼ y ↔ ∃ z, y = x + z := by
-  refine ⟨fun ⟨z, hz⟩ => ⟨z, hz⟩, fun ⟨z, hz⟩ => ⟨z, hz⟩⟩
+theorem included_iff {x y : α} : x ≼ y ↔ ∃ z, y = x + z := Iff.rfl
+
+@[rocq_alias nat_included]
+theorem inc_iff_le [LE α] [LawfulAddLE α] {x y : α} : x ≼ y ↔ x ≤ y :=
+  included_iff.trans LawfulAddLE.le_iff_exists_add.symm
 
 /-- Sufficient condition for a local update on a LeftCancelAdd structure, such as (ℕ, +) -/
+@[rocq_alias nat_local_update, rocq_alias Z_local_update]
 theorem leftCancelAdd_local_update [LeftCancelAdd α] (h : add x y' = add x' y) :
     (x, y) ~l~> (x', y') := by
   refine discrete_unital_triv_local_update (fun _ => trivial) @fun z hz => ?_
@@ -122,10 +133,15 @@ theorem leftCancelAdd_local_update [LeftCancelAdd α] (h : add x y' = add x' y) 
     _ = add y' (add z y) := by rw [comm (op := add) z]
     _ = add (add y' z) y := by rw [assoc (op := add)]
 
-scoped instance {a : α} : DiscreteE a := ⟨fun H => discrete H⟩
+scoped instance instDiscreteE {a : α} : DiscreteE a := ⟨fun H => discrete H⟩
 
-scoped instance : CoreId (α := α) 0 where
-  core_id := by rfl
+scoped instance instCoreIdZero : CoreId (α := α) 0 where
+  core_id := rfl
+
+set_option synthInstance.checkSynthOrder false in
+@[rocq_alias nat_is_op, rocq_alias Z_is_op]
+scoped instance instIsOp {x y : α} : IsOp d (x + y) x y where
+  is_op := rfl
 
 end CommMonoidLike
 
@@ -140,7 +156,7 @@ variable [IdempotentOp (α := α) (· + ·)]
 variable [Zero α]
 variable {x y x' y' : α}
 
-scoped instance : CMRA α where
+scoped instance instCMRA : CMRA α where
   pcore := some
   op := add
   ValidN _ _ := True
@@ -163,6 +179,7 @@ scoped instance : CMRA α where
     rintro ⟨rfl⟩ z
     exists z
   extend _ h := ⟨_, _, discrete h, .rfl, .rfl⟩
+
 
 #rocq_ignore max_natO "Use the (ℕ, max) Universal Core CMRA."
 #rocq_ignore max_natR "Use the (ℕ, max) Universal Core CMRA."
@@ -194,26 +211,27 @@ scoped instance : CMRA.Discrete α where
 #rocq_ignore max_Z_cmra_discrete "Use the (ℤ, max) Universal Core instance."
 #rocq_ignore min_nat_cmra_discrete "Use the (ℕ, min) Universal Core instance."
 
-scoped instance : CMRA.IsTotal α where
+scoped instance instIsTotal : CMRA.IsTotal α where
   total x := ⟨x, rfl⟩
 #rocq_ignore max_Z_cmra_total "Use the (ℤ, max) Universal Core instance."
 
-scoped instance (a : α) : CMRA.CoreId a where
-  core_id := by simp [pcore]
+scoped instance instCoreId (a : α) : CMRA.CoreId a where
+  core_id := rfl
 #rocq_ignore max_nat_core_id "Use the (ℕ, max) Universal Core instance."
 #rocq_ignore max_Z_core_id "Use the (ℤ, max) Universal Core instance."
 #rocq_ignore min_nat_core_id "Use the (ℕ, min) Universal Core instance."
 
-scoped instance [LawfulLeftIdentity (α := α) (· + ·) zero] : UCMRA α where
+scoped instance instUCMRA [LawfulLeftIdentity (α := α) (· + ·) zero] : UCMRA α where
   unit := zero
   unit_valid := trivial
   unit_left_id := left_id _
   pcore_unit := rfl
+#rocq_ignore max_Z_unit_instance "Rocq has no `max_Z_UCMRA`."
 #rocq_ignore max_natUR "Use the (ℕ, max) Universal Core instance."
 #rocq_ignore max_nat_ucmra_mixin "Use the (ℕ, max) Universal Core instance."
 #rocq_ignore max_nat_unit_instance "Use the (ℕ, max) Universal Core instance."
 
-scoped instance [LeftCancelAdd α] {a : α} : Cancelable a where
+scoped instance instCancelable [LeftCancelAdd α] {a : α} : Cancelable a where
   cancelableN {_ _ _} _ := .of_eq ∘ LeftCancelAdd.cancel_left ∘ discrete
 
 omit [Zero α] in
@@ -232,22 +250,21 @@ theorem idem_local_update {x y x' : α} (h : x ≼ x') : (x, y) ~l~> (x', x') :=
   replace hn : x = y • z := discrete hn
   exact (CMRA.op_core_left_of_inc <| .trans ⟨y, hn.trans CMRA.comm'⟩ h).symm
 
-scoped instance {a : α} : DiscreteE a := ⟨fun H => discrete H⟩
+scoped instance instDiscreteE {a : α} : DiscreteE a := ⟨fun H => discrete H⟩
 
 end OrdCommMonoidLike
 
 /- NoCore core -/
 namespace PosCommMonoidLike
 
-open Iris Iris.OFE Add Zero One Associative Commutative LawfulLeftIdentity CMRA IdempotentOp
+open Iris Iris.OFE Add Zero One Associative Commutative LawfulLeftIdentity CMRA
 
 variable [OFE α] [Discrete α]
 variable [Add α] [Associative (α := α) (· + ·)] [Commutative (α := α) (· + ·)]
-variable [IdempotentOp (α := α) (· + ·)]
 
 variable {x y x' y' : α}
 
-scoped instance : CMRA α where
+scoped instance instCMRA : CMRA α where
   pcore _ := none
   op := add
   ValidN _ _ := True
@@ -271,17 +288,31 @@ scoped instance : CMRA α where
 #rocq_ignore pos_valid_instance "Use (PNat, +) No Core CMRA."
 #rocq_ignore pos_validN_instance "Use (PNat, +) No Core CMRA."
 
-scoped instance : CMRA.Discrete α where
+scoped instance instDiscrete : CMRA.Discrete α where
   discrete_valid := id
 #rocq_ignore pos_cmra_discrete "Use (PNat, +) No Core instance."
 
-scoped instance [LeftCancelAdd α] {a : α} : Cancelable a where
+scoped instance instCancelable [LeftCancelAdd α] {a : α} : Cancelable a where
   cancelableN {_ _ _} _ := .of_eq ∘ LeftCancelAdd.cancel_left ∘ discrete
 #rocq_ignore pos_cancelable "Use (PNat, +) No Core instance."
 
-scoped instance [IdentityFree α] {a : α} : CMRA.IdFree a where
+scoped instance instIdFree [IdentityFree α] {a : α} : CMRA.IdFree a where
   id_free0_r _ _ h := IdentityFree.id_free <| discrete h
 #rocq_ignore pos_id_free "Use (PNat, +) No Core instance."
+
+@[rocq_alias pos_op_add]
+theorem op_eq {x y : α} : x • y = x + y := rfl
+
+theorem included_iff {x y : α} : x ≼ y ↔ ∃ z, y = x + z := Iff.rfl
+
+@[rocq_alias pos_included]
+theorem inc_iff_lt [LT α] [LawfulAddLT α] {x y : α} : x ≼ y ↔ x < y :=
+  included_iff.trans LawfulAddLT.lt_iff_exists_add.symm
+
+set_option synthInstance.checkSynthOrder false in
+@[rocq_alias pos_is_op]
+scoped instance instIsOp {x y : α} : IsOp d (x + y) x y where
+  is_op := rfl
 
 end PosCommMonoidLike
 
@@ -318,7 +349,8 @@ theorem MaxNat.le_toNat (a b : MaxNat) : a ≤ b ↔ a.toNat ≤ b.toNat := by r
 theorem MaxNat.toNat_add (a b : MaxNat) : (a + b).toNat = a.toNat.max b.toNat := rfl
 
 @[simp, grind =]
-theorem MaxNat.add_ofNat (a b : Nat) : (MaxNat.ofNat a + MaxNat.ofNat b) = MaxNat.ofNat (a.max b) := rfl
+theorem MaxNat.add_ofNat (a b : Nat) :
+    (MaxNat.ofNat a + MaxNat.ofNat b) = MaxNat.ofNat (a.max b) := rfl
 
 @[grind =_]
 theorem MaxNat.toNat_zero : (0 : MaxNat).toNat = 0 := rfl
@@ -337,7 +369,7 @@ scoped instance : LawfulLeftIdentity (α := MaxNat) (· + ·) (0 : MaxNat) where
 scoped instance : Std.IdempotentOp (α := MaxNat) (· + ·) where idempotent x := by grind
 scoped instance : COFE MaxNat := COFE.ofDiscrete _
 scoped instance : OFE.Discrete MaxNat := ⟨fun h => h⟩
-scoped instance : UCMRA MaxNat := OrdCommMonoidLike.instUCMRAOfLawfulLeftIdentityHAddZero
+scoped instance : UCMRA MaxNat := OrdCommMonoidLike.instUCMRA
 scoped instance : CMRA.Discrete MaxNat := OrdCommMonoidLike.instDiscrete
 scoped instance : CMRA.CoreId (a : MaxNat) := OrdCommMonoidLike.instCoreId _
 
@@ -378,7 +410,8 @@ theorem MaxInt.le_toInt (a b : MaxInt) : a ≤ b ↔ a.toInt ≤ b.toInt := by r
 theorem MaxInt.toInt_add (a b : MaxInt) : (a + b).toInt = Max.max a.toInt b.toInt := rfl
 
 @[simp, grind =]
-theorem MaxInt.add_ofInt (a b : Int) : (MaxInt.ofInt a + MaxInt.ofInt b) = MaxInt.ofInt (Max.max a b) := rfl
+theorem MaxInt.add_ofInt (a b : Int) :
+    (MaxInt.ofInt a + MaxInt.ofInt b) = MaxInt.ofInt (Max.max a b) := rfl
 
 theorem MaxInt.eq_toInt (a b : MaxInt) : a = b ↔ a.toInt = b.toInt := by
   constructor

--- a/Iris/Iris/BI/Lib.lean
+++ b/Iris/Iris/BI/Lib.lean
@@ -8,4 +8,5 @@ public import Iris.BI.Lib.Fractional
 public import Iris.BI.Lib.GenHeap
 public import Iris.BI.Lib.Laterable
 public import Iris.BI.Lib.MonoNat
+public import Iris.BI.Lib.MonoZ
 public import Iris.BI.Lib.ProphMap

--- a/Iris/Iris/BI/Lib/MonoZ.lean
+++ b/Iris/Iris/BI/Lib/MonoZ.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2026. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus de Medeiros
+-/
+module
+
+public import Iris.BI.Lib.MonoNat
+
+@[expose] public section
+
+/-! # Ghost state for a monotonically increasing non-negative integer -/
+
+namespace Iris
+open BI
+
+@[rocq_alias mono_ZG]
+class MonoZG (GF : BundledGFunctors) where
+  natG : MonoNatG GF
+
+attribute [reducible, instance] MonoZG.natG
+
+#rocq_ignore «mono_ZΣ» "Superseded by the `MonoZG` typeclass on `BundledGFunctors`."
+
+namespace MonoZ
+
+variable {GF : BundledGFunctors} [MonoZG GF]
+
+@[rocq_alias mono_Z_auth_own]
+def auth_own (γ : GName) (dq : DFrac) (n : Int) : IProp GF := iprop%
+  ⌜0 ≤ n⌝ ∗ (γ ↪●MN{dq} MaxNat.ofNat n.toNat)
+
+#rocq_ignore mono_Z_auth_own_def "`mono_Z_auth_own` is defined directly without `seal`/`unseal`."
+#rocq_ignore mono_Z_auth_own_aux "`mono_Z_auth_own` is defined directly without `seal`/`unseal`."
+#rocq_ignore mono_Z_auth_own_unseal "`mono_Z_auth_own` is defined directly without `seal`/`unseal`."
+
+@[rocq_alias mono_Z_lb_own]
+def lb_own (γ : GName) (n : Int) : IProp GF := iprop%
+  ⌜0 ≤ n⌝ ∗ (γ ↪◯MN MaxNat.ofNat n.toNat)
+
+#rocq_ignore mono_Z_lb_own_def "`mono_Z_lb_own` is defined directly without `seal`/`unseal`."
+#rocq_ignore mono_Z_lb_own_aux "`mono_Z_lb_own` is defined directly without `seal`/`unseal`."
+#rocq_ignore mono_Z_lb_own_unseal "`mono_Z_lb_own` is defined directly without `seal`/`unseal`."
+
+notation γ " ↪●MZ{" dq "} " n => auth_own γ dq n
+notation γ " ↪●MZ " n => auth_own γ (DFrac.own 1) n
+notation γ " ↪●MZ□ " n => auth_own γ DFrac.discard n
+notation γ " ↪◯MZ " n => lb_own γ n
+
+@[rocq_alias mono_Z_auth_own_timeless]
+instance : Timeless (PROP := IProp GF) (γ ↪●MZ{dq} n) := by
+  unfold auth_own
+  infer_instance
+
+@[rocq_alias mono_Z_auth_own_persistent]
+instance : Persistent (PROP := IProp GF) (γ ↪●MZ□ n) := by
+  unfold auth_own
+  infer_instance
+
+@[rocq_alias mono_Z_lb_own_timeless]
+instance : Timeless (PROP := IProp GF) (γ ↪◯MZ n) := by
+  unfold lb_own
+  infer_instance
+
+@[rocq_alias mono_Z_lb_own_persistent]
+instance : Persistent (PROP := IProp GF) (γ ↪◯MZ n) := by
+  unfold lb_own
+  infer_instance
+
+@[rocq_alias mono_Z_auth_own_fractional]
+instance {γ n} : Fractional (PROP := IProp GF) (fun q : Qp => γ ↪●MZ{.own q} n) where
+  fractional p q := by
+    unfold auth_own
+    constructor
+    · iintro ⟨%Hn, H1, H2⟩
+      iframe %Hn H1 H2
+    · iintro ⟨⟨%Hn, H1⟩, -, H2⟩
+      icombine H1 H2 as $
+      iframe %Hn
+
+@[rocq_alias mono_Z_auth_own_as_fractional]
+instance {γ n} (q : Qp) : AsFractional (PROP := IProp GF) (γ ↪●MZ{.own q} n) ioΦ
+    (fun q : Qp => γ ↪●MZ{.own q} n) ioq q where
+  as_fractional := .rfl
+  as_fractional_fractional := inferInstance
+
+@[rocq_alias mono_Z_auth_own_agree]
+theorem auth_own_agree (γ : GName) (dq1 dq2 : DFrac) (n1 n2 : Int) :
+    ⊢@{IProp GF} (γ ↪●MZ{dq1} n1) -∗ (γ ↪●MZ{dq2} n2) -∗ ⌜✓ (dq1 • dq2) ∧ n1 = n2⌝ := by
+  unfold auth_own
+  iintro ⟨%Hn1, H1⟩ ⟨%Hn2, H2⟩
+  icases MonoNat.auth_own_agree $$ H1 H2 with %⟨Hdq, Heq⟩
+  ipureintro
+  simp only [MaxNat.eq_toNat] at Heq
+  exact ⟨Hdq, by omega⟩
+
+@[rocq_alias mono_Z_auth_own_exclusive]
+theorem auth_own_exclusive (γ : GName) (n1 n2 : Int) :
+    ⊢@{IProp GF} (γ ↪●MZ n1) -∗ (γ ↪●MZ n2) -∗ False := by
+  iintro H1 H2
+  icases auth_own_agree $$ H1 H2 with %⟨Hdq, -⟩
+  ipureintro
+  exact DFrac.own_whole_exclusive.exclusive0_l _ Hdq.validN
+
+@[rocq_alias mono_Z_auth_lb_own_valid]
+theorem auth_lb_own_valid (γ : GName) (dq : DFrac) (n m : Int) :
+    ⊢@{IProp GF} (γ ↪●MZ{dq} n) -∗ (γ ↪◯MZ m) -∗ ⌜✓ dq ∧ m ≤ n⌝ := by
+  unfold auth_own lb_own
+  iintro ⟨%Hn, Hauth⟩ ⟨%Hm, Hlb⟩
+  icases MonoNat.auth_lb_own_valid $$ Hauth Hlb with %⟨Hdq, Hle⟩
+  ipureintro
+  simp only [MaxNat.le_toNat] at Hle
+  exact ⟨Hdq, by omega⟩
+
+@[rocq_alias mono_Z_lb_own_get]
+theorem lb_own_get (γ : GName) (dq : DFrac) (n : Int) :
+    ⊢@{IProp GF} (γ ↪●MZ{dq} n) -∗ (γ ↪◯MZ n) := by
+  unfold auth_own lb_own
+  iintro ⟨$, H⟩
+  iapply MonoNat.lb_own_get $$ H
+
+@[rocq_alias mono_Z_lb_own_le]
+theorem lb_own_le (γ : GName) (n n' : Int) (h : n' ≤ n) (h0 : 0 ≤ n') :
+    ⊢@{IProp GF} (γ ↪◯MZ n) -∗ (γ ↪◯MZ n') := by
+  unfold lb_own
+  iintro ⟨-, H⟩
+  iframe %h0
+  iapply MonoNat.lb_own_le (h := by simp only [MaxNat.le_toNat]; omega) $$ H
+
+@[rocq_alias mono_Z_lb_own_0]
+theorem lb_own_0 (γ : GName) : ⊢@{IProp GF} |==> (γ ↪◯MZ 0) := by
+  unfold lb_own
+  simp only [Int.toNat_zero]
+  imod MonoNat.lb_own_0 with H
+  imodintro
+  iframe H
+  ipureintro
+  omega
+
+@[rocq_alias mono_Z_own_alloc]
+theorem own_alloc (n : Int) (h : 0 ≤ n) :
+    ⊢@{IProp GF} |==> (∃ γ, (γ ↪●MZ n) ∗ (γ ↪◯MZ n)) := by
+  unfold auth_own lb_own
+  imod (MonoNat.own_alloc (MaxNat.ofNat n.toNat)) with ⟨%γ, H1, H2⟩
+  imodintro
+  iexists γ
+  iframe %h H1 H2
+
+@[rocq_alias mono_Z_own_update]
+theorem own_update (γ : GName) (n n' : Int) (h : n ≤ n') :
+    ⊢@{IProp GF} (γ ↪●MZ n) ==∗ (γ ↪●MZ n') ∗ (γ ↪◯MZ n') := by
+  iintro H
+  ihave >Hauth : |==> (γ ↪●MZ n') $$ [H]
+  · unfold auth_own
+    icases H with ⟨%Hn, H⟩
+    imod MonoNat.own_update (n' := MaxNat.ofNat n'.toNat)
+      (h := by simp only [MaxNat.le_toNat]; omega) $$ H with ⟨H, -⟩
+    imodintro
+    iframe H
+    ipureintro
+    omega
+  · imodintro
+    ihave #$ := lb_own_get $$ Hauth
+    iframe
+
+@[rocq_alias mono_Z_own_persist]
+theorem own_persist (γ : GName) (dq : DFrac) (a : Int) :
+    ⊢@{IProp GF} (γ ↪●MZ{dq} a) ==∗ (γ ↪●MZ□ a) := by
+  unfold auth_own
+  iintro ⟨$, H⟩
+  iapply MonoNat.own_persist $$ H
+
+@[rocq_alias mono_Z_own_unpersist]
+theorem own_unpersist (γ : GName) (a : Int) :
+    ⊢@{IProp GF} (γ ↪●MZ□ a) ==∗ (∃ q, γ ↪●MZ{DFrac.own q} a) := by
+  unfold auth_own
+  iintro ⟨%Ha, H⟩
+  imod MonoNat.own_unpersist $$ H with ⟨%q, H⟩
+  imodintro
+  iexists q
+  iframe %Ha H
+
+end MonoZ
+
+end Iris

--- a/IrisMath/IrisMath.lean
+++ b/IrisMath/IrisMath.lean
@@ -3,3 +3,4 @@ module
 public import IrisMath.MeasureTheory
 public import IrisMath.Numbers
 public import IrisMath.StepIndex
+public import IrisMath.Tests

--- a/IrisMath/IrisMath.lean
+++ b/IrisMath/IrisMath.lean
@@ -1,4 +1,5 @@
 module
 
 public import IrisMath.MeasureTheory
+public import IrisMath.Numbers
 public import IrisMath.StepIndex

--- a/IrisMath/IrisMath/Numbers.lean
+++ b/IrisMath/IrisMath/Numbers.lean
@@ -29,23 +29,7 @@ open scoped CommMonoidLike
 scoped instance : COFE ℝ := COFE.ofDiscrete ℝ
 scoped instance : OFE.Discrete ℝ := ⟨fun h => h⟩
 
-/-- info: CommMonoidLike.instUCMRA -/
-#guard_msgs in
-#synth UCMRA ℝ
-
 scoped instance : LeftCancelAdd ℝ := ⟨add_left_cancel⟩
-
-/-- info: CommMonoidLike.instDiscrete -/
-#guard_msgs in
-#synth CMRA.Discrete ℝ
-
-/-- info: fun x ↦ CommMonoidLike.instCancelableOfLeftCancelAdd -/
-#guard_msgs in
-#synth ∀ x : ℝ, CMRA.Cancelable x
-
-/-- info: CommMonoidLike.instCoreIdOfNat -/
-#guard_msgs in
-#synth CMRA.CoreId (0 : ℝ)
 
 theorem op_eq {x y : ℝ} : CMRA.op x y = x + y := rfl
 
@@ -67,21 +51,10 @@ open scoped CommMonoidLike
 scoped instance : COFE ℝ≥0∞ := COFE.ofDiscrete ℝ≥0∞
 scoped instance : OFE.Discrete ℝ≥0∞ := ⟨fun h => h⟩
 
-/-- info: CommMonoidLike.instUCMRA -/
-#guard_msgs in
-#synth UCMRA ℝ≥0∞
-
-/-- info: CommMonoidLike.instDiscrete -/
-#guard_msgs in
-#synth CMRA.Discrete ℝ≥0∞
-
-/-- info: CommMonoidLike.instCoreIdOfNat -/
-#guard_msgs in
-#synth CMRA.CoreId (0 : ℝ≥0∞)
+scoped instance : LawfulAddLE ℝ≥0∞ := ⟨le_iff_exists_add⟩
 
 theorem op_eq {x y : ℝ≥0∞} : CMRA.op x y = x + y := rfl
 
-theorem inc_iff {x y : ℝ≥0∞} : x ≼ y ↔ x ≤ y := by
-  rw [CommMonoidLike.included_iff, ← le_iff_exists_add]
+theorem inc_iff {x y : ℝ≥0∞} : x ≼ y ↔ x ≤ y := CommMonoidLike.inc_iff_le
 
 end ENNReal

--- a/IrisMath/IrisMath/Numbers.lean
+++ b/IrisMath/IrisMath/Numbers.lean
@@ -1,0 +1,87 @@
+module
+
+public import Mathlib.Data.Real.Basic
+public import Mathlib.Data.ENNReal.Basic
+public import Iris
+
+/-! ## Commutative Monoid CMRAs
+
+`(ℝ, +)` and `(ℝ≥0∞, +)` are commutative monoids, hence "constant core" CMRAs in the sense of
+`CommMonoidLike`: every element is valid, the core of every element is `0`, and the unit is `0`.
+
+-/
+
+@[expose] public section
+
+/-- Relationship between Mathlib's AddZeroClass to the Stdlib Std.LawfulLeftIdentity on Add. -/
+instance AddZeroClass.to_isLawfulLeftIdentity {M : Type _} [AddZeroClass M] :
+    Std.LawfulLeftIdentity (α := M) (· + ·) (Zero.zero : M) where
+  left_id := zero_add
+
+/-! ### (ℝ, +) -/
+
+namespace Real
+
+open Iris
+open scoped CommMonoidLike
+
+/-- The discrete OFE on `ℝ`. -/
+scoped instance : COFE ℝ := COFE.ofDiscrete ℝ
+scoped instance : OFE.Discrete ℝ := ⟨fun h => h⟩
+
+/-- info: CommMonoidLike.instUCMRA -/
+#guard_msgs in
+#synth UCMRA ℝ
+
+scoped instance : LeftCancelAdd ℝ := ⟨add_left_cancel⟩
+
+/-- info: CommMonoidLike.instDiscrete -/
+#guard_msgs in
+#synth CMRA.Discrete ℝ
+
+/-- info: fun x ↦ CommMonoidLike.instCancelableOfLeftCancelAdd -/
+#guard_msgs in
+#synth ∀ x : ℝ, CMRA.Cancelable x
+
+/-- info: CommMonoidLike.instCoreIdOfNat -/
+#guard_msgs in
+#synth CMRA.CoreId (0 : ℝ)
+
+theorem op_eq {x y : ℝ} : CMRA.op x y = x + y := rfl
+
+theorem inc (x y : ℝ) : x ≼ y := CommMonoidLike.included_iff.mpr ⟨y - x, by ring⟩
+
+theorem local_update {x y x' y' : ℝ} (h : x + y' = x' + y) : (x, y) ~l~> (x', y') :=
+  CommMonoidLike.leftCancelAdd_local_update h
+
+end Real
+
+/-! ### (ℝ≥0∞, +) -/
+
+namespace ENNReal
+
+open Iris
+open scoped CommMonoidLike
+
+/-- The discrete OFE on `ℝ≥0∞`. -/
+scoped instance : COFE ℝ≥0∞ := COFE.ofDiscrete ℝ≥0∞
+scoped instance : OFE.Discrete ℝ≥0∞ := ⟨fun h => h⟩
+
+/-- info: CommMonoidLike.instUCMRA -/
+#guard_msgs in
+#synth UCMRA ℝ≥0∞
+
+/-- info: CommMonoidLike.instDiscrete -/
+#guard_msgs in
+#synth CMRA.Discrete ℝ≥0∞
+
+/-- info: CommMonoidLike.instCoreIdOfNat -/
+#guard_msgs in
+#synth CMRA.CoreId (0 : ℝ≥0∞)
+
+theorem op_eq {x y : ℝ≥0∞} : CMRA.op x y = x + y := rfl
+
+theorem inc_iff {x y : ℝ≥0∞} : x ≼ y ↔ x ≤ y := by
+  rw [CommMonoidLike.included_iff, ← le_iff_exists_add]
+
+end ENNReal

--- a/IrisMath/IrisMath/Tests.lean
+++ b/IrisMath/IrisMath/Tests.lean
@@ -1,0 +1,3 @@
+module
+
+public import IrisMath.Tests.Numbers

--- a/IrisMath/IrisMath/Tests/Numbers.lean
+++ b/IrisMath/IrisMath/Tests/Numbers.lean
@@ -1,0 +1,47 @@
+module
+
+public import IrisMath.Numbers
+
+@[expose] public section
+
+namespace Real
+
+open Iris
+open scoped CommMonoidLike
+
+/-- info: CommMonoidLike.instUCMRA -/
+#guard_msgs in
+#synth UCMRA ℝ
+
+/-- info: CommMonoidLike.instDiscrete -/
+#guard_msgs in
+#synth CMRA.Discrete ℝ
+
+/-- info: fun x ↦ CommMonoidLike.instCancelable -/
+#guard_msgs in
+#synth ∀ x : ℝ, CMRA.Cancelable x
+
+/-- info: CommMonoidLike.instCoreIdZero -/
+#guard_msgs in
+#synth CMRA.CoreId (0 : ℝ)
+
+end Real
+
+namespace ENNReal
+
+open Iris
+open scoped CommMonoidLike
+
+/-- info: CommMonoidLike.instUCMRA -/
+#guard_msgs in
+#synth UCMRA ℝ≥0∞
+
+/-- info: CommMonoidLike.instDiscrete -/
+#guard_msgs in
+#synth CMRA.Discrete ℝ≥0∞
+
+/-- info: CommMonoidLike.instCoreIdZero -/
+#guard_msgs in
+#synth CMRA.CoreId (0 : ℝ≥0∞)
+
+end ENNReal


### PR DESCRIPTION
## Description
Fixes #267 plus `bi/lib/mono_Z.v`, and adds some extra stuff to IrisMath

This PR generally tidies up and completes the numbers CMRA's. It provides (scoped) instances for three classes of commutative monoids which cover every variant in Iris-Rocq. Cameras that use nonstandard `Add` instances are newtyped to avoid leaking the wrong instances. 

I'll note that in doing this I found what I believe to be dead code in Iris-Rocq as well as missing instances. A win for generalization! 

I like having a version that works for general commutative monoids because there are examples abound in mathlib, and I'd prefer to not copy-paste this for every numerical type. I presume that copy-paste was probably how Iris-Rocq ended up with dead instances. 

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
