### PR TITLE
feat: ignore sts.v

### DIFF
--- a/Iris/Iris/Algebra.lean
+++ b/Iris/Iris/Algebra.lean
@@ -26,6 +26,7 @@ public import Iris.Algebra.Numbers
 public import Iris.Algebra.Mra
 public import Iris.Algebra.IProp
 public import Iris.Algebra.OFE
+public import Iris.Algebra.Porting
 public import Iris.Algebra.ReservationMap
 public import Iris.Algebra.StepIndex
 public import Iris.Algebra.UFrac

--- a/Iris/Iris/Algebra/Porting.lean
+++ b/Iris/Iris/Algebra/Porting.lean
@@ -1,0 +1,10 @@
+/-
+Copyright (c) 2026. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus de Medeiros
+-/
+module
+
+import Iris.Init
+
+#rocq_ignore_file algebra "sts.v" "Historical code without a good reason to exist in the library"

--- a/Iris/Iris/Algebra/Porting.lean
+++ b/Iris/Iris/Algebra/Porting.lean
@@ -7,4 +7,4 @@ module
 
 import Iris.Init
 
-#rocq_ignore_file algebra "sts.v" "Historical code without a good reason to exist in the library"
+#rocq_ignore_file algebra "sts.v" "Historical code, nowadays it is preferred to encode the transition system as a CMRA"


### PR DESCRIPTION
This is a proposal to not port `sts.v`. In Rocq, the file comes with the following warning:

> `This file formalizes the STS construction from the original Iris paper (POPL15).
>
> DISCLAIMER: The definition of STSs is included in the Iris development for
> historical purposes. If you plan to mechanize an Iris proof in Rocq, it is
> usually better to use a more direct encoding of the ghost state you need as a
> resource algebra (camera). STSs are very painful to use in Rocq, and they are
> therefore barely used in practice.`

I'm inclined to heed this advice. Do any of you guys know of a modern use case for STS, or have thoughts on if this should be included? 