### PR TITLE
Fix: Porting script misses duplicate Rocq names

### DIFF
--- a/Iris/Iris/Algebra/CMRA.lean
+++ b/Iris/Iris/Algebra/CMRA.lean
@@ -478,7 +478,7 @@ theorem incN_of_incN_le {n n'} {x y : α} (l1 : n' ≤ n) : x ≼{n} y → x ≼
 theorem inc0_of_incN {n} {x y : α} : x ≼{n} y → x ≼{0} y := incN_of_incN_le (Nat.zero_le n)
 theorem IncludedN.le {n n'} {x y : α} : n' ≤ n → x ≼{n} y → x ≼{n'} y := incN_of_incN_le
 
-@[rocq_alias cmra_includedN_S]
+@[rocq_alias cmra.cmra_includedN_S]
 theorem incN_of_incN_succ {n} {x y : α} : x ≼{n.succ} y → x ≼{n} y :=
   incN_of_incN_le (Nat.le_succ n)
 theorem IncludedN.succ {n} {x y : α} : x ≼{n.succ} y → x ≼{n} y := incN_of_incN_succ

--- a/Iris/Iris/Algebra/Lib/MonoList.lean
+++ b/Iris/Iris/Algebra/Lib/MonoList.lean
@@ -80,7 +80,7 @@ theorem lb_inj {l1 l2 : List α} (h : ◯ML l1 = ◯ML l2) : l1 = l2 :=
 
 /-! ## Operation -/
 
-@[rocq_alias mono_list_lb_core_id]
+@[rocq_alias mono_list.mono_list_lb_core_id]
 instance {l : List α} : CoreId (◯ML l) := by
   unfold lb MonoList
   infer_instance

--- a/Iris/Iris/Algebra/List.lean
+++ b/Iris/Iris/Algebra/List.lean
@@ -234,7 +234,7 @@ theorem listComplGo_conv_compl {n : Nat} (c : Chain (List α)) :
         exact hxs.symm
       · simp [Chain.map_apply, tailHom_apply, hcn]
 
-@[rocq_alias list_cofe]
+@[rocq_alias list.list_cofe]
 instance : IsCOFE (List α) where
   compl c := listComplGo (c 0) c
   conv_compl {n c} := listComplGo_conv_compl c (c 0) (c.cauchy (Nat.zero_le n)).symm

--- a/Iris/Iris/Algebra/OFE.lean
+++ b/Iris/Iris/Algebra/OFE.lean
@@ -39,11 +39,11 @@ theorem dist_equivalence [OFE α] {n} : Equivalence (Dist (α := α) n) := dist_
 @[rocq_alias dist_lt]
 theorem Dist.lt [OFE α] {m n} {x y : α} : x ≡{n}≡ y → m < n → x ≡{m}≡ y := dist_lt
 
-@[rocq_alias dist_le]
+@[rocq_alias ofe.dist_le]
 theorem Dist.le [OFE α] {m n} {x y : α} (h : x ≡{n}≡ y) (h' : m ≤ n) : x ≡{m}≡ y :=
   if hm : m = n then hm ▸ h else h.lt (Nat.lt_of_le_of_ne h' hm)
 #rocq_ignore dist_le' "Use Dist.le"
-#rocq_ignore dist_S "Subsumed by `Dist.lt`/`Dist.le`."
+#rocq_ignore ofe.dist_S "Subsumed by `Dist.lt`/`Dist.le`."
 
 @[simp, refl] theorem Dist.rfl [OFE α] {n} {x : α} : x ≡{n}≡ x := dist_eqv.1 _
 @[simp, refl] theorem Dist.refl [OFE α] {n} (x : α) : x ≡{n}≡ x := dist_eqv.1 _
@@ -120,7 +120,7 @@ theorem DistLater.dist_lt [OFE α] {m n} {x y : α} (h : DistLater n x y) (hm : 
 @[simp, rocq_alias dist_later_0] theorem distLater_zero [OFE α] {x y : α} : DistLater 0 x y := nofun
 
 /-- `DistLater n`-equivalence is equivalent to `(n + 1)`-equivalence. -/
-@[rocq_alias dist_later_S]
+@[rocq_alias ofe.dist_later_S]
 theorem distLater_succ [OFE α] {n} {x y : α} : DistLater n.succ x y ↔ x ≡{n}≡ y :=
   ⟨(·.dist_lt (Nat.lt_succ_self _)), fun h1 _ h2 => h1.le (Nat.le_of_lt_succ h2)⟩
 
@@ -139,7 +139,7 @@ class Contractive [OFE α] [OFE β] (f : α → β) where
     [Contractive f] {x y} : f x ≡{0}≡ f y :=
   Contractive.distLater_dist distLater_zero
 
-@[rocq_alias contractive_S]
+@[rocq_alias ofe.contractive_S]
 theorem Contractive.succ [OFE α] [OFE β] (f : α → β) [Contractive f] {n x y}
     (h : x ≡{n}≡ y) : f x ≡{n.succ}≡ f y :=
   Contractive.distLater_dist (distLater_succ.2 h)

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -1345,7 +1345,7 @@ theorem persistently_absorb_right [BI PROP] {P Q : PROP} : P ∗ <pers> Q ⊢ <p
 theorem absorbingly_persistently [BI PROP] {P : PROP} : <absorb> <pers> P ⊣⊢ <pers> P :=
   ⟨persistently_absorb_right, absorbingly_intro⟩
 
-@[rocq_alias bi.persistently_absorbing]
+@[rocq_alias derived_laws.bi.persistently_absorbing]
 instance persistently_absorbing [BI PROP] (P : PROP) : Absorbing iprop(<pers> P) where
   absorbing := absorbingly_persistently.1
 

--- a/Iris/Iris/BI/InternalEq.lean
+++ b/Iris/Iris/BI/InternalEq.lean
@@ -181,7 +181,7 @@ theorem option_none_some_equivI {A : Type _} [OFE A] (a : A) :
     (none : Option A) ≡ some a ⊣⊢@{PROP} False :=
   ⟨symm.trans (option_some_none_equivI a).1, false_elim⟩
 
-@[rocq_alias excl_equivI]
+@[rocq_alias internal_eq.excl_equivI]
 theorem excl_equivI_excl {O : Type _} [OFE O] (a b : O) :
     Excl.excl a ≡ Excl.excl b ⊣⊢@{PROP} a ≡ b := by
   refine ⟨?_, of_internalEquiv_ne Excl.excl⟩
@@ -206,7 +206,7 @@ theorem excl_equivI_invalid_excl {O : Type _} [OFE O] (a : O) :
     (Excl.invalid : Excl O) ≡ Excl.excl a ⊣⊢@{PROP} False :=
   ⟨symm.trans (excl_equivI_excl_invalid a).1, false_elim⟩
 
-@[rocq_alias csum_equivI]
+@[rocq_alias internal_eq.csum_equivI]
 theorem csum_equivI {A B : Type _} [OFE A] [OFE B] (sx sy : Csum A B) :
     sx ≡ sy ⊣⊢@{PROP}
       match sx, sy with

--- a/Iris/Iris/BI/Lib/BUpdPlain.lean
+++ b/Iris/Iris/BI/Lib/BUpdPlain.lean
@@ -92,10 +92,9 @@ theorem BUpd_BUpdPlain [BIUpdate PROP] [BIBUpdateSbi PROP] [BIAffine PROP] {P : 
   imod HP
   iapply Hx $$ HP
 
--- FIXME: no `@[rocq_alias own_updateP]`: the short name is already claimed by
--- `base_logic/lib/own.v`'s `own_updateP`, aliased to `Iris.iOwn_updateP`.
 /-- We get the usual rule for frame preserving updates if we have an `own`
 connective satisfying the following rule w.r.t. interaction with plainly. -/
+@[rocq_alias bupd_alt.own_updateP]
 theorem own_updateP [UCMRA M] {own : M → PROP} {x : M} {Φ : M → Prop}
   (own_updateP_plainly : ∀ (x : M) (Φ : M → Prop) (R : PROP),
     (x ~~>: Φ) → iprop(own x ∗ ∀ y, ⌜Φ y⌝ -∗ own y -∗ ■ R) ⊢ ■ R)

--- a/Iris/Iris/HeapLang/Instances.lean
+++ b/Iris/Iris/HeapLang/Instances.lean
@@ -235,7 +235,7 @@ instance instAtomicFree {s} {v : Val} : Atomic s hl(free(&v)) where
 instance instAtomicXchg {s} {v1 v2 : Val} : Atomic s hl(xchg(&v1, &v2)) where
   atomic {σ obs e' σ' eₜ} Hstep := by solve_atomic Hstep
 
-@[rocq_alias heap_lang.faa_atomic]
+@[rocq_alias heap_lang.class_instances.faa_atomic]
 instance instAtomicFaa {s} {v1 v2 : Val} : Atomic s hl(faa(&v1, &v2)) where
   atomic {σ obs e' σ' eₜ} Hstep := by solve_atomic Hstep
 

--- a/Iris/Iris/HeapLang/Lib/LazyCoin.lean
+++ b/Iris/Iris/HeapLang/Lib/LazyCoin.lean
@@ -7,12 +7,12 @@ public import Iris.HeapLang.Lib.NondetBool
 namespace Iris.HeapLang
 
 -- type Coin := Ref (Option Bool) × ProphId
-@[rocq_alias heap_lang.new_coin]
+@[rocq_alias heap_lang.lazy_coin.new_coin]
 def newCoin := hl_val%
   λ _, (ref(none()), newProph())
 
 -- readCoin(cp : Coin) : Bool
-@[rocq_alias heap_lang.read_coin]
+@[rocq_alias heap_lang.lazy_coin.read_coin]
 def readCoin := hl_val%
   λ cp,
     let c := fst(cp);
@@ -47,13 +47,13 @@ theorem prophecyToBool_of_bool (vs : List (Val × Val)) (v : Val) (b : Bool) :
 
 /-- `cp` is a pair of `c` and `p`, where if p is a prophecy with resolutions `vs`
     such that if `c` is non-null, it points to the first resolution value of  `vs` -/
-@[rocq_alias heap_lang.coin]
+@[rocq_alias heap_lang.lazy_coin.coin]
 def coin (cp : Val) (b : Bool) : IProp GF := iprop%
   ∃ (c : Loc) (p : ProphId) (vs : List (Val × Val)),
   ⌜ cp = hl_val((#c, #p)) ⌝ ∗ proph p vs ∗
   (c ↦ hl_val(some(#b)) ∨ (c ↦ hl_val(none()) ∗ ⌜ b = prophecyToBool vs ⌝))
 
-@[rocq_alias heap_lang.new_coin_spec]
+@[rocq_alias heap_lang.lazy_coin.new_coin_spec]
 theorem newCoin.spec :
     {{ True }} hl(&newCoin #()) {{ c b, RET c; coin (GF := GF) c b }} := by
   iintro %Φ - K
@@ -75,7 +75,7 @@ theorem newCoin.spec :
   ipureintro
   rfl
 
-@[rocq_alias heap_lang.read_coin_spec]
+@[rocq_alias heap_lang.lazy_coin.read_coin_spec]
 theorem readCoin.spec (cp : Val) (b : Bool) :
     {{ coin (GF := GF) cp b }} hl(&readCoin &cp) {{ RET hl_val(#b); coin cp b }} := by
   conv => enter [1,1]; unfold coin

--- a/Iris/Iris/HeapLang/Lib/Lock.lean
+++ b/Iris/Iris/HeapLang/Lib/Lock.lean
@@ -84,7 +84,7 @@ instance is_lock_ne γ v : OFE.NonExpansive (lk.isLock N γ v) :=
 
 #rocq_ignore heap_lang.is_lock_proper "OFE is Leibniz; use equality"
 
-@[rocq_alias heap_lang.newlock_spec]
+@[rocq_alias heap_lang.lock.newlock_spec]
 theorem newlock_spec R :
     ⊢ □ ∀ (Φ : Val → IProp GF),
     R -∗ (∀ (v : Val) (γ : lk.name), lk.isLock N γ v R -∗ Φ v) -∗

--- a/Iris/Iris/HeapLang/PrimitiveLaws.lean
+++ b/Iris/Iris/HeapLang/PrimitiveLaws.lean
@@ -42,8 +42,8 @@ attribute [rocq_alias heap_lang.pointsto_fractional] instFractionalPointsTo
 attribute [rocq_alias heap_lang.pointsto_as_fractional] instAsFractionalPointsTo
 attribute [rocq_alias heap_lang.pointsto_valid] pointsTo_cmraValid
 attribute [rocq_alias heap_lang.pointsto_valid_2] pointsTo_op_cmraValid
-attribute [rocq_alias heap_lang.pointsto_agree] pointsTo_agree
-attribute [rocq_alias heap_lang.pointsto_combine] pointsTo_combine
+attribute [rocq_alias heap_lang.primitive_laws.pointsto_agree] pointsTo_agree
+attribute [rocq_alias heap_lang.primitive_laws.pointsto_combine] pointsTo_combine
 attribute [rocq_alias heap_lang.pointsto_frac_ne] pointsTo_frac_ne
 attribute [rocq_alias heap_lang.pointsto_ne] pointsTo_ne
 attribute [rocq_alias heap_lang.pointsto_persist] pointsTo_persist

--- a/Iris/Iris/Instances/IProp/Instance.lean
+++ b/Iris/Iris/Instances/IProp/Instance.lean
@@ -721,7 +721,7 @@ theorem singleton_updateP {a : F.ap (IProp GF)} (Hupd : a ~~>: P) :
       simp [CMRA.op, iSingleton, h_tau] at h_frame_valid ⊢
       exact h_frame_valid
 
-@[rocq_alias own_updateP]
+@[rocq_alias own.own_updateP]
 theorem iOwn_updateP {P γ a} (Hupd : a ~~>: P) : iOwn γ a ⊢ |==> ∃ a' : F.ap (IProp GF), ⌜P a'⌝ ∗ iOwn γ a' := by
   refine .trans (Q := iprop(|==> ∃ m, ⌜ ∃ a', m = (iSingleton F γ a') ∧ P a' ⌝ ∧ UPred.ownM m)) ?_ ?_
   · apply UPred.bupd_ownM_updateP

--- a/Iris/Iris/Instances/Lib/FUpdFromViewShift.lean
+++ b/Iris/Iris/Instances/Lib/FUpdFromViewShift.lean
@@ -29,12 +29,12 @@ variable {M : Type u} [UCMRA M] (vs : CoPset → CoPset → UPred M → UPred M 
 abbrev fupd_vs (E1 E2 : CoPset) (P : UPred M) : UPred M :=
   iprop(∃ R, R ∗ vs E1 E2 R P)
 
-@[rocq_alias fupd_ne]
+@[rocq_alias fancy_updates_from_vs.fupd_ne]
 instance fupd_vs_ne (E1 E2 : CoPset) [vs_ne : ∀ E1 E2, NonExpansive₂ (vs E1 E2)] :
     NonExpansive (fupd_vs vs E1 E2) where
   ne {_ _ _} h := exists_ne fun _ => sep_ne.ne .rfl ((vs_ne E1 E2).ne .rfl h)
 
-@[rocq_alias fupd_intro]
+@[rocq_alias fancy_updates_from_vs.fupd_intro]
 theorem fupd_vs_intro (E : CoPset) (P : UPred M)
     (vs_impl : ∀ E P Q, iprop(□ (P → Q)) ⊢ vs E E P Q) :
     P ⊢ fupd_vs vs E E P := by
@@ -45,7 +45,7 @@ theorem fupd_vs_intro (E : CoPset) (P : UPred M)
   iapply vs_impl
   iintro !> $
 
-@[rocq_alias fupd_mono]
+@[rocq_alias fancy_updates_from_vs.fupd_mono]
 theorem fupd_vs_mono {E1 E2 : CoPset} {P Q : UPred M} (HPQ : P ⊢ Q)
     (vs_trans : ∀ E1 E2 E3 P Q R, iprop(vs E1 E2 P Q ∧ vs E2 E3 Q R) ⊢ vs E1 E3 P R)
     (vs_impl : ∀ E P Q, iprop(□ (P → Q)) ⊢ vs E E P Q) :
@@ -59,7 +59,7 @@ theorem fupd_vs_mono {E1 E2 : CoPset} {P Q : UPred M} (HPQ : P ⊢ Q)
   iintro !> HP
   iapply HPQ $$ HP
 
-@[rocq_alias fupd_trans]
+@[rocq_alias fancy_updates_from_vs.fupd_trans]
 theorem fupd_vs_trans {E1 E2 E3 : CoPset} {P : UPred M} [∀ {E1 E2 P Q}, Persistent (vs E1 E2 P Q)]
     (vs_trans : ∀ E1 E2 E3 P Q R, iprop(vs E1 E2 P Q ∧ vs E2 E3 Q R) ⊢ vs E1 E3 P R)
     (vs_exists : ∀ {A: Type u} E1 E2 (Φ : A → UPred M) Q, (∀ x, vs E1 E2 (Φ x) Q) ⊢ vs E1 E2 iprop(∃ x, Φ x) Q)
@@ -80,7 +80,7 @@ theorem fupd_vs_trans {E1 E2 E3 : CoPset} {P : UPred M} [∀ {E1 E2 P Q}, Persis
   iapply vs_impl
   iintro !> $
 
-@[rocq_alias fupd_mask_frame_r]
+@[rocq_alias fancy_updates_from_vs.fupd_mask_frame_r]
 theorem fupd_vs_mask_frame_r {E1 E2 Ef : CoPset} {P : UPred M} (HE : E1 ## Ef)
     (vs_mask_frame_r : ∀ E1 E2 Ef P Q, E1 ## Ef → vs E1 E2 P Q ⊢ vs (E1 ∪ Ef) (E2 ∪ Ef) P Q) :
     fupd_vs vs E1 E2 P ⊢ fupd_vs vs (E1 ∪ Ef) (E2 ∪ Ef) P := by
@@ -91,7 +91,7 @@ theorem fupd_vs_mask_frame_r {E1 E2 Ef : CoPset} {P : UPred M} (HE : E1 ## Ef)
   iapply vs_mask_frame_r $$ Hvs
   trivial
 
-@[rocq_alias fupd_frame_r]
+@[rocq_alias fancy_updates_from_vs.fupd_frame_r]
 theorem fupd_vs_frame_r {E1 E2 : CoPset} {P Q : UPred M}
     (vs_frame_r : ∀ E1 E2 P Q R, vs E1 E2 P Q ⊢ vs E1 E2 iprop(P ∗ R) iprop(Q ∗ R)) :
     iprop(fupd_vs vs E1 E2 P ∗ Q) ⊢ fupd_vs vs E1 E2 iprop(P ∗ Q) := by

--- a/Iris/Iris/Instances/Lib/Token.lean
+++ b/Iris/Iris/Instances/Lib/Token.lean
@@ -33,7 +33,7 @@ attribute [reducible, instance] TokenG.elemG
 
 variable {GF : BundledGFunctors} [TokenG GF]
 
-@[rocq_alias token]
+@[rocq_alias token.token]
 def token (γ : GName) : IProp GF := iOwn (F := TokenF) γ (excl ())
 
 #rocq_ignore token_aux "`token` is defined directly without `seal`/`unseal`."

--- a/Iris/Iris/ProgramLogic/EctxLanguage.lean
+++ b/Iris/Iris/ProgramLogic/EctxLanguage.lean
@@ -174,7 +174,7 @@ class EctxLanguage (Expr  : Type _) (Ectx State Obs Val : outParam (Type _))
 attribute [rocq_alias val_base_stuck] EctxLanguage.val_stuck
 attribute [rocq_alias fill_val] EctxLanguage.fill_val
 attribute [rocq_alias step_by_val] EctxLanguage.step_by_val
-attribute [rocq_alias base_ctx_step_val] EctxLanguage.base_ctx_step_val
+attribute [rocq_alias ectx_language.base_ctx_step_val] EctxLanguage.base_ctx_step_val
 
 attribute [grind .] EctxLanguage.val_stuck
 attribute [grind →] EctxLanguage.base_ctx_step_val

--- a/Iris/Iris/ProgramLogic/Language.lean
+++ b/Iris/Iris/ProgramLogic/Language.lean
@@ -279,7 +279,7 @@ class Context (K : Expr → Expr) where
     (K e, σ) -<obs>-> (K_e', σ', eₜ) →
     ∃ e', K_e' = K e' ∧ (e, σ) -<obs>-> (e', σ', eₜ)
 
-attribute [rocq_alias fill_not_val] Context.toVal_eq_none_fill
+attribute [rocq_alias ectx_language.fill_not_val] Context.toVal_eq_none_fill
 -- attribute [rocq_alias fill_step] Context.primStep_fill
 -- attribute [rocq_alias fill_step_inv] Context.primStep_fill_inv
 

--- a/Iris/Iris/ProgramLogic/WeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/WeakestPre.lean
@@ -629,7 +629,7 @@ instance frameWp {p : Bool} [H : ∀ v, FrameInstantiateExistDisabled p R (Φ v)
     apply wp_mono
     exact fun v => (H v).frame_instantiatiate_exist_disabled.frame
 
-@[rocq_alias is_except_0_wp]
+@[rocq_alias weakestpre.is_except_0_wp]
 instance isExcept0Wp : IsExcept0 (WP e @ s ; E {{ Φ }}) where
   is_except0 :=
     calc iprop(◇ _)

--- a/Iris/Iris/Std/RocqPorting.lean
+++ b/Iris/Iris/Std/RocqPorting.lean
@@ -64,9 +64,10 @@ For the heap_lang package (`iris_heap_lang/` upstream) write:
 @[rocq_alias heap_lang.pointsto]
 ```
 
-File-local declarations normally follow the same convention. If a local name
-occurs in multiple tracked Rocq files, include the source filename to make the
-aliases distinct. For example, both
+Declarations normally follow the same convention. If a name occurs in multiple
+tracked Rocq files, include the source filename for every occurrence to make the
+aliases distinct. This applies to exported as well as file-local declarations.
+For example, both
 `iris_heap_lang/lib/spin_lock.v` and `iris_heap_lang/lib/ticket_lock.v` contain a
 local `lock_inv`, so their aliases are:
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -68,9 +68,9 @@ directory argument of `#rocq_ignore_file` / `#rocq_concept`:
 #rocq_ignore_file heap_lang.lib "diverge.v"  "Not needed"
 ```
 
-File-local declarations use the short convention unless the same name occurs
-in multiple tracked files. Ambiguous locals include their source filename, so
-the two local `lock_inv` declarations in the spin and ticket locks are
+Declarations use the short convention unless the same name occurs in multiple
+tracked files. Every ambiguous occurrence includes its source filename, so the
+two local `lock_inv` declarations in the spin and ticket locks are
 `heap_lang.spin_lock.lock_inv` and `heap_lang.ticket_lock.lock_inv`.
 
 ## Configuration Files

--- a/scripts/check_porting.py
+++ b/scripts/check_porting.py
@@ -170,14 +170,15 @@ def qualify(name: str, rel_path: str) -> str:
     return (pkg.prefix if pkg else "") + name
 
 
-def qualify_local(name: str, rel_path: str) -> str:
-    """Qualify a file-local name with its Rocq source filename.
+def qualify_ambiguous(name: str, rel_path: str) -> str:
+    """Qualify an ambiguous name with its Rocq source filename.
 
-    This is used only when the short name is ambiguous across source files.
+    This is used whenever the short name occurs in multiple source files,
+    regardless of whether the declarations are local or exported.
 
-    >>> qualify_local("lock_inv", "iris_heap_lang/lib/spin_lock.v")
+    >>> qualify_ambiguous("lock_inv", "iris_heap_lang/lib/spin_lock.v")
     'heap_lang.spin_lock.lock_inv'
-    >>> qualify_local("helper", "iris/algebra/ofe.v")
+    >>> qualify_ambiguous("helper", "iris/algebra/ofe.v")
     'ofe.helper'
     """
     pkg = package_of(rel_path)
@@ -395,11 +396,11 @@ def parse_rocq_file(text: str) -> list[ParsedDefinition]:
 def qualify_definitions(
     parsed: dict[str, list[ParsedDefinition]],
 ) -> dict[str, list[str]]:
-    """Apply package prefixes and disambiguate file-local name collisions.
+    """Apply package prefixes and disambiguate cross-file name collisions.
 
-    Unique local names retain the existing short alias convention. If the same
-    qualified short name occurs in multiple files, local occurrences gain their
-    source filename so every declaration has a distinct key.
+    Unique names retain the existing short alias convention. If the same
+    qualified short name occurs in multiple files, every occurrence gains its
+    source filename so each Rocq declaration has a distinct key.
 
     >>> qualified = qualify_definitions({
     ...   "iris_heap_lang/lib/spin_lock.v": [ParsedDefinition("lock_inv", True)],
@@ -422,8 +423,8 @@ def qualify_definitions(
 
     return {
         path: [
-            qualify_local(definition.name, path)
-            if definition.is_local and base_name in ambiguous else base_name
+            qualify_ambiguous(definition.name, path)
+            if base_name in ambiguous else base_name
             for definition, base_name in zip(definitions, base_names[path], strict=True)
         ]
         for path, definitions in parsed.items()


### PR DESCRIPTION
## Description

Fixes #640

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
