### PR TITLE
feat: port monotone list family

### DIFF
--- a/Iris/Iris/Algebra.lean
+++ b/Iris/Iris/Algebra.lean
@@ -19,6 +19,7 @@ public import Iris.Algebra.IsOp
 public import Iris.Algebra.LeibnizSet
 public import Iris.Algebra.List
 public import Iris.Algebra.LocalUpdates
+public import Iris.Algebra.MaxPrefixList
 public import Iris.Algebra.Mra
 public import Iris.Algebra.IProp
 public import Iris.Algebra.OFE

--- a/Iris/Iris/Algebra/Agree.lean
+++ b/Iris/Iris/Algebra/Agree.lean
@@ -568,8 +568,8 @@ instance {x : Agree α} : CMRA.Cancelable x where
     (Agree.op_invN hval).symm.trans (Agree.op_invN ((OFE.Dist.validN heq).mp hval))
 
 @[rocq_alias agree_core_id]
-instance (a : α) : CMRA.CoreId (toAgree a) where
-  core_id := by simp [CMRA.pcore]
+instance (x : Agree α) : CMRA.CoreId x where
+  core_id := pcore_some
 
 @[simp, rocq_alias to_agree_includedN]
 theorem toAgree_includedN {a b : α} : toAgree a ≼{n} toAgree b ↔ a ≡{n}≡ b := by

--- a/Iris/Iris/Algebra/Lib.lean
+++ b/Iris/Iris/Algebra/Lib.lean
@@ -3,5 +3,6 @@ module
 public import Iris.Algebra.Lib.DFracAgree
 public import Iris.Algebra.Lib.ExclAuth
 public import Iris.Algebra.Lib.FracAuth
+public import Iris.Algebra.Lib.MonoList
 public import Iris.Algebra.Lib.MonoNat
 public import Iris.Algebra.Lib.UFracAuth

--- a/Iris/Iris/Algebra/Lib/MonoList.lean
+++ b/Iris/Iris/Algebra/Lib/MonoList.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
+Authors: Markus de Medeiros
 -/
 module
 
@@ -10,12 +10,7 @@ public import Iris.Algebra.IsOp
 public import Iris.Algebra.MaxPrefixList
 meta import Iris.Std.RocqPorting
 
-/-!
-# Monotone lists
-
-Authoritative CMRA of append-only lists, where the fragment represents a snapshot of the list,
-and the authoritative element can only grow by appending.
--/
+/-! # Monotone lists -/
 
 @[expose] public section
 
@@ -32,13 +27,10 @@ namespace MonoList
 
 open MaxPrefixList
 
-/-- The authoritative element. The definition includes the fragment at the same value so that
-`MonoList.included` holds; without this trick a frame-preserving update would be needed. -/
 @[rocq_alias mono_list_auth]
 def auth (dq : DFrac) (l : List α) : MonoList α :=
   (●{dq} toMaxPrefixList l) • ◯ toMaxPrefixList l
 
-/-- The fragment: a snapshot recording that `l` is a prefix of the authoritative list. -/
 @[rocq_alias mono_list_lb]
 def lb (l : List α) : MonoList α := ◯ toMaxPrefixList l
 
@@ -127,8 +119,7 @@ instance {dq dq1 dq2 : DFrac} {l : List α} [h : IsOp d dq dq1 dq2] :
 
 @[rocq_alias mono_list_auth_dfrac_validN]
 theorem auth_dfrac_validN {n} (dq : DFrac) (l : List α) : ✓{n} (●ML{dq} l) ↔ ✓ dq := by
-  unfold auth
-  rw [Auth.both_dfrac_validN]
+  rw [auth, Auth.both_dfrac_validN]
   exact ⟨fun h => h.1, fun h => ⟨h, incN_refl _, toMaxPrefixList_validN _⟩⟩
 
 @[rocq_alias mono_list_auth_validN]
@@ -137,8 +128,7 @@ theorem auth_validN {n} (l : List α) : ✓{n} (●ML l) :=
 
 @[rocq_alias mono_list_auth_dfrac_valid]
 theorem auth_dfrac_valid (dq : DFrac) (l : List α) : ✓ (●ML{dq} l) ↔ ✓ dq := by
-  unfold auth
-  rw [Auth.both_dfrac_valid]
+  rw [auth, Auth.both_dfrac_valid]
   exact ⟨fun h => h.1, fun h => ⟨h, fun _ => incN_refl _, toMaxPrefixList_valid _⟩⟩
 
 @[rocq_alias mono_list_auth_valid]
@@ -165,8 +155,7 @@ theorem auth_op_validN {n} (l1 l2 : List α) : ✓{n} (●ML l1 • ●ML l2) �
 @[rocq_alias mono_list_auth_dfrac_op_valid]
 theorem auth_dfrac_op_valid (dq1 dq2 : DFrac) (l1 l2 : List α) :
     ✓ (●ML{dq1} l1 • ●ML{dq2} l2) ↔ ✓ (dq1 • dq2) ∧ l1 = l2 := by
-  rw [valid_iff_validN, eq_dist]
-  simp only [auth_dfrac_op_validN]
+  simp only [valid_iff_validN, eq_dist, auth_dfrac_op_validN]
   exact ⟨fun h => ⟨(h 0).1, fun n => (h n).2⟩, fun ⟨hdq, hl⟩ n => ⟨hdq, hl n⟩⟩
 
 @[rocq_alias mono_list_auth_op_valid]
@@ -179,8 +168,7 @@ theorem auth_op_valid (l1 l2 : List α) : ✓ (●ML l1 • ●ML l2) ↔ False 
 @[rocq_alias mono_list_both_dfrac_validN]
 theorem both_dfrac_validN {n} (dq : DFrac) (l1 l2 : List α) :
     ✓{n} (●ML{dq} l1 • ◯ML l2) ↔ ✓ dq ∧ ∃ l, l1 ≡{n}≡ l2 ++ l := by
