### PR TITLE
fix: `wp_pures` drops Rocq's `;[]` guard and `wp_finish` fallback

### DIFF
--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -373,7 +373,26 @@ elab "wp_pure " colGt ppSpace focus:hl_exp:10 : tactic =>
     mvar.assign pf
 
 macro "wp_pure" : tactic => `(tactic| wp_pure _)
-macro "wp_pures" : tactic => `(tactic| repeat wp_pure)
+
+/-- A single `wp_pure` step that must leave exactly one goal, Rocq's `wp_pure _; []`. Fails
+if the step spawns a goal besides the continuation, such as an undischarged side condition
+of the reduction. -/
+elab "wp_pure_step" : tactic => focus do
+  evalTactic (← `(tactic| wp_pure))
+  let goals ← getUnsolvedGoals
+  unless goals.length == 1 do
+    throwError "the pure reduction step must leave exactly one goal, it left {
+      goals.length}:{indentD <| .joinSep (goals.map fun g => m!"{g}") Format.line}"
+
+/-- Reduce all pure redexes at the head of the weakest precondition, then simplify the
+resulting expression and strip the weakest precondition if it has become a value.
+
+A pure step whose side condition cannot be discharged is not taken. -/
+macro "wp_pures" : tactic =>
+  -- Rocq: `first [progress repeat (wp_pure _; []) | wp_finish]`
+  `(tactic| first
+    | (wp_pure_step; repeat wp_pure_step)
+    | wp_finish)
 
 macro "wp_rec" : tactic => `(tactic | (wp_bind _ _; iapply $(mkIdent `wp_rec):ident; rfl; imodintro; wp_finish))
 
@@ -614,8 +633,16 @@ HeapLang WP (from the `HeapLangGS` instance), and strip the WP's step modality
 off the hypotheses. -/
 meta def runTacticHeapWp {α} (tacName : Name)
     (k : MVarId → HeapWpGoal → ProofModeM α) : TacticM α := do
-  -- Rocq parity: every heap tactic first normalizes pure redexes
-  evalTactic (← `(tactic| wp_pures))
+  -- Rocq parity: every heap tactic first normalizes pure redexes. `wp_pures` only fails
+  -- when the goal is not a WP, which is this tactic's failure to report, not `wp_finish`'s
+  try evalTactic (← `(tactic| wp_pures))
+  catch _ => throwError "{tacName}: the goal is not a WP"
+  -- `wp_pures` fails on a goal that is not a WP, so if it leaves one, the pure steps have
+  -- reduced the expression to a value
+  let goalType ← instantiateMVars (← (← getMainGoal).getType)
+  if let some {goal, ..} := parseIrisGoal? goalType then
+    unless goal.consumeMData.isAppOf ``Wp.wp do
+      throwError "{tacName}: the expression has been reduced to a value, there is no redex left"
   ProofModeM.runTacticWp tacName fun mvar {hyps, GF, hlc, ι, s, E, e, Φ, hu, hprop, hbi, ..} => do
     have ιQ : Q(IrisGS_gen $hlc Exp $GF) := ι
     let ~q(@HeapLang _ _ $hgs) := ιQ

