### PR TITLE
fix: merging and splitting fractions with `IsOp`

### DIFF
--- a/Iris/Iris/Algebra/Frac.lean
+++ b/Iris/Iris/Algebra/Frac.lean
@@ -58,6 +58,8 @@ def Qp.div (x y : Qp) : Qp := ⟨x.val / y.val, Rat.div_pos x.2 y.2⟩
 instance instHDivQpQpQp : HDiv Qp Qp Qp where
   hDiv := Qp.div
 
+def Qp.one : Qp := ⟨1, by grind⟩
+
 /-- The fraction `1/4`. -/
 def Qp.quarter : Qp := ⟨1 / 4, by grind⟩
 
@@ -180,3 +182,9 @@ set_option synthInstance.checkSynthOrder false in
 instance (priority := high) isOpFrac_split (q1 q2 : Qp) :
     IsOp .split (q1 + q2) q1 q2 where
   is_op := rfl
+
+instance (priority := default - 500) isOpFrac_quarters_left d : IsOp d Qp.one Qp.quarter Qp.threeQuarters where
+  is_op := by refine Qp.ext_iff.mpr ?_; grind [Qp.one]
+
+instance (priority := default - 500) isOpFrac_quarters_right d : IsOp d Qp.one Qp.threeQuarters Qp.quarter where
+  is_op := by refine Qp.ext_iff.mpr ?_; grind [Qp.one]

--- a/Iris/Iris/Algebra/Frac.lean
+++ b/Iris/Iris/Algebra/Frac.lean
@@ -152,11 +152,16 @@ theorem Frac.valid_iff {p : Qp} : ✓ p ↔ p.val ≤ 1 := .rfl
 
 set_option synthInstance.checkSynthOrder false in
 @[rocq_alias frac_is_op]
-instance (priority := default - 10) (q1 q2 : Qp) :
-    IsOp .merge (q1 + q2 : Qp) q1 q2 where
+instance (priority := default - 100) isOpFrac_merge (q1 q2 : Qp) :
+    IsOp .merge (q1 + q2) q1 q2 where
   is_op := rfl
 
 set_option synthInstance.checkSynthOrder false in
 @[rocq_alias is_op_frac]
-instance (q : Qp) : IsOp d q q.half q.half where
+instance isOpFrac_half d (q : Qp) : IsOp d q q.half q.half where
   is_op := by refine (q.ext ?_); grind
+
+set_option synthInstance.checkSynthOrder false in
+instance (priority := default + 100) isOpFrac_split (q1 q2 : Qp) :
+    IsOp .split (q1 + q2) q1 q2 where
+  is_op := rfl

--- a/Iris/Iris/Algebra/Frac.lean
+++ b/Iris/Iris/Algebra/Frac.lean
@@ -162,6 +162,11 @@ instance isOpFrac_half d (q : Qp) : IsOp d q q.half q.half where
   is_op := by refine (q.ext ?_); grind
 
 set_option synthInstance.checkSynthOrder false in
+/--
+  The sum operator `+` is not automatically unfolded as the CMRA operator (`•`).
+  As a result, `isOpSplit_op` does not automatically apply, and this instance
+  is required.
+-/
 instance (priority := default + 100) isOpFrac_split (q1 q2 : Qp) :
     IsOp .split (q1 + q2) q1 q2 where
   is_op := rfl

--- a/Iris/Iris/Algebra/Frac.lean
+++ b/Iris/Iris/Algebra/Frac.lean
@@ -58,8 +58,6 @@ def Qp.div (x y : Qp) : Qp := ⟨x.val / y.val, Rat.div_pos x.2 y.2⟩
 instance instHDivQpQpQp : HDiv Qp Qp Qp where
   hDiv := Qp.div
 
-def Qp.one : Qp := ⟨1, by grind⟩
-
 /-- The fraction `1/4`. -/
 def Qp.quarter : Qp := ⟨1 / 4, by grind⟩
 
@@ -183,8 +181,8 @@ instance (priority := high) isOpFrac_split (q1 q2 : Qp) :
     IsOp .split (q1 + q2) q1 q2 where
   is_op := rfl
 
-instance (priority := default - 500) isOpFrac_quarters_left d : IsOp d Qp.one Qp.quarter Qp.threeQuarters where
-  is_op := by refine Qp.ext_iff.mpr ?_; grind [Qp.one]
+instance (priority := default - 500) isOpFrac_quarters_left d : IsOp d instQpOne.one Qp.quarter Qp.threeQuarters where
+  is_op := by refine Qp.ext_iff.mpr ?_; grind [instQpOne]
 
