### PR TITLE
feat: remaining instances in `Instances.lean` and `InstancesLater.lean`

### DIFF
--- a/Iris/Iris/ProofMode/Instances.lean
+++ b/Iris/Iris/ProofMode/Instances.lean
@@ -152,6 +152,25 @@ instance intoWand_wandM (p q : Bool) [BI PROP] (mP' : Option PROP) (P Q : PROP)
     _ ⊢ □?p (□?q P -∗ Q)               := intuitionisticallyIf_mono <| wand_mono_left h.1
     _ ⊢ □?q P -∗ Q                     := intuitionisticallyIf_elim
 
+@[rocq_alias into_wand_forall_prop_true]
+instance (priority := default + 20) intoWand_forall_prop_true (p : Bool) [BI PROP]
+    (m : WandMode) (φ : Prop) (P : PROP) :
+    IntoWand p true iprop(∀ _ : φ, P) m iprop(⌜φ⌝) P where
+  into_wand := by
+    haveI : Absorbing P := by sorry
+    calc
+       _ ⊢ ∀ (x : φ), P := intuitionisticallyIf_elim
+       _ ⊢ ⌜φ⌝ -∗ P     := pure_wand_forall.mpr
+       _ ⊢ □ ⌜φ⌝ -∗ P   := wand_mono_left intuitionistically_elim
+
+@[rocq_alias into_wand_forall_prop_false]
+instance (priority := default + 10) intoWand_forall_prop_false (p : Bool) [BI PROP]
+    (m : WandMode) (φ : Prop) (Pφ P : PROP) [h : MakeAffinely iprop(⌜φ⌝) Pφ] :
+    IntoWand p false iprop(∀ _ : φ, P) m Pφ P where
+  into_wand := by
+    simp
+    sorry
+
 -- The set_option is ok since this is an instance for an IPM class and thus can create mvars.
 set_option synthInstance.checkSynthOrder false in
 @[rocq_alias into_wand_forall]
@@ -281,7 +300,29 @@ instance intoForall_wand_pure [BI PROP] (P Q : PROP) Φ
       _ ⊢ <affine>?a ⌜Φ⌝ := affinelyIf_mono <| pure_intro hΦ
       _ ⊢ P              := h.from_pure
 
+@[ipm_backtrack, rocq_alias into_forall_impl_pure]
+instance intoForall_imp_pure [BI PROP] (a : Bool) (φ : Prop) (P Q : PROP)
+    [h : FromPure a P .out φ] [or : TCOr (TCEq a false) (BIAffine PROP)] :
+    IntoForall iprop(P → Q) (fun _ : φ => Q) where
+  into_forall := by
+    sorry
+
+@[rocq_alias into_forall_wand]
+instance (priority := default - 10) intoForall_wand [BI PROP] (P Q : PROP) :
+    IntoForall iprop(P -∗ Q) (fun _ : (⊢ P) => Q) where
+  into_forall := forall_intro fun h => calc
+    _ ⊢ emp ∗ (P -∗ Q) := emp_sep.mpr
+    _ ⊢ P ∗ (P -∗ Q)   := sep_mono_left h
+    _ ⊢ Q              := wand_elim_right
+
+@[rocq_alias into_forall_impl]
+instance (priority := default - 10) intoForall_imp [BI PROP] [BIAffine PROP] (P Q : PROP) :
+    IntoForall iprop(P → Q) (fun _ : (⊢ P) => Q) where
+  into_forall := forall_intro fun h =>
+    (and_intro .rfl (affine.trans h)).trans imp_elim_left
+
 -- FromExists
+@[rocq_alias from_exist_exist]
 instance (priority := default + 10) fromExists_exists [BI PROP] (Φ : α → PROP) :
     FromExists iprop(∃ a, Φ a) Φ := ⟨.rfl⟩
 
@@ -399,6 +440,11 @@ instance (priority := default + 50) fromAnd_pure (φ ψ : Prop) [BI PROP] :
     FromAnd (PROP := PROP) iprop(⌜φ ∧ ψ⌝) iprop(⌜φ⌝) iprop(⌜ψ⌝) where
   from_and := pure_and.1
 
+@[rocq_alias from_and_pure_iff]
+instance (priority := default + 50) fromAnd_pure_iff (φ ψ : Prop) [BI PROP] :
+    FromAnd (PROP := PROP) iprop(⌜φ ↔ ψ⌝) iprop(⌜φ → ψ⌝) iprop(⌜ψ → φ⌝) where
+  from_and := pure_and.mp.trans <| pure_mono fun h => ⟨h.left, h.right⟩
+
 @[rocq_alias from_and_persistently]
 instance (priority := default + 40) fromAnd_persistently [BI PROP] (P Q1 Q2 : PROP)
     [h : FromAnd P Q1 Q2] : FromAnd iprop(<pers> P) iprop(<pers> Q1) iprop(<pers> Q2) where
@@ -504,6 +550,11 @@ instance (priority := default - 20) fromSep_and [BI PROP] (P1 P2 : PROP)
 instance (priority := default + 20) fromSep_pure (φ ψ : Prop) [BI PROP] :
     FromSep (PROP := PROP) iprop(⌜φ ∧ ψ⌝) iprop(⌜φ⌝) iprop(⌜ψ⌝) where
   from_sep := pure_sep.1
+
+@[rocq_alias from_sep_pure_iff]
+instance (priority := default + 20) fromSep_pure_iff (φ ψ : Prop) [BI PROP] :
+    FromSep (PROP := PROP) iprop(⌜φ ↔ ψ⌝) iprop(⌜φ → ψ⌝) iprop(⌜ψ → φ⌝) where
+  from_sep := pure_sep.mp.trans <| pure_mono fun h => ⟨h.left, h.right⟩
 
 @[rocq_alias from_sep_affinely]
 instance (priority := default + 10) fromSep_affinely [BI PROP] (P Q1 Q2 : PROP)
@@ -870,6 +921,30 @@ instance intoPure_absorbingly [BI PROP] (P : PROP) (φ : Prop)
 instance intoPure_persistently [BI PROP] (P : PROP) (φ : Prop)
     [h : IntoPure P φ] : IntoPure iprop(<pers> P) φ where
   into_pure := (persistently_mono h.1).trans persistently_elim
+
+/--
+  The Rocq instance has `BiPureForall PROP` as a premise. This premise is not
+  necessary in Lean, as `pure_forall` is provable classically for every BI,
+  and thus `BiPureForall` is ignored in Lean.
+-/
+@[rocq_alias into_pure_forall]
+instance intoPure_forall {α} [BI PROP] (Φ : α → PROP) (φ : α → Prop)
+    [h : ∀ x, IntoPure (Φ x) (φ x)] : IntoPure iprop(∀ x, Φ x) (∀ x, φ x) where
+  into_pure := (forall_mono fun x => (h x).into_pure).trans pure_forall.mpr
+
+/--
+  The Rocq instance has `BiPureForall PROP` as a premise. This premise is not
+  necessary in Lean, as `(⌜φ1⌝ → ⌜φ2⌝) ⊢ ⌜φ1 → φ2⌝` is provable directly using
+  `pure_imp` in Lean.
+-/
+@[rocq_alias into_pure_pure_wand]
+instance intoPure_pure_wand [BI PROP] (a : Bool) (φ1 φ2 : Prop) (P1 P2 : PROP)
+    [h1 : FromPure a P1 .out φ1] [h2 : IntoPure P2 φ2] :
+    IntoPure iprop(P1 -∗ P2) (φ1 → φ2) where
+  into_pure := by
+    have h1 := h1.from_pure
+    have h2 := h2.into_pure
+    sorry
 
 -- FromPure
 @[rocq_alias from_pure_emp]

--- a/Iris/Iris/ProofMode/Instances.lean
+++ b/Iris/Iris/ProofMode/Instances.lean
@@ -152,7 +152,7 @@ instance intoWand_wandM (p q : Bool) [BI PROP] (mP' : Option PROP) (P Q : PROP)
     _ ⊢ □?p (□?q P -∗ Q)               := intuitionisticallyIf_mono <| wand_mono_left h.1
     _ ⊢ □?q P -∗ Q                     := intuitionisticallyIf_elim
 
-@[rocq_alias into_wand_forall_prop_true]
+@[ipm_backtrack, rocq_alias into_wand_forall_prop_true]
 instance (priority := default + 20) intoWand_forall_prop_true (p : Bool) [BI PROP]
     (m : WandMode) (φ : Prop) (P : PROP) :
     IntoWand p true iprop(∀ _ : φ, P) m iprop(⌜φ⌝) P where
@@ -163,13 +163,12 @@ instance (priority := default + 20) intoWand_forall_prop_true (p : Bool) [BI PRO
        _ ⊢ ⌜φ⌝ -∗ P     := pure_wand_forall.mpr
        _ ⊢ □ ⌜φ⌝ -∗ P   := wand_mono_left intuitionistically_elim
 
-@[rocq_alias into_wand_forall_prop_false]
+@[ipm_backtrack, rocq_alias into_wand_forall_prop_false]
 instance (priority := default + 10) intoWand_forall_prop_false (p : Bool) [BI PROP]
-    (m : WandMode) (φ : Prop) (Pφ P : PROP) [h : MakeAffinely iprop(⌜φ⌝) Pφ] :
-    IntoWand p false iprop(∀ _ : φ, P) m Pφ P where
-  into_wand := by
-    simp
-    sorry
+    (m : WandMode) (φ : Prop) (Pφ P' P : PROP)
+    [h1 : MakeAffinely iprop(⌜φ⌝) Pφ] [h2 : FromAssumption false m.argIO P' Pφ] :
+    IntoWand p false iprop(∀ _ : φ, P) m P' P where
+  into_wand := sorry
 
 -- The set_option is ok since this is an instance for an IPM class and thus can create mvars.
 set_option synthInstance.checkSynthOrder false in

--- a/Iris/Iris/ProofMode/Instances.lean
+++ b/Iris/Iris/ProofMode/Instances.lean
@@ -157,18 +157,27 @@ instance (priority := default + 20) intoWand_forall_prop_true (p : Bool) [BI PRO
     (m : WandMode) (φ : Prop) (P : PROP) :
     IntoWand p true iprop(∀ _ : φ, P) m iprop(⌜φ⌝) P where
   into_wand := by
-    haveI : Absorbing P := by sorry
-    calc
-       _ ⊢ ∀ (x : φ), P := intuitionisticallyIf_elim
-       _ ⊢ ⌜φ⌝ -∗ P     := pure_wand_forall.mpr
-       _ ⊢ □ ⌜φ⌝ -∗ P   := wand_mono_left intuitionistically_elim
+    refine wand_intro (pure_elim φ ?_ fun hφ => ?_)
+    · exact (sep_mono_right intuitionistically_elim).trans sep_elim_right
+    · calc
+        _ ⊢ □?p ∀ a, P := sep_elim_left
+        _ ⊢ ∀ a, P     := intuitionisticallyIf_elim
+        _ ⊢ P          := forall_elim hφ
 
 @[ipm_backtrack, rocq_alias into_wand_forall_prop_false]
 instance (priority := default + 10) intoWand_forall_prop_false (p : Bool) [BI PROP]
     (m : WandMode) (φ : Prop) (Pφ P' P : PROP)
     [h1 : MakeAffinely iprop(⌜φ⌝) Pφ] [h2 : FromAssumption false m.argIO P' Pφ] :
     IntoWand p false iprop(∀ _ : φ, P) m P' P where
-  into_wand := sorry
+  into_wand := by
+    have h := h2.from_assumption.trans h1.make_affinely.mpr
+    refine wand_intro (pure_elim φ ?_ fun hφ => ?_)
+    · exact (sep_mono_right (h.trans affinely_elim)).trans sep_elim_right
+    · calc
+        _ ⊢ (□?p ∀ a, P) ∗ <affine> ⌜φ⌝ := sep_mono_right h
+        _ ⊢ □?p ∀ a, P                  := sep_elim_left
+        _ ⊢ ∀ a, P                      := intuitionisticallyIf_elim
+        _ ⊢ P                           := forall_elim hφ
 
 -- The set_option is ok since this is an instance for an IPM class and thus can create mvars.
 set_option synthInstance.checkSynthOrder false in
@@ -304,7 +313,13 @@ instance intoForall_imp_pure [BI PROP] (a : Bool) (φ : Prop) (P Q : PROP)
     [h : FromPure a P .out φ] [or : TCOr (TCEq a false) (BIAffine PROP)] :
     IntoForall iprop(P → Q) (fun _ : φ => Q) where
   into_forall := by
-    sorry
+    refine forall_intro fun hφ => ?_
+    refine (and_intro .rfl ?_).trans imp_elim_left
+    refine Entails.trans ?_ h.from_pure
+    exact match a, or with
+      | false, _ => pure_intro hφ
+      | true, TCOr.r => (affine_affinely _).mpr.trans (affinely_mono <| pure_intro hφ)
+      | true, TCOr.l (t := heq) => nomatch heq
 
 @[rocq_alias into_forall_wand]
 instance (priority := default - 10) intoForall_wand [BI PROP] (P Q : PROP) :
@@ -941,9 +956,16 @@ instance intoPure_pure_wand [BI PROP] (a : Bool) (φ1 φ2 : Prop) (P1 P2 : PROP)
     [h1 : FromPure a P1 .out φ1] [h2 : IntoPure P2 φ2] :
     IntoPure iprop(P1 -∗ P2) (φ1 → φ2) where
   into_pure := by
-    have h1 := h1.from_pure
-    have h2 := h2.into_pure
-    sorry
+    calc
+      _ ⊢ <affine>?a ⌜φ1⌝ -∗ ⌜φ2⌝ := wand_mono h1.from_pure h2.into_pure
+      _ ⊢ <affine> ⌜φ1⌝ -∗ ⌜φ2⌝   := wand_mono_left affinely_affinelyIf
+      _ ⊢ ⌜φ1⌝ → ⌜φ2⌝             := imp_intro <| pure_elim_right fun hφ1 => ?_
+      _ ⊢ ⌜φ1 → φ2⌝               := pure_imp.mpr
+    calc
+      _ ⊢ emp ∗ (<affine> ⌜φ1⌝ -∗ ⌜φ2⌝)           := emp_sep.mpr
+      _ ⊢ <affine> ⌜φ1⌝ ∗ (<affine> ⌜φ1⌝ -∗ ⌜φ2⌝) :=
+          sep_mono_left <| affinely_intro <| pure_intro hφ1
+      _ ⊢ ⌜φ2⌝                                    := wand_elim_right
 
 -- FromPure
 @[rocq_alias from_pure_emp]

--- a/Iris/Iris/ProofMode/InstancesLater.lean
+++ b/Iris/Iris/ProofMode/InstancesLater.lean
@@ -181,6 +181,7 @@ instance intoSep_except0 [BI PROP] (P Q1 Q2 : PROP)
     [h : IntoSep P Q1 Q2] : IntoSep iprop(◇ P) iprop(◇ Q1) iprop(◇ Q2) where
   into_sep := (except0_mono h.1).trans except0_sep.1
 
+/- FIXME: This instance is overly specific, generalize it. -/
 @[rocq_alias into_sep_affinely_later]
 instance intoSep_affinely_later [BI PROP] [Timeless (emp : PROP)]
     (P Q1 Q2 : PROP) [inst : IntoSep P Q1 Q2] [Affine Q1] [Affine Q2] :

--- a/Iris/Iris/ProofMode/InstancesLater.lean
+++ b/Iris/Iris/ProofMode/InstancesLater.lean
@@ -181,6 +181,16 @@ instance intoSep_except0 [BI PROP] (P Q1 Q2 : PROP)
     [h : IntoSep P Q1 Q2] : IntoSep iprop(◇ P) iprop(◇ Q1) iprop(◇ Q2) where
   into_sep := (except0_mono h.1).trans except0_sep.1
 
+@[rocq_alias into_sep_affinely_later]
+instance intoSep_affinely_later [BI PROP] [Timeless (emp : PROP)]
+    (P Q1 Q2 : PROP) [inst : IntoSep P Q1 Q2] [Affine Q1] [Affine Q2] :
+    IntoSep iprop(<affine> ▷ P) iprop(<affine> ▷ Q1) iprop(<affine> ▷ Q2) where
+  into_sep := by
+    calc
+      <affine> ▷ P ⊢ <affine> ▷ (Q1 ∗ Q2) := affinely_mono <| later_mono inst.into_sep
+      _ ⊢ <affine> (▷ Q1 ∗ ▷ Q2) := affinely_mono later_sep.mp
+      _ ⊢ <affine> ▷ Q1 ∗ <affine> ▷ Q2 := sorry
+
 /-- FromOr -/
 
 @[rocq_alias from_or_later]

--- a/Iris/Iris/ProofMode/InstancesLater.lean
+++ b/Iris/Iris/ProofMode/InstancesLater.lean
@@ -186,10 +186,21 @@ instance intoSep_affinely_later [BI PROP] [Timeless (emp : PROP)]
     (P Q1 Q2 : PROP) [inst : IntoSep P Q1 Q2] [Affine Q1] [Affine Q2] :
     IntoSep iprop(<affine> ▷ P) iprop(<affine> ▷ Q1) iprop(<affine> ▷ Q2) where
   into_sep := by
+    have step (Q : PROP) [Affine Q] : iprop(▷ Q) ⊢ iprop(◇ <affine> ▷ Q) :=
+      (later_mono (affine_affinely Q).mpr).trans later_affinely_mp
     calc
-      <affine> ▷ P ⊢ <affine> ▷ (Q1 ∗ Q2) := affinely_mono <| later_mono inst.into_sep
+      _ ⊢ <affine> ▷ (Q1 ∗ Q2)    := affinely_mono <| later_mono inst.into_sep
       _ ⊢ <affine> (▷ Q1 ∗ ▷ Q2) := affinely_mono later_sep.mp
-      _ ⊢ <affine> ▷ Q1 ∗ <affine> ▷ Q2 := sorry
+      _ ⊢ <affine> (◇ <affine> ▷ Q1 ∗ ◇ <affine> ▷ Q2) :=
+          affinely_mono <| sep_mono (step Q1) (step Q2)
+      _ ⊢ <affine> ◇ (<affine> ▷ Q1 ∗ <affine> ▷ Q2) := affinely_mono except0_sep.mpr
+      _ ⊢ <affine> ▷ False ∨ <affine> (<affine> ▷ Q1 ∗ <affine> ▷ Q2) := affinely_or.mp
+      _ ⊢ <affine> ▷ Q1 ∗ <affine> ▷ Q2 := or_elim ?_ affinely_elim
+    calc iprop(<affine> ▷ False)
+      _ ⊢ <affine> ▷ False ∧ <affine> ▷ False := and_intro .rfl .rfl
+      _ ⊢ <affine> ▷ False ∗ <affine> ▷ False := persistent_and_sep_mp
+      _ ⊢ <affine> ▷ Q1 ∗ <affine> ▷ Q2       :=
+          sep_mono (affinely_mono <| later_mono false_elim) (affinely_mono <| later_mono false_elim)
 
 /-- FromOr -/
 

--- a/Iris/IrisTest/Instances.lean
+++ b/Iris/IrisTest/Instances.lean
@@ -479,3 +479,122 @@ variable (q q1 q2 : Qp)
 #ipm_synth IsOp .split instQpOne.one _ _
 
 end IsOp
+
+section ProofModeInstances
+
+variable [BI PROP] (P Q : PROP) (φ : Prop)
+
+/-
+  The instance `intoForall_wand` has lower priority than `intoForall_wand_pure`
+  so that the synthesis returns `fun (x : φ) => Q` instead of `fun (x : ⊢ ⌜φ⌝) => Q`.
+-/
+/-- info:
+  solution: IntoForall iprop(⌜φ⌝ -∗ Q) fun (x : φ) => Q,
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+set_option pp.funBinderTypes true in
+#ipm_synth (@IntoForall PROP _ iprop(⌜φ⌝ -∗ Q) (_ : Prop) _)
+
+/-
+  The instance `intoForall_imp` has lower priority than `intoForall_imp_pure`
+  so that the synthesis returns `fun (x : φ) => Q` instead of `fun (x : ⊢ ⌜φ⌝) => Q`.
+-/
+/--
+  info: solution: IntoForall iprop(⌜φ⌝ → Q) fun (x : φ) => Q, new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+set_option pp.funBinderTypes true in
+variable [BIAffine PROP] in
+#ipm_synth (@IntoForall PROP _ iprop(⌜φ⌝ → Q) (_ : Prop) _)
+
+/-
+  Tests `IntoPure` synthesis using `intoPure_forall`.
+  There is no `BiPureForall` in Lean, and synthesis works in an arbitrary BI.
+-/
+/-- info:
+  solution: IntoPure iprop(∀ x, ⌜x = 5⌝) (∀ (x : Nat), x = 5),
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+variable (Φ : Nat → PROP) (φ1 φ2 : Prop) in
+#ipm_synth (IntoPure iprop(∀ n : Nat, ⌜n = 5⌝ : PROP) _)
+
+/-
+  Tests `IntoPure` synthesis using `intoPure_pure_wand`.
+  There is no `BiPureForall` in Lean, and synthesis works in an arbitrary BI.
+-/
+/-- info:
+  solution: IntoPure iprop(⌜φ1⌝ -∗ ⌜φ2⌝) (φ1 → φ2),
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+variable (Φ : Nat → PROP) (φ1 φ2 : Prop) in
+#ipm_synth (IntoPure (PROP := PROP) iprop(⌜φ1⌝ -∗ ⌜φ2⌝) _)
+
+/-
+  The instance `intoWand_forall_prop_true` has higher priority than `intoWand_forall`
+  so that `⌜φ⌝` is returned.
+-/
+/-- info:
+  solution: IntoWand p true iprop(∀ x, P) WandMode.unknown iprop(⌜φ⌝) P, new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+variable (Φ : Nat → PROP) (Ψ : ∀ _ : φ, PROP) (p : Bool) in
+#ipm_synth (IntoWand p true iprop(∀ _ : φ, P) .unknown _ _)
+
+/- Using `intoWand_forall_prop_false` in a non-affine BI, giving `<affine> ⌜φ⌝`. -/
+/-- info:
+  solution: IntoWand p false iprop(∀ x, P) WandMode.unknown iprop(<affine> ⌜φ⌝) P,
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+variable (Φ : Nat → PROP) (Ψ : ∀ _ : φ, PROP) (p : Bool) in
+#ipm_synth (IntoWand p false iprop(∀ _ : φ, P) .unknown _ _)
+
+/- Using `intoWand_forall_prop_false` in an affine BI, giving `⌜φ⌝`. -/
+/-- info:
+  solution: IntoWand p false iprop(∀ x, P) WandMode.unknown iprop(⌜φ⌝) P,
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+variable [BIAffine PROP] (Φ : Nat → PROP) (Ψ : ∀ _ : φ, PROP) (p : Bool) in
+#ipm_synth (IntoWand p false iprop(∀ _ : φ, P) .unknown _ _)
+
+/-
+  The instance `intoWand_forall_prop_true` fails to apply when `q` is fixed to `false`.
+  Instead, `intoWand_forall_prop_false` applies.
+-/
+/-- info:
+  solution: IntoWand p false iprop(∀ x, P)
+    (WandMode.matching WandMode.Side.argument) iprop(<affine> ⌜φ⌝) P,
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+variable (Φ : Nat → PROP) (Ψ : ∀ _ : φ, PROP) (p : Bool) in
+#ipm_synth (IntoWand p false iprop(∀ _ : φ, P) (.matching .argument) iprop(<affine> ⌜φ⌝) _)
+
+/-
+  The instance `intoWand_forall_prop_false` does not apply for `∀ n : Nat, Φ n -∗ Φ n`
+  as the binder `n` does not have type `Prop`.
+  The instance `intoWand_forall` is used instead, resulting in an uninstantiated metavariable.
+-/
+/-- info:
+  solution: IntoWand false false iprop(∀ x, Φ x -∗ Φ x) WandMode.unknown (Φ ?_) (Φ ?_),
+  new goals: [?_: Nat]
+-/
+#guard_msgs (whitespace := lax) in
+set_option pp.mvars false in
+variable (Φ : Nat → PROP) (Ψ : ∀ _ : φ, PROP) (p : Bool) in
+#ipm_synth (IntoWand false false iprop(∀ n : Nat, Φ n -∗ Φ n) .unknown _ _)
+
+/- The instance `intoWand_forall_prop_true` applies when the argument slot is an input. -/
+/-- info:
+  solution: IntoWand p true iprop(∀ x, P) (WandMode.matching WandMode.Side.argument) iprop(⌜φ⌝) P,
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+variable (p : Bool) in
+#ipm_synth (IntoWand p true iprop(∀ _ : φ, P) (.matching .argument) iprop(⌜φ⌝) _)
+
+end ProofModeInstances

--- a/Iris/IrisTest/Tactics.lean
+++ b/Iris/IrisTest/Tactics.lean
@@ -839,11 +839,26 @@ example [BI PROP] {α} (Q : α → PROP) (a b : α) : (∀ x, ∀ y, ⌜x = a⌝
   iintro H
   iapply H $$ %_ %b %rfl
 
-/-- error: iapply: iprop(P a -∗ Q b) is not a Lean premise -/
+/-
+  Tests `iapply` with an invalid attempt to specialise a wand premise using a
+  subgoal intended for discharging a pure premise.
+-/
+/-- error: iapply: Q b is not a Lean premise -/
 #guard_msgs in
-example [BI PROP] {α} (P Q : α → PROP) (a b : α) : (∀ x, ∀ y, P x -∗ Q y) ⊢ P a -∗ Q b := by
+example [BI PROP] {α} (P Q R : α → PROP) (a b c : α) :
+    (∀ x, ∀ y, P x -∗ Q y) ⊢ P a -∗ Q b -∗ R c := by
   iintro H HP
-  iapply H $$ %a %b %_ HP
+  iapply H $$ %a %b HP %_
+
+/-
+  Tests `iapply` with a specialisation pattern discharging a wand premise as
+  a subgoal (`⊢ P a`).
+-/
+example [BI PROP] {α} (P Q : α → PROP) (a b : α) (h : ⊢ P a) :
+    (∀ x, ∀ y, P x -∗ Q y) ⊢ □ P a -∗ Q b := by
+  iintro H #HP
+  iapply H $$ %a %b %_
+  exact h
 
 /-- Tests `iapply` using unification for foralls. -/
 example [BI PROP] {α} (P Q : α → PROP) (a b : α) : (∀ x, ∀ y, P x -∗ Q y) ⊢ P a -∗ Q b := by

--- a/Iris/IrisTest/Tactics.lean
+++ b/Iris/IrisTest/Tactics.lean
@@ -3417,7 +3417,7 @@ example [BI PROP] {P Q R : PROP} : ⊢ P -∗ Q -∗ □ R -∗ R ∗ P ∗ Q :=
 example {F GF} [RFunctorContractive F] [ElemG GF F] {γ}
     {a1 a2 a3 b c : F.ap (IProp GF)} [IsOp .merge b a2 a3] [IsOp .merge c a1 b] :
     ⊢ iOwn γ a1 -∗ iOwn γ a2 -∗ iOwn γ a3 -∗
-      iOwn γ c ∗ internalCmraValid (a2 • a3) ∗ internalCmraValid (a1 • b) := by
+      iOwn γ c ∗ ✓ (a2 • a3) ∗ ✓ (a1 • b) := by
   iintro H1 H2 H3
   icombine H1 H2 H3 as Hnew1 gives ⟨Hnew2, Hnew3⟩
   isplitl

--- a/Iris/IrisTest/Tactics.lean
+++ b/Iris/IrisTest/Tactics.lean
@@ -850,13 +850,13 @@ example [BI PROP] {α} (Q : α → PROP) (a b : α) : (∀ x, ∀ y, ⌜x = a⌝
 -/
 /-- error: iapply: Q b is not a Lean premise -/
 #guard_msgs in
-example [BI PROP] {α} (P Q R : α → PROP) (a b c : α) :
-    (∀ x, ∀ y, P x -∗ Q y) ⊢ P a -∗ Q b -∗ R c := by
+example [BI PROP] {α} (P Q : α → PROP) (a b : α) :
+    (∀ x, ∀ y, P x -∗ Q y) ⊢ P a -∗ Q b := by
   iintro H HP
   iapply H $$ %a %b HP %_
 
 /-
-  Tests `iapply` with a specialisation pattern discharging a wand premise as
+  Tests `iapply` with a specialization pattern discharging a wand premise as
   a subgoal (`⊢ P a`).
 -/
 example [BI PROP] {α} (P Q : α → PROP) (a b : α) (h : ⊢ P a) :
@@ -1138,7 +1138,7 @@ example [BI PROP] (P Q : PROP) (h : P ⊢ □ Q) : ⊢ P -∗ P ∗ Q := by
   · iexact HQ
 
 /--
-  Tests `ihave` with the specialisation pattern involving modalities.
+  Tests `ihave` with the specialization pattern involving modalities.
   Despite `try_dup_context` being `true`, the context is not duplicated.
 -/
 example [BI PROP] [BIAffine PROP] [BIUpdate PROP] (P : PROP) [Persistent P] :
@@ -1148,7 +1148,7 @@ example [BI PROP] [BIAffine PROP] [BIUpdate PROP] (P : PROP) [Persistent P] :
   imodintro
   iexact HP
 
-/-- Tests `ihave` with the specialisation pattern involving auto-framing with modalities. -/
+/-- Tests `ihave` with the specialization pattern involving auto-framing with modalities. -/
 example [BI PROP] [BIAffine PROP] [BIUpdate PROP] (P : PROP) [Persistent P] :
     |==> P ⊢ |==> P := by
   iintro HP
@@ -1670,7 +1670,7 @@ example [BI PROP] (φ : Prop) (P Q : PROP) :
   iintro HP HPQ
   ispecialize HPQ $$ [# HP]
 
-/-- Tests `ispecialize` with nested specialisation patterns. -/
+/-- Tests `ispecialize` with nested specialization patterns. -/
 example [BI PROP] (P Q R S T : PROP) :
     ⊢ (P -∗ <pers> T -∗ Q) -∗ (Q -∗ <pers> T -∗ R) -∗ (R -∗ S) -∗ P -∗ <pers> T -∗ S := by
   iintro HPTQ HQTR HRS HP HT
@@ -1754,14 +1754,14 @@ example [BI PROP] [BIUpdate PROP] (P Q R : PROP) :
   imodintro
   iassumption
 
-/- Tests `ispecialize` with an invalid specialisation pattern (duplicated hypotheses). -/
+/- Tests `ispecialize` with an invalid specialization pattern (duplicated hypotheses). -/
 /-- error: ispecialize: HP used twice for framing -/
 #guard_msgs in
 example [BI PROP] (P Q : PROP) : P ⊢ (P -∗ Q) -∗ Q := by
   iintro HP HPQ
   ispecialize HPQ $$ [$HP $HP]
 
-/- Tests `ispecialize` with an invalid specialisation pattern (duplicated hypotheses). -/
+/- Tests `ispecialize` with an invalid specialization pattern (duplicated hypotheses). -/
 /-- error: ispecialize: HP cannot be used for both the subgoal and framing -/
 #guard_msgs in
 example [BI PROP] (P Q : PROP) : P ⊢ (P -∗ Q) -∗ Q := by
@@ -1775,21 +1775,21 @@ example [BI PROP] (P Q : PROP) : P ⊢ Q := by
   iintro HP
   ispecialize HP $$ [$]
 
-/- Tests `ispecialize` with an invalid specialisation pattern. -/
+/- Tests `ispecialize` with an invalid specialization pattern. -/
 /-- error: ispecialize: IntoWand type class synthesis failed with P and Q -/
 #guard_msgs in
 example [BI PROP] (P Q : PROP) : P ⊢ Q -∗ Q := by
   iintro HP HQ
   ispecialize HP $$ HQ
 
-/- Tests `ispecialize` with an invalid specialisation pattern using pure hypotheses. -/
+/- Tests `ispecialize` with an invalid specialization pattern using pure hypotheses. -/
 /-- error: ispecialize: P is not a Lean premise -/
 #guard_msgs in
 example [BI PROP] (P Q : PROP) : P ⊢ Q := by
   iintro HP
   ispecialize HP $$ %(0 : Nat)
 
-/-- Tests `ispecialize` with a specialisation pattern naming the subgoal. -/
+/-- Tests `ispecialize` with a specialization pattern naming the subgoal. -/
 example [BI PROP] [BIUpdate PROP] (P Q : PROP) :
     ⊢ (P -∗ Q) -∗ (|==> P) -∗ (|==> Q) := by
   iintro HPQ HP
@@ -3795,7 +3795,7 @@ example [CInvG GF] {γ : GName} {p : Qp} :
 
 /--
   Tests `iinv` with `elimInv_acc_without_close`, `elimAcc_fupd`,
-  `intoAcc_cinv` and a specialisation pattern. -/
+  `intoAcc_cinv` and a specialization pattern. -/
 example [CInvG GF] {γ : GName} {p1 p2 : Qp} {P : IProp GF} :
     cinv N γ iprop(<pers> P) ∗ own γ p1 ∗ own γ p2
     ⊢@{IProp GF} |={⊤}=> own γ p1 ∗ own γ p2 ∗ ▷ P := by


### PR DESCRIPTION
## Description

Addresses #251 in part.

Along with #624 and #649, all remaining instances under the `ProofMode` module except those related to `BigOp` and telescopes are ported.

Additionally, some tests are added for instances that involve priorities and backtracking.

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files
