### PR TITLE
use texan triple for landin knot

### DIFF
--- a/Iris/Iris/HeapLang/Lib/LandinsKnot.lean
+++ b/Iris/Iris/HeapLang/Lib/LandinsKnot.lean
@@ -32,10 +32,13 @@ variable {GF} [HeapLangGS hlc GF]
 
 theorem wp_landinsKnot (P : Val → IProp GF) (Q : Val → Val → IProp GF) (F v1 : Val) :
     {{ (∀ (f v2 : Val),
-          iprop({{ (∀ (v3 : Val),
-                iprop({{ P v3 }} hl(&f &v3) {{ u, RET u; Q u v3 }})) ∗ P v2 }}
-            hl(&F &f &v2) {{ u, RET u; Q u v2 }})) ∗ P v1 }}
-      hl(&landinsKnot &F &v1) {{ u, RET u; Q u v1 }} := by
+          {{ (∀ (v3 : Val),
+              {{ P v3 }} hl(&f &v3) {{ u, RET u; Q u v3 }}) ∗ P v2 }}
+          hl(&F &f &v2)
+          {{ u, RET u; Q u v2 }}) ∗
+        P v1 }}
+    hl(&landinsKnot &F &v1)
+    {{ u, RET u; Q u v1 }} := by
   iintro %Φ ⟨#H, HP⟩ HQ
   wp_bind &landinsKnot _
   wp_rec

--- a/Iris/Iris/HeapLang/Lib/LandinsKnot.lean
+++ b/Iris/Iris/HeapLang/Lib/LandinsKnot.lean
@@ -30,16 +30,13 @@ section Spec
 
 variable {GF} [HeapLangGS hlc GF]
 
--- TODO: Convert to texan triple
 theorem wp_landinsKnot (P : Val → IProp GF) (Q : Val → Val → IProp GF) (F v1 : Val) :
-    ⊢ □ ∀ (Φ : Val → IProp GF),
-      ((∀ (f v2 : Val), □ ∀ (Ψ : Val → IProp GF),
-          ((∀ (v3 : Val), □ ∀ (Ξ : Val → IProp GF),
-              P v3 -∗ ▷ (∀ u, Q u v3 -∗ Ξ u) -∗ WP hl(&f &v3) {{ Ξ }}) ∗ P v2) -∗
-          ▷ (∀ u, Q u v2 -∗ Ψ u) -∗ WP hl(&F &f &v2) {{ Ψ }}) ∗ P v1) -∗
-      ▷ (∀ u, Q u v1 -∗ Φ u) -∗
-      WP hl(&landinsKnot &F &v1) {{ Φ }} := by
-  iintro !> %Φ ⟨#H, HP⟩ HQ
+    {{ (∀ (f v2 : Val),
+          iprop({{ (∀ (v3 : Val),
+                iprop({{ P v3 }} hl(&f &v3) {{ u, RET u; Q u v3 }})) ∗ P v2 }}
+            hl(&F &f &v2) {{ u, RET u; Q u v2 }})) ∗ P v1 }}
+      hl(&landinsKnot &F &v1) {{ u, RET u; Q u v1 }} := by
+  iintro %Φ ⟨#H, HP⟩ HQ
   wp_bind &landinsKnot _
   wp_rec
   wp_alloc r with Hr


### PR DESCRIPTION
## Description
Thanks to https://github.com/leanprover-community/iris-lean/pull/484 I can write a spec that looks better

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