--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -379,6 +379,7 @@ if the step spawns a goal besides the continuation, such as an undischarged side
 of the reduction. -/
 elab "wp_pure_step" : tactic => focus do
   evalTactic (← `(tactic| wp_pure))
+  -- we run under `focus` so we only see the unsolved goals of `wp_pure` 
   let goals ← getUnsolvedGoals
   unless goals.length == 1 do
     throwError "the pure reduction step must leave exactly one goal, it left {

--- a/Iris/Iris/Tests/HeapLang/HeapTactics.lean
+++ b/Iris/Iris/Tests/HeapLang/HeapTactics.lean
@@ -319,10 +319,16 @@ example {hlc'} {GF' : BundledGFunctors} [IrisGS_gen hlc' Exp GF']
   wp_load
 
 -- heap tactics reject goals that are not WPs at all
-/-- error: wp_load: The goal P must be a WP -/
+/-- error: wp_load: the goal is not a WP -/
 #guard_msgs (whitespace := lax) in
 example {P : IProp GF} : P ⊢ P := by
   iintro HP
+  wp_load
+
+-- the `wp_pures` prologue can reduce the expression to a value, leaving no redex
+/-- error: wp_load: the expression has been reduced to a value, there is no redex left -/
+#guard_msgs (whitespace := lax) in
+example : ⊢@{IProp GF} WP hl(if #true then #1 else #0) {{ v, True }} := by
   wp_load
 
 end goal_shape

--- a/Iris/Iris/Tests/HeapLang/WeakestPre.lean
+++ b/Iris/Iris/Tests/HeapLang/WeakestPre.lean
@@ -222,8 +222,7 @@ end wp_pure
 section wp_pures
 
 -- a step whose side condition survives is not taken (`compareSafe` is stuck here)
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF
@@ -231,13 +230,13 @@ v1 v2 : Val
 ⊢ ⏎
   ⊢ WP hl((v(&v1) = v(&v2))) {{ v, True }}
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example (v1 v2 : Val) : ⊢@{IProp GF} WP hl(&v1 = &v2) {{ v, True }} := by
   wp_pures
+  trace_state
 
 -- steps before the guarded one still fire
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF
@@ -245,14 +244,14 @@ v1 v2 : Val
 ⊢ ⏎
   ⊢ WP hl((v(&v1) = v(&v2))) {{ v, True }}
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example (v1 v2 : Val) :
     ⊢@{IProp GF} WP hl(if #true then (&v1 = &v2) else #false) {{ v, True }} := by
   wp_pures
+  trace_state
 
 -- `wp_pure` itself stays permissive and hands the side condition back
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF
@@ -266,26 +265,26 @@ GF : BundledGFunctors
 v1 v2 : Val
 ⊢ v1.compareSafe v2 = true
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example (v1 v2 : Val) : ⊢@{IProp GF} WP hl(&v1 = &v2) {{ v, True }} := by
   wp_pure
+  trace_state
 
 -- with no step to take, `wp_pures` still strips the weakest precondition off a value
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF
 ⊢ ⏎
   ⊢ |={⊤}=> ⌜hl_val(#1) = hl_val(#1)⌝
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF} WP hl(v(#1)) {{ v, ⌜v = hl_val(#1)⌝ }} := by
   wp_pures
+  trace_state
 
 -- ... and succeeds without doing anything when the expression is stuck
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF
@@ -293,9 +292,10 @@ l : Loc
 ⊢ ⏎
   ⊢ WP hl(!#l) {{ v, True }}
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example (l : Loc) : ⊢@{IProp GF} WP hl(!#l) {{ v, True }} := by
   wp_pures
+  trace_state
 
 -- neither branch applies when the goal is not a weakest precondition
 /-- error: wp_finish: The goal iprop(True) must be a WP -/
@@ -304,8 +304,7 @@ example : ⊢@{IProp GF} True := by
   wp_pures
 
 -- the guard counts only the goals the step produced, not those already open
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF
@@ -318,11 +317,12 @@ GF : BundledGFunctors
 ⊢ ⏎
   ⊢ True
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF} (WP hl(if #true then #1 else #0) {{ v, True }} ∧ True) := by
   istart
   isplit
   wp_pures
+  trace_state
 
 end wp_pures
 

--- a/Iris/Iris/Tests/HeapLang/WeakestPre.lean
+++ b/Iris/Iris/Tests/HeapLang/WeakestPre.lean
@@ -300,7 +300,28 @@ example (l : Loc) : ⊢@{IProp GF} WP hl(!#l) {{ v, True }} := by
 -- neither branch applies when the goal is not a weakest precondition
 /-- error: wp_finish: The goal iprop(True) must be a WP -/
 #guard_msgs in
-example : ⊢@{IProp GF} (True : IProp GF) := by
+example : ⊢@{IProp GF} True := by
+  wp_pures
+
+-- the guard counts only the goals the step produced, not those already open
+/--
+error: unsolved goals
+hlc : HasLC
+GF : BundledGFunctors
+ι : IrisGS_gen hlc Exp GF
+⊢ ⏎
+  ⊢ |={⊤}=> True
+
+hlc : HasLC
+GF : BundledGFunctors
+ι : IrisGS_gen hlc Exp GF
+⊢ ⏎
+  ⊢ True
+-/
+#guard_msgs in
+example : ⊢@{IProp GF} (WP hl(if #true then #1 else #0) {{ v, True }} ∧ True) := by
+  istart
+  isplit
   wp_pures
 
 end wp_pures

--- a/Iris/Iris/Tests/HeapLang/WeakestPre.lean
+++ b/Iris/Iris/Tests/HeapLang/WeakestPre.lean
@@ -219,6 +219,92 @@ example (n : Int) : ⊢@{IProp GF} WP hl((#1 * #2 <<< #3 ≤ #n + (#1 &&& #2 ^^^
 
 end wp_pure
 
+section wp_pures
+
+-- a step whose side condition survives is not taken (`compareSafe` is stuck here)
+/--
+error: unsolved goals
+hlc : HasLC
+GF : BundledGFunctors
+ι : IrisGS_gen hlc Exp GF
+v1 v2 : Val
+⊢ ⏎
+  ⊢ WP hl((v(&v1) = v(&v2))) {{ v, True }}
+-/
+#guard_msgs in
+example (v1 v2 : Val) : ⊢@{IProp GF} WP hl(&v1 = &v2) {{ v, True }} := by
+  wp_pures
+
+-- steps before the guarded one still fire
+/--
+error: unsolved goals
+hlc : HasLC
+GF : BundledGFunctors
+ι : IrisGS_gen hlc Exp GF
+v1 v2 : Val
+⊢ ⏎
+  ⊢ WP hl((v(&v1) = v(&v2))) {{ v, True }}
+-/
+#guard_msgs in
+example (v1 v2 : Val) :
+    ⊢@{IProp GF} WP hl(if #true then (&v1 = &v2) else #false) {{ v, True }} := by
+  wp_pures
+
+-- `wp_pure` itself stays permissive and hands the side condition back
+/--
+error: unsolved goals
+hlc : HasLC
+GF : BundledGFunctors
+ι : IrisGS_gen hlc Exp GF
+v1 v2 : Val
+⊢ ⏎
+  ⊢ |={⊤}=> True
+
+hlc : HasLC
+GF : BundledGFunctors
+ι : IrisGS_gen hlc Exp GF
+v1 v2 : Val
+⊢ v1.compareSafe v2 = true
+-/
+#guard_msgs in
+example (v1 v2 : Val) : ⊢@{IProp GF} WP hl(&v1 = &v2) {{ v, True }} := by
+  wp_pure
+
+-- with no step to take, `wp_pures` still strips the weakest precondition off a value
+/--
+error: unsolved goals
+hlc : HasLC
+GF : BundledGFunctors
+ι : IrisGS_gen hlc Exp GF
+⊢ ⏎
+  ⊢ |={⊤}=> ⌜hl_val(#1) = hl_val(#1)⌝
+-/
+#guard_msgs in
+example : ⊢@{IProp GF} WP hl(v(#1)) {{ v, ⌜v = hl_val(#1)⌝ }} := by
+  wp_pures
+
+-- ... and succeeds without doing anything when the expression is stuck
+/--
+error: unsolved goals
+hlc : HasLC
+GF : BundledGFunctors
+ι : IrisGS_gen hlc Exp GF
+l : Loc
+⊢ ⏎
+  ⊢ WP hl(!#l) {{ v, True }}
+-/
+#guard_msgs in
+example (l : Loc) : ⊢@{IProp GF} WP hl(!#l) {{ v, True }} := by
+  wp_pures
+
+-- neither branch applies when the goal is not a weakest precondition
+/-- error: wp_finish: The goal iprop(True) must be a WP -/
+#guard_msgs in
+example : ⊢@{IProp GF} (True : IProp GF) := by
+  wp_pures
+
+end wp_pures
+
 section pure_tactics
 
 variable {GF : BundledGFunctors} [HeapLangGS hlc GF]


### PR DESCRIPTION
## Description

`wp_pures` was `repeat wp_pure`, missing both halves of Rocq's
`first [progress repeat (wp_pure _; []) | wp_finish]`:

- **`;[]`**: our `wp_pure` uses `failOnUnsolved := false`, so an undischarged side
  condition (or a TC-spawned goal) just becomes an extra goal, and `repeat` takes the step
  anyway. A step now has to leave exactly one goal, otherwise `wp_pures` stops at that
  redex.
- **`wp_finish`** — when nothing fires, `repeat wp_pure` succeeded vacuously. Rocq still
  simplifies the expression and strips the WP off a value.

I opted for implementing this as a guard around the existing elaborator (`wp_pure_step`) that is called by `wp_pures`. 

### Behaviour changes

No existing tests regressed. 

1. `wp_pures` can now fail on a non-WP goal, like in Iris Rocq
2. For heap tactics, the `wp_pures` prologue in `runTacticHeapWp` can reduce the expression to a value,
   leaving no WP. Rocq hits the same branch. Now reported as ``Tactic `wp_load` failed: the
   expression has been reduced to a value, there is no redex left`` rather than complaining
   about a goal the user never saw.

Related to #480 

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
