### PR TITLE
refactor: `inext` elaboration performance improvement

### DIFF
--- a/Iris/Iris/Instances/Lib/FUpd.lean
+++ b/Iris/Iris/Instances/Lib/FUpd.lean
@@ -591,14 +591,14 @@ open Lean Elab Tactic Meta Qq Iris.BI Iris Iris.ProofMode Iris.Std
 
 @[rocq_alias tac_lc_add_laterN_split]
 theorem tac_lc_add_laterN_split {GF : BundledGFunctors} [InvGS GF]
-    {φ : Prop} {n m newM : Nat} {E : CoPset} {P Q goal : IProp GF} {stuck : Bool}
-    (inst : ElimModal φ false .in false iprop(|={E}=> goal) goal goal goal) (hφ : φ)
+    {n m newM : Nat} {E : CoPset} {P Q goal : IProp GF} {stuck : Bool}
+    (inst : AddModal iprop(|={E}=> goal) goal goal)
     (h1 : NatCancel m n newM 0 stuck) (h2 : P ∗ £ newM ⊢ ▷^[n] Q) (h3 : Q ⊢ goal) :
     P ∗ £ m ⊢ goal := by
   have h1 : m = n + newM := by have := h1.nat_cancel; omega
   subst h1
   iintro ⟨HP, Hcred⟩
-  iapply inst.elim_modal hφ
+  iapply inst.add_modal
   isplitl
   · icases lc_split.mp $$ Hcred with ⟨Hn, Hm⟩
     icombine HP Hm as H
@@ -609,46 +609,16 @@ theorem tac_lc_add_laterN_split {GF : BundledGFunctors} [InvGS GF]
     iapply h3 $$ H
   · iintro _ //
 
+/--
+  For the special case where the later credit amount reaches zero, and
+  the later credit hypothesis is dropped.
+-/
 theorem tac_lc_add_laterN_full {GF : BundledGFunctors} [InvGS GF]
-    {φ : Prop} {m : Nat} {E : CoPset} {P Q goal : IProp GF} {stuck : Bool}
-    (inst : ElimModal φ false .in false iprop(|={E}=> goal) goal goal goal) (hφ : φ)
-    (h1 : NatCancel m n 0 0 stuck)
-    (h2 : P ⊢ ▷^[n] Q) (h3 : Q ⊢ goal) :
-    P ∗ £ m ⊢ goal := by
-  iintro ⟨HP, Hcred⟩
-  iapply inst.elim_modal hφ
-  isplitl
-  have h1 := h1.nat_cancel
-  simp at h1
-  rw [← h1]
-  · ihave H := h2 $$ HP
-    iapply lc_fupd_add_laterN n $$ Hcred
-    inext
-    imodintro
-    iapply h3 $$ H
-  · iintro _ //
-
-theorem tac_lc_add_laterN_split' {GF : BundledGFunctors} [InvGS GF]
-    {φ : Prop} {n m newM : Nat} {stuck : Bool} {E : CoPset}
-    {e P R Q goal : IProp GF}
-    (heq : e ⊣⊢ P ∗ £ m)
-    (inst : ElimModal φ false .in false iprop(|={E}=> goal) goal goal goal) (hφ : φ)
-    (hc : NatCancel m n newM 0 stuck)
-    (hR : P ∗ £ newM ⊣⊢ R) (h2 : R ⊢ ▷^[n] Q) (h3 : Q ⊢ goal) :
-    e ⊢ goal := by
-  refine heq.mp.trans ?_
-  exact
-    (tac_lc_add_laterN_split inst hφ hc (hR.mp.trans h2) h3)
-
-theorem tac_lc_add_laterN_full' {GF : BundledGFunctors} [InvGS GF]
-    {φ : Prop} {n m : Nat} {stuck : Bool} {E : CoPset}
-    {e P Q goal : IProp GF}
-    (heq : e ⊣⊢ P ∗ £ m)
-    (inst : ElimModal φ false .in false iprop(|={E}=> goal) goal goal goal) (hφ : φ)
-    (hc : NatCancel m n 0 0 stuck)
-    (h2 : P ⊢ ▷^[n] Q) (h3 : Q ⊢ goal) :
-    e ⊢ goal :=
-  heq.mp.trans (tac_lc_add_laterN_full inst hφ hc h2 h3)
+    {n m : Nat} {E : CoPset} {P Q goal : IProp GF} {stuck : Bool}
+    (inst : AddModal iprop(|={E}=> goal) goal goal)
+    (h1 : NatCancel m n 0 0 stuck) (h2 : P ⊢ ▷^[n] Q) (h3 : Q ⊢ goal) :
+    P ∗ £ m ⊢ goal :=
+  tac_lc_add_laterN_split inst h1 (sep_elim_left.trans h2) h3
 
 public meta section
 
