### PR TITLE
fix: free variable error with `%rfl`

### DIFF
--- a/Iris/Iris/ProofMode/Tactics/Cases.lean
+++ b/Iris/Iris/ProofMode/Tactics/Cases.lean
@@ -94,21 +94,28 @@ private def iCasesEmptyConj {prop : Q(Type u)} (bi : Q(BI $prop))
   continuing with the body `B`.
 -/
 private def iCasesExists {prop : Q(Type u)} {bi : Q(BI $prop)} (pat : TSyntax `rcasesPat)
-    (p : Q(Bool)) (P A goal : Q($prop))
-    (k : (B : Q($prop)) → ProofModeM Q($P ∗ □?$p $B ⊢ $goal)) :
+    (p : Q(Bool)) {P : Q($prop)} (hyps : Hyps bi P) (A goal : Q($prop))
+    (k : ∀ {P' : Q($prop)}, Hyps bi P' → (B goal' : Q($prop)) →
+      ProofModeM Q($P' ∗ □?$p $B ⊢ $goal')) :
     ProofModeM (Q($P ∗ □?$p $A ⊢ $goal)) := do
   let v ← mkFreshLevelMVar
   let α : Q(Sort v) ← mkFreshExprMVarQ q(Sort v)
   let Φ : Q($α → $prop) ← mkFreshExprMVarQ q($α → $prop)
   let .some _ ← ProofModeM.trySynthInstanceQ q(IntoExists $A $Φ)
   | throwIPMError "{A} is not an existential quantifier"
-  let pf : Q(∀ x, $P ∗ □?$p $Φ x ⊢ $goal) ←
-    iPureCases q(∀ x, $P ∗ □?$p $Φ x ⊢ $goal) pat fun g => do
+  let pf : Q(∀ x, $hyps.tm ∗ □?$p $Φ x ⊢ $goal) ←
+    iPureCases q(∀ x, $hyps.tm ∗ □?$p $Φ x ⊢ $goal) pat fun g => do
+      let newTm : Q($prop) ← mkFreshExprMVarQ q($prop)
       let B : Q($prop) ← mkFreshExprMVarQ q($prop)
-      -- TODO: Is this the right way to check this?
-      unless ← withTransparency .none <| isDefEq (← g.getType) q($P ∗ □?$p $B ⊢ $goal) do
-        throwIPMError "unexpected goal {goal} after intro pattern"
-      k (Expr.headBeta (← instantiateMVars B))
+      let goal' : Q($prop) ← mkFreshExprMVarQ q($prop)
+      unless ← withTransparency .none <|
+          isDefEq (← g.getType) q($newTm ∗ □?$p $B ⊢ $goal') do
+        throwIPMError "unexpected goal {← g.getType} after intro pattern"
+      let tm' ← instantiateMVars newTm
+      let some ⟨_, hyps'⟩ := parseHyps? bi tm'
+        | throwIPMError "unable to parse the Iris context {tm'}"
+      return (← k hyps' (Expr.headBeta (← instantiateMVars B)) (← instantiateMVars goal'))
+  have : $hyps.tm =Q $P := ⟨⟩
   return q(exists_elim' $pf)
 
 /-- Destruct a conjunction hypothesis `A` and continue with only its left or right component. -/
@@ -262,7 +269,8 @@ partial def iCasesCore {u} {prop : Q(Type u)} {bi : Q(BI $prop)} {P}
     for pure assertions that are not explicit existentials.
   -/
   | .conjunction (⟨_, .pure arg⟩ :: args) =>
-    iCasesExists arg p P A goal (iCasesCore hyps goal ⟨pat.ref, (.conjunction args)⟩ p · k)
+    iCasesExists arg p hyps A goal fun hyps' B goal' =>
+      iCasesCore hyps' goal' ⟨pat.ref, (.conjunction args)⟩ p B k
 
   -- A conjunction of multiple elements (`⟨…, …⟩`)
   | .conjunction (arg :: args) =>

--- a/Iris/Iris/ProofMode/Tactics/Intro.lean
+++ b/Iris/Iris/ProofMode/Tactics/Intro.lean
@@ -85,9 +85,9 @@ open Lean Elab Tactic Meta Qq BI Std
   `.all` and `.allwand`.
 -/
 private def iIntroCoreForallIntro {u} {prop : Q(Type u)} {bi : Q(BI $prop)}
-    {P : Q($prop)} (pat : TSyntax `rcasesPat)
+    {P : Q($prop)} (hyps : Hyps bi P) (pat : TSyntax `rcasesPat)
     (Q : Q($prop)) (k' : Option <| ProofModeM Q($P ⊢ $Q))
-    (k : MVarId → (B : Q($prop)) → ProofModeM Q($P ⊢ $B)) :
+    (k : MVarId → ∀ {P' : Q($prop)}, Hyps bi P' → (B : Q($prop)) → ProofModeM Q($P' ⊢ $B)) :
     ProofModeM Q($P ⊢ $Q) := do
   let v ← mkFreshLevelMVar
   let α ← mkFreshExprMVarQ q(Sort v)
@@ -97,12 +97,13 @@ private def iIntroCoreForallIntro {u} {prop : Q(Type u)} {bi : Q(BI $prop)}
     throwIPMError "{Q} cannot be turned into a universal quantifier or pure hypothesis"
   | none, some k' => k'
   | some _, _ =>
-    let pf : Q(∀ x, $P ⊢ $Φ x) ← iPureCases q(∀ x, $P ⊢ $Φ x) pat fun g => do
-      let B : Q($prop) ← mkFreshExprMVarQ q($prop)
-      -- TODO: Is this the right way to check this?
-      unless ← withTransparency .none <| isDefEq (← g.getType) q($P ⊢ $B) do
-        throwIPMError "unexpected goal after intro pattern"
-      k g (Expr.headBeta (← instantiateMVars B))
+    let pf : Q(∀ x, $hyps.tm ⊢ $Φ x) ← iPureCases q(∀ x, $hyps.tm ⊢ $Φ x) pat fun g => do
+      let some ⟨_, _, tm', B⟩ := parseEntails? (← instantiateMVars (← g.getType))
+        | throwIPMError "unexpected goal {← g.getType} after intro pattern"
+      let some ⟨_, hyps'⟩ := parseHyps? bi tm'
+        | throwIPMError "unable to parse the Iris context {tm'}"
+      return (← k g hyps' (Expr.headBeta B) : Expr)
+    have : $hyps.tm =Q $P := ⟨⟩
     return q(from_forall_intro (Q := $Q) $pf)
 
 /-- Return `true` if there is a premise to introduce using `.allwand` (`**`). -/
@@ -154,14 +155,14 @@ partial def iIntroCore {u} {prop : Q(Type u)} {bi : Q(BI $prop)}
     | .simptrivial =>
       iIntroCore hyps Q ((ref, .simp) :: (ref, .trivial) :: pats) k
     | .all =>
-      iIntroCoreForallIntro (← `(rcasesPat| _)) Q
+      iIntroCoreForallIntro hyps (← `(rcasesPat| _)) Q
         -- No more universally quantified variable to be introduced
         (iIntroCore hyps Q pats k)
         -- Introduction of a universally quantified variable
-        (fun _ B => iIntroCore hyps B ((ref, .all) :: pats) k)
+        (fun _ _ hyps' B => iIntroCore hyps' B ((ref, .all) :: pats) k)
     | .allwand =>
       -- Introduction of a universally quantified variable
-      iIntroCoreForallIntro (← `(rcasesPat| _)) Q
+      iIntroCoreForallIntro hyps (← `(rcasesPat| _)) Q
         (some (do
           -- Introduction of a wand premise or a pure premise, if possible
           if ← iIntroCoreAllWandCheck (bi := bi) P Q then
@@ -169,7 +170,7 @@ partial def iIntroCore {u} {prop : Q(Type u)} {bi : Q(BI $prop)}
               (ref, .allwand) :: pats) k
           -- No more universally quantified variable or premise to be introduced
           else iIntroCore hyps Q pats k))
-        (fun _ B => iIntroCore hyps B ((ref, .allwand) :: pats) k)
+        (fun _ _ hyps' B => iIntroCore hyps' B ((ref, .allwand) :: pats) k)
     | .pureintro =>
       let ⟨pf, m⟩ ← iPureIntroCore bi P Q
       if pats.isEmpty then
@@ -190,8 +191,8 @@ partial def iIntroCore {u} {prop : Q(Type u)} {bi : Q(BI $prop)}
         let res ← s.resolveOne hyps >>= iFrame hyps Q
         res.finish (iIntroCore · · ((ref, .clear selPats) :: pats) k)
     | .intro ⟨_, .pure pat⟩ =>
-      iIntroCoreForallIntro pat Q none fun _ B =>
-        iIntroCore hyps B pats k
+      iIntroCoreForallIntro hyps pat Q none fun _ _ hyps' B =>
+        iIntroCore hyps' B pats k
     | .intro pat =>
       let A1 ← mkFreshExprMVarQ q($prop)
       let A2 ← mkFreshExprMVarQ q($prop)

--- a/Iris/IrisTest/Tactics.lean
+++ b/Iris/IrisTest/Tactics.lean
@@ -435,6 +435,11 @@ example [BI PROP] (a b c1 c2 c3 : Prop) (P : Prop → Prop) :
   · grind
   · grind
 
+/-- Tests `iintro` with an introduction involving substitution of an equality (`%rfl`). -/
+example [BI PROP] n (P Q : Nat → PROP) : (<affine> ⌜n = 0⌝ ∗ P 0 ∗ Q n) ⊢ P n ∗ Q n := by
+  iintro ⟨%rfl, Hp⟩
+  iexact Hp
+
 end iintro
 
 section irevert
@@ -2281,6 +2286,12 @@ example [BI PROP] (a b c1 c2 c3 : Prop) (P : Prop → Prop) :
   icases Hpure with %⟨⟨rfl, ((hb : a) | ⟨hc, _, -⟩)⟩, @⟨d : Prop, hd⟩⟩
   · ipureintro <;> grind
   · ipureintro <;> grind
+
+/-- Tests `icases` with a case destruction pattern involving substitution (`%rfl`). -/
+example [BI PROP] n (P : Nat → PROP) : (<affine> ⌜n = 0⌝ ∗ P 0) ⊢ P n := by
+  iintro H
+  icases H with ⟨%rfl, Hp⟩
+  iexact Hp
 
 end icases
 


### PR DESCRIPTION
## Description

Fixes #647.

Whilst working on #496, the same problem was already known to occur in other examples, and commit https://github.com/leanprover-community/iris-lean/pull/496/changes/da0a23a33110c7a53ba635fd27f3fffe5d826b8f specifically addressed this issue by fixing `iPureCore`. However, the same fix was not applied for `icases`, `iintro` and other tactics where `%rfl` is handled by other functions (e.g. `iCasesExists`, `iIntroCoreForallIntro`). Hence the bug occurs.

In contrast to the example in #647, the following example where `iPureCore` is used works fine:

```lean4
example [BI PROP] n (P : Nat → PROP) : <affine> ⌜n = 0⌝ ⊢ P n := by
  iintro H
  icases H with %rfl
```

In summary, `%rfl` applies the substitution and removes `n` from the context. The functions did not update the hypotheses properly and, as a result, hypotheses referring to stale variables were used.

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files
