### PR TITLE
fix: elaboration and delaboration of propositions

### DIFF
--- a/Iris/Iris/BI/BIBase.lean
+++ b/Iris/Iris/BI/BIBase.lean
@@ -11,14 +11,12 @@ public meta import Iris.Std.DelabRule
 public meta import Iris.Std.Rewrite
 public import Iris.Std.BigOp
 public meta import Iris.Std.RocqPorting
-public meta import Lean.PrettyPrinter.Delaborator
 
 @[expose] public section
 
 namespace Iris.BI
 open Iris.Std
 open Lean
-open Lean Lean.Macro Lean.Parser.Term Lean PrettyPrinter Delaborator SubExpr
 
 /--
 The basic components of a bunched implication (BI) algebra.
@@ -32,7 +30,7 @@ The primitive connectives and modalities are:
 - `⌜φ⌝` embeds a pure Lean proposition `φ` as a separation logic proposition.
 - `emp` is the unit of separating conjunction.
 - `P ∗ Q` is separating conjunction.
-- `P -∗ Q` is separating implication (the separating wand).
+- `P -∗ Q` is separating implication (the magic wand).
 - `<pers> P` is the persistently modality.
 - `▷ P` is the later modality.
 - `P ∧ Q` is conjunction.

--- a/Iris/Iris/BI/BIBase.lean
+++ b/Iris/Iris/BI/BIBase.lean
@@ -19,7 +19,27 @@ open Iris.Std
 open Lean
 
 /--
-Require the definitions of the separation logic connectives and units on a carrier type `PROP`.
+The basic components of a bunched implication (BI) algebra.
+
+A BI algebra provides the separation logic connectives and units on a carrier
+type `PROP`.
+
+The primitive connectives and modalities are:
+
+- `P ⊢ Q` is entailment: `P` entails `Q`.
+- `⌜φ⌝` embeds a pure Lean proposition `φ` as a separation logic proposition.
+- `emp` is the unit of separating conjunction.
+- `P ∗ Q` is separating conjunction.
+- `P -∗ Q` is separating implication (the separating wand).
+- `<pers> P` is the persistently modality.
+- `▷ P` is the later modality.
+- `P ∧ Q` is conjunction.
+- `P ∨ Q` is disjunction.
+- `P → Q` is ordinary implication between BI propositions.
+- `∀ x, P x` and `∃ x, P x` are the separation-logic universal and existential quantifiers.
+
+The notation `P ⊢@{PROP} Q` can be used when the carrier type `PROP` needs to
+be specified explicitly.
 -/
 class BIBase (PROP : Type u) where
   Entails : PROP → PROP → Prop
@@ -35,36 +55,33 @@ class BIBase (PROP : Type u) where
   persistently : PROP → PROP
   later : PROP → PROP
 
+attribute [inherit_doc BIBase]
+  BIBase.Entails BIBase.emp BIBase.pure BIBase.and BIBase.or BIBase.imp
+  BIBase.sForall BIBase.sExists BIBase.sep BIBase.wand BIBase.persistently
+  BIBase.later
+
 namespace BIBase
 
+@[inherit_doc BIBase.sForall]
 def «forall» [BIBase PROP] {α : Sort _} (P : α → PROP) : PROP := sForall fun p => ∃ a, P a = p
+@[inherit_doc BIBase.sExists]
 def «exists» [BIBase PROP] {α : Sort _} (P : α → PROP) : PROP := sExists fun p => ∃ a, P a = p
 
-/-- Entailment on separation logic propositions. -/
+@[inherit_doc BIBase.Entails]
 macro:25 P:term:29 " ⊢ " Q:term:25 : term => ``(BIBase.Entails iprop($P) iprop($Q))
 
-macro:25 P:term:29 " ⊢@{ " PROP:term "} " Q:term:25 : term => ``(BIBase.Entails (PROP:=$PROP) iprop($P) iprop($Q))
+@[inherit_doc BIBase.Entails]
+macro:25 P:term:29 " ⊢@{ " PROP:term "} " Q:term:25 : term =>
+  ``(BIBase.Entails (PROP:=$PROP) iprop($P) iprop($Q))
 
 delab_rule BIBase.Entails
   | `($_ $P $Q) => do ``($(← unpackIprop P) ⊢ $(← unpackIprop Q))
 
-/-- Embedding of pure Lean proposition as separation logic proposition. -/
 syntax "⌜" term "⌝" : term
-/-- Separating conjunction. -/
 syntax:35 term:36 " ∗ " term:35 : term
-/-- Separating implication. -/
 syntax:25 term:26 " -∗ " term:25 : term
-/-- Separating implication with an optional wand premise. -/
-syntax:25 term:26 " -∗? " term:25 : term
-/-- Persistency modality. `persistently` is a primitive of BI. -/
 syntax:max "<pers> " term:40 : term
-/-- Later modality. `later` is a primitive of BI. -/
 syntax:max "▷ " term:40 : term
-
-/-- Bidirectional implication on separation logic propositions. -/
-syntax:27 term:28 " ↔ " term:28 : term
-/-- Bidrectional separating implication on separation logic propositions. -/
-syntax:27 term:28 " ∗-∗ " term:28 : term
 
 /-- Existential quantification on separation logic propositions. -/
 macro "∃" xs:explicitBinders ", " b:term : term => do
@@ -157,10 +174,22 @@ macro_rules
   | `(iprop(False)) => ``(BIBase.pure False)
   | `(iprop(¬%$tk $P))   => ``(iprop($P →%$tk False))
 
+/--
+  Bidirectional implication on separation logic propositions.
+  `P ↔ Q` holds if and only if `P → Q` and `Q → P` both hold.
+-/
 @[rocq_alias bi_iff]
-def iff     [BIBase PROP] (P Q : PROP) : PROP := iprop((P → Q) ∧ (Q → P))
+def iff [BIBase PROP] (P Q : PROP) : PROP := iprop((P → Q) ∧ (Q → P))
+
+/--
+  Bidrectional separating implication on separation logic propositions:
+  `P ∗-∗ Q` holds if and only if `P -∗ Q` and `Q -∗ P` both hold.
+-/
 @[rocq_alias bi_wand_iff]
 def wandIff [BIBase PROP] (P Q : PROP) : PROP := iprop((P -∗ Q) ∧ (Q -∗ P))
+
+syntax:27 term:28 " ↔ " term:28 : term
+syntax:27 term:28 " ∗-∗ " term:28 : term
 
 macro_rules
   | `(iprop($P ↔%$tk $Q))   => ``($(wrapIprop tk ``iff) iprop($P) iprop($Q))
@@ -171,11 +200,17 @@ delab_rule iff
 delab_rule wandIff
   | `($_ $P $Q) => do ``(iprop($(← unpackIprop P) ∗-∗ $(← unpackIprop Q)))
 
+/--
+  Separating implication with an optional premise:
+  `none -∗? Q` is equivalant to `Q` while `some P -∗? Q` is equivalent to `P -∗ Q`.
+-/
 @[simp, rocq_alias bi_wandM]
 def wandM [BIBase PROP] (mP : Option PROP) (Q : PROP) : PROP :=
   match mP with
   | none => Q
   | some P => iprop(P -∗ Q)
+
+syntax:25 term:26 " -∗? " term:25 : term
 
 macro_rules
   | `(iprop($mP -∗?%$tk $Q)) => ``($(wrapIprop tk ``wandM) $mP iprop($Q))
@@ -183,23 +218,15 @@ macro_rules
 delab_rule wandM
   | `($_ $mP $Q) => do ``(iprop($mP -∗? $(← unpackIprop Q)))
 
-/-- Affine modality.
-```
-def affinely (P) := emp ∧ P
-```
--/
-syntax:max "<affine> " term:40 : term
-/-- Absorbing modality, `absorbingly`.
-```
-def absorbingly (P) := True ∗ P
-```
--/
-syntax:max "<absorb> " term:40 : term
-
+/-- Affine modality: `<affine> P` is equivalent to `emp ∧ P`. -/
 @[rocq_alias bi_affinely]
 def affinely    [BIBase PROP] (P : PROP) : PROP := iprop(emp ∧ P)
+/-- Absorbingly modality: `<absorb> P` is equivalent to `True ∗ P`. -/
 @[rocq_alias bi_absorbingly]
 def absorbingly [BIBase PROP] (P : PROP) : PROP := iprop(True ∗ P)
+
+syntax:max "<affine> " term:40 : term
+syntax:max "<absorb> " term:40 : term
 
 structure BiEntails [BIBase PROP] (P Q : PROP) where
   mp : P ⊢ Q
@@ -235,15 +262,11 @@ delab_rule affinely
 delab_rule absorbingly
   | `($_ $P) => do ``(iprop(<absorb> $(← unpackIprop P)))
 
-/-- Intuitionistic modality.
-```
-def intuitionistically (P) := <affine> <pers> P
-```
--/
-syntax:max "□ " term:40 : term
-
+/-- Intuitionistic modality: `□ P` is equivalent to `<affine> <pers> P`. -/
 @[rocq_alias bi_intuitionistically]
 def intuitionistically [BIBase PROP] (P : PROP) : PROP := iprop(<affine> <pers> P)
+
+syntax:max "□ " term:40 : term
 
 macro_rules
   | `(iprop(□%$tk $P)) => ``($(wrapIprop tk ``intuitionistically) iprop($P))
@@ -251,11 +274,11 @@ macro_rules
 delab_rule intuitionistically
   | `($_ $P) => do ``(iprop(□ $(← unpackIprop P)))
 
-/-- Iterated later modality. -/
-syntax:max "▷^[" term:45 "] " term:40 : term
-
+/-- Iterated later modality: `▷^[n] P` is equivalent to `P` with `n` leading occurrences of `▷`. -/
 @[rocq_alias bi_laterN]
 def laterN [BIBase PROP] (n : Nat) (P : PROP) : PROP := n.repeat later P
+
+syntax:max "▷^[" term:45 "] " term:40 : term
 
 macro_rules
   | `(iprop(▷^[%$tk1 $n ]%$tk2 $P))   => ``($(wrapIpropSpan tk1 tk2 ``laterN) $n iprop($P))
@@ -263,46 +286,41 @@ macro_rules
 delab_rule laterN
   | `($_ $n $P) => do ``(iprop(▷^[$n] $(← unpackIprop P)))
 
-/-- Conditional persistency modality.
-```
-def persistentlyIf (p : Bool) (P : PROP) := if p then <pers> P else P
-```
+/--
+  Conditional persistently modality:
+  `<pers>?p P` is equivalent to `<pers> P` when `p` is `true`, otherwise equivalent to `P`.
 -/
-syntax:max "<pers>?"   term:max ppHardSpace term:40 : term
-/-- Conditional affine modality.
-```
-def affinelyIf (p : Bool) (P : PROP) := if p then <affine> P else P
-```
--/
-syntax:max "<affine>?" term:max ppHardSpace term:40 : term
-/-- Conditional absorbing modality.
-```
-def absorbinglyIf (p : Bool) (P : PROP) := if p then <absorb> P else P
-```
--/
-syntax:max "<absorb>?" term:max ppHardSpace term:40 : term
-/-- Conditional intuitionistic modality.
-```
-def intuitionisticallyIf (p : Bool) (P : PROP) := if p then □ P else P
-```
--/
-syntax:max "□?"        term:max ppHardSpace term:40 : term
-/-- Conditional later modality.
-```
-def laterIf (p : Bool) (P : PROP) := if p then ▷ P else P
-```
--/
-syntax:max "▷?"        term:max ppHardSpace term:40 : term
-
 @[rocq_alias bi_persistently_if]
 def persistentlyIf [BIBase PROP] (p : Bool) (P : PROP) : PROP := iprop(if p then <pers> P else P)
+/--
+  Conditional affinely modality:
+  `<affine>?p P` is equivalent to `<affine> P` when `p` is `true`, otherwise equivalent to `P`.
+-/
 @[rocq_alias bi_affinely_if]
 def affinelyIf [BIBase PROP] (p : Bool) (P : PROP) : PROP := iprop(if p then <affine> P else P)
+/--
+  Conditional absorbingly modality:
+  `<absorb>?p P` is equivalent to `<absorb> P` when `p` is `true`, otherwise equivalent to `P`.
+-/
 @[rocq_alias bi_absorbingly_if]
 def absorbinglyIf [BIBase PROP] (p : Bool) (P : PROP) : PROP := iprop(if p then <absorb> P else P)
+/--
+  Conditional intuitionistically modality:
+  `□?p P` is equivalent to `□ P` when `p` is `true`, otherwise equivalent to `P`.
+-/
 @[rocq_alias bi_intuitionistically_if]
 def intuitionisticallyIf [BIBase PROP] (p : Bool) (P : PROP) : PROP := iprop(if p then □ P else P)
+/--
+  Conditional later modality:
+  `▷?p P` is equivalent to `▷ P` when `p` is `true`, otherwise equivalent to `P`.
+-/
 @[reducible] def laterIf [BIBase PROP] (p : Bool) (P : PROP) : PROP := iprop(▷^[p.toNat] P)
+
+syntax:max "<pers>?" term:max ppHardSpace term:40 : term
+syntax:max "<affine>?" term:max ppHardSpace term:40 : term
+syntax:max "<absorb>?" term:max ppHardSpace term:40 : term
+syntax:max "□?" term:max ppHardSpace term:40 : term
+syntax:max "▷?" term:max ppHardSpace term:40 : term
 
 macro_rules
   | `(iprop(<pers>?%$tk $p $P))   => ``($(wrapIprop tk ``persistentlyIf) $p iprop($P))
@@ -333,11 +351,11 @@ notation:40 "[∧] " Ps:max => bigAnd Ps
 notation:40 "[∨] " Ps:max => bigOr Ps
 notation:40 "[∗] " Ps:max => bigSep Ps
 
-/-- Except-0 modality -/
-syntax:max "◇ " term:40 : term
-
+/-- Except-0 modality: `◇ P` is equivalent to `▷ False ∨ P`. -/
 @[rocq_alias bi_except_0]
 def except0 [BIBase PROP] (P : PROP) := iprop(▷ False ∨ P)
+
+syntax:max "◇ " term:40 : term
 
 macro_rules
   | `(iprop(◇%$tk $P)) => ``($(wrapIprop tk ``except0) iprop($P))
@@ -345,11 +363,12 @@ macro_rules
 delab_rule except0
   | `($_ $P) => do ``(iprop(◇ $(← unpackIprop P)))
 
+/-- Plainly modality (`■`). -/
 class Plainly (PROP : Type _) where
   plainly : PROP → PROP
 export Plainly (plainly)
 
-/-- Plainly modality -/
+attribute [inherit_doc Plainly] Plainly.plainly
 syntax "■ " term:40 : term
 
 macro_rules
@@ -358,11 +377,14 @@ macro_rules
 delab_rule Plainly.plainly
   | `($_ $P) => do ``(iprop(■ $(← Iris.BI.unpackIprop P)))
 
+/--
+  Conditional plainly modality:
+  `■?p P` is equivalent to `■ P` when `p` is `true`, otherwise `P`.
+-/
 @[rocq_alias plainly_if]
 def Plainly.plainlyIf [BIBase PROP] [Plainly PROP] (p : Bool) (P : PROP) : PROP :=
   iprop(if p then ■ P else P)
 
-/-- Conditional plainly modality. -/
 syntax:max "■?" term:max ppHardSpace term:40 : term
 
 macro_rules

--- a/Iris/Iris/BI/BIBase.lean
+++ b/Iris/Iris/BI/BIBase.lean
@@ -72,16 +72,16 @@ macro "∃" xs:explicitBinders ", " b:term : term => do
 
 -- `iprop` syntax interpretation
 macro_rules