@@ -696,33 +666,31 @@ elab "inext " t:(colGt term:max)? " credit: " h:ident : tactic => do
     have c : Q(Nat) := c
     let some hcancel ← ProofModeM.trySynthInstanceQ q(NatCancel $c $n $newC $newN $stuck)
       | throwError "inext: unable to cancel {n} later credits from {c}"
-    let newC : Q(Nat) ← instantiateMVars newC
     unless ← isDefEq newN q(0) do
       throwError "inext: insufficient credits"
 
     have modality : Q(@Modality $prop $prop $bi $bi) :=
-      mkAppN (.const ``modality_laterN [.zero]) #[prop, n, bi]
-    let mkLC (k : Expr) : Expr := mkApp ty.appFn! k
+      mkAppN (.const ``modality_laterN [u]) #[prop, n, bi]
 
+    let newC : Q(Nat) ← instantiateMVars newC
     match newC.nat? with
     -- Later credits used up, discard the later credits hypothesis
     | some 0 =>
       let ⟨eQ, newHyps', pfModAction⟩ ← iModAction hyps' modality
       let pf ← addBIGoal newHyps' goal
-      mvar.assign <| mkAppN (.const ``tac_lc_add_laterN_full' [])
+      mvar.assign <| mkAppN (.const ``tac_lc_add_laterN_full [])
         #[GF, instInvGS, φ, n, c, stuck, E,
-          e, e', eQ, goal,
-          pfEq, inst, hφ, hcancel, pfModAction, pf]
+          e, e', eQ, goal, pfEq, inst, hφ, hcancel, pfModAction, pf]
     -- Update the later credits hypothesis and introduce it into the context
     | _ =>
-      let newTy := mkLC newC
+      -- The new expression `£ newC`
+      let newTy := mkApp ty.appFn! newC
       let ⟨eAdd, newHyps, pfNewHyps⟩ := Hyps.add _ name ivar q(false) newTy hyps'
       let ⟨eQ, newHyps', pfModAction⟩ ← iModAction newHyps modality
       let pf ← addBIGoal newHyps' goal
-      mvar.assign <| mkAppN (.const ``tac_lc_add_laterN_split' [])
+      mvar.assign <| mkAppN (.const ``tac_lc_add_laterN_split [])
         #[GF, instInvGS, φ, n, c, newC, stuck, E,
-          e, e', eAdd, eQ, goal,
-          pfEq, inst, hφ, hcancel, pfNewHyps, pfModAction, pf]
+          e, e', eAdd, eQ, goal, pfEq, inst, hφ, hcancel, pfNewHyps, pfModAction, pf]
 
 end
 

--- a/Iris/Iris/Instances/Lib/FUpd.lean
+++ b/Iris/Iris/Instances/Lib/FUpd.lean
@@ -652,6 +652,11 @@ theorem tac_lc_add_laterN_full' {GF : BundledGFunctors} [InvGS GF]
 
 public meta section
 
+/-- The `ElimModal` instance shape needed to eliminate a fancy update at the goal. -/
+abbrev ElimFUpdGoal (GF : BundledGFunctors) [InvGS GF]
+    (φ : Prop) (E : CoPset) (goal Q : IProp GF) : Prop :=
+  ElimModal φ false .in false iprop(|={E}=> goal) goal goal Q
+
 elab "inext " t:(colGt term:max)? " credit: " h:ident : tactic => do
   let n : Q(Nat) ← match t with
   | none => pure <| mkNatLit 1