-  unfold auth lb
-  rw [← assoc', ← Auth.frag_op, Auth.both_dfrac_validN]
+  rw [auth, lb, ← assoc', ← Auth.frag_op, Auth.both_dfrac_validN]
   refine ⟨fun ⟨hdq, hinc, _⟩ => ⟨hdq, ?_⟩, fun ⟨hdq, hl⟩ => ⟨hdq, ?_, ?_⟩⟩
   · exact toMaxPrefixList_incN_iff.mp (incN_trans (incN_op_right ..) hinc)
   · have hinc := op_monoN_right (toMaxPrefixList l1) (toMaxPrefixList_incN_iff.mpr hl)
@@ -220,8 +208,7 @@ theorem both_valid_prefix (l1 l2 : List α) : ✓ (●ML l1 • ◯ML l2) ↔ l2
 
 @[rocq_alias mono_list_lb_op_validN]
 theorem lb_op_validN {n} (l1 l2 : List α) :
-    ✓{n} (◯ML l1 • ◯ML l2)
-      ↔ (∃ l, l2 ≡{n}≡ l1 ++ l) ∨ (∃ l, l1 ≡{n}≡ l2 ++ l) := by
+    ✓{n} (◯ML l1 • ◯ML l2) ↔ (∃ l, l2 ≡{n}≡ l1 ++ l) ∨ (∃ l, l1 ≡{n}≡ l2 ++ l) := by
   unfold lb
   rw [Auth.frag_op_validN, toMaxPrefixList_op_validN]
 

--- a/Iris/Iris/Algebra/Lib/MonoList.lean
+++ b/Iris/Iris/Algebra/Lib/MonoList.lean
@@ -85,6 +85,15 @@ instance {l : List α} : CoreId (●ML□ l) := by
   unfold auth
   infer_instance
 
+theorem lb_nil : ◯ML ([] : List α) = UCMRA.unit := by
+  unfold lb
+  rw [toMaxPrefixList_nil]
+  rfl
+
+instance : IsUnit (◯ML ([] : List α)) := by
+  rw [lb_nil]
+  infer_instance
+
 @[rocq_alias mono_list_auth_dfrac_op]
 theorem auth_dfrac_op (dq1 dq2 : DFrac) (l : List α) :
     ●ML{dq1 • dq2} l = ●ML{dq1} l • ●ML{dq2} l := by

--- a/Iris/Iris/Algebra/Lib/MonoList.lean
+++ b/Iris/Iris/Algebra/Lib/MonoList.lean
@@ -21,7 +21,20 @@ open OFE CMRA
 variable {α : Type _} [OFE α]
 
 @[rocq_alias mono_listR, rocq_alias mono_listUR]
-abbrev MonoList (α : Type _) [OFE α] := Auth (MaxPrefixList α)
+def MonoList (α : Type _) [OFE α] := Auth (MaxPrefixList α)
+
+instance : OFE (MonoList α) :=
+  Auth.instOFE
+
+instance : CMRA (MonoList α) :=
+  Auth.instCMRA
+
+instance : UCMRA (MonoList α) :=
+  Auth.instUCMRA
+
+instance instDiscrete [OFE.Discrete α] : CMRA.Discrete (MonoList α) := by
+  unfold MonoList
+  infer_instance
 
 namespace MonoList
 
@@ -69,16 +82,16 @@ theorem lb_inj {l1 l2 : List α} (h : ◯ML l1 = ◯ML l2) : l1 = l2 :=
 
 @[rocq_alias mono_list_lb_core_id]
 instance {l : List α} : CoreId (◯ML l) := by
-  unfold lb
+  unfold lb MonoList
   infer_instance
 
 @[rocq_alias mono_list_auth_core_id]
 instance {l : List α} : CoreId (●ML□ l) := by
-  unfold auth
+  unfold auth MonoList
   infer_instance
 
 theorem lb_nil : ◯ML ([] : List α) = UCMRA.unit := by
-  unfold lb
+  unfold lb MonoList
   rw [toMaxPrefixList_nil]
   rfl
 
@@ -89,22 +102,23 @@ instance : IsUnit (◯ML ([] : List α)) := by
 @[rocq_alias mono_list_auth_dfrac_op]
 theorem auth_dfrac_op (dq1 dq2 : DFrac) (l : List α) :
     ●ML{dq1 • dq2} l = ●ML{dq1} l • ●ML{dq2} l := by
-  unfold auth
-  rw [op_op_op_comm, ← Auth.frag_op, op_self, Auth.auth_dfrac_op]
+  unfold auth MonoList
+  rw [Algebra.MonoidOps.op_op_op_comm (M := Auth (MaxPrefixList α)) (op := (· • ·)),
+    ← Auth.frag_op, op_self, Auth.auth_dfrac_op]
 
 @[rocq_alias mono_list_lb_op_l]
 theorem lb_op_left {l1 l2 : List α} (h : l1 <+: l2) : ◯ML l1 • ◯ML l2 = ◯ML l2 := by
-  unfold lb
+  unfold lb MonoList
   rw [← Auth.frag_op, toMaxPrefixList_op_left h]
 
 @[rocq_alias mono_list_lb_op_r]
 theorem lb_op_right {l1 l2 : List α} (h : l1 <+: l2) : ◯ML l2 • ◯ML l1 = ◯ML l2 := by
-  unfold lb
+  unfold lb MonoList
   rw [← Auth.frag_op, toMaxPrefixList_op_right h]
 
 @[rocq_alias mono_list_auth_lb_op]
 theorem auth_lb_op (dq : DFrac) (l : List α) : ●ML{dq} l = ●ML{dq} l • ◯ML l := by
-  unfold auth lb
+  unfold auth lb MonoList
   rw [← assoc', ← Auth.frag_op, op_self]
 
 set_option synthInstance.checkSynthOrder false in
@@ -119,7 +133,8 @@ instance {dq dq1 dq2 : DFrac} {l : List α} [h : IsOp d dq dq1 dq2] :
 
 @[rocq_alias mono_list_auth_dfrac_validN]
 theorem auth_dfrac_validN {n} (dq : DFrac) (l : List α) : ✓{n} (●ML{dq} l) ↔ ✓ dq := by
-  rw [auth, Auth.both_dfrac_validN]
+  unfold auth MonoList
+  rw [Auth.both_dfrac_validN]
   exact ⟨fun h => h.1, fun h => ⟨h, incN_refl _, toMaxPrefixList_validN _⟩⟩
 
 @[rocq_alias mono_list_auth_validN]
@@ -128,7 +143,8 @@ theorem auth_validN {n} (l : List α) : ✓{n} (●ML l) :=
 
 @[rocq_alias mono_list_auth_dfrac_valid]
 theorem auth_dfrac_valid (dq : DFrac) (l : List α) : ✓ (●ML{dq} l) ↔ ✓ dq := by
-  rw [auth, Auth.both_dfrac_valid]
+  unfold auth MonoList
+  rw [Auth.both_dfrac_valid]
   exact ⟨fun h => h.1, fun h => ⟨h, fun _ => incN_refl _, toMaxPrefixList_valid _⟩⟩
 
 @[rocq_alias mono_list_auth_valid]
@@ -139,8 +155,8 @@ theorem auth_valid (l : List α) : ✓ (●ML l) :=
 theorem auth_dfrac_op_validN {n} (dq1 dq2 : DFrac) (l1 l2 : List α) :
     ✓{n} (●ML{dq1} l1 • ●ML{dq2} l2) ↔ ✓ (dq1 • dq2) ∧ l1 ≡{n}≡ l2 := by
   refine ⟨fun h => ?_, fun ⟨hdq, hl⟩ => ?_⟩
-  · unfold auth at h
-    rw [op_op_op_comm] at h
+  · unfold auth MonoList at h
+    rw [Algebra.MonoidOps.op_op_op_comm (M := Auth (MaxPrefixList α)) (op := (· • ·))] at h
     have ⟨hdq, ha, _⟩ := Auth.auth_dfrac_op_validN.mp (validN_op_left h)
     exact ⟨hdq, toMaxPrefixList_dist_inj ha⟩
   · refine (Dist.validN (auth_ne.ne hl.symm).op_r).mpr ?_
@@ -168,7 +184,8 @@ theorem auth_op_valid (l1 l2 : List α) : ✓ (●ML l1 • ●ML l2) ↔ False 
 @[rocq_alias mono_list_both_dfrac_validN]
 theorem both_dfrac_validN {n} (dq : DFrac) (l1 l2 : List α) :
     ✓{n} (●ML{dq} l1 • ◯ML l2) ↔ ✓ dq ∧ ∃ l, l1 ≡{n}≡ l2 ++ l := by
-  rw [auth, lb, ← assoc', ← Auth.frag_op, Auth.both_dfrac_validN]
+  unfold auth lb MonoList
+  rw [← assoc', ← Auth.frag_op, Auth.both_dfrac_validN]
   refine ⟨fun ⟨hdq, hinc, _⟩ => ⟨hdq, ?_⟩, fun ⟨hdq, hl⟩ => ⟨hdq, ?_, ?_⟩⟩
   · exact toMaxPrefixList_incN_iff.mp (incN_trans (incN_op_right ..) hinc)
   · have hinc := op_monoN_right (toMaxPrefixList l1) (toMaxPrefixList_incN_iff.mpr hl)
@@ -183,8 +200,8 @@ theorem both_validN {n} (l1 l2 : List α) :
 
 @[rocq_alias mono_list_both_dfrac_valid]
 theorem both_dfrac_valid (dq : DFrac) (l1 l2 : List α) :
-    ✓ (●ML{dq} l1 • ◯ML l2) ↔ ✓ dq ∧ ∃ l, l1 = l2 ++ l := by
-  unfold auth lb
+    ✓ (●ML{dq} l1 • ◯ML l2) ↔ ✓ dq ∧ l2 <+: l1 := by
+  unfold auth lb MonoList
   rw [← assoc', ← Auth.frag_op, Auth.both_dfrac_valid, ← inc_iff_forall_incN]
   refine ⟨fun ⟨hdq, hinc, _⟩ => ⟨hdq, ?_⟩, fun ⟨hdq, hl⟩ => ⟨hdq, ?_, ?_⟩⟩
   · exact toMaxPrefixList_inc_iff.mp (inc_trans (inc_op_right ..) hinc)
@@ -192,37 +209,26 @@ theorem both_dfrac_valid (dq : DFrac) (l1 l2 : List α) :
     rwa [op_self] at hinc
   · exact toMaxPrefixList_valid _
 
+#rocq_ignore mono_list_both_dfrac_valid_L "Use both_dfrac_valid"
+
 @[rocq_alias mono_list_both_valid]
-theorem both_valid (l1 l2 : List α) : ✓ (●ML l1 • ◯ML l2) ↔ ∃ l, l1 = l2 ++ l := by
+theorem both_valid (l1 l2 : List α) : ✓ (●ML l1 • ◯ML l2) ↔ l2 <+: l1 := by
   rw [both_dfrac_valid]
   exact ⟨fun h => h.2, fun h => ⟨DFrac.valid_own_one, h⟩⟩
 
-@[rocq_alias mono_list_both_dfrac_valid_L]
-theorem both_dfrac_valid_prefix (dq : DFrac) (l1 l2 : List α) :
-    ✓ (●ML{dq} l1 • ◯ML l2) ↔ ✓ dq ∧ l2 <+: l1 :=
-  (both_dfrac_valid ..).trans (and_congr_right' (exists_congr fun _ => eq_comm))
-
-@[rocq_alias mono_list_both_valid_L]
-theorem both_valid_prefix (l1 l2 : List α) : ✓ (●ML l1 • ◯ML l2) ↔ l2 <+: l1 :=
-  (both_valid ..).trans (exists_congr fun _ => eq_comm)
+#rocq_ignore mono_list_both_valid_L "Use both_valid"
 
 @[rocq_alias mono_list_lb_op_validN]
 theorem lb_op_validN {n} (l1 l2 : List α) :
     ✓{n} (◯ML l1 • ◯ML l2) ↔ (∃ l, l2 ≡{n}≡ l1 ++ l) ∨ (∃ l, l1 ≡{n}≡ l2 ++ l) := by
-  unfold lb
+  unfold lb MonoList
   rw [Auth.frag_op_validN, toMaxPrefixList_op_validN]
-
-@[rocq_alias mono_list_lb_op_valid]
-theorem lb_op_valid (l1 l2 : List α) :
-    ✓ (◯ML l1 • ◯ML l2) ↔ (∃ l, l2 = l1 ++ l) ∨ (∃ l, l1 = l2 ++ l) := by
-  unfold lb
-  rw [Auth.frag_op_valid, toMaxPrefixList_op_valid]
 
 @[rocq_alias mono_list_lb_op_valid_L]
 theorem lb_op_valid_prefix (l1 l2 : List α) :
     ✓ (◯ML l1 • ◯ML l2) ↔ l1 <+: l2 ∨ l2 <+: l1 := by
-  unfold lb
-  rw [Auth.frag_op_valid, toMaxPrefixList_op_valid_prefix]
+  unfold lb MonoList
+  rw [Auth.frag_op_valid, toMaxPrefixList_op_valid]
 
 #rocq_ignore mono_list_lb_op_valid_1_L "Use lb_op_valid_prefix.mp"
 #rocq_ignore mono_list_lb_op_valid_2_L "Use lb_op_valid_prefix.mpr"

--- a/Iris/Iris/Algebra/Lib/MonoList.lean
+++ b/Iris/Iris/Algebra/Lib/MonoList.lean
@@ -1,0 +1,271 @@
+/-
+Copyright (c) 2026. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
+module
+
+public import Iris.Algebra.Auth
+public import Iris.Algebra.IsOp
+public import Iris.Algebra.MaxPrefixList
+meta import Iris.Std.RocqPorting
+
+/-!
+# Monotone lists
+
+Authoritative CMRA of append-only lists, where the fragment represents a snapshot of the list,
+and the authoritative element can only grow by appending.
+-/
+
+@[expose] public section
+
+namespace Iris
+
+open OFE CMRA
+
+variable {α : Type _} [OFE α]
+
+@[rocq_alias mono_listR, rocq_alias mono_listUR]
+abbrev MonoList (α : Type _) [OFE α] := Auth (MaxPrefixList α)
+
+namespace MonoList
+
+open MaxPrefixList
+
+/-- The authoritative element. The definition includes the fragment at the same value so that
+`MonoList.included` holds; without this trick a frame-preserving update would be needed. -/
+@[rocq_alias mono_list_auth]
+def auth (dq : DFrac) (l : List α) : MonoList α :=
+  (●{dq} toMaxPrefixList l) • ◯ toMaxPrefixList l
+
+/-- The fragment: a snapshot recording that `l` is a prefix of the authoritative list. -/
+@[rocq_alias mono_list_lb]
+def lb (l : List α) : MonoList α := ◯ toMaxPrefixList l
+
+notation:max "●ML{" dq "} " l:max => auth dq l
+notation:max "●ML " l:max => auth (DFrac.own 1) l
+notation:max "●ML□ " l:max => auth DFrac.discard l
+notation:max "◯ML " l:max => lb l
+
+/-- Exchange the two inner factors of a product of products. -/
+theorem op_op_op_comm (x y z w : MonoList α) : (x • y) • (z • w) = (x • z) • (y • w) :=
+  Algebra.MonoidOps.op_op_op_comm
+
+/-! ## Setoid properties -/
+
+@[rocq_alias mono_list_auth_ne]
+instance auth_ne {dq : DFrac} : NonExpansive (auth dq : List α → MonoList α) where
+  ne _ _ _ h :=
+    (Auth.auth_ne.ne (toMaxPrefixList_ne.ne h)).op (Auth.frag_ne.ne (toMaxPrefixList_ne.ne h))
+
+@[rocq_alias mono_list_lb_ne]
+instance lb_ne : NonExpansive (lb : List α → MonoList α) where
+  ne _ _ _ h := Auth.frag_ne.ne (toMaxPrefixList_ne.ne h)
+
+#rocq_ignore mono_list_auth_proper "OFE is Leibniz; use equality"
+#rocq_ignore mono_list_lb_proper "OFE is Leibniz; use equality"
+
+@[rocq_alias mono_list_lb_dist_inj]
+theorem lb_dist_inj {n} {l1 l2 : List α} (h : ◯ML l1 ≡{n}≡ ◯ML l2) : l1 ≡{n}≡ l2 :=
+  toMaxPrefixList_dist_inj (Auth.frag_dist_inj h)
+
+@[rocq_alias mono_list_lb_inj]
+theorem lb_inj {l1 l2 : List α} (h : ◯ML l1 = ◯ML l2) : l1 = l2 :=
+  toMaxPrefixList_inj (Auth.frag_inj h)
+
+/-! ## Operation -/
+
+@[rocq_alias mono_list_lb_core_id]
+instance {l : List α} : CoreId (◯ML l) := by
+  unfold lb
+  infer_instance
+
+@[rocq_alias mono_list_auth_core_id]
+instance {l : List α} : CoreId (●ML□ l) := by
+  unfold auth
+  infer_instance
+
+@[rocq_alias mono_list_auth_dfrac_op]
+theorem auth_dfrac_op (dq1 dq2 : DFrac) (l : List α) :
+    ●ML{dq1 • dq2} l = ●ML{dq1} l • ●ML{dq2} l := by
+  unfold auth
+  rw [op_op_op_comm, ← Auth.frag_op, op_self, Auth.auth_dfrac_op]
+
+@[rocq_alias mono_list_lb_op_l]
+theorem lb_op_left {l1 l2 : List α} (h : l1 <+: l2) : ◯ML l1 • ◯ML l2 = ◯ML l2 := by
+  unfold lb
+  rw [← Auth.frag_op, toMaxPrefixList_op_left h]
+
+@[rocq_alias mono_list_lb_op_r]
+theorem lb_op_right {l1 l2 : List α} (h : l1 <+: l2) : ◯ML l2 • ◯ML l1 = ◯ML l2 := by
+  unfold lb
+  rw [← Auth.frag_op, toMaxPrefixList_op_right h]
+
+@[rocq_alias mono_list_auth_lb_op]
+theorem auth_lb_op (dq : DFrac) (l : List α) : ●ML{dq} l = ●ML{dq} l • ◯ML l := by
+  unfold auth lb
+  rw [← assoc', ← Auth.frag_op, op_self]
+
+set_option synthInstance.checkSynthOrder false in
+@[rocq_alias mono_list_auth_dfrac_is_op]
+instance {dq dq1 dq2 : DFrac} {l : List α} [h : IsOp d dq dq1 dq2] :
+    IsOp d (●ML{dq} l) (●ML{dq1} l) (●ML{dq2} l) where
+  is_op := by
+    rw [h.is_op]
+    exact auth_dfrac_op ..
+
+/-! ## Validity -/
+
+@[rocq_alias mono_list_auth_dfrac_validN]
+theorem auth_dfrac_validN {n} (dq : DFrac) (l : List α) : ✓{n} (●ML{dq} l) ↔ ✓ dq := by
+  unfold auth
+  rw [Auth.both_dfrac_validN]
+  exact ⟨fun h => h.1, fun h => ⟨h, incN_refl _, toMaxPrefixList_validN _⟩⟩
+
+@[rocq_alias mono_list_auth_validN]
+theorem auth_validN {n} (l : List α) : ✓{n} (●ML l) :=
+  (auth_dfrac_validN ..).mpr DFrac.valid_own_one
+
+@[rocq_alias mono_list_auth_dfrac_valid]
+theorem auth_dfrac_valid (dq : DFrac) (l : List α) : ✓ (●ML{dq} l) ↔ ✓ dq := by
+  unfold auth
+  rw [Auth.both_dfrac_valid]
+  exact ⟨fun h => h.1, fun h => ⟨h, fun _ => incN_refl _, toMaxPrefixList_valid _⟩⟩
+
+@[rocq_alias mono_list_auth_valid]
+theorem auth_valid (l : List α) : ✓ (●ML l) :=
+  (auth_dfrac_valid ..).mpr DFrac.valid_own_one
+
+@[rocq_alias mono_list_auth_dfrac_op_validN]
+theorem auth_dfrac_op_validN {n} (dq1 dq2 : DFrac) (l1 l2 : List α) :
+    ✓{n} (●ML{dq1} l1 • ●ML{dq2} l2) ↔ ✓ (dq1 • dq2) ∧ l1 ≡{n}≡ l2 := by
+  refine ⟨fun h => ?_, fun ⟨hdq, hl⟩ => ?_⟩
+  · unfold auth at h
+    rw [op_op_op_comm] at h
+    have ⟨hdq, ha, _⟩ := Auth.auth_dfrac_op_validN.mp (validN_op_left h)
+    exact ⟨hdq, toMaxPrefixList_dist_inj ha⟩
+  · refine (Dist.validN (auth_ne.ne hl.symm).op_r).mpr ?_
+    rw [← auth_dfrac_op]
+    exact (auth_dfrac_validN ..).mpr hdq
+
+@[rocq_alias mono_list_auth_op_validN]
+theorem auth_op_validN {n} (l1 l2 : List α) : ✓{n} (●ML l1 • ●ML l2) ↔ False := by
+  refine (auth_dfrac_op_validN ..).trans ⟨fun ⟨h, _⟩ => ?_, False.elim⟩
+  exact DFrac.own_whole_exclusive.exclusive0_l _ h.validN
+
+@[rocq_alias mono_list_auth_dfrac_op_valid]
+theorem auth_dfrac_op_valid (dq1 dq2 : DFrac) (l1 l2 : List α) :
+    ✓ (●ML{dq1} l1 • ●ML{dq2} l2) ↔ ✓ (dq1 • dq2) ∧ l1 = l2 := by
+  rw [valid_iff_validN, eq_dist]
+  simp only [auth_dfrac_op_validN]
+  exact ⟨fun h => ⟨(h 0).1, fun n => (h n).2⟩, fun ⟨hdq, hl⟩ n => ⟨hdq, hl n⟩⟩
+
+@[rocq_alias mono_list_auth_op_valid]
+theorem auth_op_valid (l1 l2 : List α) : ✓ (●ML l1 • ●ML l2) ↔ False := by
+  refine (auth_dfrac_op_valid ..).trans ⟨fun ⟨h, _⟩ => ?_, False.elim⟩
+  exact DFrac.own_whole_exclusive.exclusive0_l _ h.validN
+
+#rocq_ignore mono_list_auth_dfrac_op_valid_L "OFE is Leibniz; use auth_dfrac_op_valid"
+
+@[rocq_alias mono_list_both_dfrac_validN]
+theorem both_dfrac_validN {n} (dq : DFrac) (l1 l2 : List α) :
+    ✓{n} (●ML{dq} l1 • ◯ML l2) ↔ ✓ dq ∧ ∃ l, l1 ≡{n}≡ l2 ++ l := by
+  unfold auth lb
+  rw [← assoc', ← Auth.frag_op, Auth.both_dfrac_validN]
+  refine ⟨fun ⟨hdq, hinc, _⟩ => ⟨hdq, ?_⟩, fun ⟨hdq, hl⟩ => ⟨hdq, ?_, ?_⟩⟩
+  · exact toMaxPrefixList_incN_iff.mp (incN_trans (incN_op_right ..) hinc)
+  · have hinc := op_monoN_right (toMaxPrefixList l1) (toMaxPrefixList_incN_iff.mpr hl)
+    rwa [op_self] at hinc
+  · exact toMaxPrefixList_validN _
+
+@[rocq_alias mono_list_both_validN]
+theorem both_validN {n} (l1 l2 : List α) :
+    ✓{n} (●ML l1 • ◯ML l2) ↔ ∃ l, l1 ≡{n}≡ l2 ++ l := by
+  rw [both_dfrac_validN]
+  exact ⟨fun h => h.2, fun h => ⟨DFrac.valid_own_one, h⟩⟩
+
+@[rocq_alias mono_list_both_dfrac_valid]
+theorem both_dfrac_valid (dq : DFrac) (l1 l2 : List α) :
+    ✓ (●ML{dq} l1 • ◯ML l2) ↔ ✓ dq ∧ ∃ l, l1 = l2 ++ l := by
+  unfold auth lb
+  rw [← assoc', ← Auth.frag_op, Auth.both_dfrac_valid, ← inc_iff_forall_incN]
+  refine ⟨fun ⟨hdq, hinc, _⟩ => ⟨hdq, ?_⟩, fun ⟨hdq, hl⟩ => ⟨hdq, ?_, ?_⟩⟩
+  · exact toMaxPrefixList_inc_iff.mp (inc_trans (inc_op_right ..) hinc)
+  · have hinc := op_mono_right (toMaxPrefixList l1) (toMaxPrefixList_inc_iff.mpr hl)
+    rwa [op_self] at hinc
+  · exact toMaxPrefixList_valid _
+
+@[rocq_alias mono_list_both_valid]
+theorem both_valid (l1 l2 : List α) : ✓ (●ML l1 • ◯ML l2) ↔ ∃ l, l1 = l2 ++ l := by
+  rw [both_dfrac_valid]
+  exact ⟨fun h => h.2, fun h => ⟨DFrac.valid_own_one, h⟩⟩
+
+@[rocq_alias mono_list_both_dfrac_valid_L]
+theorem both_dfrac_valid_prefix (dq : DFrac) (l1 l2 : List α) :
+    ✓ (●ML{dq} l1 • ◯ML l2) ↔ ✓ dq ∧ l2 <+: l1 :=
+  (both_dfrac_valid ..).trans (and_congr_right' (exists_congr fun _ => eq_comm))
+
+@[rocq_alias mono_list_both_valid_L]
+theorem both_valid_prefix (l1 l2 : List α) : ✓ (●ML l1 • ◯ML l2) ↔ l2 <+: l1 :=
+  (both_valid ..).trans (exists_congr fun _ => eq_comm)
+
+@[rocq_alias mono_list_lb_op_validN]
+theorem lb_op_validN {n} (l1 l2 : List α) :
+    ✓{n} (◯ML l1 • ◯ML l2)
+      ↔ (∃ l, l2 ≡{n}≡ l1 ++ l) ∨ (∃ l, l1 ≡{n}≡ l2 ++ l) := by
+  unfold lb
+  rw [Auth.frag_op_validN, toMaxPrefixList_op_validN]
+
+@[rocq_alias mono_list_lb_op_valid]
+theorem lb_op_valid (l1 l2 : List α) :
+    ✓ (◯ML l1 • ◯ML l2) ↔ (∃ l, l2 = l1 ++ l) ∨ (∃ l, l1 = l2 ++ l) := by
+  unfold lb
+  rw [Auth.frag_op_valid, toMaxPrefixList_op_valid]
+
+@[rocq_alias mono_list_lb_op_valid_L]
+theorem lb_op_valid_prefix (l1 l2 : List α) :
+    ✓ (◯ML l1 • ◯ML l2) ↔ l1 <+: l2 ∨ l2 <+: l1 := by
+  unfold lb
+  rw [Auth.frag_op_valid, toMaxPrefixList_op_valid_prefix]
+
+#rocq_ignore mono_list_lb_op_valid_1_L "Use lb_op_valid_prefix.mp"
+#rocq_ignore mono_list_lb_op_valid_2_L "Use lb_op_valid_prefix.mpr"
+
+@[rocq_alias mono_list_lb_mono]
+theorem lb_mono {l1 l2 : List α} (h : l1 <+: l2) : ◯ML l1 ≼ ◯ML l2 :=
+  ⟨◯ML l2, (lb_op_left h).symm⟩
+
+@[rocq_alias mono_list_included]
+theorem included (dq : DFrac) (l : List α) : ◯ML l ≼ ●ML{dq} l := inc_op_right ..
+
+/-! ## Updates -/
+
+@[rocq_alias mono_list_update]
+theorem update {l1 : List α} (l2 : List α) (h : l1 <+: l2) : ●ML l1 ~~> ●ML l2 :=
+  Auth.auth_update (local_update h)
+
+@[rocq_alias mono_list_auth_persist]
+theorem auth_persist (dq : DFrac) (l : List α) : ●ML{dq} l ~~> ●ML□ l :=
+  Update.op Auth.auth_update_auth_persist fun _ _ h => h
+
+@[rocq_alias mono_list_auth_unpersist]
+theorem auth_unpersist (l : List α) : ●ML□ l ~~>: fun k => ∃ q, k = ●ML{DFrac.own q} l :=
+  Auth.auth_updateP_both_unpersist
+
+end MonoList
+
+/-! ## Functors -/
+
+@[rocq_alias mono_listURF]
+abbrev MonoListURF (F : COFE.OFunctorPre) [COFE.OFunctor F] : COFE.OFunctorPre :=
+  Auth.AuthURF (MaxPrefixListURF F)
+
+#rocq_ignore mono_listURF_contractive "Found by typeclass inference"
+
+@[rocq_alias mono_listRF]
+abbrev MonoListRF (F : COFE.OFunctorPre) [COFE.OFunctor F] : COFE.OFunctorPre :=
+  Auth.AuthRF (MaxPrefixListURF F)
+
+#rocq_ignore mono_listRF_contractive "Found by typeclass inference"
+
+end Iris

--- a/Iris/Iris/Algebra/Lib/MonoList.lean
+++ b/Iris/Iris/Algebra/Lib/MonoList.lean
@@ -224,14 +224,15 @@ theorem lb_op_validN {n} (l1 l2 : List α) :
   unfold lb MonoList
   rw [Auth.frag_op_validN, toMaxPrefixList_op_validN]
 
-@[rocq_alias mono_list_lb_op_valid_L]
-theorem lb_op_valid_prefix (l1 l2 : List α) :
+@[rocq_alias mono_list_lb_op_valid]
+theorem lb_op_valid (l1 l2 : List α) :
     ✓ (◯ML l1 • ◯ML l2) ↔ l1 <+: l2 ∨ l2 <+: l1 := by
   unfold lb MonoList
   rw [Auth.frag_op_valid, toMaxPrefixList_op_valid]
 
-#rocq_ignore mono_list_lb_op_valid_1_L "Use lb_op_valid_prefix.mp"
-#rocq_ignore mono_list_lb_op_valid_2_L "Use lb_op_valid_prefix.mpr"
+#rocq_ignore mono_list_lb_op_valid_L "Use lb_op_valid"
+#rocq_ignore mono_list_lb_op_valid_1_L "Use lb_op_valid.mp"
+#rocq_ignore mono_list_lb_op_valid_2_L "Use lb_op_valid.mpr"
 
 @[rocq_alias mono_list_lb_mono]
 theorem lb_mono {l1 l2 : List α} (h : l1 <+: l2) : ◯ML l1 ≼ ◯ML l2 :=

--- a/Iris/Iris/Algebra/MaxPrefixList.lean
+++ b/Iris/Iris/Algebra/MaxPrefixList.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
+Authors: Markus de Medeiros
 -/
 module
 
@@ -12,18 +12,11 @@ public import Iris.Algebra.LocalUpdates
 public import Iris.Std.HeapInstances
 meta import Iris.Std.RocqPorting
 
-/-!
-# Max prefix lists
+/-! # Max prefix lists
 
-An RA on lists whose composition is only defined when one operand is a prefix of the other,
-in which case the result is the longer list. The core is the identity function for all elements.
-
-A list is represented as a finite map from indices to agreed-upon elements, so that composition
-is map union with `Agree` forcing the operands to agree on their common indices. `MaxPrefixList`
-wraps that map in a single-field structure, which keeps it a type constructor in its own right:
-the map instances in `Iris.Algebra.Heap` are stated for `M V`, so a bare type synonym would leave
-instance synthesis unifying `?M ?V` against it and picking the wrong first-order solution.
--/
+An RA on lists, whose composition is the longer of the two lists, when their prefixes agree.
+Here, the term "List" be being used liberally: it is implemented with an ExtTreeMap rather than
+the List type itself. However, there is an embedding of Lists in to this data structure. -/
 
 @[expose] public section
 
@@ -31,137 +24,68 @@ namespace Iris
 
 open OFE CMRA Std
 
--- Named as a *functor* rather than an application so that the value type stays in last
--- position: `?M ?V` then unifies against `MaxPrefixListMap (Agree α)` correctly.
-/-- The extensional finite map from list indices to agreed-upon elements. -/
-abbrev MaxPrefixListMap : Type _ → Type _ := (Std.ExtTreeMap Nat · compare)
+abbrev MaxPrefixListMap : Type _ → Type _ :=
+  (Std.ExtTreeMap Nat · compare)
 
 @[rocq_alias max_prefix_list, rocq_alias max_prefix_listR, rocq_alias max_prefix_listUR]
-structure MaxPrefixList (α : Type _) where
-  ofMap ::
-  toMap : MaxPrefixListMap (Agree α)
+abbrev MaxPrefixList : Type _ → Type _ :=
+  (MaxPrefixListMap <| Agree ·)
 
 namespace MaxPrefixList
 
-variable {α β : Type _}
-
-theorem toMap_inj {x y : MaxPrefixList α} (h : x.toMap = y.toMap) : x = y := congrArg ofMap h
-
-/-! ## Algebraic structure, inherited from the underlying map -/
+variable {α : Type _}
 
 section Instances
 
 variable [OFE α]
 
-instance : OFE (MaxPrefixList α) where
-  Dist n x y := x.toMap ≡{n}≡ y.toMap
-  dist_eqv := ⟨fun _ => .rfl, (·.symm), (·.trans ·)⟩
-  eq_dist := ⟨fun h _ => h ▸ .rfl, fun h => toMap_inj (eq_dist.mpr h)⟩
-  dist_lt h hlt := h.lt hlt
+/-- OFE instance on [MaxPrefixList], inherited from the OFE on the underlying map. -/
+instance instOFE : OFE (MaxPrefixList α) :=
+  PartialMap.instOFE (M := MaxPrefixListMap) (K := Nat) (V := Agree α)
 
-@[local simp] theorem dist_toMap {n} {x y : MaxPrefixList α} :
-    x ≡{n}≡ y ↔ x.toMap ≡{n}≡ y.toMap := .rfl
+/-- CMRA instance on [MaxPrefixList], inherited from the CMRA on the underlying map. -/
+instance instCMRA : CMRA (MaxPrefixList α) :=
+  Heap.instStoreCMRA (M := MaxPrefixListMap) (K := Nat) (V := Agree α)
 
--- Every `Agree` element is its own core, so the core here is the identity; `pcore_toMap`
--- records that this agrees with the core of the underlying map.
-instance : CMRA (MaxPrefixList α) where
-  pcore x := some x
-  op x y := ofMap (x.toMap • y.toMap)
-  ValidN n x := ✓{n} x.toMap
-  Valid x := ✓ x.toMap
-  op_ne.ne _ _ _ h := dist_toMap.mpr (CMRA.op_ne.ne h)
-  pcore_ne hd hcx := ⟨_, rfl, Option.some.inj hcx ▸ hd⟩
-  validN_ne hd hv := CMRA.validN_ne hd hv
-  valid_iff_validN := CMRA.valid_iff_validN
-  validN_succ := CMRA.validN_succ
-  validN_op_left := CMRA.validN_op_left
-  assoc := toMap_inj CMRA.assoc
-  comm := toMap_inj CMRA.comm
-  pcore_op_left hcx := by
-    obtain rfl := Option.some.inj hcx
-    exact toMap_inj (op_self _)
-  pcore_idem _ := rfl
-  pcore_op_mono hcx y := by
-    obtain rfl := Option.some.inj hcx
-    exact ⟨y, rfl⟩
-  extend hv hd := by
-    obtain ⟨m₁, m₂, heq, h₁, h₂⟩ := CMRA.extend hv hd
-    exact ⟨ofMap m₁, ofMap m₂, toMap_inj heq, h₁, h₂⟩
+/-- UCMRA instance on [MaxPrefixList], inherited from the UCMRA on the underlying map. -/
+instance instUCMRA : UCMRA (MaxPrefixList α) :=
+  Heap.instStoreUCMRA (M := MaxPrefixListMap) (K := Nat) (V := Agree α)
 
-@[local simp] theorem toMap_op (x y : MaxPrefixList α) :
-    (x • y).toMap = x.toMap • y.toMap := rfl
-@[local simp] theorem pcore_eq_some (x : MaxPrefixList α) : pcore x = some x := rfl
-@[local simp] theorem validN_toMap {n} {x : MaxPrefixList α} : ✓{n} x ↔ ✓{n} x.toMap := .rfl
-@[local simp] theorem valid_toMap {x : MaxPrefixList α} : ✓ x ↔ ✓ x.toMap := .rfl
+instance instCoreId (x : MaxPrefixList α) : CoreId x :=
+  Heap.instCoreId (M := MaxPrefixListMap) (K := Nat) (V := Agree α) (m := x)
 
-/-- The core agrees with the core of the underlying map. -/
-theorem pcore_toMap (x : MaxPrefixList α) : pcore x = (pcore x.toMap).map ofMap := by
-  simp [core_id (x := x.toMap)]
-
-instance : UCMRA (MaxPrefixList α) where
-  unit := ofMap UCMRA.unit
-  unit_valid := valid_toMap.mpr UCMRA.unit_valid
-  unit_left_id := toMap_inj UCMRA.unit_left_id
-  pcore_unit := rfl
-
--- Rocq calls this `mono_list_lb_core_id`, a name `mono_list.v` reuses for the fragment; the
--- alias is attached there, on `MonoList.instCoreIdLb`.
-instance (x : MaxPrefixList α) : CoreId x where
-  core_id := rfl
-
-instance [OFE.Discrete α] : CMRA.Discrete (MaxPrefixList α) where
-  discrete_0 h := toMap_inj (OFE.discrete_0 h)
+instance instDiscrete [OFE.Discrete α] : CMRA.Discrete (MaxPrefixList α) where
+  discrete_0 := OFE.discrete_0 (α := MaxPrefixListMap (Agree α))
   discrete_valid := CMRA.discrete_valid (α := MaxPrefixListMap (Agree α))
-
-@[local simp] theorem incN_toMap {n} {x y : MaxPrefixList α} :
-    x ≼{n} y ↔ x.toMap ≼{n} y.toMap :=
-  ⟨fun ⟨z, h⟩ => ⟨z.toMap, h⟩, fun ⟨m, h⟩ => ⟨ofMap m, h⟩⟩
-
-@[local simp] theorem inc_toMap {x y : MaxPrefixList α} : x ≼ y ↔ x.toMap ≼ y.toMap :=
-  ⟨fun ⟨z, h⟩ => ⟨z.toMap, congrArg toMap h⟩,
-   fun ⟨m, h⟩ => ⟨ofMap m, toMap_inj h⟩⟩
-
-/-- Lift a CMRA homomorphism between the underlying maps to one between `MaxPrefixList`s. -/
-def homLift [OFE β] (f : MaxPrefixListMap (Agree α) -C> MaxPrefixListMap (Agree β)) :
-    MaxPrefixList α -C> MaxPrefixList β where
-  f x := ofMap (f x.toMap)
-  ne.ne _ _ _ h := dist_toMap.mpr (f.ne.ne h)
-  validN := f.validN
-  pcore _ := rfl
-  op x y := toMap_inj (f.op x.toMap y.toMap)
-
-@[local simp] theorem toMap_homLift [OFE β]
-    (f : MaxPrefixListMap (Agree α) -C> MaxPrefixListMap (Agree β)) (x : MaxPrefixList α) :
-    (homLift f x).toMap = f x.toMap := rfl
 
 end Instances
 
-/-! ## The canonical embedding of lists -/
+/-! ## Embedding of lists into MaxPrefixList -/
 
-/-- `l`, agreed upon and placed at the indices `start`, `start + 1`, … -/
+/-- `l`, placed at the indices `start`, `start + 1`, … -/
 def ofListFrom (start : Nat) (l : List α) : MaxPrefixList α :=
-  ofMap (Std.PartialMap.map toAgree (FiniteMap.map_seq start l))
+  Std.PartialMap.map (M := MaxPrefixListMap) toAgree (FiniteMap.map_seq start l)
 
 @[rocq_alias to_max_prefix_list]
 def toMaxPrefixList (l : List α) : MaxPrefixList α := ofListFrom 0 l
 
 theorem get?_ofListFrom {start i : Nat} {l : List α} :
-    get? (ofListFrom start l).toMap i
+    get? (M := MaxPrefixListMap) (ofListFrom start l) i
       = (if start ≤ i then l[i - start]? else none).map toAgree := by
   rw [ofListFrom, LawfulPartialMap.get?_map, LawfulFiniteMap.get?_map_seq]
 
 theorem get?_toMaxPrefixList {i : Nat} {l : List α} :
-    get? (toMaxPrefixList l).toMap i = l[i]?.map toAgree := by
+    get? (M := MaxPrefixListMap) (toMaxPrefixList l) i = l[i]?.map toAgree := by
   simp [toMaxPrefixList, get?_ofListFrom]
 
 variable [OFE α]
 
 theorem toMaxPrefixList_nil : toMaxPrefixList ([] : List α) = UCMRA.unit := by
-  refine toMap_inj (LawfulPartialMap.equiv_iff_eq.mp fun i => ?_)
+  refine LawfulPartialMap.equiv_iff_eq (M := MaxPrefixListMap).mp fun i => ?_
   rw [get?_toMaxPrefixList, List.getElem?_nil]
   exact (LawfulPartialMap.get?_empty i).symm
 
-/-! ## Setoid properties -/
+/-! ## OFE properties -/
 
 @[rocq_alias to_max_prefix_list_ne]
 instance toMaxPrefixList_ne : NonExpansive (toMaxPrefixList (α := α)) where
@@ -175,8 +99,9 @@ instance toMaxPrefixList_ne : NonExpansive (toMaxPrefixList (α := α)) where
 theorem toMaxPrefixList_dist_inj {n} {l1 l2 : List α}
     (h : toMaxPrefixList l1 ≡{n}≡ toMaxPrefixList l2) : l1 ≡{n}≡ l2 := by
   refine list_dist_lookup.mpr fun i => ?_
-  have hi := h i
-  rw [get?_toMaxPrefixList, get?_toMaxPrefixList] at hi
+  obtain hi : Option.map toAgree l1[i]? ≡{n}≡ Option.map toAgree l2[i]? := by
+    rw [← get?_toMaxPrefixList, ← get?_toMaxPrefixList]
+    exact h i
   cases h1 : l1[i]? <;> cases h2 : l2[i]? <;> rw [h1, h2] at hi <;> simp_all
   exact Agree.toAgree_injN hi
 
@@ -185,7 +110,7 @@ theorem toMaxPrefixList_inj {l1 l2 : List α}
     (h : toMaxPrefixList l1 = toMaxPrefixList l2) : l1 = l2 :=
   eq_dist.mpr fun _ => toMaxPrefixList_dist_inj (Dist.of_eq h)
 
-/-! ## Validity -/
+/-! ## CMRA Properties -/
 
 @[rocq_alias to_max_prefix_list_valid]
 theorem toMaxPrefixList_valid (l : List α) : ✓ toMaxPrefixList l := fun i => by
@@ -198,14 +123,11 @@ theorem toMaxPrefixList_valid (l : List α) : ✓ toMaxPrefixList l := fun i => 
 theorem toMaxPrefixList_validN {n} (l : List α) : ✓{n} toMaxPrefixList l :=
   (toMaxPrefixList_valid l).validN
 
-/-! ## Operation -/
-
 @[rocq_alias to_max_prefix_list_app]
 theorem toMaxPrefixList_app (l1 l2 : List α) :
     toMaxPrefixList (l1 ++ l2) = toMaxPrefixList l1 • ofListFrom l1.length l2 := by
-  refine toMap_inj (LawfulPartialMap.equiv_iff_eq.mp fun i => ?_)
-  rw [toMap_op, Heap.get?_op, get?_toMaxPrefixList, get?_toMaxPrefixList, get?_ofListFrom,
-    List.getElem?_append]
+  refine LawfulPartialMap.equiv_iff_eq (M := MaxPrefixListMap).mp fun i => ?_
+  rw [Heap.get?_op, get?_toMaxPrefixList, get?_toMaxPrefixList, get?_ofListFrom, List.getElem?_append]
   by_cases hi : i < l1.length
   · rw [if_pos hi, if_neg (by omega)]
     cases l1[i]? <;> simp [op, optionOp]
@@ -223,8 +145,6 @@ theorem toMaxPrefixList_op_right {l1 l2 : List α} (h : l1 <+: l2) :
     toMaxPrefixList l2 • toMaxPrefixList l1 = toMaxPrefixList l2 :=
   comm'.trans (toMaxPrefixList_op_left h)
 
-/-! ## Inclusion -/
-
 @[rocq_alias max_prefix_list_included_includedN]
 theorem inc_iff_forall_incN {ml1 ml2 : MaxPrefixList α} :
     ml1 ≼ ml2 ↔ ∀ n, ml1 ≼{n} ml2 := by
@@ -239,7 +159,7 @@ theorem inc_iff_forall_incN {ml1 ml2 : MaxPrefixList α} :
 theorem toMaxPrefixList_incN_aux {n} {l1 l2 : List α}
     (h : toMaxPrefixList l1 ≼{n} toMaxPrefixList l2) : l2 ≡{n}≡ l1 ++ l2.drop l1.length := by
   refine list_dist_lookup.mpr fun i => ?_
-  have hi := Heap.lookup_incN.mp (incN_toMap.mp h) i
+  have hi := Heap.lookup_incN (M := MaxPrefixListMap).mp h i
   rw [get?_toMaxPrefixList, get?_toMaxPrefixList] at hi
   rw [List.getElem?_append]
   rcases Option.incN_iff_is_total.mp hi with hnone | ⟨a1, a2, ha1, ha2, ha⟩
@@ -272,15 +192,14 @@ theorem toMaxPrefixList_inc_iff_prefix {l1 l2 : List α} :
     toMaxPrefixList l1 ≼ toMaxPrefixList l2 ↔ l1 <+: l2 :=
   toMaxPrefixList_inc_iff.trans (exists_congr fun _ => eq_comm)
 
-/-! ## Validity of compositions -/
-
 @[rocq_alias to_max_prefix_list_op_validN_aux]
 theorem toMaxPrefixList_op_validN_aux {n} {l1 l2 : List α} (hlen : l1.length ≤ l2.length)
     (h : ✓{n} (toMaxPrefixList l1 • toMaxPrefixList l2)) :
     l2 ≡{n}≡ l1 ++ l2.drop l1.length := by
   refine list_dist_lookup.mpr fun i => ?_
-  have hi := validN_toMap.mp h i
-  rw [toMap_op, Heap.get?_op, get?_toMaxPrefixList, get?_toMaxPrefixList] at hi
+  obtain hi :  ✓{n} Option.map toAgree l1[i]? • Option.map toAgree l2[i]? := by
+    rw [← get?_toMaxPrefixList, ← get?_toMaxPrefixList, ← Heap.get?_op]
+    exact h i
   rw [List.getElem?_append]
   cases h1 : l1[i]? with
   | none =>
@@ -290,7 +209,8 @@ theorem toMaxPrefixList_op_validN_aux {n} {l1 l2 : List α} (hlen : l1.length �
   | some x1 =>
     have hlt := (List.getElem?_eq_some_iff.mp h1).1
     cases h2 : l2[i]? with
-    | none => exact absurd (List.getElem?_eq_none_iff.mp h2) (by omega)
+    | none =>
+      grind
     | some x2 =>
       rw [if_pos hlt]
       rw [h1, h2] at hi
@@ -335,7 +255,7 @@ theorem toMaxPrefixList_op_valid_prefix {l1 l2 : List α} :
   toMaxPrefixList_op_valid.trans
     (or_congr (exists_congr fun _ => eq_comm) (exists_congr fun _ => eq_comm))
 
-/-! ## Local updates -/
+/-! ## Updates -/
 
 @[rocq_alias max_prefix_list_local_update]
 theorem local_update {l1 l2 : List α} (h : l1 <+: l2) :
@@ -350,32 +270,14 @@ end MaxPrefixList
 
 /-! ## Functors -/
 
-open MaxPrefixList
-
 @[rocq_alias max_prefix_listURF]
 abbrev MaxPrefixListURF (F : COFE.OFunctorPre) : COFE.OFunctorPre :=
-  fun A B _ _ => MaxPrefixList (F A B)
-
-/-- The underlying map functor that `MaxPrefixListURF` wraps. -/
-abbrev MaxPrefixListMapOF (F : COFE.OFunctorPre) : COFE.OFunctorPre :=
   PartialMap.PartialMapOF MaxPrefixListMap (AgreeRF F)
-
-instance {F} [COFE.OFunctor F] : URFunctor (MaxPrefixListURF F) where
-  map f g := homLift (URFunctor.map (F := MaxPrefixListMapOF F) f g)
-  map_ne.ne _ _ _ hf _ _ hg x :=
-    dist_toMap.mpr ((URFunctor.map_ne (F := MaxPrefixListMapOF F)).ne hf hg x.toMap)
-  map_id x := toMap_inj (URFunctor.map_id (F := MaxPrefixListMapOF F) x.toMap)
-  map_comp f g f' g' x :=
-    toMap_inj (URFunctor.map_comp (F := MaxPrefixListMapOF F) f g f' g' x.toMap)
-
-@[rocq_alias max_prefix_listURF_contractive]
-instance {F} [COFE.OFunctorContractive F] : URFunctorContractive (MaxPrefixListURF F) where
-  map_contractive.1 h x := dist_toMap.mpr
-    ((URFunctorContractive.map_contractive (F := MaxPrefixListMapOF F)).1 h x.toMap)
 
 @[rocq_alias max_prefix_listRF]
 abbrev MaxPrefixListRF (F : COFE.OFunctorPre) : COFE.OFunctorPre := MaxPrefixListURF F
 
+#rocq_ignore max_prefix_listURF_contractive "Found by typeclass inference"
 #rocq_ignore max_prefix_listRF_contractive "Found by typeclass inference"
 
 end Iris

--- a/Iris/Iris/Algebra/MaxPrefixList.lean
+++ b/Iris/Iris/Algebra/MaxPrefixList.lean
@@ -28,7 +28,7 @@ abbrev MaxPrefixListMap : Type _ → Type _ :=
   (Std.ExtTreeMap Nat · compare)
 
 @[rocq_alias max_prefix_list, rocq_alias max_prefix_listR, rocq_alias max_prefix_listUR]
-abbrev MaxPrefixList : Type _ → Type _ :=
+def MaxPrefixList : Type _ → Type _ :=
   (MaxPrefixListMap <| Agree ·)
 
 namespace MaxPrefixList
@@ -41,18 +41,18 @@ variable [OFE α]
 
 /-- OFE instance on [MaxPrefixList], inherited from the OFE on the underlying map. -/
 instance instOFE : OFE (MaxPrefixList α) :=
-  PartialMap.instOFE (M := MaxPrefixListMap) (K := Nat) (V := Agree α)
+  PartialMap.instOFE (M:= MaxPrefixListMap) (V := Agree α)
 
 /-- CMRA instance on [MaxPrefixList], inherited from the CMRA on the underlying map. -/
 instance instCMRA : CMRA (MaxPrefixList α) :=
-  Heap.instStoreCMRA (M := MaxPrefixListMap) (K := Nat) (V := Agree α)
+  Heap.instStoreCMRA (M:= MaxPrefixListMap) (V := Agree α)
 
 /-- UCMRA instance on [MaxPrefixList], inherited from the UCMRA on the underlying map. -/
 instance instUCMRA : UCMRA (MaxPrefixList α) :=
-  Heap.instStoreUCMRA (M := MaxPrefixListMap) (K := Nat) (V := Agree α)
+  Heap.instStoreUCMRA  (M:= MaxPrefixListMap) (V := Agree α)
 
 instance instCoreId (x : MaxPrefixList α) : CoreId x :=
-  Heap.instCoreId (M := MaxPrefixListMap) (K := Nat) (V := Agree α) (m := x)
+  Heap.instCoreId (M:= MaxPrefixListMap) (V := Agree α)
 
 instance instDiscrete [OFE.Discrete α] : CMRA.Discrete (MaxPrefixList α) where
   discrete_0 := OFE.discrete_0 (α := MaxPrefixListMap (Agree α))
@@ -76,7 +76,7 @@ theorem get?_ofListFrom {start i : Nat} {l : List α} :
 
 theorem get?_toMaxPrefixList {i : Nat} {l : List α} :
     get? (M := MaxPrefixListMap) (toMaxPrefixList l) i = l[i]?.map toAgree := by
-  simp [toMaxPrefixList, get?_ofListFrom]
+  grind [get?_ofListFrom, toMaxPrefixList]
 
 variable [OFE α]
 
@@ -112,35 +112,34 @@ theorem toMaxPrefixList_inj {l1 l2 : List α}
 
 /-! ## CMRA Properties -/
 
-@[rocq_alias to_max_prefix_list_valid]
+@[local grind ., rocq_alias to_max_prefix_list_valid]
 theorem toMaxPrefixList_valid (l : List α) : ✓ toMaxPrefixList l := fun i => by
   rw [get?_toMaxPrefixList]
   cases l[i]? with
   | none => trivial
   | some a => exact Agree.toAgree_valid
 
-@[rocq_alias to_max_prefix_list_validN]
+@[local grind ., rocq_alias to_max_prefix_list_validN]
 theorem toMaxPrefixList_validN {n} (l : List α) : ✓{n} toMaxPrefixList l :=
   (toMaxPrefixList_valid l).validN
 
-@[rocq_alias to_max_prefix_list_app]
+@[local grind =, rocq_alias to_max_prefix_list_app]
 theorem toMaxPrefixList_app (l1 l2 : List α) :
     toMaxPrefixList (l1 ++ l2) = toMaxPrefixList l1 • ofListFrom l1.length l2 := by
+  unfold MaxPrefixList
   refine LawfulPartialMap.equiv_iff_eq (M := MaxPrefixListMap).mp fun i => ?_
   rw [Heap.get?_op, get?_toMaxPrefixList, get?_toMaxPrefixList, get?_ofListFrom, List.getElem?_append]
-  by_cases hi : i < l1.length
-  · rw [if_pos hi, if_neg (by omega)]
-    cases l1[i]? <;> simp [op, optionOp]
-  · rw [if_neg hi, if_pos (by omega), List.getElem?_eq_none (by omega : l1.length ≤ i)]
-    cases l2[i - l1.length]? <;> simp [op, optionOp]
+  have op_none (x : Option (Agree α)) : x • none = x ∧ none • x = x :=
+    ⟨unit_right_id, unit_left_id⟩
+  grind
 
-@[rocq_alias to_max_prefix_list_op_l]
+@[local grind →, rocq_alias to_max_prefix_list_op_l]
 theorem toMaxPrefixList_op_left {l1 l2 : List α} (h : l1 <+: l2) :
     toMaxPrefixList l1 • toMaxPrefixList l2 = toMaxPrefixList l2 := by
   obtain ⟨l, rfl⟩ := h
-  rw [toMaxPrefixList_app, assoc', op_self]
+  grind [assoc', op_self]
 
-@[rocq_alias to_max_prefix_list_op_r]
+@[local grind →, rocq_alias to_max_prefix_list_op_r]
 theorem toMaxPrefixList_op_right {l1 l2 : List α} (h : l1 <+: l2) :
     toMaxPrefixList l2 • toMaxPrefixList l1 = toMaxPrefixList l2 :=
   comm'.trans (toMaxPrefixList_op_left h)
@@ -161,14 +160,11 @@ theorem toMaxPrefixList_incN_aux {n} {l1 l2 : List α}
   refine list_dist_lookup.mpr fun i => ?_
   have hi := Heap.lookup_incN (M := MaxPrefixListMap).mp h i
   rw [get?_toMaxPrefixList, get?_toMaxPrefixList] at hi
-  rw [List.getElem?_append]
   rcases Option.incN_iff_is_total.mp hi with hnone | ⟨a1, a2, ha1, ha2, ha⟩
-  · have hlen : l1.length ≤ i := List.getElem?_eq_none_iff.mp (by simpa using hnone)
-    refine .of_eq ?_
-    rw [if_neg (by omega), List.getElem?_drop, show l1.length + (i - l1.length) = i by omega]
+  · refine .of_eq (by grind)
   · obtain ⟨x1, hx1, rfl⟩ := Option.map_eq_some_iff.mp ha1
     obtain ⟨x2, hx2, rfl⟩ := Option.map_eq_some_iff.mp ha2
-    rw [hx2, if_pos (List.getElem?_eq_some_iff.mp hx1).1, hx1]
+    rw [List.getElem?_append, hx2, if_pos (List.getElem?_eq_some_iff.mp hx1).1, hx1]
     exact some_dist_some.mpr (Agree.toAgree_includedN.mp ha).symm
 
 @[rocq_alias to_max_prefix_list_includedN]
@@ -176,21 +172,16 @@ theorem toMaxPrefixList_incN_iff {n} {l1 l2 : List α} :
     toMaxPrefixList l1 ≼{n} toMaxPrefixList l2 ↔ ∃ l, l2 ≡{n}≡ l1 ++ l := by
   refine ⟨fun h => ⟨_, toMaxPrefixList_incN_aux h⟩, fun ⟨l, hl⟩ => ?_⟩
   refine incN_of_incN_of_dist ?_ (toMaxPrefixList_ne.ne hl).symm
-  rw [toMaxPrefixList_app]
-  exact incN_of_inc n (inc_op_left ..)
+  grind [incN_of_inc, inc_op_left]
 
 @[rocq_alias to_max_prefix_list_included]
 theorem toMaxPrefixList_inc_iff {l1 l2 : List α} :
-    toMaxPrefixList l1 ≼ toMaxPrefixList l2 ↔ ∃ l, l2 = l1 ++ l := by
-  refine ⟨fun h => ⟨_, eq_dist.mpr fun n => toMaxPrefixList_incN_aux (incN_of_inc n h)⟩, ?_⟩
-  rintro ⟨l, rfl⟩
-  rw [toMaxPrefixList_app]
-  exact inc_op_left ..
+    toMaxPrefixList l1 ≼ toMaxPrefixList l2 ↔ l1 <+: l2 := by
+  refine ⟨fun h => ⟨_, eq_dist.mpr fun n =>
+    (toMaxPrefixList_incN_aux (incN_of_inc n h)).symm⟩, ?_⟩
+  grind [inc_op_left]
 
-@[rocq_alias to_max_prefix_list_included_L]
-theorem toMaxPrefixList_inc_iff_prefix {l1 l2 : List α} :
-    toMaxPrefixList l1 ≼ toMaxPrefixList l2 ↔ l1 <+: l2 :=
-  toMaxPrefixList_inc_iff.trans (exists_congr fun _ => eq_comm)
+#rocq_ignore to_max_prefix_list_included_L "Use toMaxPrefixList_inc_iff"
 
 @[rocq_alias to_max_prefix_list_op_validN_aux]
 theorem toMaxPrefixList_op_validN_aux {n} {l1 l2 : List α} (hlen : l1.length ≤ l2.length)
@@ -202,21 +193,15 @@ theorem toMaxPrefixList_op_validN_aux {n} {l1 l2 : List α} (hlen : l1.length �
     exact h i
   rw [List.getElem?_append]
   cases h1 : l1[i]? with
-  | none =>
-    have hlen1 : l1.length ≤ i := List.getElem?_eq_none_iff.mp h1
-    refine .of_eq ?_
-    rw [if_neg (by omega), List.getElem?_drop, show l1.length + (i - l1.length) = i by omega]
+  | none => refine .of_eq (by grind)
   | some x1 =>
-    have hlt := (List.getElem?_eq_some_iff.mp h1).1
     cases h2 : l2[i]? with
-    | none =>
-      grind
+    | none => grind
     | some x2 =>
-      rw [if_pos hlt]
       rw [h1, h2] at hi
-      have hv : ✓{n} (toAgree x1 • toAgree x2) := by
-        simpa [op, optionOp, Option.some_validN] using hi
-      exact some_dist_some.mpr (Agree.toAgree_op_validN_iff_dist.mp hv).symm
+      rw [if_pos (List.getElem?_eq_some_iff.mp h1).1]
+      refine some_dist_some.mpr (Agree.toAgree_op_validN_iff_dist.mp ?_).symm
+      simpa [op, optionOp, Option.some_validN] using hi
 
 @[rocq_alias to_max_prefix_list_op_validN]
 theorem toMaxPrefixList_op_validN {n} {l1 l2 : List α} :
@@ -228,43 +213,28 @@ theorem toMaxPrefixList_op_validN {n} {l1 l2 : List α} :
     · exact .inr ⟨_, toMaxPrefixList_op_validN_aux (by omega) (comm'.dist.validN.mp h)⟩
   · rintro (⟨l, hl⟩ | ⟨l, hl⟩)
     · refine (Dist.validN (toMaxPrefixList_ne.ne hl).op_r).mpr ?_
-      rw [toMaxPrefixList_op_left (List.prefix_append ..)]
-      exact toMaxPrefixList_validN _
+      grind [List.prefix_append]
     · refine (Dist.validN (toMaxPrefixList_ne.ne hl).op_l).mpr ?_
-      rw [toMaxPrefixList_op_right (List.prefix_append ..)]
-      exact toMaxPrefixList_validN _
+      grind [List.prefix_append]
 
 @[rocq_alias to_max_prefix_list_op_valid]
 theorem toMaxPrefixList_op_valid {l1 l2 : List α} :
-    ✓ (toMaxPrefixList l1 • toMaxPrefixList l2)
-      ↔ (∃ l, l2 = l1 ++ l) ∨ (∃ l, l1 = l2 ++ l) := by
+    ✓ (toMaxPrefixList l1 • toMaxPrefixList l2) ↔ l1 <+: l2 ∨ l2 <+: l1 := by
   refine ⟨fun h => ?_, ?_⟩
   · by_cases hlen : l1.length ≤ l2.length
-    · exact .inl ⟨_, eq_dist.mpr fun n => toMaxPrefixList_op_validN_aux hlen h.validN⟩
+    · exact .inl ⟨_, eq_dist.mpr fun n => (toMaxPrefixList_op_validN_aux hlen h.validN).symm⟩
     · exact .inr ⟨_, eq_dist.mpr fun n =>
-        toMaxPrefixList_op_validN_aux (by omega) (comm'.dist.validN.mp h.validN)⟩
-  · rintro (⟨l, rfl⟩ | ⟨l, rfl⟩)
-    · rw [toMaxPrefixList_op_left (List.prefix_append ..)]
-      exact toMaxPrefixList_valid _
-    · rw [toMaxPrefixList_op_right (List.prefix_append ..)]
-      exact toMaxPrefixList_valid _
+        (toMaxPrefixList_op_validN_aux (by omega) (comm'.dist.validN.mp h.validN)).symm⟩
+  · rintro (⟨l, rfl⟩ | ⟨l, rfl⟩) <;> grind [List.prefix_append]
 
-@[rocq_alias to_max_prefix_list_op_valid_L]
-theorem toMaxPrefixList_op_valid_prefix {l1 l2 : List α} :
-    ✓ (toMaxPrefixList l1 • toMaxPrefixList l2) ↔ l1 <+: l2 ∨ l2 <+: l1 :=
-  toMaxPrefixList_op_valid.trans
-    (or_congr (exists_congr fun _ => eq_comm) (exists_congr fun _ => eq_comm))
+#rocq_ignore to_max_prefix_list_op_valid_L "Use toMaxPrefixList_op_valid"
 
 /-! ## Updates -/
 
 @[rocq_alias max_prefix_list_local_update]
 theorem local_update {l1 l2 : List α} (h : l1 <+: l2) :
     (toMaxPrefixList l1, toMaxPrefixList l1) ~l~> (toMaxPrefixList l2, toMaxPrefixList l2) := by
-  obtain ⟨l, rfl⟩ := h
-  rw [toMaxPrefixList_app, comm' (x := toMaxPrefixList l1)]
-  refine LocalUpdate.op fun n _ => ?_
-  rw [comm', ← toMaxPrefixList_app]
-  exact toMaxPrefixList_validN _
+  grind [LocalUpdate.op, comm']
 
 end MaxPrefixList
 

--- a/Iris/Iris/Algebra/MaxPrefixList.lean
+++ b/Iris/Iris/Algebra/MaxPrefixList.lean
@@ -31,9 +31,9 @@ namespace Iris
 
 open OFE CMRA Std
 
-/-- The extensional finite map from list indices to agreed-upon elements underlying
-`MaxPrefixList`. Naming the map *functor* (rather than its application) keeps the value type in
-last position, so `?M ?V` unifies against it correctly. -/
+-- Named as a *functor* rather than an application so that the value type stays in last
+-- position: `?M ?V` then unifies against `MaxPrefixListMap (Agree α)` correctly.
+/-- The extensional finite map from list indices to agreed-upon elements. -/
 abbrev MaxPrefixListMap : Type _ → Type _ := (Std.ExtTreeMap Nat · compare)
 
 @[rocq_alias max_prefix_list, rocq_alias max_prefix_listR, rocq_alias max_prefix_listUR]
@@ -47,7 +47,7 @@ variable {α β : Type _}
 
 theorem toMap_inj {x y : MaxPrefixList α} (h : x.toMap = y.toMap) : x = y := congrArg ofMap h
 
-/-! ## Algebraic structure, transported from the underlying map -/
+/-! ## Algebraic structure, inherited from the underlying map -/
 
 section Instances
 
@@ -59,19 +59,18 @@ instance : OFE (MaxPrefixList α) where
   eq_dist := ⟨fun h _ => h ▸ .rfl, fun h => toMap_inj (eq_dist.mpr h)⟩
   dist_lt h hlt := h.lt hlt
 
-@[simp] theorem dist_toMap {n} {x y : MaxPrefixList α} :
+@[local simp] theorem dist_toMap {n} {x y : MaxPrefixList α} :
     x ≡{n}≡ y ↔ x.toMap ≡{n}≡ y.toMap := .rfl
 
+-- Every `Agree` element is its own core, so the core here is the identity; `pcore_toMap`
+-- records that this agrees with the core of the underlying map.
 instance : CMRA (MaxPrefixList α) where
-  pcore x := (CMRA.pcore x.toMap).map ofMap
+  pcore x := some x
   op x y := ofMap (x.toMap • y.toMap)
   ValidN n x := ✓{n} x.toMap
   Valid x := ✓ x.toMap
   op_ne.ne _ _ _ h := dist_toMap.mpr (CMRA.op_ne.ne h)
-  pcore_ne hd hcx := by
-    obtain ⟨m, hm, rfl⟩ := Option.map_eq_some_iff.mp hcx
-    obtain ⟨cy, hcy, hd'⟩ := CMRA.pcore_ne hd hm
-    exact ⟨ofMap cy, by simp [hcy], hd'⟩
+  pcore_ne hd hcx := ⟨_, rfl, Option.some.inj hcx ▸ hd⟩
   validN_ne hd hv := CMRA.validN_ne hd hv
   valid_iff_validN := CMRA.valid_iff_validN
   validN_succ := CMRA.validN_succ
@@ -79,39 +78,46 @@ instance : CMRA (MaxPrefixList α) where
   assoc := toMap_inj CMRA.assoc
   comm := toMap_inj CMRA.comm
   pcore_op_left hcx := by
-    obtain ⟨m, hm, rfl⟩ := Option.map_eq_some_iff.mp hcx
-    exact toMap_inj (CMRA.pcore_op_left hm)
-  pcore_idem hcx := by
-    obtain ⟨m, hm, rfl⟩ := Option.map_eq_some_iff.mp hcx
-    simp [CMRA.pcore_idem hm]
+    obtain rfl := Option.some.inj hcx
+    exact toMap_inj (op_self _)
+  pcore_idem _ := rfl
   pcore_op_mono hcx y := by
-    obtain ⟨m, hm, rfl⟩ := Option.map_eq_some_iff.mp hcx
-    obtain ⟨cy, hcy⟩ := CMRA.pcore_op_mono hm y.toMap
-    exact ⟨ofMap cy, by simp [hcy]⟩
+    obtain rfl := Option.some.inj hcx
+    exact ⟨y, rfl⟩
   extend hv hd := by
     obtain ⟨m₁, m₂, heq, h₁, h₂⟩ := CMRA.extend hv hd
     exact ⟨ofMap m₁, ofMap m₂, toMap_inj heq, h₁, h₂⟩
 
-@[simp] theorem toMap_op (x y : MaxPrefixList α) : (x • y).toMap = x.toMap • y.toMap := rfl
-@[simp] theorem pcore_toMap (x : MaxPrefixList α) : pcore x = (pcore x.toMap).map ofMap := rfl
-@[simp] theorem validN_toMap {n} {x : MaxPrefixList α} : ✓{n} x ↔ ✓{n} x.toMap := .rfl
-@[simp] theorem valid_toMap {x : MaxPrefixList α} : ✓ x ↔ ✓ x.toMap := .rfl
+@[local simp] theorem toMap_op (x y : MaxPrefixList α) :
+    (x • y).toMap = x.toMap • y.toMap := rfl
+@[local simp] theorem pcore_eq_some (x : MaxPrefixList α) : pcore x = some x := rfl
+@[local simp] theorem validN_toMap {n} {x : MaxPrefixList α} : ✓{n} x ↔ ✓{n} x.toMap := .rfl
+@[local simp] theorem valid_toMap {x : MaxPrefixList α} : ✓ x ↔ ✓ x.toMap := .rfl
+
+/-- The core agrees with the core of the underlying map. -/
+theorem pcore_toMap (x : MaxPrefixList α) : pcore x = (pcore x.toMap).map ofMap := by
+  simp [core_id (x := x.toMap)]
 
 instance : UCMRA (MaxPrefixList α) where
   unit := ofMap UCMRA.unit
   unit_valid := valid_toMap.mpr UCMRA.unit_valid
   unit_left_id := toMap_inj UCMRA.unit_left_id
-  pcore_unit := by simp [UCMRA.pcore_unit]
+  pcore_unit := rfl
 
 -- Rocq calls this `mono_list_lb_core_id`, a name `mono_list.v` reuses for the fragment; the
 -- alias is attached there, on `MonoList.instCoreIdLb`.
 instance (x : MaxPrefixList α) : CoreId x where
-  core_id := by simp [core_id (x := x.toMap)]
+  core_id := rfl
 
-@[simp] theorem incN_toMap {n} {x y : MaxPrefixList α} : x ≼{n} y ↔ x.toMap ≼{n} y.toMap :=
+instance [OFE.Discrete α] : CMRA.Discrete (MaxPrefixList α) where
+  discrete_0 h := toMap_inj (OFE.discrete_0 h)
+  discrete_valid := CMRA.discrete_valid (α := MaxPrefixListMap (Agree α))
+
+@[local simp] theorem incN_toMap {n} {x y : MaxPrefixList α} :
+    x ≼{n} y ↔ x.toMap ≼{n} y.toMap :=
   ⟨fun ⟨z, h⟩ => ⟨z.toMap, h⟩, fun ⟨m, h⟩ => ⟨ofMap m, h⟩⟩
 
-@[simp] theorem inc_toMap {x y : MaxPrefixList α} : x ≼ y ↔ x.toMap ≼ y.toMap :=
+@[local simp] theorem inc_toMap {x y : MaxPrefixList α} : x ≼ y ↔ x.toMap ≼ y.toMap :=
   ⟨fun ⟨z, h⟩ => ⟨z.toMap, congrArg toMap h⟩,
    fun ⟨m, h⟩ => ⟨ofMap m, toMap_inj h⟩⟩
 
@@ -121,13 +127,10 @@ def homLift [OFE β] (f : MaxPrefixListMap (Agree α) -C> MaxPrefixListMap (Agre
   f x := ofMap (f x.toMap)
   ne.ne _ _ _ h := dist_toMap.mpr (f.ne.ne h)
   validN := f.validN
-  pcore x := by
-    show Option.map _ ((CMRA.pcore x.toMap).map ofMap) = (CMRA.pcore (f x.toMap)).map ofMap
-    rw [← f.pcore x.toMap]
-    cases CMRA.pcore x.toMap <;> rfl
+  pcore _ := rfl
   op x y := toMap_inj (f.op x.toMap y.toMap)
 
-@[simp] theorem toMap_homLift [OFE β]
+@[local simp] theorem toMap_homLift [OFE β]
     (f : MaxPrefixListMap (Agree α) -C> MaxPrefixListMap (Agree β)) (x : MaxPrefixList α) :
     (homLift f x).toMap = f x.toMap := rfl
 
@@ -135,21 +138,28 @@ end Instances
 
 /-! ## The canonical embedding of lists -/
 
-@[rocq_alias to_max_prefix_list]
-def toMaxPrefixList (l : List α) : MaxPrefixList α :=
-  ofMap (Std.PartialMap.map toAgree (FiniteMap.map_seq 0 l))
+/-- `l`, agreed upon and placed at the indices `start`, `start + 1`, … -/
+def ofListFrom (start : Nat) (l : List α) : MaxPrefixList α :=
+  ofMap (Std.PartialMap.map toAgree (FiniteMap.map_seq start l))
 
-/-- Lookup in the tail segment of a list, as it appears on the right of `toMaxPrefixList_app`. -/
-private theorem get?_agree_map_seq {start i : Nat} {l : List α} :
-    get? (Std.PartialMap.map (M := MaxPrefixListMap) toAgree (FiniteMap.map_seq start l)) i
+@[rocq_alias to_max_prefix_list]
+def toMaxPrefixList (l : List α) : MaxPrefixList α := ofListFrom 0 l
+
+theorem get?_ofListFrom {start i : Nat} {l : List α} :
+    get? (ofListFrom start l).toMap i
       = (if start ≤ i then l[i - start]? else none).map toAgree := by
-  rw [LawfulPartialMap.get?_map, LawfulFiniteMap.get?_map_seq]
+  rw [ofListFrom, LawfulPartialMap.get?_map, LawfulFiniteMap.get?_map_seq]
 
 theorem get?_toMaxPrefixList {i : Nat} {l : List α} :
     get? (toMaxPrefixList l).toMap i = l[i]?.map toAgree := by
-  simp [toMaxPrefixList, get?_agree_map_seq]
+  simp [toMaxPrefixList, get?_ofListFrom]
 
 variable [OFE α]
+
+theorem toMaxPrefixList_nil : toMaxPrefixList ([] : List α) = UCMRA.unit := by
+  refine toMap_inj (LawfulPartialMap.equiv_iff_eq.mp fun i => ?_)
+  rw [get?_toMaxPrefixList, List.getElem?_nil]
+  exact (LawfulPartialMap.get?_empty i).symm
 
 /-! ## Setoid properties -/
 
@@ -192,10 +202,9 @@ theorem toMaxPrefixList_validN {n} (l : List α) : ✓{n} toMaxPrefixList l :=
 
 @[rocq_alias to_max_prefix_list_app]
 theorem toMaxPrefixList_app (l1 l2 : List α) :
-    toMaxPrefixList (l1 ++ l2) = toMaxPrefixList l1
-      • ofMap (Std.PartialMap.map toAgree (FiniteMap.map_seq l1.length l2)) := by
+    toMaxPrefixList (l1 ++ l2) = toMaxPrefixList l1 • ofListFrom l1.length l2 := by
   refine toMap_inj (LawfulPartialMap.equiv_iff_eq.mp fun i => ?_)
-  rw [toMap_op, Heap.get?_op, get?_toMaxPrefixList, get?_toMaxPrefixList, get?_agree_map_seq,
+  rw [toMap_op, Heap.get?_op, get?_toMaxPrefixList, get?_toMaxPrefixList, get?_ofListFrom,
     List.getElem?_append]
   by_cases hi : i < l1.length
   · rw [if_pos hi, if_neg (by omega)]

--- a/Iris/Iris/Algebra/MaxPrefixList.lean
+++ b/Iris/Iris/Algebra/MaxPrefixList.lean
@@ -1,0 +1,372 @@
+/-
+Copyright (c) 2026. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
+module
+
+public import Iris.Algebra.Agree
+public import Iris.Algebra.Heap
+public import Iris.Algebra.List
+public import Iris.Algebra.LocalUpdates
+public import Iris.Std.HeapInstances
+meta import Iris.Std.RocqPorting
+
+/-!
+# Max prefix lists
+
+An RA on lists whose composition is only defined when one operand is a prefix of the other,
+in which case the result is the longer list. The core is the identity function for all elements.
+
+A list is represented as a finite map from indices to agreed-upon elements, so that composition
+is map union with `Agree` forcing the operands to agree on their common indices. `MaxPrefixList`
+wraps that map in a single-field structure, which keeps it a type constructor in its own right:
+the map instances in `Iris.Algebra.Heap` are stated for `M V`, so a bare type synonym would leave
+instance synthesis unifying `?M ?V` against it and picking the wrong first-order solution.
+-/
+
+@[expose] public section
+
+namespace Iris
+
+open OFE CMRA Std
+
+/-- The extensional finite map from list indices to agreed-upon elements underlying
+`MaxPrefixList`. Naming the map *functor* (rather than its application) keeps the value type in
+last position, so `?M ?V` unifies against it correctly. -/
+abbrev MaxPrefixListMap : Type _ → Type _ := (Std.ExtTreeMap Nat · compare)
+
+@[rocq_alias max_prefix_list, rocq_alias max_prefix_listR, rocq_alias max_prefix_listUR]
+structure MaxPrefixList (α : Type _) where
+  ofMap ::
+  toMap : MaxPrefixListMap (Agree α)
+
+namespace MaxPrefixList
+
+variable {α β : Type _}
+
+theorem toMap_inj {x y : MaxPrefixList α} (h : x.toMap = y.toMap) : x = y := congrArg ofMap h
+
+/-! ## Algebraic structure, transported from the underlying map -/
+
+section Instances
+
+variable [OFE α]
+
+instance : OFE (MaxPrefixList α) where
+  Dist n x y := x.toMap ≡{n}≡ y.toMap
+  dist_eqv := ⟨fun _ => .rfl, (·.symm), (·.trans ·)⟩
+  eq_dist := ⟨fun h _ => h ▸ .rfl, fun h => toMap_inj (eq_dist.mpr h)⟩
+  dist_lt h hlt := h.lt hlt
+
+@[simp] theorem dist_toMap {n} {x y : MaxPrefixList α} :
+    x ≡{n}≡ y ↔ x.toMap ≡{n}≡ y.toMap := .rfl
+
+instance : CMRA (MaxPrefixList α) where
+  pcore x := (CMRA.pcore x.toMap).map ofMap
+  op x y := ofMap (x.toMap • y.toMap)
+  ValidN n x := ✓{n} x.toMap
+  Valid x := ✓ x.toMap
+  op_ne.ne _ _ _ h := dist_toMap.mpr (CMRA.op_ne.ne h)
+  pcore_ne hd hcx := by
+    obtain ⟨m, hm, rfl⟩ := Option.map_eq_some_iff.mp hcx
+    obtain ⟨cy, hcy, hd'⟩ := CMRA.pcore_ne hd hm
+    exact ⟨ofMap cy, by simp [hcy], hd'⟩
+  validN_ne hd hv := CMRA.validN_ne hd hv
+  valid_iff_validN := CMRA.valid_iff_validN
+  validN_succ := CMRA.validN_succ
+  validN_op_left := CMRA.validN_op_left
+  assoc := toMap_inj CMRA.assoc
+  comm := toMap_inj CMRA.comm
+  pcore_op_left hcx := by
+    obtain ⟨m, hm, rfl⟩ := Option.map_eq_some_iff.mp hcx
+    exact toMap_inj (CMRA.pcore_op_left hm)
+  pcore_idem hcx := by
+    obtain ⟨m, hm, rfl⟩ := Option.map_eq_some_iff.mp hcx
+    simp [CMRA.pcore_idem hm]
+  pcore_op_mono hcx y := by
+    obtain ⟨m, hm, rfl⟩ := Option.map_eq_some_iff.mp hcx
+    obtain ⟨cy, hcy⟩ := CMRA.pcore_op_mono hm y.toMap
+    exact ⟨ofMap cy, by simp [hcy]⟩
+  extend hv hd := by
+    obtain ⟨m₁, m₂, heq, h₁, h₂⟩ := CMRA.extend hv hd
+    exact ⟨ofMap m₁, ofMap m₂, toMap_inj heq, h₁, h₂⟩
+
+@[simp] theorem toMap_op (x y : MaxPrefixList α) : (x • y).toMap = x.toMap • y.toMap := rfl
+@[simp] theorem pcore_toMap (x : MaxPrefixList α) : pcore x = (pcore x.toMap).map ofMap := rfl
+@[simp] theorem validN_toMap {n} {x : MaxPrefixList α} : ✓{n} x ↔ ✓{n} x.toMap := .rfl
+@[simp] theorem valid_toMap {x : MaxPrefixList α} : ✓ x ↔ ✓ x.toMap := .rfl
+
+instance : UCMRA (MaxPrefixList α) where
+  unit := ofMap UCMRA.unit
+  unit_valid := valid_toMap.mpr UCMRA.unit_valid
+  unit_left_id := toMap_inj UCMRA.unit_left_id
+  pcore_unit := by simp [UCMRA.pcore_unit]
+
+-- Rocq calls this `mono_list_lb_core_id`, a name `mono_list.v` reuses for the fragment; the
+-- alias is attached there, on `MonoList.instCoreIdLb`.
+instance (x : MaxPrefixList α) : CoreId x where
+  core_id := by simp [core_id (x := x.toMap)]
+
+@[simp] theorem incN_toMap {n} {x y : MaxPrefixList α} : x ≼{n} y ↔ x.toMap ≼{n} y.toMap :=
+  ⟨fun ⟨z, h⟩ => ⟨z.toMap, h⟩, fun ⟨m, h⟩ => ⟨ofMap m, h⟩⟩
+
+@[simp] theorem inc_toMap {x y : MaxPrefixList α} : x ≼ y ↔ x.toMap ≼ y.toMap :=
+  ⟨fun ⟨z, h⟩ => ⟨z.toMap, congrArg toMap h⟩,
+   fun ⟨m, h⟩ => ⟨ofMap m, toMap_inj h⟩⟩
+
+/-- Lift a CMRA homomorphism between the underlying maps to one between `MaxPrefixList`s. -/
+def homLift [OFE β] (f : MaxPrefixListMap (Agree α) -C> MaxPrefixListMap (Agree β)) :
+    MaxPrefixList α -C> MaxPrefixList β where
+  f x := ofMap (f x.toMap)
+  ne.ne _ _ _ h := dist_toMap.mpr (f.ne.ne h)
+  validN := f.validN
+  pcore x := by
+    show Option.map _ ((CMRA.pcore x.toMap).map ofMap) = (CMRA.pcore (f x.toMap)).map ofMap
+    rw [← f.pcore x.toMap]
+    cases CMRA.pcore x.toMap <;> rfl
+  op x y := toMap_inj (f.op x.toMap y.toMap)
+
+@[simp] theorem toMap_homLift [OFE β]
+    (f : MaxPrefixListMap (Agree α) -C> MaxPrefixListMap (Agree β)) (x : MaxPrefixList α) :
+    (homLift f x).toMap = f x.toMap := rfl
+
+end Instances
+
+/-! ## The canonical embedding of lists -/
+
+@[rocq_alias to_max_prefix_list]
+def toMaxPrefixList (l : List α) : MaxPrefixList α :=
+  ofMap (Std.PartialMap.map toAgree (FiniteMap.map_seq 0 l))
+
+/-- Lookup in the tail segment of a list, as it appears on the right of `toMaxPrefixList_app`. -/
+private theorem get?_agree_map_seq {start i : Nat} {l : List α} :
+    get? (Std.PartialMap.map (M := MaxPrefixListMap) toAgree (FiniteMap.map_seq start l)) i
+      = (if start ≤ i then l[i - start]? else none).map toAgree := by
+  rw [LawfulPartialMap.get?_map, LawfulFiniteMap.get?_map_seq]
+
+theorem get?_toMaxPrefixList {i : Nat} {l : List α} :
+    get? (toMaxPrefixList l).toMap i = l[i]?.map toAgree := by
+  simp [toMaxPrefixList, get?_agree_map_seq]
+
+variable [OFE α]
+
+/-! ## Setoid properties -/
+
+@[rocq_alias to_max_prefix_list_ne]
+instance toMaxPrefixList_ne : NonExpansive (toMaxPrefixList (α := α)) where
+  ne _ _ _ h i := by
+    rw [get?_toMaxPrefixList, get?_toMaxPrefixList]
+    exact Option.map_ne (fun _ _ hd => NonExpansive.ne hd) (list_dist_lookup.mp h i)
+
+#rocq_ignore to_max_prefix_list_proper "OFE is Leibniz; use equality"
+
+@[rocq_alias to_max_prefix_list_dist_inj]
+theorem toMaxPrefixList_dist_inj {n} {l1 l2 : List α}
+    (h : toMaxPrefixList l1 ≡{n}≡ toMaxPrefixList l2) : l1 ≡{n}≡ l2 := by
+  refine list_dist_lookup.mpr fun i => ?_
+  have hi := h i
+  rw [get?_toMaxPrefixList, get?_toMaxPrefixList] at hi
+  cases h1 : l1[i]? <;> cases h2 : l2[i]? <;> rw [h1, h2] at hi <;> simp_all
+  exact Agree.toAgree_injN hi
+
+@[rocq_alias to_max_prefix_list_inj]
+theorem toMaxPrefixList_inj {l1 l2 : List α}
+    (h : toMaxPrefixList l1 = toMaxPrefixList l2) : l1 = l2 :=
+  eq_dist.mpr fun _ => toMaxPrefixList_dist_inj (Dist.of_eq h)
+
+/-! ## Validity -/
+
+@[rocq_alias to_max_prefix_list_valid]
+theorem toMaxPrefixList_valid (l : List α) : ✓ toMaxPrefixList l := fun i => by
+  rw [get?_toMaxPrefixList]
+  cases l[i]? with
+  | none => trivial
+  | some a => exact Agree.toAgree_valid
+
+@[rocq_alias to_max_prefix_list_validN]
+theorem toMaxPrefixList_validN {n} (l : List α) : ✓{n} toMaxPrefixList l :=
+  (toMaxPrefixList_valid l).validN
+
+/-! ## Operation -/
+
+@[rocq_alias to_max_prefix_list_app]
+theorem toMaxPrefixList_app (l1 l2 : List α) :
+    toMaxPrefixList (l1 ++ l2) = toMaxPrefixList l1
+      • ofMap (Std.PartialMap.map toAgree (FiniteMap.map_seq l1.length l2)) := by
+  refine toMap_inj (LawfulPartialMap.equiv_iff_eq.mp fun i => ?_)
+  rw [toMap_op, Heap.get?_op, get?_toMaxPrefixList, get?_toMaxPrefixList, get?_agree_map_seq,
+    List.getElem?_append]
+  by_cases hi : i < l1.length
+  · rw [if_pos hi, if_neg (by omega)]
+    cases l1[i]? <;> simp [op, optionOp]
+  · rw [if_neg hi, if_pos (by omega), List.getElem?_eq_none (by omega : l1.length ≤ i)]
+    cases l2[i - l1.length]? <;> simp [op, optionOp]
+
+@[rocq_alias to_max_prefix_list_op_l]
+theorem toMaxPrefixList_op_left {l1 l2 : List α} (h : l1 <+: l2) :
+    toMaxPrefixList l1 • toMaxPrefixList l2 = toMaxPrefixList l2 := by
+  obtain ⟨l, rfl⟩ := h
+  rw [toMaxPrefixList_app, assoc', op_self]
+
+@[rocq_alias to_max_prefix_list_op_r]
+theorem toMaxPrefixList_op_right {l1 l2 : List α} (h : l1 <+: l2) :
+    toMaxPrefixList l2 • toMaxPrefixList l1 = toMaxPrefixList l2 :=
+  comm'.trans (toMaxPrefixList_op_left h)
+
+/-! ## Inclusion -/
+
+@[rocq_alias max_prefix_list_included_includedN]
+theorem inc_iff_forall_incN {ml1 ml2 : MaxPrefixList α} :
+    ml1 ≼ ml2 ↔ ∀ n, ml1 ≼{n} ml2 := by
+  refine ⟨fun h n => incN_of_inc n h, fun h => ⟨ml2, eq_dist.mpr fun n => ?_⟩⟩
+  obtain ⟨l, hl⟩ := h n
+  calc ml2 ≡{n}≡ ml1 • l := hl
+    _ ≡{n}≡ (ml1 • ml1) • l := (congrArg (· • l) (op_self ml1)).symm.dist
+    _ ≡{n}≡ ml1 • (ml1 • l) := assoc'.symm.dist
+    _ ≡{n}≡ ml1 • ml2 := hl.symm.op_r
+
+@[rocq_alias to_max_prefix_list_includedN_aux]
+theorem toMaxPrefixList_incN_aux {n} {l1 l2 : List α}
+    (h : toMaxPrefixList l1 ≼{n} toMaxPrefixList l2) : l2 ≡{n}≡ l1 ++ l2.drop l1.length := by
+  refine list_dist_lookup.mpr fun i => ?_
+  have hi := Heap.lookup_incN.mp (incN_toMap.mp h) i
+  rw [get?_toMaxPrefixList, get?_toMaxPrefixList] at hi
+  rw [List.getElem?_append]
+  rcases Option.incN_iff_is_total.mp hi with hnone | ⟨a1, a2, ha1, ha2, ha⟩
+  · have hlen : l1.length ≤ i := List.getElem?_eq_none_iff.mp (by simpa using hnone)
+    refine .of_eq ?_
+    rw [if_neg (by omega), List.getElem?_drop, show l1.length + (i - l1.length) = i by omega]
+  · obtain ⟨x1, hx1, rfl⟩ := Option.map_eq_some_iff.mp ha1
+    obtain ⟨x2, hx2, rfl⟩ := Option.map_eq_some_iff.mp ha2
+    rw [hx2, if_pos (List.getElem?_eq_some_iff.mp hx1).1, hx1]
+    exact some_dist_some.mpr (Agree.toAgree_includedN.mp ha).symm
+
+@[rocq_alias to_max_prefix_list_includedN]
+theorem toMaxPrefixList_incN_iff {n} {l1 l2 : List α} :
+    toMaxPrefixList l1 ≼{n} toMaxPrefixList l2 ↔ ∃ l, l2 ≡{n}≡ l1 ++ l := by
+  refine ⟨fun h => ⟨_, toMaxPrefixList_incN_aux h⟩, fun ⟨l, hl⟩ => ?_⟩
+  refine incN_of_incN_of_dist ?_ (toMaxPrefixList_ne.ne hl).symm
+  rw [toMaxPrefixList_app]
+  exact incN_of_inc n (inc_op_left ..)
+
+@[rocq_alias to_max_prefix_list_included]
+theorem toMaxPrefixList_inc_iff {l1 l2 : List α} :
+    toMaxPrefixList l1 ≼ toMaxPrefixList l2 ↔ ∃ l, l2 = l1 ++ l := by
+  refine ⟨fun h => ⟨_, eq_dist.mpr fun n => toMaxPrefixList_incN_aux (incN_of_inc n h)⟩, ?_⟩
+  rintro ⟨l, rfl⟩
+  rw [toMaxPrefixList_app]
+  exact inc_op_left ..
+
+@[rocq_alias to_max_prefix_list_included_L]
+theorem toMaxPrefixList_inc_iff_prefix {l1 l2 : List α} :
+    toMaxPrefixList l1 ≼ toMaxPrefixList l2 ↔ l1 <+: l2 :=
+  toMaxPrefixList_inc_iff.trans (exists_congr fun _ => eq_comm)
+
+/-! ## Validity of compositions -/
+
+@[rocq_alias to_max_prefix_list_op_validN_aux]
+theorem toMaxPrefixList_op_validN_aux {n} {l1 l2 : List α} (hlen : l1.length ≤ l2.length)
+    (h : ✓{n} (toMaxPrefixList l1 • toMaxPrefixList l2)) :
+    l2 ≡{n}≡ l1 ++ l2.drop l1.length := by
+  refine list_dist_lookup.mpr fun i => ?_
+  have hi := validN_toMap.mp h i
+  rw [toMap_op, Heap.get?_op, get?_toMaxPrefixList, get?_toMaxPrefixList] at hi
+  rw [List.getElem?_append]
+  cases h1 : l1[i]? with
+  | none =>
+    have hlen1 : l1.length ≤ i := List.getElem?_eq_none_iff.mp h1
+    refine .of_eq ?_
+    rw [if_neg (by omega), List.getElem?_drop, show l1.length + (i - l1.length) = i by omega]
+  | some x1 =>
+    have hlt := (List.getElem?_eq_some_iff.mp h1).1
+    cases h2 : l2[i]? with
+    | none => exact absurd (List.getElem?_eq_none_iff.mp h2) (by omega)
+    | some x2 =>
+      rw [if_pos hlt]
+      rw [h1, h2] at hi
+      have hv : ✓{n} (toAgree x1 • toAgree x2) := by
+        simpa [op, optionOp, Option.some_validN] using hi
+      exact some_dist_some.mpr (Agree.toAgree_op_validN_iff_dist.mp hv).symm
+
+@[rocq_alias to_max_prefix_list_op_validN]
+theorem toMaxPrefixList_op_validN {n} {l1 l2 : List α} :
+    ✓{n} (toMaxPrefixList l1 • toMaxPrefixList l2)
+      ↔ (∃ l, l2 ≡{n}≡ l1 ++ l) ∨ (∃ l, l1 ≡{n}≡ l2 ++ l) := by
+  refine ⟨fun h => ?_, ?_⟩
+  · by_cases hlen : l1.length ≤ l2.length
+    · exact .inl ⟨_, toMaxPrefixList_op_validN_aux hlen h⟩
+    · exact .inr ⟨_, toMaxPrefixList_op_validN_aux (by omega) (comm'.dist.validN.mp h)⟩
+  · rintro (⟨l, hl⟩ | ⟨l, hl⟩)
+    · refine (Dist.validN (toMaxPrefixList_ne.ne hl).op_r).mpr ?_
+      rw [toMaxPrefixList_op_left (List.prefix_append ..)]
+      exact toMaxPrefixList_validN _
+    · refine (Dist.validN (toMaxPrefixList_ne.ne hl).op_l).mpr ?_
+      rw [toMaxPrefixList_op_right (List.prefix_append ..)]
+      exact toMaxPrefixList_validN _
+
+@[rocq_alias to_max_prefix_list_op_valid]
+theorem toMaxPrefixList_op_valid {l1 l2 : List α} :
+    ✓ (toMaxPrefixList l1 • toMaxPrefixList l2)
+      ↔ (∃ l, l2 = l1 ++ l) ∨ (∃ l, l1 = l2 ++ l) := by
+  refine ⟨fun h => ?_, ?_⟩
+  · by_cases hlen : l1.length ≤ l2.length
+    · exact .inl ⟨_, eq_dist.mpr fun n => toMaxPrefixList_op_validN_aux hlen h.validN⟩
+    · exact .inr ⟨_, eq_dist.mpr fun n =>
+        toMaxPrefixList_op_validN_aux (by omega) (comm'.dist.validN.mp h.validN)⟩
+  · rintro (⟨l, rfl⟩ | ⟨l, rfl⟩)
+    · rw [toMaxPrefixList_op_left (List.prefix_append ..)]
+      exact toMaxPrefixList_valid _
+    · rw [toMaxPrefixList_op_right (List.prefix_append ..)]
+      exact toMaxPrefixList_valid _
+
+@[rocq_alias to_max_prefix_list_op_valid_L]
+theorem toMaxPrefixList_op_valid_prefix {l1 l2 : List α} :
+    ✓ (toMaxPrefixList l1 • toMaxPrefixList l2) ↔ l1 <+: l2 ∨ l2 <+: l1 :=
+  toMaxPrefixList_op_valid.trans
+    (or_congr (exists_congr fun _ => eq_comm) (exists_congr fun _ => eq_comm))
+
+/-! ## Local updates -/
+
+@[rocq_alias max_prefix_list_local_update]
+theorem local_update {l1 l2 : List α} (h : l1 <+: l2) :
+    (toMaxPrefixList l1, toMaxPrefixList l1) ~l~> (toMaxPrefixList l2, toMaxPrefixList l2) := by
+  obtain ⟨l, rfl⟩ := h
+  rw [toMaxPrefixList_app, comm' (x := toMaxPrefixList l1)]
+  refine LocalUpdate.op fun n _ => ?_
+  rw [comm', ← toMaxPrefixList_app]
+  exact toMaxPrefixList_validN _
+
+end MaxPrefixList
+
+/-! ## Functors -/
+
+open MaxPrefixList
+
+@[rocq_alias max_prefix_listURF]
+abbrev MaxPrefixListURF (F : COFE.OFunctorPre) : COFE.OFunctorPre :=
+  fun A B _ _ => MaxPrefixList (F A B)
+
+/-- The underlying map functor that `MaxPrefixListURF` wraps. -/
+abbrev MaxPrefixListMapOF (F : COFE.OFunctorPre) : COFE.OFunctorPre :=
+  PartialMap.PartialMapOF MaxPrefixListMap (AgreeRF F)
+
+instance {F} [COFE.OFunctor F] : URFunctor (MaxPrefixListURF F) where
+  map f g := homLift (URFunctor.map (F := MaxPrefixListMapOF F) f g)
+  map_ne.ne _ _ _ hf _ _ hg x :=
+    dist_toMap.mpr ((URFunctor.map_ne (F := MaxPrefixListMapOF F)).ne hf hg x.toMap)
+  map_id x := toMap_inj (URFunctor.map_id (F := MaxPrefixListMapOF F) x.toMap)
+  map_comp f g f' g' x :=
+    toMap_inj (URFunctor.map_comp (F := MaxPrefixListMapOF F) f g f' g' x.toMap)
+
+@[rocq_alias max_prefix_listURF_contractive]
+instance {F} [COFE.OFunctorContractive F] : URFunctorContractive (MaxPrefixListURF F) where
+  map_contractive.1 h x := dist_toMap.mpr
+    ((URFunctorContractive.map_contractive (F := MaxPrefixListMapOF F)).1 h x.toMap)
+
+@[rocq_alias max_prefix_listRF]
+abbrev MaxPrefixListRF (F : COFE.OFunctorPre) : COFE.OFunctorPre := MaxPrefixListURF F
+
+#rocq_ignore max_prefix_listRF_contractive "Found by typeclass inference"
+
+end Iris

--- a/Iris/Iris/BI/Lib.lean
+++ b/Iris/Iris/BI/Lib.lean
@@ -7,5 +7,6 @@ public import Iris.BI.Lib.FixpointBanach
 public import Iris.BI.Lib.Fractional
 public import Iris.BI.Lib.GenHeap
 public import Iris.BI.Lib.Laterable
+public import Iris.BI.Lib.MonoList
 public import Iris.BI.Lib.MonoNat
 public import Iris.BI.Lib.ProphMap

--- a/Iris/Iris/BI/Lib/MonoList.lean
+++ b/Iris/Iris/BI/Lib/MonoList.lean
@@ -18,10 +18,6 @@ Wraps the `MonoList` RA, providing three assertions:
 - an authoritative proposition `γ ↪●ML{dq} l` for the authoritative list `l`;
 - a persistent assertion `γ ↪◯ML l` witnessing that the authoritative list is at least `l`;
 - a persistent assertion `γ ↪◯ML[i] a` witnessing that index `i` holds `a`.
-
-The key rules are `auth_lb_own_valid`, which asserts that an auth at `l` and a lower bound at
-`l'` imply `l' <+: l`, and `auth_own_update`, which grows the auth element by appending only. At
-any time the auth list can be snapshotted with `lb_own_get` to produce a persistent lower bound.
 -/
 
 @[expose] public section
@@ -43,11 +39,7 @@ namespace MonoList
 
 variable {GF : BundledGFunctors} {α : Type _} [MonoListG GF α]
 
-/-! ## Reflecting `DiscreteO` through lists
-
-Rocq indexes the RA by `leibnizO A`; here the discrete OFE on `α` is `DiscreteO α`, so the
-ghost-state definitions carry lists through `DiscreteO.mk` and the lemmas reflect back.
--/
+/-! ## Helper functions -/
 
 theorem map_mk_inj : ∀ {l1 l2 : List α}, l1.map DiscreteO.mk = l2.map DiscreteO.mk → l1 = l2
   | [], [], _ => rfl
@@ -93,8 +85,8 @@ notation γ " ↪●ML□ " l => auth_own γ DFrac.discard l
 notation γ " ↪◯ML " l => lb_own γ l
 
 @[rocq_alias mono_list_idx_own]
-def idx_own (γ : GName) (i : Nat) (a : α) : IProp GF :=
-  iprop(∃ l, ⌜l[i]? = some a⌝ ∗ lb_own γ l)
+def idx_own (γ : GName) (i : Nat) (a : α) : IProp GF := iprop%
+  ∃ l, ⌜l[i]? = some a⌝ ∗ lb_own γ l
 
 notation γ " ↪◯ML[" i "] " a => idx_own γ i a
 
@@ -137,9 +129,6 @@ instance {γ} {l : List α} :
     unfold auth_own
     rw [← iOwn_op.to_eq]
     exact (congrArg (iOwn _) (auth_dfrac_op (.own p) (.own q) _)).to_bi
-
-#rocq_ignore mono_list_auth_own_as_fractional
-  "Follows from the Fractional instance via fractional_as_fractional"
 
 /-! ## Agreement -/
 

--- a/Iris/Iris/BI/Lib/MonoList.lean
+++ b/Iris/Iris/BI/Lib/MonoList.lean
@@ -129,6 +129,12 @@ instance {γ} {l : List α} :
     rw [← iOwn_op.to_eq]
     exact (congrArg (iOwn _) (auth_dfrac_op (.own p) (.own q) _)).to_bi
 
+@[rocq_alias mono_list_auth_own_as_fractional]
+instance {γ} {l : List α} q :
+   AsFractional (PROP := IProp GF) (γ ↪●ML{.own q} l) ioΦ (γ ↪●ML{.own ·} l) ioq q where
+  as_fractional := .rfl
+  as_fractional_fractional := inferInstance
+
 /-! ## Agreement -/
 
 @[rocq_alias mono_list_auth_own_agree]
@@ -168,7 +174,7 @@ theorem lb_own_valid (γ : GName) (l1 l2 : List α) :
   iintro H1 H2
   icases iOwn_cmraValid_op $$ [$H1 $H2] with %Hvalid
   ipureintro
-  exact (lb_op_valid_prefix ..).mp Hvalid |>.imp map_mk_prefix map_mk_prefix
+  exact (lb_op_valid ..).mp Hvalid |>.imp map_mk_prefix map_mk_prefix
 
 @[rocq_alias mono_list_idx_agree]
 theorem idx_agree (γ : GName) (i : Nat) (a1 a2 : α) :

--- a/Iris/Iris/BI/Lib/MonoList.lean
+++ b/Iris/Iris/BI/Lib/MonoList.lean
@@ -58,8 +58,7 @@ theorem map_mk_prefix {l1 l2 : List α} (h : l1.map DiscreteO.mk <+: l2.map Disc
 theorem prefix_getElem? {l1 l2 : List α} {i : Nat} {a : α} (h : l1 <+: l2)
     (hi : l1[i]? = some a) : l2[i]? = some a := by
   obtain ⟨t, rfl⟩ := h
-  rw [List.getElem?_append_left (List.getElem?_eq_some_iff.mp hi).1]
-  exact hi
+  grind
 
 /-! ## Definitions -/
 
@@ -159,7 +158,7 @@ theorem auth_lb_own_valid (γ : GName) (dq : DFrac) (l1 l2 : List α) :
   iintro H1 H2
   icases iOwn_cmraValid_op $$ [$H1 $H2] with %Hvalid
   ipureintro
-  obtain ⟨hdq, hpre⟩ := (both_dfrac_valid_prefix ..).mp Hvalid
+  obtain ⟨hdq, hpre⟩ := (both_dfrac_valid ..).mp Hvalid
   exact ⟨hdq, map_mk_prefix hpre⟩
 
 @[rocq_alias mono_list_lb_own_valid]
@@ -180,9 +179,7 @@ theorem idx_agree (γ : GName) (i : Nat) (a1 a2 : α) :
   icases H2 with ⟨%l2, %Hl2, H2⟩
   icases lb_own_valid γ l1 l2 $$ H1 H2 with %Hpre
   ipureintro
-  rcases Hpre with hpre | hpre
-  · exact Option.some.inj (Hl2 ▸ prefix_getElem? hpre Hl1).symm
-  · exact Option.some.inj (Hl1 ▸ prefix_getElem? hpre Hl2)
+  grind [prefix_getElem?]
 
 @[rocq_alias mono_list_auth_idx_lookup]
 theorem auth_idx_lookup (γ : GName) (dq : DFrac) (l : List α) (i : Nat) (a : α) :
@@ -224,9 +221,7 @@ theorem idx_own_get (γ : GName) {l : List α} (i : Nat) (a : α) (h : l[i]? = s
   unfold idx_own
   iintro H
   iexists l
-  iframe H
-  ipureintro
-  exact h
+  iframe H %h
 
 /-! ## Allocation and updates -/
 
@@ -236,7 +231,7 @@ theorem own_alloc (l : List α) :
   unfold auth_own lb_own
   imod iOwn_alloc (F := constOF (MonoList (DiscreteO α)))
       (●ML (l.map DiscreteO.mk) • ◯ML (l.map DiscreteO.mk)) with ⟨%γ, H⟩
-  · exact (both_valid ..).mpr ⟨[], (List.append_nil _).symm⟩
+  · exact (both_valid ..).mpr List.prefix_rfl
   imodintro
   iexists γ
   icases iOwn_op $$ H with ⟨$, $⟩
@@ -249,8 +244,7 @@ theorem auth_own_update (γ : GName) {l : List α} (l' : List α) (h : l <+: l')
   · unfold auth_own
     iapply iOwn_update $$ H
     exact update _ (h.map _)
-  · imodintro
-    ihave #$ := lb_own_get $$ Hauth
+  · ihave #$ := lb_own_get $$ Hauth
     iframe
 
 @[rocq_alias mono_list_auth_own_update_app]
@@ -271,9 +265,7 @@ theorem auth_own_unpersist (γ : GName) (l : List α) :
     ⊢@{IProp GF} (γ ↪●ML□ l) ==∗ ∃ q, γ ↪●ML{DFrac.own q} l := by
   unfold auth_own
   iintro H
-  imod iOwn_updateP (auth_unpersist _) $$ H with ⟨%a, %Ha, H⟩
-  obtain ⟨q, rfl⟩ := Ha
-  imodintro
+  imod iOwn_updateP (auth_unpersist _) $$ H with ⟨%a, %⟨q, rfl⟩, H⟩
   iexists q
   iframe
 

--- a/Iris/Iris/BI/Lib/MonoList.lean
+++ b/Iris/Iris/BI/Lib/MonoList.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
+Authors: Markus de Medeiros
 -/
 module
 

--- a/Iris/Iris/BI/Lib/MonoList.lean
+++ b/Iris/Iris/BI/Lib/MonoList.lean
@@ -1,0 +1,293 @@
+/-
+Copyright (c) 2026. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
+module
+
+public import Iris.Algebra.Lib.MonoList
+public import Iris.BI
+public import Iris.BI.Lib.Fractional
+public import Iris.ProofMode
+public import Iris.Instances.IProp
+
+/-!
+# Ghost state for append-only lists
+
+Wraps the `MonoList` RA, providing three assertions:
+- an authoritative proposition `γ ↪●ML{dq} l` for the authoritative list `l`;
+- a persistent assertion `γ ↪◯ML l` witnessing that the authoritative list is at least `l`;
+- a persistent assertion `γ ↪◯ML[i] a` witnessing that index `i` holds `a`.
+
+The key rules are `auth_lb_own_valid`, which asserts that an auth at `l` and a lower bound at
+`l'` imply `l' <+: l`, and `auth_own_update`, which grows the auth element by appending only. At
+any time the auth list can be snapshotted with `lb_own_get` to produce a persistent lower bound.
+-/
+
+@[expose] public section
+
+namespace Iris
+
+open BI MonoList
+
+@[rocq_alias mono_listG]
+class MonoListG (GF : BundledGFunctors) (α : Type _) where
+  elem : ElemG GF (constOF (MonoList (DiscreteO α)))
+
+attribute [reducible, instance] MonoListG.elem
+
+#rocq_ignore «mono_listΣ» "Subsumed by BundledGFunctors typeclass synthesis"
+#rocq_ignore «subG_mono_listΣ» "Subsumed by BundledGFunctors typeclass synthesis"
+
+namespace MonoList
+
+variable {GF : BundledGFunctors} {α : Type _} [MonoListG GF α]
+
+/-! ## Reflecting `DiscreteO` through lists
+
+Rocq indexes the RA by `leibnizO A`; here the discrete OFE on `α` is `DiscreteO α`, so the
+ghost-state definitions carry lists through `DiscreteO.mk` and the lemmas reflect back.
+-/
+
+theorem map_mk_inj : ∀ {l1 l2 : List α}, l1.map DiscreteO.mk = l2.map DiscreteO.mk → l1 = l2
+  | [], [], _ => rfl
+  | [], _ :: _, h => nomatch h
+  | _ :: _, [], h => nomatch h
+  | _ :: _, _ :: _, h => by
+    simp only [List.map_cons, List.cons.injEq] at h
+    rw [DiscreteO.eqv_inj h.1, map_mk_inj h.2]
+
+theorem map_mk_prefix {l1 l2 : List α} (h : l1.map DiscreteO.mk <+: l2.map DiscreteO.mk) :
+    l1 <+: l2 := by
+  obtain ⟨t, ht⟩ := h
+  obtain ⟨a, b, rfl, ha, _⟩ := List.map_eq_append_iff.mp ht.symm
+  exact ⟨b, by rw [map_mk_inj ha]⟩
+
+theorem prefix_getElem? {l1 l2 : List α} {i : Nat} {a : α} (h : l1 <+: l2)
+    (hi : l1[i]? = some a) : l2[i]? = some a := by
+  obtain ⟨t, rfl⟩ := h
+  rw [List.getElem?_append_left (List.getElem?_eq_some_iff.mp hi).1]
+  exact hi
+
+/-! ## Definitions -/
+
+@[rocq_alias mono_list_auth_own]
+def auth_own (γ : GName) (dq : DFrac) (l : List α) : IProp GF :=
+  iOwn (E := MonoListG.elem) γ (auth dq (l.map DiscreteO.mk))
+
+#rocq_ignore mono_list_auth_own_def "Not needed"
+#rocq_ignore mono_list_auth_own_aux "Not needed"
+#rocq_ignore mono_list_auth_own_unseal "Not needed"
+
+@[rocq_alias mono_list_lb_own]
+def lb_own (γ : GName) (l : List α) : IProp GF :=
+  iOwn (E := MonoListG.elem) γ (lb (l.map DiscreteO.mk))
+
+#rocq_ignore mono_list_lb_own_def "Not needed"
+#rocq_ignore mono_list_lb_own_aux "Not needed"
+#rocq_ignore mono_list_lb_own_unseal "Not needed"
+
+notation γ " ↪●ML{" dq "} " l => auth_own γ dq l
+notation γ " ↪●ML " l => auth_own γ (DFrac.own 1) l
+notation γ " ↪●ML□ " l => auth_own γ DFrac.discard l
+notation γ " ↪◯ML " l => lb_own γ l
+
+@[rocq_alias mono_list_idx_own]
+def idx_own (γ : GName) (i : Nat) (a : α) : IProp GF :=
+  iprop(∃ l, ⌜l[i]? = some a⌝ ∗ lb_own γ l)
+
+notation γ " ↪◯ML[" i "] " a => idx_own γ i a
+
+/-! ## Instances -/
+
+@[rocq_alias mono_list_auth_own_timeless]
+instance {γ dq} {l : List α} : Timeless (PROP := IProp GF) (γ ↪●ML{dq} l) := by
+  unfold auth_own
+  infer_instance
+
+@[rocq_alias mono_list_auth_own_persistent]
+instance {γ} {l : List α} : Persistent (PROP := IProp GF) (γ ↪●ML□ l) := by
+  unfold auth_own
+  infer_instance
+
+@[rocq_alias mono_list_lb_own_timeless]
+instance {γ} {l : List α} : Timeless (PROP := IProp GF) (γ ↪◯ML l) := by
+  unfold lb_own
+  infer_instance
+
+@[rocq_alias mono_list_lb_own_persistent]
+instance {γ} {l : List α} : Persistent (PROP := IProp GF) (γ ↪◯ML l) := by
+  unfold lb_own
+  infer_instance
+
+@[rocq_alias mono_list_idx_own_timeless]
+instance {γ i} {a : α} : Timeless (PROP := IProp GF) (γ ↪◯ML[i] a) := by
+  unfold idx_own
+  infer_instance
+
+@[rocq_alias mono_list_idx_own_persistent]
+instance {γ i} {a : α} : Persistent (PROP := IProp GF) (γ ↪◯ML[i] a) := by
+  unfold idx_own
+  infer_instance
+
+@[rocq_alias mono_list_auth_own_fractional]
+instance {γ} {l : List α} :
+    Fractional (PROP := IProp GF) (fun q : Qp => γ ↪●ML{.own q} l) where
+  fractional p q := by
+    unfold auth_own
+    rw [← iOwn_op.to_eq]
+    exact (congrArg (iOwn _) (auth_dfrac_op (.own p) (.own q) _)).to_bi
+
+#rocq_ignore mono_list_auth_own_as_fractional
+  "Follows from the Fractional instance via fractional_as_fractional"
+
+/-! ## Agreement -/
+
+@[rocq_alias mono_list_auth_own_agree]
+theorem auth_own_agree (γ : GName) (dq1 dq2 : DFrac) (l1 l2 : List α) :
+    ⊢@{IProp GF} (γ ↪●ML{dq1} l1) -∗ (γ ↪●ML{dq2} l2) -∗
+      ⌜✓ (dq1 • dq2) ∧ l1 = l2⌝ := by
+  unfold auth_own
+  iintro H1 H2
+  icases iOwn_cmraValid_op $$ [$H1 $H2] with %Hvalid
+  ipureintro
+  obtain ⟨hdq, hl⟩ := (auth_dfrac_op_valid ..).mp Hvalid
+  exact ⟨hdq, map_mk_inj hl⟩
+
+@[rocq_alias mono_list_auth_own_exclusive]
+theorem auth_own_exclusive (γ : GName) (l1 l2 : List α) :
+    ⊢@{IProp GF} (γ ↪●ML l1) -∗ (γ ↪●ML l2) -∗ False := by
+  unfold auth_own
+  iintro H1 H2
+  icases iOwn_cmraValid_op $$ [$H1 $H2] with %Hvalid
+  ipureintro
+  exact (auth_op_valid ..).mp Hvalid
+
+@[rocq_alias mono_list_auth_lb_own_valid]
+theorem auth_lb_own_valid (γ : GName) (dq : DFrac) (l1 l2 : List α) :
+    ⊢@{IProp GF} (γ ↪●ML{dq} l1) -∗ (γ ↪◯ML l2) -∗ ⌜✓ dq ∧ l2 <+: l1⌝ := by
+  unfold auth_own lb_own
+  iintro H1 H2
+  icases iOwn_cmraValid_op $$ [$H1 $H2] with %Hvalid
+  ipureintro
+  obtain ⟨hdq, hpre⟩ := (both_dfrac_valid_prefix ..).mp Hvalid
+  exact ⟨hdq, map_mk_prefix hpre⟩
+
+@[rocq_alias mono_list_lb_own_valid]
+theorem lb_own_valid (γ : GName) (l1 l2 : List α) :
+    ⊢@{IProp GF} (γ ↪◯ML l1) -∗ (γ ↪◯ML l2) -∗ ⌜l1 <+: l2 ∨ l2 <+: l1⌝ := by
+  unfold lb_own
+  iintro H1 H2
+  icases iOwn_cmraValid_op $$ [$H1 $H2] with %Hvalid
+  ipureintro
+  exact (lb_op_valid_prefix ..).mp Hvalid |>.imp map_mk_prefix map_mk_prefix
+
+@[rocq_alias mono_list_idx_agree]
+theorem idx_agree (γ : GName) (i : Nat) (a1 a2 : α) :
+    ⊢@{IProp GF} (γ ↪◯ML[i] a1) -∗ (γ ↪◯ML[i] a2) -∗ ⌜a1 = a2⌝ := by
+  unfold idx_own
+  iintro H1 H2
+  icases H1 with ⟨%l1, %Hl1, H1⟩
+  icases H2 with ⟨%l2, %Hl2, H2⟩
+  icases lb_own_valid γ l1 l2 $$ H1 H2 with %Hpre
+  ipureintro
+  rcases Hpre with hpre | hpre
+  · exact Option.some.inj (Hl2 ▸ prefix_getElem? hpre Hl1).symm
+  · exact Option.some.inj (Hl1 ▸ prefix_getElem? hpre Hl2)
+
+@[rocq_alias mono_list_auth_idx_lookup]
+theorem auth_idx_lookup (γ : GName) (dq : DFrac) (l : List α) (i : Nat) (a : α) :
+    ⊢@{IProp GF} (γ ↪●ML{dq} l) -∗ (γ ↪◯ML[i] a) -∗ ⌜l[i]? = some a⌝ := by
+  unfold idx_own
+  iintro H1 H2
+  icases H2 with ⟨%l1, %Hl1, H2⟩
+  icases auth_lb_own_valid γ dq l l1 $$ H1 H2 with %Hpre
+  ipureintro
+  exact prefix_getElem? Hpre.2 Hl1
+
+/-! ## Snapshots -/
+
+@[rocq_alias mono_list_lb_own_get]
+theorem lb_own_get (γ : GName) (dq : DFrac) (l : List α) :
+    ⊢@{IProp GF} (γ ↪●ML{dq} l) -∗ (γ ↪◯ML l) := by
+  unfold auth_own lb_own
+  iintro H
+  iapply iOwn_mono $$ H
+  exact included ..
+
+@[rocq_alias mono_list_lb_own_le]
+theorem lb_own_le (γ : GName) {l : List α} (l' : List α) (h : l' <+: l) :
+    ⊢@{IProp GF} (γ ↪◯ML l) -∗ (γ ↪◯ML l') := by
+  unfold lb_own
+  iintro H
+  iapply iOwn_mono $$ H
+  exact lb_mono (h.map _)
+
+@[rocq_alias mono_list_lb_own_nil]
+theorem lb_own_nil (γ : GName) : ⊢@{IProp GF} |==> (γ ↪◯ML ([] : List α)) := by
+  unfold lb_own
+  rw [List.map_nil]
+  iapply iOwn_unit
+
+@[rocq_alias mono_list_idx_own_get]
+theorem idx_own_get (γ : GName) {l : List α} (i : Nat) (a : α) (h : l[i]? = some a) :
+    ⊢@{IProp GF} (γ ↪◯ML l) -∗ (γ ↪◯ML[i] a) := by
+  unfold idx_own
+  iintro H
+  iexists l
+  iframe H
+  ipureintro
+  exact h
+
+/-! ## Allocation and updates -/
+
+@[rocq_alias mono_list_own_alloc]
+theorem own_alloc (l : List α) :
+    ⊢@{IProp GF} |==> ∃ γ, (γ ↪●ML l) ∗ (γ ↪◯ML l) := by
+  unfold auth_own lb_own
+  imod iOwn_alloc (F := constOF (MonoList (DiscreteO α)))
+      (●ML (l.map DiscreteO.mk) • ◯ML (l.map DiscreteO.mk)) with ⟨%γ, H⟩
+  · exact (both_valid ..).mpr ⟨[], (List.append_nil _).symm⟩
+  imodintro
+  iexists γ
+  icases iOwn_op $$ H with ⟨$, $⟩
+
+@[rocq_alias mono_list_auth_own_update]
+theorem auth_own_update (γ : GName) {l : List α} (l' : List α) (h : l <+: l') :
+    ⊢@{IProp GF} (γ ↪●ML l) ==∗ (γ ↪●ML l') ∗ (γ ↪◯ML l') := by
+  iintro H
+  ihave >Hauth : |==> (γ ↪●ML l') $$ [H]
+  · unfold auth_own
+    iapply iOwn_update $$ H
+    exact update _ (h.map _)
+  · imodintro
+    ihave #$ := lb_own_get $$ Hauth
+    iframe
+
+@[rocq_alias mono_list_auth_own_update_app]
+theorem auth_own_update_app (γ : GName) {l : List α} (l' : List α) :
+    ⊢@{IProp GF} (γ ↪●ML l) ==∗ (γ ↪●ML (l ++ l')) ∗ (γ ↪◯ML (l ++ l')) :=
+  auth_own_update γ (l ++ l') (List.prefix_append ..)
+
+@[rocq_alias mono_list_auth_own_persist]
+theorem auth_own_persist (γ : GName) (dq : DFrac) (l : List α) :
+    ⊢@{IProp GF} (γ ↪●ML{dq} l) ==∗ (γ ↪●ML□ l) := by
+  unfold auth_own
+  iintro H
+  iapply iOwn_update $$ H
+  exact auth_persist dq (l.map DiscreteO.mk)
+
+@[rocq_alias mono_list_auth_own_unpersist]
+theorem auth_own_unpersist (γ : GName) (l : List α) :
+    ⊢@{IProp GF} (γ ↪●ML□ l) ==∗ ∃ q, γ ↪●ML{DFrac.own q} l := by
+  unfold auth_own
+  iintro H
+  imod iOwn_updateP (auth_unpersist _) $$ H with ⟨%a, %Ha, H⟩
+  obtain ⟨q, rfl⟩ := Ha
+  imodintro
+  iexists q
+  iframe
+
+end MonoList
+
+end Iris


### PR DESCRIPTION
## Description
Fixes #268 and #257 

Ports `Algebra/MaxPrefixList`, `Algebra/Lib/MonoList` and `BI/Lib/MonoList`

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