-instance (priority := default - 500) isOpFrac_quarters_right d : IsOp d Qp.one Qp.threeQuarters Qp.quarter where
-  is_op := by refine Qp.ext_iff.mpr ?_; grind [Qp.one]
+instance (priority := default - 500) isOpFrac_quarters_right d : IsOp d instQpOne.one Qp.threeQuarters Qp.quarter where
+  is_op := by refine Qp.ext_iff.mpr ?_; grind [instQpOne]

--- a/Iris/Iris/Algebra/Frac.lean
+++ b/Iris/Iris/Algebra/Frac.lean
@@ -152,7 +152,7 @@ theorem Frac.valid_iff {p : Qp} : ✓ p ↔ p.val ≤ 1 := .rfl
 
 set_option synthInstance.checkSynthOrder false in
 @[rocq_alias frac_is_op]
-instance (priority := default - 100) isOpFrac_merge (q1 q2 : Qp) :
+instance (priority := low) isOpFrac_merge (q1 q2 : Qp) :
     IsOp .merge (q1 + q2) q1 q2 where
   is_op := rfl
 
@@ -167,6 +167,6 @@ set_option synthInstance.checkSynthOrder false in
   As a result, `isOpSplit_op` does not automatically apply, and this instance
   is required.
 -/
-instance (priority := default + 100) isOpFrac_split (q1 q2 : Qp) :
+instance (priority := high) isOpFrac_split (q1 q2 : Qp) :
     IsOp .split (q1 + q2) q1 q2 where
   is_op := rfl