@@ -661,45 +666,42 @@ elab "inext " t:(colGt term:max)? " credit: " h:ident : tactic => do
     instantiateMVars n
 
   ProofModeM.runTactic `inext λ mvar { u, prop, bi, e, hyps, goal, .. } => do
-    let .defEq _ ← isLevelDefEqQ u 0
-      | throwError "inext: the goal must be an `IProp` at universe level 0"
-    let ~q(IProp $GF) := prop
-      | throwError "inext: the goal must be an `IProp`"
-    let .some instInvGS ← trySynthInstanceQ q(InvGS $GF)
-      | throwError "inext: requires an InvGS (HasLC) context"
-    let ~q(UPred.instBIUPred) := bi
-      | throwError "Expected the BI implementation of `IProp` to be `UPred.instBIUPred`"
-
     -- Search for the later credit hypothesis from the context
     let ivar ← hyps.findWithInfo h
     let some ⟨name, _, p, ty⟩ := hyps.getDecl? ivar
       | throwError m!"inext: unknown hypothesis {h}"
     if isTrue p then throwError "inext: {h} is not in the spatial context"
-    let ~q(£ $c) := ty
+    let some #[_, _, _, c] := Expr.appM? ty ``lc
       | throwError m!"inext: {h} is not a spatial later credit hypothesis"
+    let some #[GF] := Expr.appM? prop ``IProp
+      | throwError "inext: the goal must be an `IProp`"
     let ⟨e', hyps', _, _, _, _, pfEq⟩ := hyps.remove false ivar
+    let .some instInvGS ← trySynthInstance (mkApp (.const ``InvGS []) GF)
+      | throwError "inext: requires an InvGS (HasLC) context"
 
     let φ ← mkFreshExprMVarQ q(Prop)
     let E ← mkFreshExprMVarQ q(CoPset)
     let Q' ← mkFreshExprMVarQ q($prop)
-    let some inst ← ProofModeM.trySynthInstanceQ q(ElimModal $φ false .in false iprop(|={$E}=> $goal) $goal $goal $Q')
+    let elimTy := mkAppN (.const ``ElimFUpdGoal []) #[GF, instInvGS, φ, E, goal, Q']
+    let .some ⟨inst, _⟩ ← ProofMode.trySynthInstance elimTy
     | throwError "inext: ElimModal type class synthesis failed with {goal}"
     unless ← isDefEq Q' goal do
       throwError "inext: eliminating the fancy update does not preserve the goal {goal}"
-    have inst : Q(ElimModal $φ false .in false iprop(|={$E}=> $goal) $goal $goal $goal) := inst
 
     let hφ ← iSolveSidecondition q($φ)
 
     let newC ← mkFreshExprMVarQ q(Nat)
     let newN ← mkFreshExprMVarQ q(Nat)
     let stuck ← mkFreshExprMVarQ q(Bool)
+    have c : Q(Nat) := c
     let some hcancel ← ProofModeM.trySynthInstanceQ q(NatCancel $c $n $newC $newN $stuck)
       | throwError "inext: unable to cancel {n} later credits from {c}"
     let newC : Q(Nat) ← instantiateMVars newC
     unless ← isDefEq newN q(0) do
       throwError "inext: insufficient credits"
 
-    let modality := q(@modality_laterN $prop $n $bi)
+    have modality : Q(@Modality $prop $prop $bi $bi) :=
+      mkAppN (.const ``modality_laterN [.zero]) #[prop, n, bi]
     let mkLC (k : Expr) : Expr := mkApp ty.appFn! k
 
     match newC.nat? with

--- a/Iris/Iris/Instances/Lib/FUpd.lean
+++ b/Iris/Iris/Instances/Lib/FUpd.lean
@@ -587,38 +587,41 @@ end Iris
 
 public section
 
-open Lean Elab Tactic Meta Qq Iris.BI Iris Iris.ProofMode Iris.Std
+open Lean Tactic Meta Qq Iris BI ProofMode
 
 @[rocq_alias tac_lc_add_laterN_split]
 theorem tac_lc_add_laterN_split {GF : BundledGFunctors} [InvGS GF]
-    {n m newM : Nat} {E : CoPset} {P Q goal : IProp GF} {stuck : Bool}
-    (inst : AddModal iprop(|={E}=> goal) goal goal)
-    (h1 : NatCancel m n newM 0 stuck) (h2 : P ∗ £ newM ⊢ ▷^[n] Q) (h3 : Q ⊢ goal) :
-    P ∗ £ m ⊢ goal := by
-  have h1 : m = n + newM := by have := h1.nat_cancel; omega
-  subst h1
+    {φ : Prop} {n m newM : Nat} {stuck : Bool} {E : CoPset}
+    {e P R Q goal : IProp GF}
+    (heq : e ⊣⊢ P ∗ £ m)
+    (inst : ElimModal φ false .in false iprop(|={E}=> goal) goal goal goal) (hφ : φ)
+    (hc : NatCancel m n newM 0 stuck)
+    (hR : P ∗ £ newM ⊣⊢ R) (h2 : R ⊢ ▷^[n] Q) (h3 : Q ⊢ goal) :
+    e ⊢ goal := by
+  have hm : m = n + newM := by have := hc.nat_cancel; omega
+  subst hm
+  refine heq.mp.trans ?_
   iintro ⟨HP, Hcred⟩
-  iapply inst.add_modal
+  iapply inst.elim_modal hφ
   isplitl
   · icases lc_split.mp $$ Hcred with ⟨Hn, Hm⟩
     icombine HP Hm as H
-    ihave H := h2 $$ H
+    ihave H := (hR.mp.trans h2) $$ H
     iapply lc_fupd_add_laterN n $$ Hn
     inext
     imodintro
     iapply h3 $$ H
   · iintro _ //
 
-/--
-  For the special case where the later credit amount reaches zero, and
-  the later credit hypothesis is dropped.
--/
 theorem tac_lc_add_laterN_full {GF : BundledGFunctors} [InvGS GF]
-    {n m : Nat} {E : CoPset} {P Q goal : IProp GF} {stuck : Bool}
-    (inst : AddModal iprop(|={E}=> goal) goal goal)
-    (h1 : NatCancel m n 0 0 stuck) (h2 : P ⊢ ▷^[n] Q) (h3 : Q ⊢ goal) :
-    P ∗ £ m ⊢ goal :=
-  tac_lc_add_laterN_split inst h1 (sep_elim_left.trans h2) h3
+    {φ : Prop} {n m : Nat} {stuck : Bool} {E : CoPset}
+    {e P Q goal : IProp GF}
+    (heq : e ⊣⊢ P ∗ £ m)
+    (inst : ElimModal φ false .in false iprop(|={E}=> goal) goal goal goal) (hφ : φ)
+    (hc : NatCancel m n 0 0 stuck)
+    (h2 : P ⊢ ▷^[n] Q) (h3 : Q ⊢ goal) :
+    e ⊢ goal :=
+  tac_lc_add_laterN_split heq inst hφ hc .rfl (sep_elim_left.trans h2) h3
 
 public meta section
 
@@ -631,8 +634,8 @@ elab "inext " t:(colGt term:max)? " credit: " h:ident : tactic => do
   let n : Q(Nat) ← match t with
   | none => pure <| mkNatLit 1
   | some t => do
-    let n ← Term.elabTermEnsuringType t q(Nat)
-    Term.synthesizeSyntheticMVarsNoPostponing
+    let n ← Lean.Elab.Term.elabTermEnsuringType t q(Nat)
+    Lean.Elab.Term.synthesizeSyntheticMVarsNoPostponing
     instantiateMVars n
 
   ProofModeM.runTactic `inext λ mvar { u, prop, bi, e, hyps, goal, .. } => do
