### PR TITLE
fix: solving side conditions with `infer_instance`

### DIFF
--- a/Iris/Iris/HeapLang/Lib/LandinsKnot.lean
+++ b/Iris/Iris/HeapLang/Lib/LandinsKnot.lean
@@ -52,7 +52,6 @@ theorem wp_landinsKnot (P : Val → IProp GF) (Q : Val → Val → IProp GF) (F 
   wp_rec
   wp_bind !_
   iinv Hinv with >Hr
-  · simp; infer_instance -- TODO: iinv should solve this
   wp_load
   imodintro; iframe
   iapply H $$ [$HP] [$]

--- a/Iris/Iris/HeapLang/Lib/NondetBool.lean
+++ b/Iris/Iris/HeapLang/Lib/NondetBool.lean
@@ -32,7 +32,6 @@ theorem nondetBool.spec :
   · inext
     wp_pures
     iinv Hinv with >⟨%b, Hl⟩
-    · simp; infer_instance -- TODO: iinv should solve this
     wp_load
     iintro !> {$Hl}
     iapply K $$ [//]

--- a/Iris/Iris/HeapLang/Lib/NondetBool.lean
+++ b/Iris/Iris/HeapLang/Lib/NondetBool.lean
@@ -37,6 +37,5 @@ theorem nondetBool.spec :
     iapply K $$ [//]
   · inext
     iinv Hinv with >⟨%b, Hl⟩
-    · simp; infer_instance
     wp_store
     iframe

--- a/Iris/Iris/HeapLang/Lib/Spawn.lean
+++ b/Iris/Iris/HeapLang/Lib/Spawn.lean
@@ -110,7 +110,6 @@ theorem spawn_spec (Ψ : Val → IProp GF) (f : Val) :
   iintro %v HΨ
   wp_pures
   iinv Hinv with Hpt
-  · simp; infer_instance -- TODO: iinv should solve this
   unfold spawnInv
   icases Hpt with ⟨%_, Hl, _⟩
   wp_store
@@ -132,7 +131,6 @@ theorem join_spec (Ψ : Val → IProp GF) (l : Loc) :
   wp_rec
   wp_bind !_
   iinv Hinv with Hpt
-  · simp; infer_instance -- TODO: iinv should solve this
   unfold spawnInv
   icases Hpt with ⟨%lv, Hl, Hcond⟩
   wp_load; imodintro; iframe Hl

--- a/Iris/Iris/HeapLang/Lib/SpinLock.lean
+++ b/Iris/Iris/HeapLang/Lib/SpinLock.lean
@@ -131,7 +131,6 @@ theorem try_acquire_spec (γ : GName) (lk : Val) (R : IProp GF) :
   subst Heq
   wp_bind cmpXchg(_,_,_)
   iinv Hinv with G1
-  · simp; infer_instance -- TODO: iinv should solve this
   unfold lockInv
   icases G1 with ⟨%b, Hpt, Hcond⟩
   cases b
@@ -188,7 +187,6 @@ theorem release_spec (γ : GName) (lk : Val) (R : IProp GF) :
   icases Hlock with ⟨%l, %Heq, #Hinv⟩
   subst Heq
   iinv Hinv with G1
-  · simp; infer_instance -- TODO: iinv should solve this
   unfold lockInv
   icases G1 with ⟨%b, Hpt, Hcond⟩
   wp_store

--- a/Iris/Iris/ProofMode/Tactics/Basic.lean
+++ b/Iris/Iris/ProofMode/Tactics/Basic.lean
@@ -44,7 +44,7 @@ def iSolveSidecondition (target : Q(Prop)) (failOnUnsolved := true) : ProofModeM
       throwError "{msg}"
   | _ =>
       let gs ← (observing? <|
-        evalTacticAt (← `(tactic | first | trivial | (simp [*] <;> done))) mvar.mvarId!) <&>
+        evalTacticAt (← `(tactic | (and_intros <;> (first | trivial | infer_instance | (simp [*] <;> done))))) mvar.mvarId!) <&>
         (·.getD [mvar.mvarId!])
       if !gs.isEmpty then
         if failOnUnsolved then


### PR DESCRIPTION
## Description

Response to the Zulip discussion thread [#iris-lean > Porting iris-tutorial @ 💬](https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/Porting.20iris-tutorial/near/616157566) regarding `iinv` not solving certain side conditions. 

The [Rocq equivalent](https://gitlab.mpi-sws.org/iris/iris/-/blob/master/iris/proofmode/ltac_tactics.v?ref_type=heads#L39) of `iSolveSidecondition` tries `tc_solve` after `split_and?`. Likewise, `iSolveSidecondition` should try `infer_instance` after `and_intros`.

This fix also resolves a few `TODO` items introduced in #611.

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files