-  | `(iprop(emp))       => ``(BIBase.emp)
-  | `(iprop(⌜$φ⌝))      => ``(BIBase.pure $φ)
-  | `(iprop($P ∧ $Q))   => ``(BIBase.and iprop($P) iprop($Q))
-  | `(iprop($P ∨ $Q))   => ``(BIBase.or iprop($P) iprop($Q))
-  | `(iprop($P → $Q))   => ``(BIBase.imp iprop($P) iprop($Q))
+  | `(iprop(emp))           => ``(BIBase.emp)
+  | `(iprop(⌜%$tk1 $φ ⌝%$tk2)) => ``($(wrapIpropSpan tk1 tk2 ``BIBase.pure) $φ)
+  | `(iprop($P ∧%$tk $Q))   => ``($(wrapIprop tk ``BIBase.and) iprop($P) iprop($Q))
+  | `(iprop($P ∨%$tk $Q))   => ``($(wrapIprop tk ``BIBase.or) iprop($P) iprop($Q))
+  | `(iprop($P →%$tk $Q))   => ``($(wrapIprop tk ``BIBase.imp) iprop($P) iprop($Q))
   | `(iprop(∃ $xs, $Ψ)) => do expandExplicitBinders ``BIBase.exists xs (← ``(iprop($Ψ)))
-  | `(iprop($P ∗ $Q))   => ``(BIBase.sep iprop($P) iprop($Q))
-  | `(iprop($P -∗ $Q))  => ``(BIBase.wand iprop($P) iprop($Q))
-  | `(iprop(<pers> $P)) => ``(BIBase.persistently iprop($P))
-  | `(iprop(▷ $P))      => ``(BIBase.later iprop($P))
+  | `(iprop($P ∗%$tk $Q))   => ``($(wrapIprop tk ``BIBase.sep) iprop($P) iprop($Q))
+  | `(iprop($P -∗%$tk $Q))  => ``($(wrapIprop tk ``BIBase.wand) iprop($P) iprop($Q))
+  | `(iprop(<pers>%$tk $P)) => ``($(wrapIprop tk ``BIBase.persistently) iprop($P))
+  | `(iprop(▷%$tk $P))     => ``($(wrapIprop tk ``BIBase.later) iprop($P))
 
 delab_rule BIBase.emp
   | `($_) => ``(iprop($(mkIdent `emp)))
@@ -119,37 +119,43 @@ delab_rule BIBase.imp
 /- This is necessary since the `∀` syntax is not defined using `explicitBinders` and we can
 therefore not use `expandExplicitBinders` as for `∃`. -/
 macro_rules
-  | `(iprop(∀ _%$tk, $Ψ)) => ``(BIBase.forall (fun _%$tk => iprop($Ψ)))
+  | `(iprop(∀%$tk' _%$tk, $Ψ)) =>
+    ``($(wrapIprop tk' ``BIBase.forall) (fun _%$tk => iprop($Ψ)))
 macro_rules
-  | `(iprop(∀ $x:ident, $Ψ)) => ``(BIBase.forall (fun $x => iprop($Ψ)))
+  | `(iprop(∀%$tk' $x:ident, $Ψ)) =>
+    ``($(wrapIprop tk' ``BIBase.forall) (fun $x => iprop($Ψ)))
 macro_rules
-  | `(iprop(∀ _%$tk : $t, $Ψ)) => ``(BIBase.forall (fun (_%$tk : $t) => iprop($Ψ)))
-  | `(iprop(∀ (_%$tk : $t), $Ψ)) => ``(BIBase.forall (fun (_%$tk : $t) => iprop($Ψ)))
-  | `(iprop(∀ (_%$tk $xs* : $t), $Ψ)) =>
-    ``(BIBase.forall (fun (_%$tk : $t) => iprop(∀ ($xs* : $t), $Ψ)))
+  | `(iprop(∀%$tk' _%$tk : $t, $Ψ)) =>
+    ``($(wrapIprop tk' ``BIBase.forall) (fun (_%$tk : $t) => iprop($Ψ)))
+  | `(iprop(∀%$tk' (_%$tk : $t), $Ψ)) =>
+    ``($(wrapIprop tk' ``BIBase.forall) (fun (_%$tk : $t) => iprop($Ψ)))
+  | `(iprop(∀%$tk' (_%$tk $xs* : $t), $Ψ)) =>
+    ``($(wrapIprop tk' ``BIBase.forall) (fun (_%$tk : $t) => iprop(∀ ($xs* : $t), $Ψ)))
 macro_rules
-  | `(iprop(∀ $x:ident : $t, $Ψ)) => ``(BIBase.forall (fun ($x : $t) => iprop($Ψ)))
-  | `(iprop(∀ ($x:ident : $t), $Ψ)) => ``(BIBase.forall (fun ($x : $t) => iprop($Ψ)))
-  | `(iprop(∀ ($x:ident $xs* : $t), $Ψ)) =>
-    ``(BIBase.forall (fun ($x : $t) => iprop(∀ ($xs* : $t), $Ψ)))
+  | `(iprop(∀%$tk' $x:ident : $t, $Ψ)) =>
+    ``($(wrapIprop tk' ``BIBase.forall) (fun ($x : $t) => iprop($Ψ)))
+  | `(iprop(∀%$tk' ($x:ident : $t), $Ψ)) =>
+    ``($(wrapIprop tk' ``BIBase.forall) (fun ($x : $t) => iprop($Ψ)))
+  | `(iprop(∀%$tk' ($x:ident $xs* : $t), $Ψ)) =>
+    ``($(wrapIprop tk' ``BIBase.forall) (fun ($x : $t) => iprop(∀ ($xs* : $t), $Ψ)))
 macro_rules
-  | `(iprop(∀ {_%$tk : $t}, $Ψ)) =>
-    ``(BIBase.forall (fun {_%$tk : $t}  => iprop($Ψ)))
-  | `(iprop(∀ {_%$tk $xs* : $t}, $Ψ)) =>
-    ``(BIBase.forall (fun {_%$tk : $t}  => iprop(∀ {$xs* : $t}, $Ψ)))
+  | `(iprop(∀%$tk' {_%$tk : $t}, $Ψ)) =>
+    ``($(wrapIprop tk' ``BIBase.forall) (fun {_%$tk : $t}  => iprop($Ψ)))
+  | `(iprop(∀%$tk' {_%$tk $xs* : $t}, $Ψ)) =>
+    ``($(wrapIprop tk' ``BIBase.forall) (fun {_%$tk : $t}  => iprop(∀ {$xs* : $t}, $Ψ)))
 macro_rules
-  | `(iprop(∀ {$x:ident : $t}, $Ψ)) =>
-    ``(BIBase.forall (fun ($x : $t) => iprop($Ψ)))
-  | `(iprop(∀ {$x:ident $xs* : $t}, $Ψ)) =>
-    ``(BIBase.forall (fun ($x : $t) => iprop(∀ {$xs* : $t}, $Ψ)))
+  | `(iprop(∀%$tk' {$x:ident : $t}, $Ψ)) =>
+    ``($(wrapIprop tk' ``BIBase.forall) (fun ($x : $t) => iprop($Ψ)))
+  | `(iprop(∀%$tk' {$x:ident $xs* : $t}, $Ψ)) =>
+    ``($(wrapIprop tk' ``BIBase.forall) (fun ($x : $t) => iprop(∀ {$xs* : $t}, $Ψ)))
 macro_rules
-  | `(iprop(∀ $x $y $xs*, $Ψ)) => ``(iprop(∀ $x, ∀ $y $xs*, $Ψ))
+  | `(iprop(∀%$tk $x $y $xs*, $Ψ)) => ``(iprop(∀%$tk $x, ∀%$tk $y $xs*, $Ψ))
 
 -- `iprop` macros
 macro_rules
   | `(iprop(True))  => ``(BIBase.pure True)
   | `(iprop(False)) => ``(BIBase.pure False)
-  | `(iprop(¬$P))   => ``(iprop($P → False))
+  | `(iprop(¬%$tk $P))   => ``(iprop($P →%$tk False))
 
 @[rocq_alias bi_iff]
 def iff     [BIBase PROP] (P Q : PROP) : PROP := iprop((P → Q) ∧ (Q → P))
@@ -157,8 +163,8 @@ def iff     [BIBase PROP] (P Q : PROP) : PROP := iprop((P → Q) ∧ (Q → P))
 def wandIff [BIBase PROP] (P Q : PROP) : PROP := iprop((P -∗ Q) ∧ (Q -∗ P))
 
 macro_rules
-  | `(iprop($P ↔ $Q))   => ``(iff iprop($P) iprop($Q))
-  | `(iprop($P ∗-∗ $Q)) => ``(wandIff iprop($P) iprop($Q))
+  | `(iprop($P ↔%$tk $Q))   => ``($(wrapIprop tk ``iff) iprop($P) iprop($Q))
+  | `(iprop($P ∗-∗%$tk $Q)) => ``($(wrapIprop tk ``wandIff) iprop($P) iprop($Q))
 
 delab_rule iff
   | `($_ $P $Q) => do ``(iprop($(← unpackIprop P) ↔ $(← unpackIprop Q)))
@@ -172,7 +178,7 @@ def wandM [BIBase PROP] (mP : Option PROP) (Q : PROP) : PROP :=
   | some P => iprop(P -∗ Q)
 
 macro_rules
-  | `(iprop($mP -∗? $Q)) => ``(wandM $mP iprop($Q))
+  | `(iprop($mP -∗?%$tk $Q)) => ``($(wrapIprop tk ``wandM) $mP iprop($Q))
 
 delab_rule wandM
   | `($_ $mP $Q) => do ``(iprop($mP -∗? $(← unpackIprop Q)))
@@ -221,8 +227,8 @@ delab_rule BIBase.BiEntails
   | `($_ $P $Q) => do ``($(← unpackIprop P) ⊣⊢ $(← unpackIprop Q))
 
 macro_rules
-  | `(iprop(<affine> $P)) => ``(affinely iprop($P))
-  | `(iprop(<absorb> $P)) => ``(absorbingly iprop($P))
+  | `(iprop(<affine>%$tk $P)) => ``($(wrapIprop tk ``affinely) iprop($P))
+  | `(iprop(<absorb>%$tk $P)) => ``($(wrapIprop tk ``absorbingly) iprop($P))
 
 delab_rule affinely
   | `($_ $P) => do ``(iprop(<affine> $(← unpackIprop P)))
@@ -240,7 +246,7 @@ syntax:max "□ " term:40 : term
 def intuitionistically [BIBase PROP] (P : PROP) : PROP := iprop(<affine> <pers> P)
 
 macro_rules
-  | `(iprop(□ $P)) => ``(intuitionistically iprop($P))
+  | `(iprop(□%$tk $P)) => ``($(wrapIprop tk ``intuitionistically) iprop($P))
 
 delab_rule intuitionistically
   | `($_ $P) => do ``(iprop(□ $(← unpackIprop P)))
@@ -252,7 +258,7 @@ syntax:max "▷^[" term:45 "] " term:40 : term
 def laterN [BIBase PROP] (n : Nat) (P : PROP) : PROP := n.repeat later P
 
 macro_rules
-  | `(iprop(▷^[$n] $P))   => ``(laterN $n iprop($P))
+  | `(iprop(▷^[%$tk1 $n ]%$tk2 $P))   => ``($(wrapIpropSpan tk1 tk2 ``laterN) $n iprop($P))
 
 delab_rule laterN
   | `($_ $n $P) => do ``(iprop(▷^[$n] $(← unpackIprop P)))
@@ -299,11 +305,11 @@ def intuitionisticallyIf [BIBase PROP] (p : Bool) (P : PROP) : PROP := iprop(if 
 @[reducible] def laterIf [BIBase PROP] (p : Bool) (P : PROP) : PROP := iprop(▷^[p.toNat] P)
 
 macro_rules
-  | `(iprop(<pers>?$p $P))   => ``(persistentlyIf $p iprop($P))
-  | `(iprop(<affine>?$p $P)) => ``(affinelyIf $p iprop($P))
-  | `(iprop(<absorb>?$p $P)) => ``(absorbinglyIf $p iprop($P))
-  | `(iprop(□?$p $P))        => ``(intuitionisticallyIf $p iprop($P))
-  | `(iprop(▷?$p $P))        => ``(laterIf $p iprop($P))
+  | `(iprop(<pers>?%$tk $p $P))   => ``($(wrapIprop tk ``persistentlyIf) $p iprop($P))
+  | `(iprop(<affine>?%$tk $p $P)) => ``($(wrapIprop tk ``affinelyIf) $p iprop($P))
+  | `(iprop(<absorb>?%$tk $p $P)) => ``($(wrapIprop tk ``absorbinglyIf) $p iprop($P))
+  | `(iprop(□?%$tk $p $P))        => ``($(wrapIprop tk ``intuitionisticallyIf) $p iprop($P))
+  | `(iprop(▷?%$tk $p $P))       => ``($(wrapIprop tk ``laterIf) $p iprop($P))
 
 delab_rule persistentlyIf
   | `($_ $p $P) => do ``(iprop(<pers>?$p $(← unpackIprop P)))
@@ -334,21 +340,20 @@ syntax:max "◇ " term:40 : term
 def except0 [BIBase PROP] (P : PROP) := iprop(▷ False ∨ P)
 
 macro_rules
-  | `(iprop(◇ $P)) => ``(except0 iprop($P))
+  | `(iprop(◇%$tk $P)) => ``($(wrapIprop tk ``except0) iprop($P))
 
 delab_rule except0
   | `($_ $P) => do ``(iprop(◇ $(← unpackIprop P)))
 
-
-/-- Plainly modality -/
 class Plainly (PROP : Type _) where
   plainly : PROP → PROP
 export Plainly (plainly)
 
+/-- Plainly modality -/
 syntax "■ " term:40 : term
 
 macro_rules
-  | `(iprop(■ $P))  => ``(Plainly.plainly iprop($P))
+  | `(iprop(■%$tk $P))  => ``($(wrapIprop tk ``Plainly.plainly) iprop($P))
 
 delab_rule Plainly.plainly
   | `($_ $P) => do ``(iprop(■ $(← Iris.BI.unpackIprop P)))
@@ -357,10 +362,11 @@ delab_rule Plainly.plainly
 def Plainly.plainlyIf [BIBase PROP] [Plainly PROP] (p : Bool) (P : PROP) : PROP :=
   iprop(if p then ■ P else P)
 
+/-- Conditional plainly modality. -/
 syntax:max "■?" term:max ppHardSpace term:40 : term
 
 macro_rules
-  | `(iprop(■? $p $P))  => ``(Plainly.plainlyIf $p iprop($P))
+  | `(iprop(■?%$tk $p $P))  => ``($(wrapIprop tk ``Plainly.plainlyIf) $p iprop($P))
 
 delab_rule Plainly.plainlyIf
   | `($_ $p $P) => do ``(iprop(■? $p $(← Iris.BI.unpackIprop P)))

--- a/Iris/Iris/BI/BIBase.lean
+++ b/Iris/Iris/BI/BIBase.lean
@@ -11,12 +11,14 @@ public meta import Iris.Std.DelabRule
 public meta import Iris.Std.Rewrite
 public import Iris.Std.BigOp
 public meta import Iris.Std.RocqPorting
+public meta import Lean.PrettyPrinter.Delaborator
 
 @[expose] public section
 
 namespace Iris.BI
 open Iris.Std
 open Lean
+open Lean Lean.Macro Lean.Parser.Term Lean PrettyPrinter Delaborator SubExpr
 
 /--
 The basic components of a bunched implication (BI) algebra.
@@ -228,18 +230,18 @@ def absorbingly [BIBase PROP] (P : PROP) : PROP := iprop(True ∗ P)
 syntax:max "<affine> " term:40 : term
 syntax:max "<absorb> " term:40 : term
 
+/-- Bidirectional entailment on separation logic propositions. -/
 structure BiEntails [BIBase PROP] (P Q : PROP) where
   mp : P ⊢ Q
   mpr : Q ⊢ P
 
+/-- Entailment on separation logic propositions with an empty context. -/
 @[rocq_alias bi_emp_valid]
 def EmpValid [BIBase PROP] (P : PROP) : Prop := emp ⊢ P
 
-/-- Entailment on separation logic propositions with an empty context. -/
 macro:25 "⊢ " P:term:25 : term => ``(EmpValid iprop($P))
 macro:25 "⊢@{ " PROP:term " } " P:term:25 : term =>
   ``(EmpValid (PROP:=$PROP) iprop($P))
-/-- Bidirectional entailment on separation logic propositions. -/
 macro:25 P:term:29 " ⊣⊢ " Q:term:29 : term => ``(BiEntails iprop($P) iprop($Q))
 macro:25 P:term:29 " ⊣⊢@{ " PROP:term " } " Q:term:29 : term =>
   ``(BiEntails (PROP:=$PROP) iprop($P) iprop($Q))

--- a/Iris/Iris/BI/BigOp/BigOp.lean
+++ b/Iris/Iris/BI/BigOp/BigOp.lean
@@ -62,19 +62,44 @@ theorem WeakMonoidHomomorphism.ofEq [OFE PROP] {op₁ op₂ : PROP → PROP → 
   map_ne := hne
   map_op := hop
 
-/-- Big separating conjunction over a list with index access. -/
+/--
+Big separating conjunction over a list with index access.
+- Big separating conjunction over a list: `[∗list] x ∈ l, P x`.
+- Big separating conjunction over a list, with the index bound: `[∗list] i ↦ x ∈ l, P i x`.
+- Big separating conjunction over two lists in lockstep: `[∗list] x; y ∈ l1; l2, P x y`.
+- Big separating conjunction over two lists in lockstep, with the index bound:
+  `[∗list] i ↦ x; y ∈ l1; l2, P i x y`.
+-/
 abbrev bigSepL [BI PROP] {A : Type _} (Φ : Nat → A → PROP) (l : List A) : PROP :=
   bigOpL sep Φ l
 
-/-- Big conjunction over a list with index access. -/
+/--
+Big conjunction over a list with index access.
+
+- Big conjunction over a list: `[∧list] x ∈ l, P x`.
+- Big conjunction over a list, with the index bound: `[∧list] i ↦ x ∈ l, P i x`.
+-/
 abbrev bigAndL [BI PROP] {A : Type _} (Φ : Nat → A → PROP) (l : List A) : PROP :=
   bigOpL and Φ l
 
-/-- Big disjunction over a list with index access. -/
+/--
+Big disjunction over a list with index access.
+
+- Big disjunction over a list: `[∨list] x ∈ l, P x`.
+- Big disjunction over a list, with the index bound: `[∨list] i ↦ x ∈ l, P i x`.
+-/
 abbrev bigOrL [BI PROP] {A : Type _} (Φ : Nat → A → PROP) (l : List A) : PROP :=
   bigOpL or Φ l
 
-@[rocq_alias big_sepL2, expose] def bigSepL2 [BI PROP] {A B : Type _} (Φ : Nat → A → B → PROP)
+/--
+Big separating conjunction over two lists in lockstep.
+
+- Big separating conjunction over two lists: `[∗list] x;y ∈ l1; l2, P x y`.
+- Big separating conjunction over two lists, with the index bound:
+  `[∗list] i ↦ x; y ∈ l1; l2, P i x y`.
+-/
+@[rocq_alias big_sepL2, expose]
+def bigSepL2 [BI PROP] {A B : Type _} (Φ : Nat → A → B → PROP)
     (l1 : List A) (l2 : List B) : PROP :=
   match l1, l2 with
   | [], [] => emp
@@ -86,14 +111,22 @@ end List
 public section Map
 open Iris.Algebra Iris.Std OFE BIBase
 
-/-- Big separating conjunction over a map with key access. -/
-abbrev bigSepM [BI PROP] {K : Type _} {V : Type _} {M : Type _ → Type _} [LawfulFiniteMap M K]
-    (Φ : K → V → PROP) (m : M V) : PROP :=
+/--
+Big separating conjunction over a finite map's values, with key access.
+- Big separating conjunction over a map: `[∗map] v ∈ m, P v`.
+- Big separating conjunction over a map, with the key bound: `[∗map] k ↦ v ∈ m, P k v`.
+-/
+abbrev bigSepM [BI PROP] {K : Type _} {V : Type _} {M : Type _ → Type _}
+    [LawfulFiniteMap M K] (Φ : K → V → PROP) (m : M V) : PROP :=
   bigOpM sep Φ m
 
-/-- Big conjunction over a map with key access. -/
-abbrev bigAndM [BI PROP] {K : Type _} {V : Type _} {M : Type _ → Type _} [LawfulFiniteMap M K]
-    (Φ : K → V → PROP) (m : M V) : PROP :=
+/--
+Big conjunction over a finite map's values, with key access.
+- Big conjunction over a map: `[∧map] v ∈ m, P v`.
+- Big conjunction over a map, with the key bound: `[∧map] k ↦ v ∈ m, P k v`.
+-/
+abbrev bigAndM [BI PROP] {K : Type _} {V : Type _} {M : Type _ → Type _}
+    [LawfulFiniteMap M K] (Φ : K → V → PROP) (m : M V) : PROP :=
   bigOpM and Φ m
 
 end Map
@@ -101,54 +134,47 @@ end Map
 public section Set
 open Iris.Algebra Iris.Std OFE BIBase
 
-/-- Big separating conjunction over a finite set. -/
-abbrev bigSepS [BI PROP] {A : Type _} {S : Type _} [FiniteSet S A] (Φ : A → PROP) (s : S) : PROP :=
+/--
+Big separating conjunction over a finite set: `[∗set] x ∈ s, P x`.
+-/
+abbrev bigSepS [BI PROP] {A : Type _} {S : Type _}
+    [FiniteSet S A] (Φ : A → PROP) (s : S) : PROP :=
   bigOpS sep Φ s
 
-/-- Big separating conjunction over a finite multiset. -/
-abbrev bigSepMS [BI PROP] {A : Type _} {MS : Type _} [FiniteMultiSet MS A] (Φ : A → PROP) (X : MS) : PROP :=
+/--
+Big separating conjunction over a finite multiset: `[∗mset] x ∈ X, P x`.
+-/
+abbrev bigSepMS [BI PROP] {A : Type _} {MS : Type _}
+    [FiniteMultiSet MS A] (Φ : A → PROP) (X : MS) : PROP :=
   bigOpMS sep Φ X
 
 end Set
 
 public meta section
 open Lean PrettyPrinter Delaborator SubExpr
+
 /-! ## Notation -/
 
-/-- Big separating conjunction over a list: `[∗list] x ∈ l, P x`. -/
-syntax "[∗list] " ident " ∈ " term ", " term : term
-/-- Big separating conjunction over a list, with the index bound: `[∗list] i ↦ x ∈ l, P i x`. -/
-syntax "[∗list] " ident " ↦ " ident " ∈ " term ", " term : term
-/-- Big separating conjunction over two lists in lockstep: `[∗list] x;y ∈ l1;l2, P x y`. -/
-syntax "[∗list] " ident ";" ident " ∈ " term ";" term ", " term : term
-/-- Big separating conjunction over two lists in lockstep, with the index bound. -/
-syntax "[∗list] " ident " ↦ " ident ";" ident " ∈ " term ";" term ", " term : term
+@[inherit_doc bigSepL] syntax "[∗list] " ident " ∈ " term ", " term : term
+@[inherit_doc bigSepL] syntax "[∗list] " ident " ↦ " ident " ∈ " term ", " term : term
+@[inherit_doc bigSepL] syntax "[∗list] " ident ";" ident " ∈ " term ";" term ", " term : term
+@[inherit_doc bigSepL] syntax "[∗list] " ident " ↦ " ident ";" ident " ∈ " term ";" term ", " term : term
 
-/-- Big conjunction over a list: `[∧list] x ∈ l, P x`. -/
-syntax "[∧list] " ident " ∈ " term ", " term : term
-/-- Big conjunction over a list, with the index bound: `[∧list] i ↦ x ∈ l, P i x`. -/
-syntax "[∧list] " ident " ↦ " ident " ∈ " term ", " term : term
+@[inherit_doc bigAndL] syntax "[∧list] " ident " ∈ " term ", " term : term
+@[inherit_doc bigAndL] syntax "[∧list] " ident " ↦ " ident " ∈ " term ", " term : term
 
-/-- Big disjunction over a list: `[∨list] x ∈ l, P x`. -/
-syntax "[∨list] " ident " ∈ " term ", " term : term
-/-- Big disjunction over a list, with the index bound: `[∨list] i ↦ x ∈ l, P i x`. -/
-syntax "[∨list] " ident " ↦ " ident " ∈ " term ", " term : term
+@[inherit_doc bigOrL] syntax "[∨list] " ident " ∈ " term ", " term : term
+@[inherit_doc bigOrL] syntax "[∨list] " ident " ↦ " ident " ∈ " term ", " term : term
 
-/-- Big separating conjunction over a finite map's values: `[∗map] v ∈ m, P v`. -/
-syntax "[∗map] " ident " ∈ " term ", " term : term
-/-- Big separating conjunction over a finite map, with the key bound: `[∗map] k ↦ v ∈ m, P k v`. -/
-syntax "[∗map] " ident " ↦ " ident " ∈ " term ", " term : term
+@[inherit_doc bigSepM] syntax "[∗map] " ident " ∈ " term ", " term : term
+@[inherit_doc bigSepM] syntax "[∗map] " ident " ↦ " ident " ∈ " term ", " term : term
 
-/-- Big conjunction over a finite map's values: `[∧map] v ∈ m, P v`. -/
-syntax "[∧map] " ident " ∈ " term ", " term : term
-/-- Big conjunction over a finite map, with the key bound: `[∧map] k ↦ v ∈ m, P k v`. -/
-syntax "[∧map] " ident " ↦ " ident " ∈ " term ", " term : term
+@[inherit_doc bigAndM] syntax "[∧map] " ident " ∈ " term ", " term : term
+@[inherit_doc bigAndM] syntax "[∧map] " ident " ↦ " ident " ∈ " term ", " term : term
 
-/-- Big separating conjunction over a finite set: `[∗set] x ∈ s, P x`. -/
-syntax "[∗set] " ident " ∈ " term ", " term : term
+@[inherit_doc bigSepS] syntax "[∗set] " ident " ∈ " term ", " term : term
 
-/-- Big separating conjunction over a finite multiset: `[∗mset] x ∈ X, P x`. -/
-syntax "[∗mset] " ident " ∈ " term ", " term : term
+@[inherit_doc bigSepMS] syntax "[∗mset] " ident " ∈ " term ", " term : term
 
 macro_rules
   | `([∗list]%$tk $x:ident ∈ $l, $P) => do

--- a/Iris/Iris/BI/BigOp/BigOp.lean
+++ b/Iris/Iris/BI/BigOp/BigOp.lean
@@ -8,6 +8,7 @@ module
 public import Iris.Algebra.Monoid
 public import Iris.Algebra.BigOp
 public import Iris.BI.DerivedLaws
+public import Iris.BI.Notation
 import Lean
 
 namespace Iris.BI
@@ -114,73 +115,101 @@ public meta section
 open Lean PrettyPrinter Delaborator SubExpr
 /-! ## Notation -/
 
--- Notation for bigSepL without index
+/-- Big separating conjunction over a list: `[∗list] x ∈ l, P x`. -/
 syntax "[∗list] " ident " ∈ " term ", " term : term
--- Notation for bigSepL with index
+/-- Big separating conjunction over a list, with the index bound: `[∗list] i ↦ x ∈ l, P i x`. -/
 syntax "[∗list] " ident " ↦ " ident " ∈ " term ", " term : term
--- Notation for bigSepL2 without index
+/-- Big separating conjunction over two lists in lockstep: `[∗list] x;y ∈ l1;l2, P x y`. -/
 syntax "[∗list] " ident ";" ident " ∈ " term ";" term ", " term : term
--- Notation for bigSepL2 with index
+/-- Big separating conjunction over two lists in lockstep, with the index bound. -/
 syntax "[∗list] " ident " ↦ " ident ";" ident " ∈ " term ";" term ", " term : term
 
--- Notation for bigAndL without index
+/-- Big conjunction over a list: `[∧list] x ∈ l, P x`. -/
 syntax "[∧list] " ident " ∈ " term ", " term : term
--- Notation for bigAndL with index
+/-- Big conjunction over a list, with the index bound: `[∧list] i ↦ x ∈ l, P i x`. -/
 syntax "[∧list] " ident " ↦ " ident " ∈ " term ", " term : term
 
--- Notation for bigOrL without index
+/-- Big disjunction over a list: `[∨list] x ∈ l, P x`. -/
 syntax "[∨list] " ident " ∈ " term ", " term : term
--- Notation for bigOrL with index
+/-- Big disjunction over a list, with the index bound: `[∨list] i ↦ x ∈ l, P i x`. -/
 syntax "[∨list] " ident " ↦ " ident " ∈ " term ", " term : term
 
--- Notation for bigSepM without key
+/-- Big separating conjunction over a finite map's values: `[∗map] v ∈ m, P v`. -/
 syntax "[∗map] " ident " ∈ " term ", " term : term
--- Notation for bigSepM with key
+/-- Big separating conjunction over a finite map, with the key bound: `[∗map] k ↦ v ∈ m, P k v`. -/
 syntax "[∗map] " ident " ↦ " ident " ∈ " term ", " term : term
 
--- Notation for bigAndM without key
+/-- Big conjunction over a finite map's values: `[∧map] v ∈ m, P v`. -/
 syntax "[∧map] " ident " ∈ " term ", " term : term
--- Notation for bigAndM with key
+/-- Big conjunction over a finite map, with the key bound: `[∧map] k ↦ v ∈ m, P k v`. -/
 syntax "[∧map] " ident " ↦ " ident " ∈ " term ", " term : term
 
--- Notation for bigSepS
+/-- Big separating conjunction over a finite set: `[∗set] x ∈ s, P x`. -/
 syntax "[∗set] " ident " ∈ " term ", " term : term
 
--- Notation for bigSepMS
+/-- Big separating conjunction over a finite multiset: `[∗mset] x ∈ X, P x`. -/
 syntax "[∗mset] " ident " ∈ " term ", " term : term
 
 macro_rules
-  | `([∗list] $x:ident ∈ $l, $P) => `(bigSepL (fun _ $x => $P) $l)
-  | `([∗list] $k:ident ↦ $x:ident ∈ $l, $P) => `(bigSepL (fun $k $x => $P) $l)
-  | `([∧list] $x:ident ∈ $l, $P) => `(bigAndL (fun _ $x => $P) $l)
-  | `([∧list] $k:ident ↦ $x:ident ∈ $l, $P) => `(bigAndL (fun $k $x => $P) $l)
-  | `([∨list] $x:ident ∈ $l, $P) => `(bigOrL (fun _ $x => $P) $l)
-  | `([∨list] $k:ident ↦ $x:ident ∈ $l, $P) => `(bigOrL (fun $k $x => $P) $l)
-  | `([∗list] $x1:ident;$x2:ident ∈ $l1;$l2, $P) => `(bigSepL2 (fun _ $x1 $x2 => $P) $l1 $l2)
-  | `([∗list] $k:ident ↦ $x1:ident;$x2:ident ∈ $l1;$l2, $P) => `(bigSepL2 (fun $k $x1 $x2 => $P) $l1 $l2)
-  | `([∗map] $x:ident ∈ $m, $P) => `(bigSepM (fun _ $x => $P) $m)
-  | `([∗map] $k:ident ↦ $x:ident ∈ $m, $P) => `(bigSepM (fun $k $x => $P) $m)
-  | `([∧map] $x:ident ∈ $m, $P) => `(bigAndM (fun _ $x => $P) $m)
-  | `([∧map] $k:ident ↦ $x:ident ∈ $m, $P) => `(bigAndM (fun $k $x => $P) $m)
-  | `([∗set] $x:ident ∈ $s, $P) => `(bigSepS (fun $x => $P) $s)
-  | `([∗mset] $x:ident ∈ $X, $P) => `(bigSepMS (fun $x => $P) $X)
+  | `([∗list]%$tk $x:ident ∈ $l, $P) => do
+      `($(wrapIprop tk ``bigSepL) (fun _ $x => $P) $l)
+  | `([∗list]%$tk $k:ident ↦ $x:ident ∈ $l, $P) => do
+      `($(wrapIprop tk ``bigSepL) (fun $k $x => $P) $l)
+  | `([∧list]%$tk $x:ident ∈ $l, $P) => do
+      `($(wrapIprop tk ``bigAndL) (fun _ $x => $P) $l)
+  | `([∧list]%$tk $k:ident ↦ $x:ident ∈ $l, $P) => do
+      `($(wrapIprop tk ``bigAndL) (fun $k $x => $P) $l)
+  | `([∨list]%$tk $x:ident ∈ $l, $P) => do
+      `($(wrapIprop tk ``bigOrL) (fun _ $x => $P) $l)
+  | `([∨list]%$tk $k:ident ↦ $x:ident ∈ $l, $P) => do
+      `($(wrapIprop tk ``bigOrL) (fun $k $x => $P) $l)
+  | `([∗list]%$tk $x1:ident;$x2:ident ∈ $l1;$l2, $P) => do
+      `($(wrapIprop tk ``bigSepL2) (fun _ $x1 $x2 => $P) $l1 $l2)
+  | `([∗list]%$tk $k:ident ↦ $x1:ident;$x2:ident ∈ $l1;$l2, $P) => do
+      `($(wrapIprop tk ``bigSepL2) (fun $k $x1 $x2 => $P) $l1 $l2)
+  | `([∗map]%$tk $x:ident ∈ $m, $P) => do
+      `($(wrapIprop tk ``bigSepM) (fun _ $x => $P) $m)
+  | `([∗map]%$tk $k:ident ↦ $x:ident ∈ $m, $P) => do
+      `($(wrapIprop tk ``bigSepM) (fun $k $x => $P) $m)
+  | `([∧map]%$tk $x:ident ∈ $m, $P) => do
+      `($(wrapIprop tk ``bigAndM) (fun _ $x => $P) $m)
+  | `([∧map]%$tk $k:ident ↦ $x:ident ∈ $m, $P) => do
+      `($(wrapIprop tk ``bigAndM) (fun $k $x => $P) $m)
+  | `([∗set]%$tk $x:ident ∈ $s, $P) => do
+      `($(wrapIprop tk ``bigSepS) (fun $x => $P) $s)
+  | `([∗mset]%$tk $x:ident ∈ $X, $P) => do
+      `($(wrapIprop tk ``bigSepMS) (fun $x => $P) $X)
 
 -- iprop macro rules
 macro_rules
-  | `(iprop([∗list] $x:ident ∈ $l, $P)) => `(bigSepL (fun _ $x => iprop($P)) $l)
-  | `(iprop([∗list] $k:ident ↦ $x:ident ∈ $l, $P)) => `(bigSepL (fun $k $x => iprop($P)) $l)
-  | `(iprop([∧list] $x:ident ∈ $l, $P)) => `(bigAndL (fun _ $x => iprop($P)) $l)
-  | `(iprop([∧list] $k:ident ↦ $x:ident ∈ $l, $P)) => `(bigAndL (fun $k $x => iprop($P)) $l)
-  | `(iprop([∨list] $x:ident ∈ $l, $P)) => `(bigOrL (fun _ $x => iprop($P)) $l)
-  | `(iprop([∨list] $k:ident ↦ $x:ident ∈ $l, $P)) => `(bigOrL (fun $k $x => iprop($P)) $l)
-  | `(iprop([∗list] $x1:ident;$x2:ident ∈ $l1;$l2, $P)) => `(bigSepL2 (fun _ $x1 $x2 => iprop($P)) $l1 $l2)
-  | `(iprop([∗list] $k:ident ↦ $x1:ident;$x2:ident ∈ $l1;$l2, $P)) => `(bigSepL2 (fun $k $x1 $x2 => iprop($P)) $l1 $l2)
-  | `(iprop([∗map] $x:ident ∈ $m, $P)) => `(bigSepM (fun _ $x => iprop($P)) $m)
-  | `(iprop([∗map] $k:ident ↦ $x:ident ∈ $m, $P)) => `(bigSepM (fun $k $x => iprop($P)) $m)
-  | `(iprop([∧map] $x:ident ∈ $m, $P)) => `(bigAndM (fun _ $x => iprop($P)) $m)
-  | `(iprop([∧map] $k:ident ↦ $x:ident ∈ $m, $P)) => `(bigAndM (fun $k $x => iprop($P)) $m)
-  | `(iprop([∗set] $x:ident ∈ $s, $P)) => `(bigSepS (fun $x => iprop($P)) $s)
-  | `(iprop([∗mset] $x:ident ∈ $X, $P)) => `(bigSepMS (fun $x => iprop($P)) $X)
+  | `(iprop([∗list]%$tk $x:ident ∈ $l, $P)) => do
+      `($(wrapIprop tk ``bigSepL) (fun _ $x => iprop($P)) $l)
+  | `(iprop([∗list]%$tk $k:ident ↦ $x:ident ∈ $l, $P)) => do
+      `($(wrapIprop tk ``bigSepL) (fun $k $x => iprop($P)) $l)
+  | `(iprop([∧list]%$tk $x:ident ∈ $l, $P)) => do
+      `($(wrapIprop tk ``bigAndL) (fun _ $x => iprop($P)) $l)
+  | `(iprop([∧list]%$tk $k:ident ↦ $x:ident ∈ $l, $P)) => do
+      `($(wrapIprop tk ``bigAndL) (fun $k $x => iprop($P)) $l)
+  | `(iprop([∨list]%$tk $x:ident ∈ $l, $P)) => do
+      `($(wrapIprop tk ``bigOrL) (fun _ $x => iprop($P)) $l)
+  | `(iprop([∨list]%$tk $k:ident ↦ $x:ident ∈ $l, $P)) => do
+      `($(wrapIprop tk ``bigOrL) (fun $k $x => iprop($P)) $l)
+  | `(iprop([∗list]%$tk $x1:ident;$x2:ident ∈ $l1;$l2, $P)) => do
+      `($(wrapIprop tk ``bigSepL2) (fun _ $x1 $x2 => iprop($P)) $l1 $l2)
+  | `(iprop([∗list]%$tk $k:ident ↦ $x1:ident;$x2:ident ∈ $l1;$l2, $P)) => do
+      `($(wrapIprop tk ``bigSepL2) (fun $k $x1 $x2 => iprop($P)) $l1 $l2)
+  | `(iprop([∗map]%$tk $x:ident ∈ $m, $P)) => do
+      `($(wrapIprop tk ``bigSepM) (fun _ $x => iprop($P)) $m)
+  | `(iprop([∗map]%$tk $k:ident ↦ $x:ident ∈ $m, $P)) => do
+      `($(wrapIprop tk ``bigSepM) (fun $k $x => iprop($P)) $m)
+  | `(iprop([∧map]%$tk $x:ident ∈ $m, $P)) => do
+      `($(wrapIprop tk ``bigAndM) (fun _ $x => iprop($P)) $m)
+  | `(iprop([∧map]%$tk $k:ident ↦ $x:ident ∈ $m, $P)) => do
+      `($(wrapIprop tk ``bigAndM) (fun $k $x => iprop($P)) $m)
+  | `(iprop([∗set]%$tk $x:ident ∈ $s, $P)) => do
+      `($(wrapIprop tk ``bigSepS) (fun $x => iprop($P)) $s)
+  | `(iprop([∗mset]%$tk $x:ident ∈ $X, $P)) => do
+      `($(wrapIprop tk ``bigSepMS) (fun $x => iprop($P)) $X)
 
 /-- Helper to delaborate a bigOpL-shaped lambda body into list notation.
     `opConst` is checked against the `op` argument; `mkWithIdx` / `mkNoIdx` build syntax. -/

--- a/Iris/Iris/BI/Cmra.lean
+++ b/Iris/Iris/BI/Cmra.lean
@@ -30,7 +30,7 @@ variable [Sbi PROP] [CMRA A]
 def internalCmraValid (a : A) : PROP := siPure (cmraValid a)
 
 macro_rules
-  | `(iprop(✓ $a)) => ``(internalCmraValid $a)
+  | `(iprop(✓%$tk $a)) => ``($(wrapIprop tk ``internalCmraValid) $a)
 
 delab_rule internalCmraValid
   | `($_ $a) => ``(iprop(✓ $a))
@@ -51,7 +51,7 @@ theorem internalCmraValid_intro {P : PROP} {a : A} (h : Valid a) :
 
 @[rocq_alias internal_cmra_valid_elim]
 theorem internalCmraValid_elim (a : A) : ✓ a ⊢@{PROP} ⌜✓{0} a⌝ :=
-  calc internalCmraValid a
+  calc iprop(✓ a)
     _ ⊢ <si_pure> ⌜✓{0} a⌝ := siPure_mono cmraValid_elim
     _ ⊢ ⌜✓{0} a⌝ := siPure_pure.mp
 

--- a/Iris/Iris/BI/Embedding.lean
+++ b/Iris/Iris/BI/Embedding.lean
@@ -26,15 +26,21 @@ open Iris Iris.Std OFE Iris.Algebra Iris.Algebra.BigOpL Iris.Algebra.BigOpM
 
 /-! ## The `Embed` operation `⎡·⎤` -/
 
-/-- The embedding operation `⎡·⎤ : A → B`. `B` is intentionally *not*
-an `outParam`: the target logic is fixed by the expected type, not inferred. -/
+/--
+The embedding operation `⎡·⎤ : A → B`.
+
+`B` is intentionally *not* an `outParam`: the target logic is fixed by the
+expected type, not inferred.
+-/
 @[rocq_alias Embed]
 class Embed (A B : Type _) where
   embed : A → B
 export Embed (embed)
 
+attribute [inherit_doc Embed] Embed.embed
+
 syntax "⎡" term "⎤" : term
-macro_rules | `(iprop(⎡$P⎤)) => ``(Embed.embed iprop($P))
+macro_rules | `(iprop(⎡%$tk1 $P ⎤%$tk2)) => ``($(wrapIpropSpan tk1 tk2 ``Embed.embed) iprop($P))
 
 delab_rule Embed.embed
   | `($_ $P) => do ``(⎡$(← unpackIprop P)⎤)

--- a/Iris/Iris/BI/InternalEq.lean
+++ b/Iris/Iris/BI/InternalEq.lean
@@ -14,15 +14,17 @@ public import Iris.Algebra.Excl
 namespace Iris
 open BI OFE Iris.Std
 
-/-- Internal equality in a BI with step-indexed structure, defined as
-`siPure (SiProp.internalEq a b)`. -/
+/--
+  Internal equality in a BI with step-indexed structure, where `a ≡ b` is
+  defined as `siPure (SiProp.internalEq a b)`.
+-/
 @[rocq_alias internal_eq]
 def internalEq [Sbi PROP] {A : Type _} [OFE A] (a b : A) : PROP :=
   iprop(<si_pure> (SiProp.internalEq a b))
 
 syntax:40 term:40 " ≡ " term:41 : term
 macro_rules
-  | `(iprop($a ≡ $b)) => ``(internalEq $a $b)
+  | `(iprop($a ≡%$tk $b)) => ``($(wrapIprop tk ``internalEq) $a $b)
 
 delab_rule internalEq
   | `($_ $a $b) => ``(iprop($a ≡ $b))

--- a/Iris/Iris/BI/Notation.lean
+++ b/Iris/Iris/BI/Notation.lean
@@ -48,9 +48,11 @@ syntax:min "iprop% " term:min : term
 macro_rules
   | `(iprop% $t) => `(iprop($t))
 
+/-- Used by macro elaboration rules for linking source information to connectives. -/
 meta def wrapIprop (tk : Syntax) (c : Name) : Ident :=
   mkCIdentFrom tk c (canonical := true)
 
+/-- A variant of `wrapIprop` where the operator spans over two tokens (e.g. `⌜·⌝`). -/
 meta def wrapIpropSpan (tk1 tk2 : Syntax) (c : Name) : Ident :=
   match tk1.getPos?, tk2.getTailPos? with
   | some pos, some endPos => ⟨(mkCIdent c).raw.setInfo (.synthetic pos endPos (canonical := true))⟩

--- a/Iris/Iris/BI/Notation.lean
+++ b/Iris/Iris/BI/Notation.lean
@@ -6,17 +6,17 @@ Authors: Lars König, Alex Keizer
 module
 
 public meta import Lean.PrettyPrinter.Delaborator
-
+meta import Lean.PrettyPrinter.Delaborator.Builtins
 meta import Lean.Parser.Term
 
 public meta section
 
 namespace Iris.BI
-open Lean Lean.Macro Lean.Parser.Term
+open Lean Lean.Macro Lean.Parser.Term Lean PrettyPrinter Delaborator SubExpr
 
-/-- `iprop(P)` embeds a separation logic proposition `P` into `term`. -/
+/- `iprop(P)` embeds a separation logic proposition `P` into `term`. -/
 syntax:max (name := iprop) "iprop(" term ")" : term
-/-- `term(t)` escapes from an `iprop(…)` embedding. -/
+/- `term(t)` escapes from an `iprop(…)` embedding. -/
 syntax:max "term(" term ")" : term
 
 -- allow fallback to `term`

--- a/Iris/Iris/BI/Notation.lean
+++ b/Iris/Iris/BI/Notation.lean
@@ -5,14 +5,12 @@ Authors: Lars König, Alex Keizer
 -/
 module
 
-public meta import Lean.PrettyPrinter.Delaborator
-meta import Lean.PrettyPrinter.Delaborator.Builtins
 meta import Lean.Parser.Term
 
 public meta section
 
 namespace Iris.BI
-open Lean Lean.Macro Lean.Parser.Term Lean PrettyPrinter Delaborator SubExpr
+open Lean Lean.Parser.Term
 
 /- `iprop(P)` embeds a separation logic proposition `P` into `term`. -/
 syntax:max (name := iprop) "iprop(" term ")" : term
@@ -35,7 +33,7 @@ macro_rules
               $[$alts:matchAlt]*)) => do
         let alts ← alts.mapM <| fun
           | `(matchAltExpr| | $[$lhs]|* => $rhs) => `(matchAltExpr| | $[$lhs]|* => iprop($rhs))
-          | _ => throwUnsupported
+          | _ => Macro.throwUnsupported
         `(match $[$g:generalizingParam]? $[$m:motive]? $[$x:matchDiscr],* with $[$alts:matchAlt]*)
 
 macro:max "iprop(" P:term " : " t:term ")" : term => `((iprop($P) : $t))

--- a/Iris/Iris/BI/Notation.lean
+++ b/Iris/Iris/BI/Notation.lean
@@ -14,8 +14,9 @@ public meta section
 namespace Iris.BI
 open Lean Lean.Macro Lean.Parser.Term
 
--- define `iprop` embedding in `term`
+/-- `iprop(P)` embeds a separation logic proposition `P` into `term`. -/
 syntax:max (name := iprop) "iprop(" term ")" : term
+/-- `term(t)` escapes from an `iprop(…)` embedding. -/
 syntax:max "term(" term ")" : term
 
 -- allow fallback to `term`
@@ -39,10 +40,22 @@ macro_rules
 
 macro:max "iprop(" P:term " : " t:term ")" : term => `((iprop($P) : $t))
 
--- paren-less form: eats the rest of the term at minimum precedence
+/--
+  `iprop% P` is `iprop(P)` without parentheses; it consumes the remainder of
+  the term at minimum precedence.
+-/
 syntax:min "iprop% " term:min : term
 macro_rules
   | `(iprop% $t) => `(iprop($t))
+
+meta def wrapIprop (tk : Syntax) (c : Name) : Ident :=
+  mkCIdentFrom tk c (canonical := true)
+
+meta def wrapIpropSpan (tk1 tk2 : Syntax) (c : Name) : Ident :=
+  match tk1.getPos?, tk2.getTailPos? with
+  | some pos, some endPos => ⟨(mkCIdent c).raw.setInfo (.synthetic pos endPos (canonical := true))⟩
+  | none, _ => wrapIprop tk2 c
+  | _, none => wrapIprop tk1 c
 
 /-- Retain the syntax source information for correct delaboration. -/
 def keepInfo (src : Syntax) (t : Term) : Term :=

--- a/Iris/Iris/BI/Notation.lean
+++ b/Iris/Iris/BI/Notation.lean
@@ -44,19 +44,26 @@ syntax:min "iprop% " term:min : term
 macro_rules
   | `(iprop% $t) => `(iprop($t))
 
+/-- Retain the syntax source information for correct delaboration. -/
+def keepInfo (src : Syntax) (t : Term) : Term :=
+  match src.getHeadInfo with
+  | info@(.synthetic ..) => ⟨t.raw.setInfo info⟩
+  | _                    => t
+
 /-- Remove an `iprop` quotation from a `term` syntax object. -/
-partial def unpackIprop [Monad m] [MonadRef m] [MonadQuotation m] : Term → m Term
-  | `(iprop($P))             => do `($P)
-  | `($P:ident)              => do `($P)
-  | `(?$P:ident)             => do `(?$P)
-  | `(($P))                  => do `(($(← unpackIprop P)))
-  | `($P $[ $Q]*)            => do ``($P $[ $Q]*)
-  | `(if $c then $t else $e) => do
+partial def unpackIprop [Monad m] [MonadRef m] [MonadQuotation m] (stx : Term) : m Term := do
+  match stx with
+  | `(iprop($P))             => return keepInfo stx (← `($P))
+  | `($P:ident)              => `($P)
+  | `(?$P:ident)             => `(?$P)
+  | `(($P))                  => return keepInfo stx (← `(($(← unpackIprop P))))
+  | `($P $[ $Q]*)            => return keepInfo stx (← ``($P $[ $Q]*))
+  | `(if $c then $t else $e) =>
     let t ← unpackIprop t
     let e ← unpackIprop e
     `(if $c then $t else $e)
-  | `(($P : $t))             => do ``(($(← unpackIprop P) : $t))
-  | `(match $[$g:generalizingParam]? $[$mot:motive]? $[$x:matchDiscr],* with $[$alts:matchAlt]*) => do
+  | `(($P : $t))             => ``(($(← unpackIprop P) : $t))
+  | `(match $[$g:generalizingParam]? $[$mot:motive]? $[$x:matchDiscr],* with $[$alts:matchAlt]*) =>
       -- The following type ascriptions look redundant, but, without them, the ``(match ...)`
       -- syntax quotation below fails with an error about types containing metavariables.
       let g : Option (TSyntax ``generalizingParam) := g

--- a/Iris/Iris/BI/Sbi.lean
+++ b/Iris/Iris/BI/Sbi.lean
@@ -26,7 +26,7 @@ step-index, and `siEmpValid : PROP → SiProp` that expresses that a proposition
 -/
 
 namespace Iris
-open OFE BI
+open OFE BI Iris.BI.BIBase
 
 /-- Embedding of step-indexed propositions into a BI. -/
 @[rocq_alias SiPure]
@@ -46,8 +46,8 @@ syntax "<si_pure> " term:40 : term
 syntax "<si_emp_valid> " term:40 : term
 
 macro_rules
-  | `(iprop(<si_pure> $P)) => ``(SiPure.siPure iprop($P))
-  | `(iprop(<si_emp_valid> $P)) => ``(SiEmpValid.siEmpValid iprop($P))
+  | `(iprop(<si_pure>%$tk $P)) => ``($(wrapIprop tk ``SiPure.siPure) iprop($P))
+  | `(iprop(<si_emp_valid>%$tk $P)) => ``($(wrapIprop tk ``SiEmpValid.siEmpValid) iprop($P))
 
 delab_rule SiPure.siPure
   | `($_ $P) => do ``(iprop(<si_pure> $(← BI.unpackIprop P)))

--- a/Iris/Iris/BI/Sbi.lean
+++ b/Iris/Iris/BI/Sbi.lean
@@ -34,11 +34,15 @@ class SiPure (PROP : Type _) where
   siPure : SiProp → PROP
 export SiPure (siPure)
 
+attribute [inherit_doc SiPure] SiPure.siPure
+
 /-- Step-indexed validity of BI propositions. -/
 @[rocq_alias SiEmpValid]
 class SiEmpValid (PROP : Type _) where
   siEmpValid : PROP → SiProp
 export SiEmpValid (siEmpValid)
+
+attribute [inherit_doc SiEmpValid] SiEmpValid.siEmpValid
 
 section Notation
 

--- a/Iris/Iris/BI/Updates.lean
+++ b/Iris/Iris/BI/Updates.lean
@@ -9,6 +9,7 @@ public import Iris.BI.BI
 public import Iris.BI.BIBase
 public import Iris.BI.Classes
 public import Iris.BI.DerivedLaws
+public import Iris.BI.Notation
 public import Iris.Algebra
 public import Iris.BI.Plainly
 public import Iris.Std.CoPset
@@ -23,108 +24,154 @@ class BUpd (PROP : Type _) where
   bupd : PROP → PROP
 export BUpd (bupd)
 
+/-- Basic update modality. -/
 syntax "|==> " term:40 : term
+/-- Basic update modality with a wand: `P ==∗ Q` is a shorthand for `|==> P -∗ Q`. -/
 syntax:25 term:26 " ==∗ " term:25 : term
 
 macro_rules
-  | `(iprop(|==> $P))  => ``(BUpd.bupd iprop($P))
-  | `(iprop($P ==∗ $Q))  => ``(BIBase.wand iprop($P) (BUpd.bupd iprop($Q)))
-  | `($P ==∗ $Q)  => ``(⊢ $P ==∗ $Q)
+  | `(iprop(|==>%$tk $P))   => ``($(wrapIprop tk ``BUpd.bupd) iprop($P))
+  | `(iprop($P ==∗%$tk $Q)) =>
+    ``(BIBase.wand iprop($P) ($(wrapIprop tk ``BUpd.bupd) iprop($Q)))
+  | `($P ==∗%$tk $Q)        => ``(⊢ $P ==∗%$tk $Q)
 
 delab_rule BUpd.bupd
-  | `($_ $P) => do ``(iprop(|==> $(← Iris.BI.unpackIprop P)))
+  | `($_ $P) => do ``(iprop(|==> $(← unpackIprop P)))
 
 delab_rule BIBase.wand
-  | `($_ $P iprop(|==> $Q)) => do `(iprop($(←Iris.BI.unpackIprop P) ==∗ $Q))
+  | `($_ $P iprop(|==> $Q)) => do `(iprop($(← unpackIprop P) ==∗ $Q))
 
 @[rocq_alias FUpd]
 class FUpd (PROP : Type _) where
   fupd : CoPset → CoPset → PROP → PROP
 export FUpd (fupd)
 
+/-- Fancy update modality (`|={E1,E2}=>`) with a mask change from `E1` to `E2`. -/
 syntax "|={" term ", " term "}=> " term : term
+/-- Fancy update modality with a wand: `P ={E1,E2}=∗ Q` is a shorthand for `|={E1,E2}=> P -∗ Q`. -/
 syntax:25 term:26 " ={" term "," term "}=∗ " term:25 : term
+/-- Fancy update modality with a fixed mask: `|={E}=> P` is a shorthand for `|={E,E}=> P`. -/
 syntax "|={" term "}=> " term : term
+/--
+  Fancy update modality with a fixed mask and a wand:
+  `P ={E}=∗ Q` is a shorthand for `|={E}=> P -∗ Q`.
+-/
 syntax:25 term:26 " ={" term "}=∗ " term:25 : term
 
 macro_rules
-  | `(iprop(|={$E1,$E2}=> $P))  => ``(FUpd.fupd $E1 $E2 iprop($P))
-  | `(iprop($P ={$E1,$E2}=∗ $Q))  => ``(BIBase.wand iprop($P) (FUpd.fupd $E1 $E2 iprop($Q)))
-  | `(iprop(|={$E1}=> $P))  => ``(FUpd.fupd $E1 $E1 iprop($P))
-  | `(iprop($P ={$E1}=∗ $Q))  => ``(BIBase.wand iprop($P) (FUpd.fupd $E1 $E1 iprop($Q)))
-  | `($P ={$E1,$E2}=∗ $Q)  => ``(⊢ $P ={$E1,$E2}=∗ $Q)
-  | `($P ={$E1}=∗ $Q)  => ``(⊢ $P ={$E1}=∗ $Q)
+  | `(iprop(|={%$tk1 $E1,$E2 }=>%$tk2 $P))   => do
+      ``($(wrapIpropSpan tk1 tk2 ``FUpd.fupd) $E1 $E2 iprop($P))
+  | `(iprop($P ={%$tk1 $E1,$E2 }=∗%$tk2 $Q)) => do
+      ``(BIBase.wand iprop($P) ($(wrapIpropSpan tk1 tk2 ``FUpd.fupd) $E1 $E2 iprop($Q)))
+  | `(iprop(|={%$tk1 $E1}=>%$tk2 $P))       => do
+      ``($(wrapIpropSpan tk1 tk2 ``FUpd.fupd) $E1 $E1 iprop($P))
+  | `(iprop($P ={%$tk1 $E1 }=∗%$tk2 $Q))     => do
+      ``(BIBase.wand iprop($P) ($(wrapIpropSpan tk1 tk2 ``FUpd.fupd) $E1 $E1 iprop($Q)))
+  | `($P ={%$tk $E1,$E2}=∗ $Q)        => ``(⊢ $P ={%$tk $E1,$E2}=∗ $Q)
+  | `($P ={%$tk $E1}=∗ $Q)            => ``(⊢ $P ={%$tk $E1}=∗ $Q)
 
 delab_rule FUpd.fupd
   | `($_ $E1 $E2 $P) => do
-      let P ← Iris.BI.unpackIprop P
+      let P ← unpackIprop P
       if E1 == E2 then ``(iprop(|={$E1}=> $P))
       else ``(iprop(|={$E1,$E2}=> $P))
 
 delab_rule BIBase.wand
-  | `($_ $P iprop(|={$E₁,$E₂}=> $Q)) => do `(iprop($(←Iris.BI.unpackIprop P) ={$E₁,$E₂}=∗ $Q))
-  | `($_ $P iprop(|={$E₁}=> $Q)) => do `(iprop($(←Iris.BI.unpackIprop P) ={$E₁}=∗ $Q))
+  | `($_ $P iprop(|={$E₁,$E₂}=> $Q)) => do `(iprop($(← unpackIprop P) ={$E₁,$E₂}=∗ $Q))
+  | `($_ $P iprop(|={$E₁}=> $Q)) => do `(iprop($(← unpackIprop P) ={$E₁}=∗ $Q))
 
+/--
+  Fancy update taking one step:
+  `|={E1}[E2]▷=> P` is a shorthand for `|={E1,E2}=> ▷ (|={E2,E1}=> P)`.
+-/
 syntax "|={" term "}[" term "]▷=> " term : term
+/--
+  Fancy update taking one step with a wand: `P =={E1}[E2]▷=∗ Q` is a
+  shorthand for `|={E1}[E2]=> P -∗ Q`.
+-/
 syntax:25 term:26 " ={" term "}[" term "]▷=∗ " term:25 : term
+/-- Fancy update taking one step with a fixed mask. -/
 syntax "|={" term "}▷=> " term : term
+/-- Fancy update taking one step with a fixed mask and a wand. -/
 syntax:25 term:26 " ={" term "}▷=∗ " term:25 : term
 
 macro_rules
-  | `(iprop(|={$E1}[$E2]▷=> $P))  => ``(iprop(|={$E1,$E2}=> ▷ (|={$E2,$E1}=> iprop($P))))
-  | `(iprop($P ={$E1}[$E2]▷=∗ $Q))  => ``(iprop(iprop($P) -∗ |={$E1}[$E2]▷=> iprop($Q)))
-  | `(iprop(|={$E1}▷=> $P))  => ``(iprop(|={$E1}[$E1]▷=> iprop($P)))
-  | `(iprop($P ={$E1}▷=∗ $Q))  => ``(iprop(iprop($P) ={$E1}[$E1]▷=∗ iprop($Q)))
+  | `(iprop(|={%$tk $E1}[$E2]▷=> $P))   =>
+    ``(iprop(|={%$tk $E1,$E2}=> ▷ (|={$E2,$E1}=> iprop($P))))
+  | `(iprop($P ={%$tk $E1}[$E2]▷=∗ $Q)) =>
+    ``(iprop(iprop($P) -∗ |={%$tk $E1}[$E2]▷=> iprop($Q)))
+  | `(iprop(|={%$tk $E1}▷=> $P))        =>
+    ``(iprop(|={%$tk $E1}[$E1]▷=> iprop($P)))
+  | `(iprop($P ={%$tk $E1}▷=∗ $Q))      =>
+    ``(iprop(iprop($P) ={%$tk $E1}[$E1]▷=∗ iprop($Q)))
 
 delab_rule FUpd.fupd
   | `($_ $E₁ $E₂ iprop(▷ |={$E₂',$E₁'}=> $P)) => do
     unless E₁ == E₁' ∧ E₂ == E₂' do throw ()
-    `(iprop(|={$E₁}[$E₂]▷=> $(←Iris.BI.unpackIprop P)))
+    `(iprop(|={$E₁}[$E₂]▷=> $(← unpackIprop P)))
   | `($_ $E₁ $E₁' iprop(▷ |={$E₁''}=> $P)) => do
     unless E₁ == E₁' ∧ E₁' == E₁'' do throw ()
-    `(iprop(|={$E₁}▷=> $(←Iris.BI.unpackIprop P)))
+    `(iprop(|={$E₁}▷=> $(← unpackIprop P)))
 
 delab_rule BIBase.wand
   | `($_ $Q iprop(|={$E₁}[$E₂]▷=> $P)) => do
-    `(iprop($(←Iris.BI.unpackIprop Q) ={$E₁}[$E₂]▷=∗ $P))
+    `(iprop($(← unpackIprop Q) ={$E₁}[$E₂]▷=∗ $P))
   | `($_ $Q iprop(|={$E₁}▷=> $P)) => do
-    `(iprop($(←Iris.BI.unpackIprop Q) ={$E₁}▷=∗ $P))
+    `(iprop($(← unpackIprop Q) ={$E₁}▷=∗ $P))
 
+/-- Fancy update taking `n` steps. -/
 syntax "|={" term "}[" term "]▷^" term "=> " term : term
+/-- Fancy update taking `n` steps with a wand. -/
 syntax:25 term:26 " ={" term "}[" term "]▷^" term "=∗ " term:25 : term
+/-- Fancy update taking `n` steps with a fixed mask. -/
 syntax "|={" term "}▷^" term "=> " term : term
+/-- Fancy update taking `n` steps with a fixed mask and a wand. -/
 syntax:25 term:26 " ={" term "}▷^" term "=∗ " term:25 : term
 
 macro_rules
-  | `(iprop(|={$E1}[$E2]▷^$n=> $P))  => ``(iprop(|={$E1,$E2}=> ▷^[$n] (|={$E2,$E1}=> iprop($P))))
-  | `(iprop($P ={$E1}[$E2]▷^$n=∗ $Q))  => ``(iprop(iprop($P) -∗ |={$E1}[$E2]▷^$n=> iprop($Q)))
-  | `(iprop(|={$E1}▷^$n=> $P))  => ``(iprop(|={$E1}[$E1]▷^$n=> iprop($P)))
-  | `(iprop($P ={$E1}▷^$n=∗ $Q))  => ``(iprop(iprop($P) ={$E1}[$E1]▷^$n=∗ iprop($Q)))
+  | `(iprop(|={%$tk $E1}[$E2]▷^$n=> $P))   =>
+      ``(iprop(|={%$tk $E1,$E2}=> ▷^[$n] (|={$E2,$E1}=> iprop($P))))
+  | `(iprop($P ={%$tk $E1}[$E2]▷^$n=∗ $Q)) =>
+      ``(iprop(iprop($P) -∗ |={%$tk $E1}[$E2]▷^$n=> iprop($Q)))
+  | `(iprop(|={%$tk $E1}▷^$n=> $P))        =>
+      ``(iprop(|={%$tk $E1}[$E1]▷^$n=> iprop($P)))
+  | `(iprop($P ={%$tk $E1}▷^$n=∗ $Q))      =>
+      ``(iprop(iprop($P) ={%$tk $E1}[$E1]▷^$n=∗ iprop($Q)))
 
 delab_rule FUpd.fupd
   | `($_ $E₁ $E₂ iprop(▷^[$n] |={$E₂',$E₁'}=> $P)) => do
     unless E₁ == E₁' ∧ E₂ == E₂' do throw ()
-    `(iprop(|={$E₁}[$E₂]▷^$n=> $(←Iris.BI.unpackIprop P)))
+    `(iprop(|={$E₁}[$E₂]▷^$n=> $(← unpackIprop P)))
   | `($_ $E₁ $E₁' iprop(▷^[$n] |={$E₁''}=> $P)) => do
     unless E₁ == E₁' ∧ E₁' == E₁'' do throw ()
-    `(iprop(|={$E₁}▷^$n=> $(←Iris.BI.unpackIprop P)))
+    `(iprop(|={$E₁}▷^$n=> $(← unpackIprop P)))
 
 delab_rule BIBase.wand
   | `($_ $Q iprop(|={$E₁}[$E₂]▷^$n=> $P)) => do
-    `(iprop($(←Iris.BI.unpackIprop Q) ={$E₁}[$E₂]▷^$n=∗ $P))
+    `(iprop($(← unpackIprop Q) ={$E₁}[$E₂]▷^$n=∗ $P))
   | `($_ $Q iprop(|={$E₁}▷^$n=> $P)) => do
-    `(iprop($(←Iris.BI.unpackIprop Q) ={$E₁}▷^$n=∗ $P))
+    `(iprop($(← unpackIprop Q) ={$E₁}▷^$n=∗ $P))
 
+/-- Iterated one-step fancy update: `n` repetitions of `|={E1}[E2]▷=>`. -/
 syntax "|={" term "}[" term "]▷=>^[" term "] " term : term
+/-- Iterated one-step fancy update with a wand. -/
 syntax:25 term:26 " ={" term "}[" term "]▷=∗^[" term "] " term:25 : term
+/-- Iterated one-step fancy update with a fixed mask. -/
 syntax "|={" term "}▷=>^[" term "] " term : term
+/-- Iterated one-step fancy update with a fixed mask and a wand. -/
 syntax:25 term:26 " ={" term "}▷=∗^[" term "] " term:25 : term
 
 macro_rules
-  | `(iprop(|={ $E1 }[ $E2 ]▷=>^[ $n ] $P))  => ``(Nat.repeat (fun Q => iprop(|={ $E1 }[ $E2 ]▷=> Q)) $n iprop($P))
-  | `(iprop($P ={ $E1 }[ $E2 ]▷=∗^[ $n ] $Q))  => ``(BIBase.wand iprop($P) (Nat.repeat (fun Q => iprop(|={ $E1 }[ $E2 ]▷=> Q)) $n iprop($Q)))
-  | `(iprop(|={ $E1 }▷=>^[ $n ] $P))  => ``(Nat.repeat (fun Q => iprop(|={ $E1 }[ $E1 ]▷=> Q)) $n iprop($P))
-  | `(iprop($P ={ $E1 }▷=∗^[ $n ] $Q))  => ``(BIBase.wand iprop($P) (Nat.repeat (fun Q => iprop(|={ $E1 }[ $E1 ]▷=> Q)) $n iprop($Q)))
+  | `(iprop(|={%$tk $E1 }[ $E2 ]▷=>^[ $n ] $P))   =>
+      ``(Nat.repeat (fun Q => iprop(|={%$tk $E1 }[ $E2 ]▷=> Q)) $n iprop($P))
+  | `(iprop($P ={%$tk $E1 }[ $E2 ]▷=∗^[ $n ] $Q)) =>
+      ``(BIBase.wand iprop($P)
+         (Nat.repeat (fun Q => iprop(|={%$tk $E1 }[ $E2 ]▷=> Q)) $n iprop($Q)))
+  | `(iprop(|={%$tk $E1 }▷=>^[ $n ] $P))          =>
+      ``(Nat.repeat (fun Q => iprop(|={%$tk $E1 }[ $E1 ]▷=> Q)) $n iprop($P))
+  | `(iprop($P ={%$tk $E1 }▷=∗^[ $n ] $Q))        =>
+      ``(BIBase.wand iprop($P)
+         (Nat.repeat (fun Q => iprop(|={%$tk $E1 }[ $E1 ]▷=> Q)) $n iprop($Q)))
 
 open Lean.PrettyPrinter.Delaborator SubExpr in
 @[app_delab Nat.repeat]
@@ -151,9 +198,9 @@ meta def delabStepFUpdN : Delab :=  do
 
 delab_rule BIBase.wand
   | `($_ $Q iprop(|={$E₁}[$E₂]▷=>^[$n] $P)) => do
-    `(iprop($(←Iris.BI.unpackIprop Q) ={$E₁}[$E₂]▷=∗^[$n] $P))
+    `(iprop($(← unpackIprop Q) ={$E₁}[$E₂]▷=∗^[$n] $P))
   | `($_ $Q iprop(|={$E₁}▷=>^[$n] $P)) => do
-    `(iprop($(←Iris.BI.unpackIprop Q) ={$E₁}▷=∗^[$n] $P))
+    `(iprop($(← unpackIprop Q) ={$E₁}▷=∗^[$n] $P))
 
 @[rocq_alias BiBUpd]
 class BIUpdate (PROP : Type _) [BI PROP] extends BUpd PROP where

--- a/Iris/Iris/BI/Updates.lean
+++ b/Iris/Iris/BI/Updates.lean
@@ -19,14 +19,19 @@ public import Iris.Std.CoPset
 namespace Iris
 open Iris.Std BI
 
+/--
+Basic update modality.
+
+- `|==> P` is the basic update modality.
+- `P ==∗ Q` is shorthand for `|==> P -∗ Q`.
+-/
 @[rocq_alias BUpd]
 class BUpd (PROP : Type _) where
   bupd : PROP → PROP
 export BUpd (bupd)
 
-/-- Basic update modality. -/
+attribute [inherit_doc BUpd] BUpd.bupd
 syntax "|==> " term:40 : term
-/-- Basic update modality with a wand: `P ==∗ Q` is a shorthand for `|==> P -∗ Q`. -/
 syntax:25 term:26 " ==∗ " term:25 : term
 
 macro_rules
@@ -41,21 +46,32 @@ delab_rule BUpd.bupd
 delab_rule BIBase.wand
   | `($_ $P iprop(|==> $Q)) => do `(iprop($(← unpackIprop P) ==∗ $Q))
 
+/--
+Fancy update modality.
+
+- `|={E1,E2}=> P` changes the mask from `E1` to `E2`.
+- `|={E}=> P` is shorthand for `|={E,E}=> P`.
+- `P ={E1,E2}=∗ Q` is shorthand for `|={E1,E2}=> P -∗ Q`.
+- `P ={E}=∗ Q` is shorthand for `|={E}=> P -∗ Q`.
+- `|={E1}[E2]▷=> P` is a one-step fancy update.
+- `|={E}▷=> P` is a one-step fancy update with a fixed mask.
+- `|={E1}[E2]▷^n=> P` is a fancy update taking `n` steps.
+- `|={E}▷^n=> P` is a fancy update taking `n` steps with a fixed mask.
+- `|={E1}[E2]▷=>^[n] P` iterates the one-step fancy update `n` times.
+- `|={E}▷=>^[n] P` iterates the one-step fancy update `n` times with a fixed mask.
+
+The wand form `P ={E1,E2}=∗ Q` is a shorthand for `|={E1,E2}=> P -∗ Q`.
+The wand forms of the other notations are analogous.
+-/
 @[rocq_alias FUpd]
 class FUpd (PROP : Type _) where
   fupd : CoPset → CoPset → PROP → PROP
 export FUpd (fupd)
 
-/-- Fancy update modality (`|={E1,E2}=>`) with a mask change from `E1` to `E2`. -/
+attribute [inherit_doc FUpd] FUpd.fupd
 syntax "|={" term ", " term "}=> " term : term
-/-- Fancy update modality with a wand: `P ={E1,E2}=∗ Q` is a shorthand for `|={E1,E2}=> P -∗ Q`. -/
 syntax:25 term:26 " ={" term "," term "}=∗ " term:25 : term
-/-- Fancy update modality with a fixed mask: `|={E}=> P` is a shorthand for `|={E,E}=> P`. -/
 syntax "|={" term "}=> " term : term
-/--
-  Fancy update modality with a fixed mask and a wand:
-  `P ={E}=∗ Q` is a shorthand for `|={E}=> P -∗ Q`.
--/
 syntax:25 term:26 " ={" term "}=∗ " term:25 : term
 
 macro_rules
@@ -80,19 +96,9 @@ delab_rule BIBase.wand
   | `($_ $P iprop(|={$E₁,$E₂}=> $Q)) => do `(iprop($(← unpackIprop P) ={$E₁,$E₂}=∗ $Q))
   | `($_ $P iprop(|={$E₁}=> $Q)) => do `(iprop($(← unpackIprop P) ={$E₁}=∗ $Q))
 
-/--
-  Fancy update taking one step:
-  `|={E1}[E2]▷=> P` is a shorthand for `|={E1,E2}=> ▷ (|={E2,E1}=> P)`.
--/
 syntax "|={" term "}[" term "]▷=> " term : term
-/--
-  Fancy update taking one step with a wand: `P =={E1}[E2]▷=∗ Q` is a
-  shorthand for `|={E1}[E2]=> P -∗ Q`.
--/
 syntax:25 term:26 " ={" term "}[" term "]▷=∗ " term:25 : term
-/-- Fancy update taking one step with a fixed mask. -/
 syntax "|={" term "}▷=> " term : term
-/-- Fancy update taking one step with a fixed mask and a wand. -/
 syntax:25 term:26 " ={" term "}▷=∗ " term:25 : term
 
 macro_rules
@@ -119,13 +125,9 @@ delab_rule BIBase.wand
   | `($_ $Q iprop(|={$E₁}▷=> $P)) => do
     `(iprop($(← unpackIprop Q) ={$E₁}▷=∗ $P))
 
-/-- Fancy update taking `n` steps. -/
 syntax "|={" term "}[" term "]▷^" term "=> " term : term
-/-- Fancy update taking `n` steps with a wand. -/
 syntax:25 term:26 " ={" term "}[" term "]▷^" term "=∗ " term:25 : term
-/-- Fancy update taking `n` steps with a fixed mask. -/
 syntax "|={" term "}▷^" term "=> " term : term
-/-- Fancy update taking `n` steps with a fixed mask and a wand. -/
 syntax:25 term:26 " ={" term "}▷^" term "=∗ " term:25 : term
 
 macro_rules
@@ -152,13 +154,9 @@ delab_rule BIBase.wand
   | `($_ $Q iprop(|={$E₁}▷^$n=> $P)) => do
     `(iprop($(← unpackIprop Q) ={$E₁}▷^$n=∗ $P))
 
-/-- Iterated one-step fancy update: `n` repetitions of `|={E1}[E2]▷=>`. -/
 syntax "|={" term "}[" term "]▷=>^[" term "] " term : term
-/-- Iterated one-step fancy update with a wand. -/
 syntax:25 term:26 " ={" term "}[" term "]▷=∗^[" term "] " term:25 : term
-/-- Iterated one-step fancy update with a fixed mask. -/
 syntax "|={" term "}▷=>^[" term "] " term : term
-/-- Iterated one-step fancy update with a fixed mask and a wand. -/
 syntax:25 term:26 " ={" term "}▷=∗^[" term "] " term:25 : term
 
 macro_rules

--- a/Iris/Iris/BI/WeakestPre.lean
+++ b/Iris/Iris/BI/WeakestPre.lean
@@ -95,13 +95,13 @@ meta def parseWpPostcond (stx : TSyntax `wpPostcond) : MacroM (TSyntax `term × 
 @[macro wp]
 meta def wpMacro : Lean.Macro := fun stx => do
   match stx with
-  | `(WP $expr $postcond) =>
+  | `(WP%$tk $expr $postcond) =>
     let (e, s, E) ← parseWpExpr expr
     let (Φ, useTotal?) ← parseWpPostcond postcond
     if useTotal? then
       `(TotalWp.totalWp $s $E $e $Φ)
     else
-      `(Wp.wp $s $E $e $Φ)
+      `($(BI.wrapIpropSpan tk stx ``Wp.wp) $s $E $e $Φ)
   | _ => Lean.Macro.throwUnsupported
 
 meta def parseTexanTriple : Syntax → MacroM Term

--- a/Iris/Iris/Instances/Classical/Notation.lean
+++ b/Iris/Iris/Instances/Classical/Notation.lean
@@ -19,7 +19,7 @@ def maps_to (l : Nat) (v : Val) : HeapProp Val :=
 syntax:52 term:53 " ↦ " term:53 : term
 
 macro_rules
-  | `(iprop($l ↦ $v)) => `(maps_to $l $v)
+  | `(iprop($l ↦%$tk $v)) => `($(BI.wrapIprop tk ``maps_to) $l $v)
 
 delab_rule maps_to
   | `($_ $l $v) => `(iprop($l ↦ $v))

--- a/Iris/Iris/Instances/Lib/FUpd.lean
+++ b/Iris/Iris/Instances/Lib/FUpd.lean
@@ -10,6 +10,7 @@ public import Iris.Algebra.Auth
 public import Iris.Algebra.Numbers
 public import Iris.ProofMode
 public import Iris.BI.Algebra
+public import Iris.BI.Notation
 public import Iris.Instances.IProp
 public import Iris.Instances.Lib.WSat
 public import Iris.Instances.Lib.LaterCredits
@@ -210,20 +211,20 @@ def fupd_finally [InvGS_gen hlc GF] (E : CoPset) (P : IProp GF) : IProp GF :=
 #rocq_ignore fupd_finally_aux "Not needed"
 #rocq_ignore fupd_finally_unseal "Not needed"
 
-
 syntax "|={" term "|}=> " term : term
 syntax:25 term:26 "={" term "|}=∗ " term:25 : term
 
 macro_rules
-  | `(iprop(|={$E|}=> $P))  => ``(fupd_finally $E iprop($P))
-  | `(iprop($P ={$E|}=∗ $Q))  => ``(BIBase.wand iprop($P) (fupd_finally $E iprop($Q)))
+  | `(iprop(|={%$tk1 $E |}=>%$tk2 $P))  =>
+    ``($(wrapIpropSpan tk1 tk2 ``fupd_finally) $E iprop($P))
+  | `(iprop($P ={%$tk1 $E |}=∗%$tk2 $Q))  =>
+    ``(BIBase.wand iprop($P) ($(wrapIpropSpan tk1 tk2 ``fupd_finally) $E iprop($Q)))
   | `($P ={$E|}=∗ $Q)  => ``(⊢ $P ={$E|}=∗ $Q)
 
 delab_rule fupd_finally
   | `($_ $E $P) => do
       let P ← Iris.BI.unpackIprop P
       ``(iprop(|={$E|}=> $P))
-
 
 section fupd_finally
 

--- a/Iris/Iris/Instances/Lib/LaterCredits.lean
+++ b/Iris/Iris/Instances/Lib/LaterCredits.lean
@@ -250,7 +250,7 @@ def le_upd (P : IProp GF) : IProp GF := fixpoint (le_upd_pre P)
 syntax:max "|==£> " term:40 : term
 
 macro_rules
-| `(iprop(|==£> $P)) => ``(le_upd iprop($P))
+| `(iprop(|==£>%$tk $P)) => ``($(wrapIprop tk ``le_upd) iprop($P))
 
 delab_rule le_upd
 | `($_ $P) => do ``(iprop(|==£> $(← unpackIprop P)))
@@ -511,7 +511,7 @@ def le_upd_finally [LcGS hlc GF] (P : IProp GF) : IProp GF :=
 syntax:max "|==£|> " term:40 : term
 
 macro_rules
-| `(iprop(|==£|> $P)) => ``(le_upd_finally iprop($P))
+| `(iprop(|==£|>%$tk $P)) => ``($(wrapIprop tk ``le_upd_finally) iprop($P))
 
 delab_rule le_upd_finally
 | `($_ $P) => do ``(iprop(|==£|> $(← unpackIprop P)))

--- a/Iris/Iris/Tests/Display.lean
+++ b/Iris/Iris/Tests/Display.lean
@@ -66,10 +66,12 @@ info:
   ⋆ R : PROP
 ⋆ HPQ (binder) : P ∗ P -∗ R -∗ Q
   ⋆ P ∗ P -∗ R -∗ Q : PROP
-    ⋆ P : PROP
-    ⋆ P : PROP
-    ⋆ R : PROP
-    ⋆ Q : PROP
+    ⋆ P ∗ P : PROP
+      ⋆ P : PROP
+      ⋆ P : PROP
+    ⋆ R -∗ Q : PROP
+      ⋆ R : PROP
+      ⋆ Q : PROP
 ⋆ Q : PROP
 -/
 #guard_msgs (whitespace := lax) in
@@ -98,19 +100,24 @@ info:
     ⋆ P2 : PROP
 ⋆ HP3 (binder) : <absorb> <affine> P3
   ⋆ <absorb> <affine> P3 : PROP
-    ⋆ P3 : PROP
+    ⋆ <affine> P3 : PROP
+      ⋆ P3 : PROP
 ⋆ HP4 (binder) : <absorb> <affine> P4
   ⋆ <absorb> <affine> P4 : PROP
-    ⋆ P4 : PROP
+    ⋆ <affine> P4 : PROP
+      ⋆ P4 : PROP
 ⋆ H (binder) : <absorb> (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) -∗ Q
   ⋆ <absorb> (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) -∗ Q : PROP
-    ⋆ (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) : PROP
-      ⋆ P1 : PROP
-      ⋆ P2 : PROP
-      ⋆ (P3 ∗ P4) : PROP
-        ⋆ P3 : PROP
-        ⋆ P4 : PROP
-  ⋆ Q : PROP
+    ⋆ <absorb> (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) : PROP
+      ⋆ (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) : PROP
+        ⋆ P1 : PROP
+        ⋆ P2 ∗ <affine> (P3 ∗ P4) : PROP
+        ⋆ P2 : PROP
+      ⋆ <affine> (P3 ∗ P4) : PROP
+        ⋆ (P3 ∗ P4) : PROP
+          ⋆ P3 : PROP
+          ⋆ P4 : PROP
+    ⋆ Q : PROP
 ⋆ Q : PROP
 -/
 #guard_msgs (whitespace := lax) in
@@ -182,10 +189,12 @@ info:
 ⋆ Hwand (binder) : ∀ x, Q -∗ ⌜x = n⌝
   ⋆ ∀ x, Q -∗ ⌜x = n⌝ : PROP
     ⋆ x : Nat
-    ⋆ Q : PROP
-    ⋆ x = n : Prop
-      ⋆ x : Nat
-      ⋆ n : Nat
+    ⋆ Q -∗ ⌜x = n⌝ : PROP
+      ⋆ Q : PROP
+      ⋆ ⌜x = n⌝ : PROP
+        ⋆ x = n : Prop
+          ⋆ x : Nat
+          ⋆ n : Nat
 ⋆ HQ (binder) : Q
   ⋆ Q : PROP
 ⋆ False : PROP

--- a/Iris/Iris/Tests/HeapLang/HeapTactics.lean
+++ b/Iris/Iris/Tests/HeapLang/HeapTactics.lean
@@ -115,8 +115,7 @@ example {l : Loc} {v v' v'' : Val} :
 
 -- Rocq parity (`first [wp_seq|wp_finish]`): a store in sequencing position discards its
 -- `#()` result, so `wp_store` steps through the `;` instead of leaving a pure redex behind
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 ι : HeapLangGS hlc GF
@@ -129,16 +128,16 @@ v v' : Val
   ∗Hpt : l ↦ some v'
   ⊢ WP hl(!#l) @ s ; E {{ w, ⌜w = v'⌝ ∗ l ↦ some v' }}
 -/
-#guard_msgs (whitespace := lax) in
+#guard_msgs (whitespace := lax, trace, drop error) in
 example {l : Loc} {v v' : Val} :
     (l ↦ some v) ⊢
       WP hl(v(#l) ← &v'; !v(#l)) @ s ; E {{ w, ⌜w = v'⌝ ∗ l ↦ some v' }} := by
   iintro Hpt
   wp_store
+  trace_state
 
 -- the fast-forward is *only* for the sequencing redex: a `let` binding the result stays
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 ι : HeapLangGS hlc GF
@@ -151,12 +150,13 @@ v v' : Val
   ∗Hpt : l ↦ some v'
   ⊢ WP hl(let x := #(); !#l) @ s ; E {{ _r, l ↦ some v' }}
 -/
-#guard_msgs (whitespace := lax) in
+#guard_msgs (whitespace := lax, trace, drop error) in
 example {l : Loc} {v v' : Val} :
     (l ↦ some v) ⊢
       WP hl(let x := v(#l) ← &v'; !v(#l)) @ s ; E {{ _r, l ↦ some v' }} := by
   iintro Hpt
   wp_store
+  trace_state
 
 /-- error: wp_store: cannot find a points-to hypothesis for l ↦{DFrac.own 1} _ -/
 #guard_msgs (whitespace := lax) in

--- a/Iris/Iris/Tests/HeapLang/WeakestPre.lean
+++ b/Iris/Iris/Tests/HeapLang/WeakestPre.lean
@@ -22,8 +22,7 @@ namespace wp_value_head
 
 variable (v : Val)
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF
@@ -31,12 +30,12 @@ v : Val
 ⊢ ⏎
   ⊢ |={⊤}=> True
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF} WP (v : Exp) {{ v, True }} := by
   wp_value_head
+  trace_state
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF
@@ -44,12 +43,12 @@ v : Val
 ⊢ ⏎
   ⊢ |={⊤}=> True
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF} WP (v : Exp) {{ v, |={⊤}=> True }} := by
   wp_value_head
+  trace_state
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF
@@ -57,155 +56,154 @@ v : Val
 ⊢ ⏎
   ⊢ WP hl(v(&v)) {{ v, True }}
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF} WP (v : Exp) {{ v, WP ((v : Val) : Exp) {{ v, True }} }} := by
   istart
   wp_value_head
+  trace_state
 
 end wp_value_head
 
 namespace wp_bind
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF
 ⊢ ⏎
   ⊢ WP hl(((#0 + #1) + #2)) {{ v, WP hl((v(&v) + #3)) {{ v, True }} }}
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF}  WP hl(((#0 + #1) + #2) + #3) {{ v, True }} := by
   wp_bind ((#0 + _) + _)
+  trace_state
 
 /-- error: wp_bind: Cannot unify hl((#2 + &?_)) with any possible evaluation context -/
 #guard_msgs in
 example : ⊢@{IProp GF}  WP hl(((#0 + #1) + #2) + #3) {{ v, True }} := by
   wp_bind (#2 + _)
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF
 ⊢ ⏎
   ⊢ WP hl(((#0 + #1) + #2)) {{ v, WP hl((v(&v) + #3)) {{ v, True }} }}
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF}  WP hl(((#0 + #1) + #2) + #3) {{ v, True }} := by
   wp_bind (_ + #2)
+  trace_state
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF
 ⊢ ⏎
   ⊢ WP hl((#0 + #1)) {{ v, WP hl(((v(&v) + #2) + #3)) {{ v, True }} }}
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF}  WP hl(((#0 + #1) + #2) + #3) {{ v, True }} := by
   wp_bind (#0 + #1)
+  trace_state
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF
 ⊢ ⏎
   ⊢ WP hl((#2 + (#1 + #2))) {{ v, True }}
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF}  WP hl(#2 + (#1 + #2)) {{ v, True }} := by
   wp_bind (#2 + _)
+  trace_state
 
-
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF
 ⊢ ⏎
   ⊢ WP hl((#1 + #2)) {{ v, WP hl((#2 + v(&v))) {{ v, True }} }}
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF}  WP hl(#2 + (#1 + #2)) {{ v, True }} := by
   wp_bind (_ + #2)
+  trace_state
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF
 ⊢ ⏎
   ⊢ WP hl(snd((#1, #0))) {{ v, WP hl((v(&v) + #1)) {{ v, True }} }}
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF}  WP hl(snd((#1,#0)) + #1) {{ v, True }} := by
   wp_bind (snd(_))
+  trace_state
 
 end wp_bind
 
 section wp_pure
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF
 ⊢ ⏎
   ⊢ |={⊤}=> ⌜hl_val(#0) = hl_val(#0)⌝
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF}  WP hl(if #false then #1 else #0) {{ v, ⌜v = hl_val(#0)⌝ }} := by
   istart
   wp_pure
+  trace_state
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF
 ⊢ ⏎
   ⊢ |={⊤}=> ⌜hl_val(#1) = hl_val(#1)⌝
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF}  WP hl(if #true then #1 else #0) {{ v, ⌜v = hl_val(#1)⌝ }} := by
   istart
   wp_pure
+  trace_state
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF
 ⊢ ⏎
   ⊢ |={⊤}=> ⌜hl_val(#2) = hl_val(#2)⌝
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF}  WP hl(snd(v((#1,#2)))) {{ v, ⌜v = hl_val(#2)⌝ }} := by
   istart
   wp_pure
+  trace_state
 
 example : ⊢@{IProp GF}  WP hl(snd(v((#1,#2)))) {{ v, ⌜v = hl_val(#2)⌝ }} := by
   istart
   wp_pure
   itrivial
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF
 ⊢ ⏎
   ⊢ |={⊤}=> ⌜hl_val(#2) = hl_val(#2)⌝
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF} WP hl(if #true then if #false then #1 else #2 else #3) {{ v, ⌜v = hl_val(#2)⌝ }} := by
   wp_pures
+  trace_state
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF
@@ -213,9 +211,10 @@ n : Int
 ⊢ ⏎
   ⊢ |={⊤}=> ⌜hl_val(#(hl_val(#(decide (1 * 2 <<< 3 ≤ n + (1 &&& 2 ^^^ 3)))) == hl_val(#true))) = hl_val(#true)⌝
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example (n : Int) : ⊢@{IProp GF} WP hl((#1 * #2 <<< #3 ≤ #n + (#1 &&& #2 ^^^ #3)) = #true) {{ v, ⌜v = hl_val(#true)⌝ }} := by
   wp_pures
+  trace_state
 
 end wp_pure
 
@@ -227,8 +226,7 @@ section wp_lam
 
 def addOne : Val := hl_val% λ x, x + #1
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF✝ : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF✝
@@ -237,9 +235,10 @@ inst✝ : HeapLangGS hlc GF
 ⊢ ⏎
   ⊢ WP hl((#1 + #1)) {{ v, ⌜v = hl_val(#2)⌝ }}
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF} WP hl(v(λ x, x + #1) #1) {{ v, ⌜v = hl_val(#2)⌝ }} := by
   wp_lam
+  trace_state
 
 /--
 error: iapply: cannot apply WP hl(v(&?_) v(&?_)) @ ?_ ; ?_ {{ ?_ }} to WP hl(let x := #1; (x + #1)) {{ v, ⌜v = hl_val(#2)⌝ }}
@@ -248,8 +247,7 @@ error: iapply: cannot apply WP hl(v(&?_) v(&?_)) @ ?_ ; ?_ {{ ?_ }} to WP hl(let
 example : ⊢@{IProp GF} WP hl((λ x, x + #1) #1) {{ v, ⌜v = hl_val(#2)⌝ }} := by
   wp_lam
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF✝ : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF✝
@@ -258,9 +256,10 @@ inst✝ : HeapLangGS hlc GF
 ⊢ ⏎
   ⊢ WP hl((#1 + #1)) {{ v, ⌜v = hl_val(#2)⌝ }}
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF} WP hl(&addOne #1) {{ v, ⌜v = hl_val(#2)⌝ }} := by
   wp_lam
+  trace_state
 
 /--
 error: iapply: cannot apply WP hl(v(&?_) v(&?_)) @ ?_ ; ?_ {{ ?_ }} to WP hl(v(&addOne) (#1 + #1)) {{ v, ⌜v = hl_val(#3)⌝ }}
@@ -278,8 +277,7 @@ section wp_let
 example : ⊢@{IProp GF} WP hl(#1; #2) {{ v, ⌜v = hl_val(#2)⌝ }} := by
   wp_let
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF✝ : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF✝
@@ -288,16 +286,16 @@ inst✝ : HeapLangGS hlc GF
 ⊢ ⏎
   ⊢ WP hl((#1 + #1)) {{ v, ⌜v = hl_val(#2)⌝ }}
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF} WP hl(let x := #1; x + #1) {{ v, ⌜v = hl_val(#2)⌝ }} := by
   wp_let
+  trace_state
 
 end wp_let
 
 section wp_seq
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF✝ : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF✝
@@ -306,9 +304,10 @@ inst✝ : HeapLangGS hlc GF
 ⊢ ⏎
   ⊢ |={⊤}=> ⌜hl_val(#2) = hl_val(#2)⌝
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF} WP hl(#1; #2) {{ v, ⌜v = hl_val(#2)⌝ }} := by
   wp_seq
+  trace_state
 
 /-- error: wp_pure: Cannot find expression to evaluate -/
 #guard_msgs in
@@ -324,8 +323,7 @@ section wp_closure
 example : ⊢@{IProp GF} WP hl(#1 + #1) {{ v, ⌜v = hl_val(#2)⌝ }} := by
   wp_closure
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF✝ : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF✝
@@ -334,16 +332,16 @@ inst✝ : HeapLangGS hlc GF
 ⊢ ⏎
   ⊢ WP hl((v(λ x, (x + #1))) #1) {{ v, ⌜v = hl_val(#2)⌝ }}
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF} WP hl((λ x, x + #1) #1) {{ v, ⌜v = hl_val(#2)⌝ }} := by
   wp_closure
+  trace_state
 
 end wp_closure
 
 section wp_if
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF✝ : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF✝
@@ -352,9 +350,10 @@ inst✝ : HeapLangGS hlc GF
 ⊢ ⏎
   ⊢ |={⊤}=> ⌜hl_val(#1) = hl_val(#1)⌝
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF} WP hl(if #true then #1 else #2) {{ v, ⌜v = hl_val(#1)⌝ }} := by
   wp_if
+  trace_state
 
 /-- error: wp_pure: Cannot find expression to evaluate -/
 #guard_msgs in
@@ -370,8 +369,7 @@ section wp_if_true
 example : ⊢@{IProp GF} WP hl(if #false then #1 else #2) {{ v, ⌜v = hl_val(#2)⌝ }} := by
   wp_if_true
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF✝ : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF✝
@@ -380,16 +378,16 @@ inst✝ : HeapLangGS hlc GF
 ⊢ ⏎
   ⊢ |={⊤}=> ⌜hl_val(#1) = hl_val(#1)⌝
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF} WP hl(if #true then #1 else #2) {{ v, ⌜v = hl_val(#1)⌝ }} := by
   wp_if_true
+  trace_state
 
 end wp_if_true
 
 section wp_if_false
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF✝ : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF✝
@@ -398,9 +396,10 @@ inst✝ : HeapLangGS hlc GF
 ⊢ ⏎
   ⊢ |={⊤}=> ⌜hl_val(#2) = hl_val(#2)⌝
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF} WP hl(if #false then #1 else #2) {{ v, ⌜v = hl_val(#2)⌝ }} := by
   wp_if_false
+  trace_state
 
 /-- error: wp_pure: Cannot find expression to evaluate -/
 #guard_msgs in
@@ -411,8 +410,7 @@ end wp_if_false
 
 section wp_proj
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF✝ : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF✝
@@ -421,17 +419,17 @@ inst✝ : HeapLangGS hlc GF
 ⊢ ⏎
   ⊢ |={⊤}=> ⌜hl_val(#1) = hl_val(#1)⌝
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF} WP hl(fst(v((#1, #2)))) {{ v, ⌜v = hl_val(#1)⌝ }} := by
   wp_proj
+  trace_state
 
 /-- error: wp_pure: Cannot find expression to evaluate -/
 #guard_msgs in
 example : ⊢@{IProp GF} WP hl((#1, #2)) {{ v, ⌜v = hl_val((#1, #2))⌝ }} := by
   wp_proj
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF✝ : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF✝
@@ -440,9 +438,10 @@ inst✝ : HeapLangGS hlc GF
 ⊢ ⏎
   ⊢ |={⊤}=> ⌜hl_val(#2) = hl_val(#2)⌝
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF} WP hl(snd(v((#1, #2)))) {{ v, ⌜v = hl_val(#2)⌝ }} := by
   wp_proj
+  trace_state
 
 end wp_proj
 
@@ -453,8 +452,7 @@ section wp_inj
 example : ⊢@{IProp GF} WP hl(injr(#1 + #1)) {{ v, ⌜v = hl_val(injr(#2))⌝ }} := by
   wp_inj
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF✝ : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF✝
@@ -463,12 +461,12 @@ inst✝ : HeapLangGS hlc GF
 ⊢ ⏎
   ⊢ |={⊤}=> ⌜hl_val(injr(#1)) = hl_val(injr(#1))⌝
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF} WP hl(injr(#1)) {{ v, ⌜v = hl_val(injr(#1))⌝ }} := by
   wp_inj
+  trace_state
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF✝ : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF✝
@@ -477,16 +475,16 @@ inst✝ : HeapLangGS hlc GF
 ⊢ ⏎
   ⊢ |={⊤}=> ⌜hl_val(injl(#1)) = hl_val(injl(#1))⌝
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF} WP hl(injl(#1)) {{ v, ⌜v = hl_val(injl(#1))⌝ }} := by
   wp_inj
+  trace_state
 
 end wp_inj
 
 section wp_pair
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF✝ : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF✝
@@ -495,9 +493,10 @@ inst✝ : HeapLangGS hlc GF
 ⊢ ⏎
   ⊢ |={⊤}=> ⌜hl_val((#1, #2)) = hl_val((#1, #2))⌝
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF} WP hl((#1, #2)) {{ v, ⌜v = hl_val((#1, #2))⌝ }} := by
   wp_pair
+  trace_state
 
 /-- error: wp_pure: Cannot find expression to evaluate -/
 #guard_msgs in
@@ -513,8 +512,7 @@ section wp_unop
 example : ⊢@{IProp GF} WP hl(#1 + #2) {{ v, ⌜v = hl_val(#3)⌝ }} := by
   wp_unop
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF✝ : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF✝
@@ -523,16 +521,16 @@ inst✝ : HeapLangGS hlc GF
 ⊢ ⏎
   ⊢ |={⊤}=> ⌜hl_val(#!true) = hl_val(#false)⌝
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF} WP hl(~#true) {{ v, ⌜v = hl_val(#false)⌝ }} := by
   wp_unop
+  trace_state
 
 end wp_unop
 
 section wp_binop
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF✝ : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF✝
@@ -541,9 +539,10 @@ inst✝ : HeapLangGS hlc GF
 ⊢ ⏎
   ⊢ |={⊤}=> ⌜hl_val(#(1 + 2)) = hl_val(#3)⌝
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF} WP hl(#1 + #2) {{ v, ⌜v = hl_val(#3)⌝ }} := by
   wp_binop
+  trace_state
 
 /-- error: wp_pure: Cannot find expression to evaluate -/
 #guard_msgs in
@@ -554,8 +553,7 @@ end wp_binop
 
 section wp_op
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF✝ : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF✝
@@ -564,17 +562,17 @@ inst✝ : HeapLangGS hlc GF
 ⊢ ⏎
   ⊢ |={⊤}=> ⌜hl_val(#!true) = hl_val(#false)⌝
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF} WP hl(~#true) {{ v, ⌜v = hl_val(#false)⌝ }} := by
   wp_op
+  trace_state
 
 /-- error: wp_pure: Cannot find expression to evaluate -/
 #guard_msgs in
 example : ⊢@{IProp GF} WP hl(if #true then #1 else #2) {{ v, ⌜v = hl_val(#1)⌝ }} := by
   wp_op
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF✝ : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF✝
@@ -583,9 +581,10 @@ inst✝ : HeapLangGS hlc GF
 ⊢ ⏎
   ⊢ |={⊤}=> ⌜hl_val(#(1 + 2)) = hl_val(#3)⌝
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF} WP hl(#1 + #2) {{ v, ⌜v = hl_val(#3)⌝ }} := by
   wp_op
+  trace_state
 
 end wp_op
 
@@ -598,8 +597,7 @@ example : ⊢@{IProp GF}
       {{ v, ⌜v = hl_val(#2)⌝ }} := by
   wp_case
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF✝ : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF✝
@@ -608,18 +606,18 @@ inst✝ : HeapLangGS hlc GF
 ⊢ ⏎
   ⊢ WP hl(let x := #1; (x + #1)) {{ v, ⌜v = hl_val(#2)⌝ }}
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF}
     WP hl(match v(injl(#1)) with | injl(x) => x + #1 | injr(y) => y)
       {{ v, ⌜v = hl_val(#2)⌝ }} := by
   wp_case
+  trace_state
 
 end wp_case
 
 section wp_match
 
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF✝ : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF✝
@@ -628,11 +626,12 @@ inst✝ : HeapLangGS hlc GF
 ⊢ ⏎
   ⊢ WP hl((#1 + #1)) {{ v, ⌜v = hl_val(#2)⌝ }}
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example : ⊢@{IProp GF}
     WP hl(match v(injl(#1)) with | injl(x) => x + #1 | injr(y) => y)
       {{ v, ⌜v = hl_val(#2)⌝ }} := by
   wp_match
+  trace_state
 
 /-- error: wp_pure: Cannot find expression to evaluate -/
 #guard_msgs in

--- a/Iris/Iris/Tests/Tactics.lean
+++ b/Iris/Iris/Tests/Tactics.lean
@@ -525,17 +525,17 @@ example [BI PROP] (Φ : Bool → PROP) : ⊢ ∀ x, <affine> ⌜x = true⌝ -∗
   iexact H
 
 /- Tests that `irevert` clears binder info (see https://github.com/leanprover-community/iris-lean/pull/393#issuecomment-4506443579). -/
-/--
-error: unsolved goals
+/-- trace:
 PROP : Type u_1
 inst✝ : BI PROP
 P : PROP
 ⊢ ⏎
   ⊢ ∀ x, P
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example [BI PROP] (P : PROP) {x : Nat} : ⊢ P := by
   irevert %x
+  trace_state
 
 /- Tests `irevert` failing with dependency. -/
 /-- info: Try this:
@@ -1963,8 +1963,7 @@ example [BI PROP] (P Q : PROP) : Q ∧ <pers> P ⊢ Q := by
   iexact HQ
 
 /- Tests `icases` on conjunction with persistent right in an affine logic. -/
-/--
- error: unsolved goals
+/-- trace:
 PROP : Type u_1
 inst✝¹ : BI PROP
 inst✝ : BIAffine PROP
@@ -1974,11 +1973,12 @@ P Q : PROP
   ∗HQ : <pers> Q
   ⊢ Q
 -/
-#guard_msgs (whitespace := lax) in
+#guard_msgs (whitespace := lax, trace, drop all) in
 example [BI PROP] [BIAffine PROP] (P Q : PROP) :
   P ∧ <pers> Q ⊢ Q := by
   iintro H
   icases H with ⟨_, HQ⟩
+  trace_state
 
 /-- Tests `icases` with nested separating conjunction. -/
 example [BI PROP] [BIAffine PROP] (P1 P2 Q : PROP) : P1 ∗ P2 ∗ Q ⊢ Q := by
@@ -2824,8 +2824,7 @@ example [BI PROP] (P : PROP) : P ⊢ P := by
   iframe HP
 
 /- Tests `iframe` not closing goal with non-affine assumption. -/
-/--
-error: unsolved goals
+/-- trace:
 PROP : Type u_1
 inst✝ : BI PROP
 P Q : PROP
@@ -2833,10 +2832,11 @@ P Q : PROP
   ∗HQ : Q
   ⊢ emp
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example [BI PROP] (P Q : PROP) : P ∗ Q ⊢ P := by
   iintro ⟨HP, HQ⟩
   iframe HP
+  trace_state
 
 /- Tests `iframe` closing goal with absorbing goal. -/
 example [BI PROP] (P Q : PROP) : <absorb> P ∗ Q ⊢ <absorb> P := by
@@ -3008,8 +3008,7 @@ example [BI PROP] {α} (a : α) {β} (b : β) (P : PROP)
   iframe HS HP HR HQ
 
 /- Tests `iframe` with multiple existential quantifiers framed at once. -/
-/--
-error: unsolved goals
+/-- trace:
 PROP : Type u_1
 inst✝ : BI PROP
 α : Sort u_2
@@ -3018,11 +3017,12 @@ Q : α → PROP
 ⊢ ⏎
   ⊢ «exists» fun {n} => Q n
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example [BI PROP] {α} (P : PROP) (Q : α → PROP) :
     ⊢ P -∗ BI.exists fun {n} => iprop(Q n  ∗ P) := by
   iintro HP
   iframe HP
+  trace_state
 
 /- Tests `iframe` with existential quantifers in various orders. -/
 example [BI PROP] {α} (a : α) {β} (b : β) {γ} (c : γ)
@@ -3379,24 +3379,23 @@ section iloeb
 variable {PROP : Type u} [ι₁ : BI PROP] [ι₂ : BILoeb PROP]
 
 /- Tests `iloeb` basic. -/
-/--
-error: unsolved goals
+/-- trace:
 PROP : Type u
 ι₁ : BI PROP
 ι₂ : BILoeb PROP
 P Q : PROP
 ⊢ ⏎
-  □IHH : ▷ (P -∗ Q)
+  □IH : ▷ (P -∗ Q)
   ⊢ P -∗ Q
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example (P Q : PROP) :
     P ⊢ Q := by
-  iloeb as IHH
+  iloeb as IH
+  trace_state
 
 /- Tests `iloeb` automatically generalizing spatial context. -/
-/--
-error: unsolved goals
+/-- trace:
 PROP : Type u
 ι₁ : BI PROP
 ι₂ : BILoeb PROP
@@ -3406,15 +3405,15 @@ P Q : PROP
   ∗HP : P
   ⊢ Q
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example (P Q : PROP) :
     P ⊢ Q := by
   iintro HP
   iloeb as IH
+  trace_state
 
 /- Tests `iloeb` not automatically generalizing persistent context. -/
-/--
-error: unsolved goals
+/-- trace:
 PROP : Type u
 ι₁ : BI PROP
 ι₂ : BILoeb PROP
@@ -3425,15 +3424,15 @@ P₁ P₂ Q : PROP
   ∗HP2 : P₂
   ⊢ Q
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example (P₁ P₂ Q : PROP) :
     ⊢ □ P₁ -∗ P₂ -∗ Q := by
   iintro #HP1 HP2
   iloeb as IH
+  trace_state
 
 /- Tests reordering spatial hypothesis in `iloeb`. -/
-/--
-error: unsolved goals
+/-- trace:
 PROP : Type u
 ι₁ : BI PROP
 ι₂ : BILoeb PROP
@@ -3445,15 +3444,15 @@ P₁ P₂ P₃ Q : PROP
   ∗HP2 : P₂
   ⊢ Q
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example (P₁ P₂ P₃ Q : PROP) :
     ⊢ □ P₁ -∗ P₂ -∗ P₃ -∗ Q := by
   iintro #HP1 HP2 HP3
   iloeb as IH generalizing HP3
+  trace_state
 
 /- Tests `iloeb` with pure hypothesis. -/
-/--
-error: unsolved goals
+/-- trace:
 PROP : Type u
 ι₁ : BI PROP
 ι₂ : BILoeb PROP
@@ -3466,16 +3465,15 @@ h1 : H₁ n
   ∗p : P n
   ⊢ Q n
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example (n : Nat) (H₁ : Nat → Prop) (P Q : Nat → PROP) :
     H₁ n → ⊢ P n -∗ Q n := by
   iintro %h1 p
   iloeb as IH generalizing %n %h1
-
+  trace_state
 
 /- Tests `iloeb` with pure hypothesis in affine logic. -/
-/--
-error: unsolved goals
+/-- trace:
 PROP : Type u
 ι₁ : BI PROP
 ι₂ : BILoeb PROP
@@ -3489,11 +3487,12 @@ h1 : H₁ n
   ∗p : P n
   ⊢ Q n
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example [i : BIAffine PROP] (n : Nat) (H₁ : Nat → Prop) (P Q : Nat → PROP) :
     H₁ n → ⊢ P n -∗ Q n := by
   iintro %h1 p
   iloeb as IH generalizing %n %h1
+  trace_state
 
 variable {PROP : Type u} [ι₁ : BI PROP] in
 /- Tests `iloeb` failing without `BILoeb`. -/
@@ -3539,8 +3538,7 @@ example {n : Nat} {P T : Nat → PROP} {Q : Nat → Prop} {h1 : Q n} {_ : (Q n) 
   iloeb as IH generalizing %n
 
 /- Same test as above, except `generalizing!` is used. -/
-/--
-error: unsolved goals
+/-- trace:
 PROP : Type u
 ι₁ : BI PROP
 ι₂ : BILoeb PROP
@@ -3554,11 +3552,12 @@ x✝ : Q n → Prop
   □x✝ : T n
   ⊢ □ P n
 -/
-#guard_msgs in
+#guard_msgs (trace, drop error) in
 example {n : Nat} {P T : Nat → PROP} {Q : Nat → Prop} {h1 : Q n} {_ : (Q n) → Prop} :
     ⊢ □ T n -∗ □ P n := by
   iintro #_
   iloeb as IH generalizing! %n
+  trace_state
 
 end iloeb
 


### PR DESCRIPTION
## Description

Several bug fixes regarding the elaboration and delaboration of propositions, as well as related tests.

### Type Signature Mismatch in Pop-Ups

A follow-up on https://github.com/leanprover-community/iris-lean/pull/591#issuecomment-5238622397.

I mentioned the bug in the comment but forgot to push the fix to the PR. In a nutshell, `unpackIprop` in `BI/Notation.lean` now sets the source information of each syntax node correctly.

<details>

<summary><b>The incorrect trace mentioned in the previous comment</b></summary>

```
⋆ H (binder) : <absorb> (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) -∗ Q
  ⋆ <absorb> (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) -∗ Q : PROP
    ⋆ (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) : PROP
      ⋆ P1 : PROP
      ⋆ P2 : PROP
      ⋆ (P3 ∗ P4) : PROP
        ⋆ P3 : PROP
        ⋆ P4 : PROP
```

</details>

<details>

<summary><b>The correct trace for the same test upon applying the fix</b></summary>

```
⋆ H (binder) : <absorb> (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) -∗ Q
  ⋆ <absorb> (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) -∗ Q : PROP
    ⋆ <absorb> (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) : PROP
      ⋆ (P1 ∗ P2 ∗ <affine> (P3 ∗ P4)) : PROP
        ⋆ P1 : PROP
        ⋆ P2 ∗ <affine> (P3 ∗ P4) : PROP
        ⋆ P2 : PROP
      ⋆ <affine> (P3 ∗ P4) : PROP
        ⋆ (P3 ∗ P4) : PROP
          ⋆ P3 : PROP
          ⋆ P4 : PROP
    ⋆ Q : PROP
⋆ Q : PROP
```

</details>

Commit: [7cee0e3](https://github.com/leanprover-community/iris-lean/commit/7cee0e3ea6216a2292f0577ad27a5ca34a302342)

### Go-to definition under `iprop(...)` notation

Fixes #535.

The solution likewise has to do with the source information of syntax nodes. We introduce a one-line function `wrapIprop` and use it in all `macro_rules` for `iprop(...)` notations. No changes to the notations from the user's perspective.

Before: 

<img width="465" height="125" alt="Go-to definition before the bug fix" src="https://github.com/user-attachments/assets/5982e0f3-f868-41a2-98cc-e4268275888e" />

After:

<img width="465" height="125" alt="Go-to definition before the bug fix" src="https://github.com/user-attachments/assets/f33bdf7b-1d1d-490a-8e1c-caedb1153c84" />

Commits: [0667201](https://github.com/leanprover-community/iris-lean/commit/0667201241db5127b2565038c5ecf7459f466070), [ce87234](https://github.com/leanprover-community/iris-lean/commit/ce87234fa8e4facc1172786afdf5ee546a64d69d), [7779a6a](https://github.com/leanprover-community/iris-lean/commit/7779a6af72385c41073c9aeee7e4d458a7934d12) and [b1056cb](https://github.com/leanprover-community/iris-lean/commit/b1056cb9c19708b80758e271ebd74567b5e04a07)

### Docstrings for BI Connectives

Documentation is missing from lots of the BI connectives, so they are now added. Along with the fix above, it should be much easier to nagivate through the definitions and available notations, especially the BI-related ones. A nice feature in Lean is the `inherit_doc` annotation, which allows notations, type classes and definitions to share the same documentation without repeating the comments.

<img width="465" height="160" alt="Docstring for BUpd" src="https://github.com/user-attachments/assets/5ac76788-53d8-4922-a6e2-00cd7895ae32" />

Commit: [1f4426d](https://github.com/leanprover-community/iris-lean/commit/1f4426d74d33b5a898bc4379f1fd6a94028b6ec8)

### A minor suggestion

A minor thing I realised while writing tests for the fixes above: some tests in `Tests/Tactics.lean` (for `iloeb`) and `Tests/HeapLang/WeakestPre.lean` uses `guard_msgs` for "unsolved goals" errors.

These tests check whether the tactics generate the correct proof goals, which are technically not "errors". The use of the built-in tactic `trace_state` along with proper configuration for `guard_msgs` seems more fit for purpose. Any thoughts?

Commit: [e59a3c9](https://github.com/leanprover-community/iris-lean/commit/e59a3c9d90ce589789460dd12d947aebc921e2c9)

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files