@@ -683,7 +686,6 @@ elab "inext " t:(colGt term:max)? " credit: " h:ident : tactic => do
           e, e', eQ, goal, pfEq, inst, hφ, hcancel, pfModAction, pf]
     -- Update the later credits hypothesis and introduce it into the context
     | _ =>
-      -- The new expression `£ newC`
       let newTy := mkApp ty.appFn! newC
       let ⟨eAdd, newHyps, pfNewHyps⟩ := Hyps.add _ name ivar q(false) newTy hyps'
       let ⟨eQ, newHyps', pfModAction⟩ ← iModAction newHyps modality

--- a/Iris/Iris/Instances/Lib/FUpd.lean
+++ b/Iris/Iris/Instances/Lib/FUpd.lean
@@ -628,6 +628,28 @@ theorem tac_lc_add_laterN_full {GF : BundledGFunctors} [InvGS GF]
     iapply h3 $$ H
   · iintro _ //
 
+theorem tac_lc_add_laterN_split' {GF : BundledGFunctors} [InvGS GF]
+    {φ : Prop} {n m newM : Nat} {stuck : Bool} {E : CoPset}
+    {e P R Q goal : IProp GF}
+    (heq : e ⊣⊢ P ∗ £ m)
+    (inst : ElimModal φ false .in false iprop(|={E}=> goal) goal goal goal) (hφ : φ)
+    (hc : NatCancel m n newM 0 stuck)
+    (hR : P ∗ £ newM ⊣⊢ R) (h2 : R ⊢ ▷^[n] Q) (h3 : Q ⊢ goal) :
+    e ⊢ goal := by
+  refine heq.mp.trans ?_
+  exact
+    (tac_lc_add_laterN_split inst hφ hc (hR.mp.trans h2) h3)
+
+theorem tac_lc_add_laterN_full' {GF : BundledGFunctors} [InvGS GF]
+    {φ : Prop} {n m : Nat} {stuck : Bool} {E : CoPset}
+    {e P Q goal : IProp GF}
+    (heq : e ⊣⊢ P ∗ £ m)
+    (inst : ElimModal φ false .in false iprop(|={E}=> goal) goal goal goal) (hφ : φ)
+    (hc : NatCancel m n 0 0 stuck)
+    (h2 : P ⊢ ▷^[n] Q) (h3 : Q ⊢ goal) :
+    e ⊢ goal :=
+  heq.mp.trans (tac_lc_add_laterN_full inst hφ hc h2 h3)
+
 public meta section
 
 elab "inext " t:(colGt term:max)? " credit: " h:ident : tactic => do