--- a/Iris/Iris/Algebra/IsOp.lean
+++ b/Iris/Iris/Algebra/IsOp.lean
@@ -66,15 +66,15 @@ instance isOp_pair [CMRA α] {d : IsOp.Direction} (a b1 b2 : α) (a' b1' b2' : �
   is_op := OFE.equiv_prod_ext h1.is_op h2.is_op
 
 set_option synthInstance.checkSynthOrder false in
-@[rocq_alias is_op_pair_core_id_l]
+@[ipm_backtrack, rocq_alias is_op_pair_core_id_l]
 instance isOp_pair_core_id_l [CMRA α] [CMRA β] {d : IsOp.Direction}
     (a : α) (a' b1' b2' : β) [h1 : CoreId a] [h2 : IsOp d a' b1' b2'] :
     IsOp d (a, a') (a, b1') (a, b2') where
   is_op := OFE.equiv_prod_ext (op_self a).symm h2.is_op
 
 set_option synthInstance.checkSynthOrder false in
-@[rocq_alias is_op_pair_core_id_r]
-instance isOpMerge_pair_core_id_r [CMRA α] [CMRA β] {d : IsOp.Direction}
+@[ipm_backtrack, rocq_alias is_op_pair_core_id_r]
+instance isOp_pair_core_id_r [CMRA α] [CMRA β] {d : IsOp.Direction}
     (a b1 b2 : α) (a' : β) [h1 : CoreId a'] [h2 : IsOp d a b1 b2] :
     IsOp d (a, a') (b1, a') (b2, a') where
   is_op := OFE.equiv_prod_ext h2.is_op (op_self a').symm

--- a/Iris/Iris/Algebra/IsOp.lean
+++ b/Iris/Iris/Algebra/IsOp.lean
@@ -42,14 +42,14 @@ class IsOp [CMRA α]
 set_option synthInstance.checkSynthOrder false in
 /-- Merging with `•` should have the lowest priority. -/
 @[rocq_alias is_op_op]
-instance (priority := default - 100) isOpMerge_op [CMRA α] (a b : α) :
+instance (priority := low) isOpMerge_op [CMRA α] (a b : α) :
     IsOp .merge (a • b) a b where
   is_op := rfl
 
 set_option synthInstance.checkSynthOrder false in
 /-- Splitting with `•` should have the highest priority. -/
 @[rocq_alias is_op_lr_op]
-instance (priority := default + 100) isOpSplit_op [CMRA α] (a b : α) :
+instance (priority := high) isOpSplit_op [CMRA α] (a b : α) :
     IsOp .split (a • b) a b where
   is_op := rfl
 

--- a/Iris/Iris/HeapLang/Lib/RwSpinLock.lean
+++ b/Iris/Iris/HeapLang/Lib/RwSpinLock.lean
@@ -391,7 +391,6 @@ theorem releaseWriter_spec (γ : GName) (lk : Val) (Φ : Qp → IProp GF) :
   wp_store
   icases Hz with (⟨-, Hquarter⟩ | ⟨-, %-, %-, Hauth, -⟩)
   · icombine Hquarter Hlocked as Hown
-    rw [Qp.quarter_add_threeQuarters]
     imod Hclose $$ [Hl Hown HΦ] with -
     · iapply rwStateInv_unlocked; iframe
     iapply Hφ; itrivial

--- a/Iris/IrisTest/Instances.lean
+++ b/Iris/IrisTest/Instances.lean
@@ -408,7 +408,7 @@ variable (q q1 q2 : Qp)
   new goals: []
 -/
 #guard_msgs (whitespace := lax) in
-#ipm_synth (IsOp .split (q1 + q2 : Qp) _ _)
+#ipm_synth IsOp .split (q1 + q2 : Qp) _ _
 
 /- Splitting a CMRA operation: `isOpFrac_split` is used instead of `isOpFrac_half`. -/
 /-- info:
@@ -416,7 +416,7 @@ variable (q q1 q2 : Qp)
   new goals: []
 -/
 #guard_msgs (whitespace := lax) in
-#ipm_synth (IsOp .split (q1 • q2) _ _)
+#ipm_synth IsOp .split (q1 • q2) _ _
 
 /- Splitting a `Qp` value, where `isOpFrac_split` is not applicable: use `isOpFrac_half`. -/
 /-- info:
@@ -424,7 +424,7 @@ variable (q q1 q2 : Qp)
   new goals: []
 -/
 #guard_msgs (whitespace := lax) in
-#ipm_synth (IsOp .split q _ _)
+#ipm_synth IsOp .split q _ _
 
 /- Merging two `Qp` values: `isOpFrac_half` is not applicable, use `isOpFrac_merge`. -/
 /-- info:
@@ -432,7 +432,7 @@ variable (q q1 q2 : Qp)
   new goals: []
 -/
 #guard_msgs (whitespace := lax) in
-#ipm_synth (IsOp .merge _ q1 q2)
+#ipm_synth IsOp .merge _ q1 q2
 
 /- Merging two `Qp` values: `isOpFrac_half` is applicable and preferred for eliminating `.half`. -/
 /-- info:
@@ -440,7 +440,7 @@ variable (q q1 q2 : Qp)
   new goals: []
 -/
 #guard_msgs (whitespace := lax) in
-#ipm_synth (IsOp .merge _ q.half q.half)
+#ipm_synth IsOp .merge _ q.half q.half
 
 /-
   Splitting a pair:
@@ -453,6 +453,29 @@ variable (q q1 q2 : Qp)
   new goals: []
 -/
 #guard_msgs (whitespace := lax) in
-#ipm_synth (IsOp .split (some (q, q1 + q2)) _ _)
+#ipm_synth IsOp .split (some (q, q1 + q2)) _ _
+
+/-
+  Merging `Qp.quarter` and `Qp.threeQuarters`:
+  `isOpFrac_quarters_left` and `isOpFrac_quarters_right` take precedence over `isOpFrac_merge`.
+-/
+/-- info:
+  solution: IsOp IsOp.Direction.merge (Qp.one, Qp.one)
+    (Qp.quarter, Qp.threeQuarters) (Qp.threeQuarters, Qp.quarter),
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+#ipm_synth IsOp .merge _ (Qp.quarter, Qp.threeQuarters) (Qp.threeQuarters, Qp.quarter)
+
+/-
+  Split `Qp.one`: `isOpFrac_half` takes precedence over
+  `isOpFrac_quarters_left`/`isOpFrac_quarters_right`.
+-/
+/-- info:
+  solution: IsOp IsOp.Direction.split Qp.one Qp.one.half Qp.one.half,
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+#ipm_synth IsOp .split Qp.one _ _
 
 end IsOp

--- a/Iris/IrisTest/Instances.lean
+++ b/Iris/IrisTest/Instances.lean
@@ -460,7 +460,7 @@ variable (q q1 q2 : Qp)
   `isOpFrac_quarters_left` and `isOpFrac_quarters_right` take precedence over `isOpFrac_merge`.
 -/
 /-- info:
-  solution: IsOp IsOp.Direction.merge (Qp.one, Qp.one)
+  solution: IsOp IsOp.Direction.merge (One.one, One.one)
     (Qp.quarter, Qp.threeQuarters) (Qp.threeQuarters, Qp.quarter),
   new goals: []
 -/
@@ -472,10 +472,10 @@ variable (q q1 q2 : Qp)
   `isOpFrac_quarters_left`/`isOpFrac_quarters_right`.
 -/
 /-- info:
-  solution: IsOp IsOp.Direction.split Qp.one Qp.one.half Qp.one.half,
+  solution: IsOp IsOp.Direction.split One.one One.one.half One.one.half,
   new goals: []
 -/
 #guard_msgs (whitespace := lax) in
-#ipm_synth IsOp .split Qp.one _ _
+#ipm_synth IsOp .split instQpOne.one _ _
 
 end IsOp

--- a/Iris/IrisTest/Instances.lean
+++ b/Iris/IrisTest/Instances.lean
@@ -6,6 +6,7 @@ Authors: Michael Sammler
 module
 
 public import Iris.BI
+public import Iris.Algebra.Frac
 public import Iris.ProofMode.SynthInstance
 public import Iris.ProofMode.Instances
 public import Iris.ProofMode.InstancesMake
@@ -395,3 +396,72 @@ variable (m n p q : Nat)
 #ipm_synth (NatCancel (1 + m + 2) 3 _ _ _)
 
 end NatCancel
+
+section IsOp
+open Iris Iris.CMRA Iris.ProofMode
+
+private def Qp.quarter : Qp := ⟨1 / 4, by grind⟩
+private def Qp.threeQuarters : Qp := ⟨3 / 4, by grind⟩
+
+/-- info:
+  solution: IsOp IsOp.Direction.split (Qp.threeQuarters + Qp.quarter) Qp.threeQuarters Qp.quarter,
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+#ipm_synth (IsOp (α := Qp) .split (Qp.threeQuarters + Qp.quarter) _ _)
+
+/-- info:
+  solution: IsOp IsOp.Direction.split (Qp.threeQuarters • Qp.quarter) Qp.threeQuarters Qp.quarter,
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+#ipm_synth (IsOp (α := Qp) .split (Qp.threeQuarters • Qp.quarter) _ _)
+
+/-- info:
+  solution: IsOp IsOp.Direction.split q q.half q.half,
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+variable (q : Qp) in
+#ipm_synth (IsOp (α := Qp) .split q _ _)
+
+/-- info:
+  solution: IsOp IsOp.Direction.merge (Qp.quarter + Qp.threeQuarters) Qp.quarter Qp.threeQuarters,
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+#ipm_synth (IsOp (α := Qp) .merge _ Qp.quarter Qp.threeQuarters)
+
+/-- info:
+  solution: IsOp IsOp.Direction.merge q q.half q.half,
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+variable (q : Qp) in
+#ipm_synth (IsOp (α := Qp) .merge _ q.half q.half)
+
+/-- info:
+  solution: IsOp IsOp.Direction.split (q1 + q2, q3 + q4) (q1, q3) (q2, q4),
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+variable (q1 q2 q3 q4 : Qp) in
+#ipm_synth (IsOp (α := Qp × Qp) .split (q1 + q2, q3 + q4) _ _)
+
+/-- info:
+  solution: IsOp IsOp.Direction.split (q, q1 + q2) (q.half, q1) (q.half, q2),
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+variable (q1 q2 q : Qp) in
+#ipm_synth (IsOp (α := Qp × Qp) .split (q, q1 + q2) _ _)
+
+/-- info:
+  solution: IsOp IsOp.Direction.split (some (q1 + q2)) (some q1) (some q2),
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+variable (q1 q2 : Qp) in
+#ipm_synth (IsOp (α := Option Qp) .split (some (q1 + q2)) _ _)
+
+end IsOp

--- a/Iris/IrisTest/Instances.lean
+++ b/Iris/IrisTest/Instances.lean
@@ -403,65 +403,60 @@ open Iris Iris.CMRA Iris.ProofMode
 private def Qp.quarter : Qp := ⟨1 / 4, by grind⟩
 private def Qp.threeQuarters : Qp := ⟨3 / 4, by grind⟩
 
+/- Splitting a sum: `isOpFrac_split` is used instead of `isOpFrac_half`. -/
 /-- info:
   solution: IsOp IsOp.Direction.split (Qp.threeQuarters + Qp.quarter) Qp.threeQuarters Qp.quarter,
   new goals: []
 -/
 #guard_msgs (whitespace := lax) in
-#ipm_synth (IsOp (α := Qp) .split (Qp.threeQuarters + Qp.quarter) _ _)
+#ipm_synth (IsOp .split (Qp.threeQuarters + Qp.quarter) _ _)
 
+/- Splitting a CMRA operation: `isOpFrac_split` is used instead of `isOpFrac_half`. -/
 /-- info:
   solution: IsOp IsOp.Direction.split (Qp.threeQuarters • Qp.quarter) Qp.threeQuarters Qp.quarter,
   new goals: []
 -/
 #guard_msgs (whitespace := lax) in
-#ipm_synth (IsOp (α := Qp) .split (Qp.threeQuarters • Qp.quarter) _ _)
+#ipm_synth (IsOp .split (Qp.threeQuarters • Qp.quarter) _ _)
 
+/- Splitting a `Qp` value, where `isOpFrac_split` is not applicable: use `isOpFrac_half`. -/
 /-- info:
   solution: IsOp IsOp.Direction.split q q.half q.half,
   new goals: []
 -/
 #guard_msgs (whitespace := lax) in
 variable (q : Qp) in
-#ipm_synth (IsOp (α := Qp) .split q _ _)
+#ipm_synth (IsOp .split q _ _)
 
+/- Merging two `Qp` values: `isOpFrac_half` is not applicable, use `isOpFrac_merge`. -/
 /-- info:
   solution: IsOp IsOp.Direction.merge (Qp.quarter + Qp.threeQuarters) Qp.quarter Qp.threeQuarters,
   new goals: []
 -/
 #guard_msgs (whitespace := lax) in
-#ipm_synth (IsOp (α := Qp) .merge _ Qp.quarter Qp.threeQuarters)
+#ipm_synth (IsOp .merge _ Qp.quarter Qp.threeQuarters)
 
+/- Merging two `Qp` values: `isOpFrac_half` is applicable and preferred for eliminating `.half`. -/
 /-- info:
   solution: IsOp IsOp.Direction.merge q q.half q.half,
   new goals: []
 -/
 #guard_msgs (whitespace := lax) in
 variable (q : Qp) in
-#ipm_synth (IsOp (α := Qp) .merge _ q.half q.half)
+#ipm_synth (IsOp .merge _ q.half q.half)
 
-/-- info:
-  solution: IsOp IsOp.Direction.split (q1 + q2, q3 + q4) (q1, q3) (q2, q4),
-  new goals: []
+/-
+  Splitting a pair:
+  `isOp_pair`, `isOp_pair_core_id_l`, `isOp_pair_core_id_r` and `isOp_some` are used.
+  Backtracking is involved after `isOp_pair_core_id_r` fails to split the first
+  half of the pair.
 -/
-#guard_msgs (whitespace := lax) in
-variable (q1 q2 q3 q4 : Qp) in
-#ipm_synth (IsOp (α := Qp × Qp) .split (q1 + q2, q3 + q4) _ _)
-
 /-- info:
-  solution: IsOp IsOp.Direction.split (q, q1 + q2) (q.half, q1) (q.half, q2),
+  solution: IsOp IsOp.Direction.split (some (q, q1 + q2)) (some (q.half, q1)) (some (q.half, q2)),
   new goals: []
 -/
 #guard_msgs (whitespace := lax) in
 variable (q1 q2 q : Qp) in
-#ipm_synth (IsOp (α := Qp × Qp) .split (q, q1 + q2) _ _)
-
-/-- info:
-  solution: IsOp IsOp.Direction.split (some (q1 + q2)) (some q1) (some q2),
-  new goals: []
--/
-#guard_msgs (whitespace := lax) in
-variable (q1 q2 : Qp) in
-#ipm_synth (IsOp (α := Option Qp) .split (some (q1 + q2)) _ _)
+#ipm_synth (IsOp .split (some (q, q1 + q2)) _ _)
 
 end IsOp

--- a/Iris/IrisTest/Instances.lean
+++ b/Iris/IrisTest/Instances.lean
@@ -448,7 +448,7 @@ variable (q : Qp) in
 /-
   Splitting a pair:
   `isOp_pair`, `isOp_pair_core_id_l`, `isOp_pair_core_id_r` and `isOp_some` are used.
-  Backtracking is involved after `isOp_pair_core_id_r` fails to split the first
+  Backtracking is involved after `isOp_pair_core_id_r` fails to split the second
   half of the pair.
 -/
 /-- info:

--- a/Iris/IrisTest/Instances.lean
+++ b/Iris/IrisTest/Instances.lean
@@ -398,26 +398,25 @@ variable (m n p q : Nat)
 end NatCancel
 
 section IsOp
-open Iris Iris.CMRA Iris.ProofMode
+open Iris CMRA ProofMode
 
-private def Qp.quarter : Qp := ⟨1 / 4, by grind⟩
-private def Qp.threeQuarters : Qp := ⟨3 / 4, by grind⟩
+variable (q q1 q2 : Qp)
 
 /- Splitting a sum: `isOpFrac_split` is used instead of `isOpFrac_half`. -/
 /-- info:
-  solution: IsOp IsOp.Direction.split (Qp.threeQuarters + Qp.quarter) Qp.threeQuarters Qp.quarter,
+  solution: IsOp IsOp.Direction.split (q1 + q2) q1 q2,
   new goals: []
 -/
 #guard_msgs (whitespace := lax) in
-#ipm_synth (IsOp .split (Qp.threeQuarters + Qp.quarter) _ _)
+#ipm_synth (IsOp .split (q1 + q2 : Qp) _ _)
 
 /- Splitting a CMRA operation: `isOpFrac_split` is used instead of `isOpFrac_half`. -/
 /-- info:
-  solution: IsOp IsOp.Direction.split (Qp.threeQuarters • Qp.quarter) Qp.threeQuarters Qp.quarter,
+  solution: IsOp IsOp.Direction.split (q1 • q2) q1 q2,
   new goals: []
 -/
 #guard_msgs (whitespace := lax) in
-#ipm_synth (IsOp .split (Qp.threeQuarters • Qp.quarter) _ _)
+#ipm_synth (IsOp .split (q1 • q2) _ _)
 
 /- Splitting a `Qp` value, where `isOpFrac_split` is not applicable: use `isOpFrac_half`. -/
 /-- info:
@@ -425,16 +424,15 @@ private def Qp.threeQuarters : Qp := ⟨3 / 4, by grind⟩
   new goals: []
 -/
 #guard_msgs (whitespace := lax) in
-variable (q : Qp) in
 #ipm_synth (IsOp .split q _ _)
 
 /- Merging two `Qp` values: `isOpFrac_half` is not applicable, use `isOpFrac_merge`. -/
 /-- info:
-  solution: IsOp IsOp.Direction.merge (Qp.quarter + Qp.threeQuarters) Qp.quarter Qp.threeQuarters,
+  solution: IsOp IsOp.Direction.merge (q1 + q2) q1 q2,
   new goals: []
 -/
 #guard_msgs (whitespace := lax) in
-#ipm_synth (IsOp .merge _ Qp.quarter Qp.threeQuarters)
+#ipm_synth (IsOp .merge _ q1 q2)
 
 /- Merging two `Qp` values: `isOpFrac_half` is applicable and preferred for eliminating `.half`. -/
 /-- info:
@@ -442,7 +440,6 @@ variable (q : Qp) in
   new goals: []
 -/
 #guard_msgs (whitespace := lax) in
-variable (q : Qp) in
 #ipm_synth (IsOp .merge _ q.half q.half)
 
 /-
@@ -456,7 +453,6 @@ variable (q : Qp) in
   new goals: []
 -/
 #guard_msgs (whitespace := lax) in
-variable (q1 q2 q : Qp) in
 #ipm_synth (IsOp .split (some (q, q1 + q2)) _ _)
 
 end IsOp


### PR DESCRIPTION
## Description

Fixes #637 and an additional bug with `IsOp`.

The sum `q1 + q2` should be split as `q1` and `q2` instead of `q1.half` and `q2.half`.

Currently, `isOpSplit_op` in `IsOp.lean` corresponds to `is_op_lr_op` in Iris-Rocq and has higher priority (`default + 100`) than `isOpFrac_half`. This instance is expressed using the CMRA operation `•`:

```lean4
/-- info:
  solution: IsOp IsOp.Direction.split (Qp.threeQuarters • Qp.quarter) Qp.threeQuarters Qp.quarter,
  new goals: []
-/
#guard_msgs (whitespace := lax) in
#ipm_synth (IsOp .split (Qp.threeQuarters • Qp.quarter) _ _)
```

The problem is that Lean does not unfold the sum (`+`) into the operation (`•`) automatically during type class synthesis, so `isOpSplit_op` is not used.

The solution is to have an additional instance for this with a *higher* priority than `isOpFrac_half`. On the contrary, two `q.half` are merged into `q` instead of `q.half + q.half`. The instance for merging has a *lower* priority than `isOpFrac_half`.

Furthermore, `ipm_backtrack` is necessary for `isOp_pair_core_id_r` or otherwise `isOp_pair_core_id_l` is never reached.

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files
