### PR TITLE
feat: Annotations for bupd_alt

### DIFF
--- a/Iris/Iris/BI/Lib/BUpdPlain.lean
+++ b/Iris/Iris/BI/Lib/BUpdPlain.lean
@@ -1,11 +1,13 @@
+/-
+Copyright (c) 2026. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.Std
 public import Iris.Algebra.Updates
-public import Iris.ProofMode.Classes
-public import Iris.ProofMode.Tactics
-public import Iris.ProofMode.Display
-public import Iris.ProofMode.InstancesUpdates
+public import Iris.ProofMode
 
 @[expose] public section
 
@@ -36,6 +38,8 @@ variable [Sbi PROP]
 instance BUpdPlain_ne : NonExpansive (BUpdPlain (PROP := PROP)) where
   ne _ _ _ H := forall_ne fun _ => wand_ne.ne (wand_ne.ne H .rfl) .rfl
 
+#rocq_ignore bupd_alt_proper "OFE is Leibniz; use equality"
+
 @[rocq_alias bupd_alt_intro]
 theorem BUpdPlain_intro {P : PROP} : P ⊢ BUpdPlain P := by
   iintro Hp
@@ -53,6 +57,9 @@ theorem BUpdPlain_mono {P Q : PROP} : (P ⊢ Q) → (BUpdPlain P ⊢ BUpdPlain Q
   iapply Hp
   iapply H $$ HP
 
+#rocq_ignore bupd_alt_mono' "Use BUpdPlain_mono."
+#rocq_ignore bupd_alt_flip_mono' "Use BUpdPlain_mono."
+
 @[rocq_alias bupd_alt_trans]
 theorem BUpdPlain_idem {P : PROP} : BUpdPlain (BUpdPlain P) ⊢ BUpdPlain P := by
   unfold BUpdPlain
@@ -68,9 +75,7 @@ theorem BUpdPlain_frame_right {P Q : PROP} : BUpdPlain P ∗ Q ⊢ (BUpdPlain ip
   iapply Hp
   iintro Hp
   iapply H
-  isplitl [Hp]
-  · iexact Hp
-  · iexact Hq
+  iframe Hp Hq
 
 @[rocq_alias bupd_alt_plainly]
 theorem BUpdPlain_plainly {P : PROP} : BUpdPlain iprop(■ P) ⊢ (■ P) := by
@@ -87,26 +92,24 @@ theorem BUpd_BUpdPlain [BIUpdate PROP] [BIBUpdateSbi PROP] [BIAffine PROP] {P : 
   imod HP
   iapply Hx $$ HP
 
--- FIXME: @[rocq_alias own_updateP] duplicate alias
-/-- We get the usual rule for frame preserving updates if we have an [own]
-  connective satisfying the following rule w.r.t. interaction with plainly. -/
+-- FIXME: no `@[rocq_alias own_updateP]`: the short name is already claimed by
+-- `base_logic/lib/own.v`'s `own_updateP`, aliased to `Iris.iOwn_updateP`.
+/-- We get the usual rule for frame preserving updates if we have an `own`
+connective satisfying the following rule w.r.t. interaction with plainly. -/
 theorem own_updateP [UCMRA M] {own : M → PROP} {x : M} {Φ : M → Prop}
   (own_updateP_plainly : ∀ (x : M) (Φ : M → Prop) (R : PROP),
-    (x ~~>: Φ) → own x ∗ (∀ y, iprop(⌜Φ y⌝) -∗ own y -∗ ■ R) ⊢ ■ R)
+    (x ~~>: Φ) → iprop(own x ∗ ∀ y, ⌜Φ y⌝ -∗ own y -∗ ■ R) ⊢ ■ R)
   (Hup : x ~~>: Φ) :
     own x ⊢ BUpdPlain iprop(∃ y, ⌜Φ y⌝ ∧ own y) := by
   iintro Hx
   unfold BUpdPlain
   iintro %R H
   iapply own_updateP_plainly x Φ R Hup
-  isplitl [Hx]
-  · iexact Hx
+  iframe Hx
   iintro %y %HΦ Hy
   iapply H
   iexists y
-  isplit
-  · itrivial
-  · iexact Hy
+  iframe %HΦ Hy
 
 end BupdPlainDef
 end BUpdPlain

--- a/Iris/Iris/BI/Lib/BUpdPlain.lean
+++ b/Iris/Iris/BI/Lib/BUpdPlain.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
+Authors: Alex Bai, Markus de Medeiros
 -/
 module
 

--- a/Iris/Iris/Instances/UPred/Instance.lean
+++ b/Iris/Iris/Instances/UPred/Instance.lean
@@ -836,8 +836,6 @@ open BUpdPlain CMRA UPred
 ## Compatibility between the UPred model of BUpd and the BUpd construction for generic Sbi instances
 -/
 
-/-- The predicate instantiating the universally quantified `R` in `BUpdPlain` to derive `|==> P`:
-`P` holds of some resource composable with the frame `y`. -/
 def BUpdPlain_pred [UCMRA M] (P : UPred M) (y : M) : UPred M where
   holds k _ := ∃ x'', ∃ H : ✓{k} (x'' • y), P k ⟨x'', validN_op_left H⟩
   mono {_ _ _ _} := fun ⟨z, Hz1, Hz2⟩ _ Hn =>

--- a/Iris/Iris/Instances/UPred/Instance.lean
+++ b/Iris/Iris/Instances/UPred/Instance.lean
@@ -856,8 +856,6 @@ theorem BUpdPlain_bupd [UCMRA M] (P : UPred M) : BUpdPlain P ⊢ |==> P := by
 theorem BUpdPlain_bupd_iff [UCMRA M] (P : UPred M) : BUpdPlain P ⊣⊢ |==> P :=
   ⟨BUpdPlain_bupd P, BUpd_BUpdPlain (PROP := UPred M)⟩
 
-/-- The law about the interaction between `UPred.ownM` and plainly holds, so `own_updateP`
-applies to the `UPred` model. -/
 @[rocq_alias ownM_updateP]
 theorem ownM_updateP [UCMRA M] {x : M} {R : UPred M} (Φ : M → Prop) (Hup : x ~~>: Φ) :
     iprop(ownM x ∗ ∀ y, ⌜Φ y⌝ -∗ ownM y -∗ ■ R) ⊢ ■ R := by

--- a/Iris/Iris/Instances/UPred/Instance.lean
+++ b/Iris/Iris/Instances/UPred/Instance.lean
@@ -836,12 +836,15 @@ open BUpdPlain CMRA UPred
 ## Compatibility between the UPred model of BUpd and the BUpd construction for generic Sbi instances
 -/
 
+/-- The predicate instantiating the universally quantified `R` in `BUpdPlain` to derive `|==> P`:
+`P` holds of some resource composable with the frame `y`. -/
 def BUpdPlain_pred [UCMRA M] (P : UPred M) (y : M) : UPred M where
   holds k _ := ∃ x'', ∃ H : ✓{k} (x'' • y), P k ⟨x'', validN_op_left H⟩
   mono {_ _ _ _} := fun ⟨z, Hz1, Hz2⟩ _ Hn =>
     ⟨z, validN_of_le Hn Hz1, P.mono Hz2 (incN_refl z) Hn⟩
 
 /-- The alternative definition entails the ordinary basic update -/
+@[rocq_alias bupd_alt_bupd]
 theorem BUpdPlain_bupd [UCMRA M] (P : UPred M) : BUpdPlain P ⊢ |==> P := by
   intro _ _ H k y Hkn Hxy
   have := (H _ ⟨BUpdPlain_pred P y, rfl⟩) k y Hkn Hxy ?_
@@ -851,11 +854,15 @@ theorem BUpdPlain_bupd [UCMRA M] (P : UPred M) : BUpdPlain P ⊢ |==> P := by
     rw [plainly_eq_uPred_plainly]
     refine ⟨z, validN_ne op_commN Hvyz, HP⟩
 
+@[rocq_alias bupd_alt_bupd_iff]
 theorem BUpdPlain_bupd_iff [UCMRA M] (P : UPred M) : BUpdPlain P ⊣⊢ |==> P :=
   ⟨BUpdPlain_bupd P, BUpd_BUpdPlain (PROP := UPred M)⟩
 
+/-- The law about the interaction between `UPred.ownM` and plainly holds, so `own_updateP`
+applies to the `UPred` model. -/
+@[rocq_alias ownM_updateP]
 theorem ownM_updateP [UCMRA M] {x : M} {R : UPred M} (Φ : M → Prop) (Hup : x ~~>: Φ) :
-    ownM x ∗ (∀ y, iprop(⌜Φ y⌝) -∗ ownM y -∗ ■ R) ⊢ ■ R := by
+    iprop(ownM x ∗ ∀ y, ⌜Φ y⌝ -∗ ownM y -∗ ■ R) ⊢ ■ R := by
   rw [plainly_eq_uPred_plainly]
   intro n z ⟨x1, z2, Hx, ⟨z1, Hz1⟩, HR⟩
   have Hvalid : ✓{n} (x •? some (z1 • z2)) := by
@@ -873,4 +880,6 @@ theorem ownM_updateP [UCMRA M] {x : M} {R : UPred M} (Φ : M → Prop) (Hup : x 
     (validN_ne comm.dist (validN_op_right Hvalid)) HΦy n y .refl
     (validN_ne Hcomm Hvalid_y) (incN_refl y)
 
-section UPredAlt
+end UPredAlt
+
+end UPredInstance


### PR DESCRIPTION
## Description
There is one that needs a change to the annotations script to fix, but we should defer doing that until the very end. 

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