@@ -643,7 +665,7 @@ elab "inext " t:(colGt term:max)? " credit: " h:ident : tactic => do
       | throwError "inext: the goal must be an `IProp` at universe level 0"
     let ~q(IProp $GF) := prop
       | throwError "inext: the goal must be an `IProp`"
-    let .some _ ← trySynthInstanceQ q(InvGS $GF)
+    let .some instInvGS ← trySynthInstanceQ q(InvGS $GF)
       | throwError "inext: requires an InvGS (HasLC) context"
     let ~q(UPred.instBIUPred) := bi
       | throwError "Expected the BI implementation of `IProp` to be `UPred.instBIUPred`"
@@ -678,27 +700,27 @@ elab "inext " t:(colGt term:max)? " credit: " h:ident : tactic => do
       throwError "inext: insufficient credits"
 
     let modality := q(@modality_laterN $prop $n $bi)
+    let mkLC (k : Expr) : Expr := mkApp ty.appFn! k
 
     match newC.nat? with
     -- Later credits used up, discard the later credits hypothesis
     | some 0 =>
-      let ⟨_, newHyps', pfModAction⟩ ← iModAction hyps' modality
+      let ⟨eQ, newHyps', pfModAction⟩ ← iModAction hyps' modality
       let pf ← addBIGoal newHyps' goal
-      have pfEq : Q($e ⊣⊢ $e' ∗ £ $c) := pfEq
-      have hcancel : Q(NatCancel $c $n 0 0 $stuck) := hcancel
-      let pf' : Q($e' ∗ £ $c ⊢ $goal) := q(tac_lc_add_laterN_full $inst $hφ $hcancel $pfModAction $pf)
-      mvar.assign q($(pfEq).mp.trans $pf')
+      mvar.assign <| mkAppN (.const ``tac_lc_add_laterN_full' [])
+        #[GF, instInvGS, φ, n, c, stuck, E,
+          e, e', eQ, goal,
+          pfEq, inst, hφ, hcancel, pfModAction, pf]
     -- Update the later credits hypothesis and introduce it into the context
     | _ =>
-      let newTy : Q($prop) := q(£ $newC)
-      let ⟨_, newHyps, pfNewHyps⟩ := Hyps.add _ name ivar q(false) newTy hyps'
-      let ⟨_, newHyps', pfModAction⟩ ← iModAction newHyps modality
+      let newTy := mkLC newC
+      let ⟨eAdd, newHyps, pfNewHyps⟩ := Hyps.add _ name ivar q(false) newTy hyps'
+      let ⟨eQ, newHyps', pfModAction⟩ ← iModAction newHyps modality
       let pf ← addBIGoal newHyps' goal
-      have hcancel : Q(NatCancel $c $n $newC 0 $stuck) := hcancel
-      have pfEq : Q($e ⊣⊢ $e' ∗ £ $c) := pfEq
-      let pf'' : Q($e' ∗ £ $c ⊢ $goal) :=
-        q(tac_lc_add_laterN_split $inst $hφ $hcancel ($(pfNewHyps).mp.trans $pfModAction) $pf)
-      mvar.assign q($(pfEq).mp.trans $pf'')
+      mvar.assign <| mkAppN (.const ``tac_lc_add_laterN_split' [])
+        #[GF, instInvGS, φ, n, c, newC, stuck, E,
+          e, e', eAdd, eQ, goal,
+          pfEq, inst, hφ, hcancel, pfNewHyps, pfModAction, pf]
 
 end
 

--- a/Iris/Iris/Instances/Lib/FUpd.lean
+++ b/Iris/Iris/Instances/Lib/FUpd.lean
@@ -644,6 +644,8 @@ elab "inext " t:(colGt term:max)? " credit: " h:ident : tactic => do
     let some ⟨name, _, p, ty⟩ := hyps.getDecl? ivar
       | throwError m!"inext: unknown hypothesis {h}"
     if isTrue p then throwError "inext: {h} is not in the spatial context"
+    -- We use direct `Expr` manipulation here and below since `Qq` makes compiling this function very slow
+    --- see https://github.com/leanprover-community/iris-lean/pull/633
     let some #[_, _, _, c] := Expr.appM? ty ``lc
       | throwError m!"inext: {h} is not a spatial later credit hypothesis"
     let some #[GF] := Expr.appM? prop ``IProp


### PR DESCRIPTION
## Description

The extensive use of Qq in the implementation of `inext` for later credits results in the build of `FUpd.lean` being notably time-consuming. The refactoring aims to address the issue.

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files
